### PR TITLE
Refactor dependency injection setup 

### DIFF
--- a/GenHub/GenHub.Linux/Program.cs
+++ b/GenHub/GenHub.Linux/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Avalonia;
 using GenHub.Core;
+using GenHub.Infrastructure.DependencyInjection;
 using GenHub.Services;
 using GenHub.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,9 +33,8 @@ public class Program
         // Linux-specific DI
         services.AddSingleton<IGameDetector, LinuxGameDetector>();
 
-        // Core DI
-        services.AddSingleton<GameDetectionService>();
-        services.AddSingleton<MainViewModel>();
+        // Register shared services
+        services.ConfigureApplicationServices();
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/GenHub/GenHub.Windows/Program.cs
+++ b/GenHub/GenHub.Windows/Program.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia;
 using GenHub.Core;
+using GenHub.Infrastructure.DependencyInjection;
 using GenHub.Services;
 using GenHub.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,9 +48,8 @@ public class Program
         // Windows-specific DI
         services.AddSingleton<IGameDetector, WindowsGameDetector>();
 
-        // Core DI
-        services.AddSingleton<GameDetectionService>();
-        services.AddSingleton<MainViewModel>();
+        // Register shared services
+        services.ConfigureApplicationServices();
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/AppServices.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/AppServices.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+using GenHub.Services;
+using GenHub.ViewModels;
+using GenHub.Core;
+
+namespace GenHub.Infrastructure.DependencyInjection
+{
+    /// <summary>
+    /// Main module that orchestrates registration of all application services.
+    /// </summary>
+    public static class AppServices
+    {
+        /// <summary>
+        /// Registers all shared services (non-platform-specific).
+        /// </summary>
+        public static IServiceCollection ConfigureApplicationServices(this IServiceCollection services)
+        {
+            // Register shared services here via extension modules
+            services.AddGameDetectionService();
+            services.AddSharedViewModelModule();
+            // Add more shared modules here as needed
+            return services;
+        }
+    }
+}

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/AppServices.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/AppServices.cs
@@ -1,7 +1,7 @@
-using Microsoft.Extensions.DependencyInjection;
+using GenHub.Core;
 using GenHub.Services;
 using GenHub.ViewModels;
-using GenHub.Core;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GenHub.Infrastructure.DependencyInjection
 {
@@ -13,11 +13,14 @@ namespace GenHub.Infrastructure.DependencyInjection
         /// <summary>
         /// Registers all shared services (non-platform-specific).
         /// </summary>
+        /// <param name="services">The service collection to which application services will be registered.</param>
+        /// <returns>The updated <see cref="IServiceCollection"/> with registered application services.</returns>
         public static IServiceCollection ConfigureApplicationServices(this IServiceCollection services)
         {
             // Register shared services here via extension modules
             services.AddGameDetectionService();
             services.AddSharedViewModelModule();
+
             // Add more shared modules here as needed
             return services;
         }

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/GameDetectionModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/GameDetectionModule.cs
@@ -1,10 +1,18 @@
-using Microsoft.Extensions.DependencyInjection;
 using GenHub.Services;
+using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace GenHub.Infrastructure.DependencyInjection
 {
-    public static class GameDetectionServiceModule
+    /// <summary>
+    /// Provides extension methods for registering game detection services.
+    /// </summary>
+    public static class GameDetectionModule
     {
+        /// <summary>
+        /// Registers the <see cref="GameDetectionService"/> as a singleton in the service collection.
+        /// </summary>
+        /// <param name="services">The service collection to add the service to.</param>
+        /// <returns>The updated service collection.</returns>
         public static IServiceCollection AddGameDetectionService(this IServiceCollection services)
         {
             services.AddSingleton<GameDetectionService>();

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/GameDetectionModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/GameDetectionModule.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using GenHub.Services;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class GameDetectionServiceModule
+    {
+        public static IServiceCollection AddGameDetectionService(this IServiceCollection services)
+        {
+            services.AddSingleton<GameDetectionService>();
+            return services;
+        }
+    }
+}

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
@@ -1,10 +1,17 @@
-using Microsoft.Extensions.DependencyInjection;
 using GenHub.ViewModels;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Provides extension methods to register shared ViewModels in the dependency injection container.
+    /// </summary>
     public static class SharedViewModelModule
     {
+        /// <summary>
+        /// Registers shared ViewModels as singletons in the service collection.
+        /// </summary>
+        /// <param name="services">The service collection to add the ViewModels to.</param>
+        /// <returns>The updated service collection.</returns>
         public static IServiceCollection AddSharedViewModelModule(this IServiceCollection services)
         {
             services.AddSingleton<MainViewModel>();

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using GenHub.ViewModels;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class SharedViewModelModule
+    {
+        public static IServiceCollection AddSharedViewModelModule(this IServiceCollection services)
+        {
+            services.AddSingleton<MainViewModel>();
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
With this PR I aim to create a clear and modular way to load services into GenHub.

For this I have created a GenHub/Infrastructure/DependencyInjection directory whereby `AppServices.cs` is responsible for adding all the shared services. 

Furthermore I have seperated each service registration and grouped them together into modules. 
`GameDetectionModule.cs` for game detection services.
`SharedViewModelModule.cs` for shared viewmodels.