### PR TITLE
Extends #44: Split detection responsibilities into GameInstallation and GameVersion 

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/GameInstallations/IGameInstallationDetectionOrchestrator.cs
+++ b/GenHub/GenHub.Core/Interfaces/GameInstallations/IGameInstallationDetectionOrchestrator.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Core.Interfaces.GameInstallations
+{
+    /// <summary>
+    /// Orchestrates all IGameInstallationDetector implementations.
+    /// </summary>
+    public interface IGameInstallationDetectionOrchestrator
+    {
+        /// <summary>
+        /// Detects all game installations from all detectors.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a <see cref="DetectionResult{GameInstallation}"/> containing detected installations.</returns>
+        Task<DetectionResult<GameInstallation>> DetectAllInstallationsAsync(
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Convenience: return only the Items if Success, else empty.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a list of detected <see cref="GameInstallation"/>s.</returns>
+        Task<List<GameInstallation>> GetDetectedInstallationsAsync(
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/GenHub/GenHub.Core/Interfaces/GameInstallations/IGameInstallationDetector.cs
+++ b/GenHub/GenHub.Core/Interfaces/GameInstallations/IGameInstallationDetector.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Core.Interfaces.GameInstallations
+{
+    /// <summary>
+    /// Discovers “official” game installations (Steam, EA App, Origin, CD, etc.).
+    /// </summary>
+    public interface IGameInstallationDetector
+    {
+        /// <summary>
+        /// Gets the human-readable name for logs/UI.
+        /// </summary>
+        string DetectorName { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this detector can run on the current OS/platform.
+        /// </summary>
+        bool CanDetectOnCurrentPlatform { get; }
+
+        /// <summary>
+        /// Scan for base platform installations and return them.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a <see cref="DetectionResult{GameInstallation}"/> containing detected installations.</returns>
+        Task<DetectionResult<GameInstallation>> DetectInstallationsAsync(
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/GenHub/GenHub.Core/Interfaces/GameVersions/IGameVersionDetectionOrchestrator.cs
+++ b/GenHub/GenHub.Core/Interfaces/GameVersions/IGameVersionDetectionOrchestrator.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Models.GameVersions;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Core.Interfaces.GameVersions
+{
+    /// <summary>
+    /// Orchestrates version detection for game installations.
+    /// </summary>
+    public interface IGameVersionDetectionOrchestrator
+    {
+        /// <summary>
+        /// Detects all game versions from all installations.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a <see cref="DetectionResult{GameVersion}"/> containing detected versions.</returns>
+        Task<DetectionResult<GameVersion>> DetectAllVersionsAsync(
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Convenience: return only the Items if Success, else empty.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a list of detected <see cref="GameVersion"/>s.</returns>
+        Task<List<GameVersion>> GetDetectedVersionsAsync(
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/GenHub/GenHub.Core/Interfaces/GameVersions/IGameVersionDetector.cs
+++ b/GenHub/GenHub.Core/Interfaces/GameVersions/IGameVersionDetector.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.GameVersions;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Core.Interfaces.GameVersions
+{
+    /// <summary>
+    /// From one or more GameInstallation(s), finds all runnable executables/patches.
+    /// </summary>
+    public interface IGameVersionDetector
+    {
+        /// <summary>
+        /// Given a set of base installations, produce all GameVersion variants.
+        /// </summary>
+        /// <param name="installations">The set of base game installations.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a <see cref="DetectionResult{GameVersion}"/> containing detected versions.</returns>
+        Task<DetectionResult<GameVersion>> DetectVersionsFromInstallationsAsync(
+           IEnumerable<GameInstallation> installations,
+           CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Scan an arbitrary directory (e.g. a GitHub‐extracted folder) for executables.
+        /// </summary>
+        /// <param name="path">The directory path to scan.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a <see cref="DetectionResult{GameVersion}"/> containing detected versions.</returns>
+        Task<DetectionResult<GameVersion>> ScanDirectoryForVersionsAsync(
+           string path,
+           CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Validate a single GameVersion (e.g. does the EXE exist?).
+        /// </summary>
+        /// <param name="version">The game version to validate.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation, with a boolean indicating validity.</returns>
+        Task<bool> ValidateVersionAsync(
+           GameVersion version,
+           CancellationToken cancellationToken = default);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationDetectionOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationDetectionOrchestratorTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Models;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Results;
+using GenHub.Features.GameInstallations;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameInstallations
+{
+    /// <summary>
+    /// Tests for <see cref="GameInstallationDetectionOrchestrator"/>.
+    /// </summary>
+    public class GameInstallationDetectionOrchestratorTests
+    {
+        /// <summary>
+        /// Verifies that all detectors' results are combined when all succeed.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        [Fact]
+        public async Task DetectAllInstallationsAsync_AllDetectorsSucceed_CombinesItems()
+        {
+            // Arrange
+            var instA = new GameInstallation { Id = "A", InstallationType = GameInstallationType.Steam, };
+            var instB = new GameInstallation { Id = "B", InstallationType = GameInstallationType.EaApp, };
+
+            var mockD1 = new Mock<IGameInstallationDetector>();
+            mockD1.SetupGet(d => d.CanDetectOnCurrentPlatform).Returns(true);
+            mockD1.Setup(d => d.DetectInstallationsAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(DetectionResult<GameInstallation>.Succeeded(
+                      new[] { instA }, TimeSpan.Zero));
+
+            var mockD2 = new Mock<IGameInstallationDetector>();
+            mockD2.SetupGet(d => d.CanDetectOnCurrentPlatform).Returns(true);
+            mockD2.Setup(d => d.DetectInstallationsAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(DetectionResult<GameInstallation>.Succeeded(
+                      new[] { instB }, TimeSpan.Zero));
+
+            var svc = new GameInstallationDetectionOrchestrator(
+                new[] { mockD1.Object, mockD2.Object });
+
+            // Act
+            var result = await svc.DetectAllInstallationsAsync();
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Contains(instA, result.Items);
+            Assert.Contains(instB, result.Items);
+        }
+
+        /// <summary>
+        /// Verifies that a failed detector returns a failed result.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        [Fact]
+        public async Task DetectAllInstallationsAsync_DetectorFails_ReturnsFailed()
+        {
+            // Arrange
+            var mockD = new Mock<IGameInstallationDetector>();
+            mockD.SetupGet(d => d.CanDetectOnCurrentPlatform).Returns(true);
+            mockD.Setup(d => d.DetectInstallationsAsync(It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(DetectionResult<GameInstallation>.Failed("detector error"));
+
+            var svc = new GameInstallationDetectionOrchestrator(new[] { mockD.Object });
+
+            // Act
+            var result = await svc.DetectAllInstallationsAsync();
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("detector error", result.Errors);
+            Assert.Empty(result.Items);
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameVersions/GameVersionDetectionOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameVersions/GameVersionDetectionOrchestratorTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GameVersions;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.GameVersions;
+using GenHub.Core.Models.Results;
+using GenHub.Features.GameVersions;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameVersions
+{
+    /// <summary>
+    /// Tests for <see cref="GameVersionDetectionOrchestrator"/>.
+    /// </summary>
+    public class GameVersionDetectionOrchestratorTests
+    {
+        /// <summary>
+        /// Verifies that a failed installation detection returns a failed result.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+        [Fact]
+        public async Task DetectAllVersionsAsync_InstallationDetectionFails_ReturnsFailed()
+        {
+            var mockInst = new Mock<IGameInstallationDetectionOrchestrator>();
+            mockInst.Setup(x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(DetectionResult<GameInstallation>.Failed("install error"));
+
+            var mockVer = new Mock<IGameVersionDetector>();
+            var svc = new GameVersionDetectionOrchestrator(mockInst.Object, mockVer.Object);
+
+            var result = await svc.DetectAllVersionsAsync();
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Errors, e => e.Contains("install error"));
+        }
+
+        /// <summary>
+        /// Verifies that version detection returns the expected versions when successful.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+        [Fact]
+        public async Task DetectAllVersionsAsync_VersionDetectionSucceeds_ReturnsVersions()
+        {
+            var installations = new List<GameInstallation>
+            {
+                new GameInstallation { Id = "I1", InstallationType = GameInstallationType.Steam, },
+            };
+            var mockInst = new Mock<IGameInstallationDetectionOrchestrator>();
+            mockInst.Setup(x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(DetectionResult<GameInstallation>.Succeeded(
+                        installations, TimeSpan.Zero));
+
+            var versions = new List<GameVersion>
+            {
+                new GameVersion
+                {
+                    Id = "V1",
+                    Name = "Generals (Steam)",
+                    ExecutablePath = @"C:\\Games\\Generals\\generals.exe",
+                    WorkingDirectory = @"C:\\Games\\Generals",
+                    GameType = "Generals",
+                    IsZeroHour = false,
+                    BaseInstallationId = "I1",
+                },
+            };
+            var mockVer = new Mock<IGameVersionDetector>();
+            mockVer.Setup(x => x.DetectVersionsFromInstallationsAsync(
+                        installations, It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(DetectionResult<GameVersion>.Succeeded(
+                        versions, TimeSpan.Zero));
+
+            var svc = new GameVersionDetectionOrchestrator(mockInst.Object, mockVer.Object);
+            var result = await svc.DetectAllVersionsAsync();
+
+            Assert.True(result.Success);
+            Assert.Equal(versions, result.Items);
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameVersions/GameVersionDetectionOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameVersions/GameVersionDetectionOrchestratorTests.cs
@@ -63,8 +63,7 @@ namespace GenHub.Tests.Core.Features.GameVersions
                     Name = "Generals (Steam)",
                     ExecutablePath = @"C:\\Games\\Generals\\generals.exe",
                     WorkingDirectory = @"C:\\Games\\Generals",
-                    GameType = "Generals",
-                    IsZeroHour = false,
+                    GameType = GameType.Generals,
                     BaseInstallationId = "I1",
                 },
             };

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
@@ -25,13 +25,13 @@ namespace GenHub.Features.GameInstallations
             var all = new List<GameInstallation>();
             var errors = new List<string>();
 
-            foreach (var d in detectors.Where(d => d.CanDetectOnCurrentPlatform))
+            foreach (var detector in detectors.Where(detector => detector.CanDetectOnCurrentPlatform))
             {
-                var r = await d.DetectInstallationsAsync(cancellationToken);
-                if (r.Success)
-                    all.AddRange(r.Items);
+                var result = await detector.DetectInstallationsAsync(cancellationToken);
+                if (result.Success)
+                    all.AddRange(result.Items);
                 else
-                    errors.AddRange(r.Errors);
+                    errors.AddRange(result.Errors);
             }
 
             sw.Stop();
@@ -44,8 +44,8 @@ namespace GenHub.Features.GameInstallations
         public async Task<List<GameInstallation>> GetDetectedInstallationsAsync(
             CancellationToken cancellationToken = default)
         {
-            var r = await DetectAllInstallationsAsync(cancellationToken);
-            return r.Success ? r.Items.ToList() : new List<GameInstallation>();
+            var result = await DetectAllInstallationsAsync(cancellationToken);
+            return result.Success ? result.Items.ToList() : new List<GameInstallation>();
         }
     }
 }

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
@@ -14,7 +14,7 @@ namespace GenHub.Features.GameInstallations
     /// Aggregates all IGameInstallationDetector implementations.
     /// </summary>
     /// <param name="detectors">The collection of installation detectors.</param>
-    public class GameInstallationDetectionOrchestrator(IEnumerable<IGameInstallationDetector> detectors)
+    public sealed class GameInstallationDetectionOrchestrator(IEnumerable<IGameInstallationDetector> detectors)
         : IGameInstallationDetectionOrchestrator
     {
         /// <inheritdoc/>

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Features.GameInstallations
+{
+    /// <summary>
+    /// Aggregates all IGameInstallationDetector implementations.
+    /// </summary>
+    public class GameInstallationDetectionOrchestrator : IGameInstallationDetectionOrchestrator
+    {
+        private readonly IEnumerable<IGameInstallationDetector> _detectors;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GameInstallationDetectionOrchestrator"/> class.
+        /// </summary>
+        /// <param name="detectors">The collection of installation detectors.</param>
+        public GameInstallationDetectionOrchestrator(IEnumerable<IGameInstallationDetector> detectors)
+        {
+            _detectors = detectors;
+        }
+
+        /// <inheritdoc/>
+        public async Task<DetectionResult<GameInstallation>> DetectAllInstallationsAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var sw = Stopwatch.StartNew();
+            var all = new List<GameInstallation>();
+            var errors = new List<string>();
+
+            foreach (var d in _detectors.Where(d => d.CanDetectOnCurrentPlatform))
+            {
+                var r = await d.DetectInstallationsAsync(cancellationToken);
+                if (r.Success)
+                    all.AddRange(r.Items);
+                else
+                    errors.AddRange(r.Errors);
+            }
+
+            sw.Stop();
+            return errors.Any()
+                ? DetectionResult<GameInstallation>.Failed(string.Join("; ", errors))
+                : DetectionResult<GameInstallation>.Succeeded(all, sw.Elapsed);
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<GameInstallation>> GetDetectedInstallationsAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var r = await DetectAllInstallationsAsync(cancellationToken);
+            return r.Success ? r.Items : new List<GameInstallation>();
+        }
+    }
+}

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
@@ -13,19 +13,10 @@ namespace GenHub.Features.GameInstallations
     /// <summary>
     /// Aggregates all IGameInstallationDetector implementations.
     /// </summary>
-    public class GameInstallationDetectionOrchestrator : IGameInstallationDetectionOrchestrator
+    /// <param name="detectors">The collection of installation detectors.</param>
+    public class GameInstallationDetectionOrchestrator(IEnumerable<IGameInstallationDetector> detectors)
+        : IGameInstallationDetectionOrchestrator
     {
-        private readonly IEnumerable<IGameInstallationDetector> _detectors;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GameInstallationDetectionOrchestrator"/> class.
-        /// </summary>
-        /// <param name="detectors">The collection of installation detectors.</param>
-        public GameInstallationDetectionOrchestrator(IEnumerable<IGameInstallationDetector> detectors)
-        {
-            _detectors = detectors;
-        }
-
         /// <inheritdoc/>
         public async Task<DetectionResult<GameInstallation>> DetectAllInstallationsAsync(
             CancellationToken cancellationToken = default)
@@ -34,7 +25,7 @@ namespace GenHub.Features.GameInstallations
             var all = new List<GameInstallation>();
             var errors = new List<string>();
 
-            foreach (var d in _detectors.Where(d => d.CanDetectOnCurrentPlatform))
+            foreach (var d in detectors.Where(d => d.CanDetectOnCurrentPlatform))
             {
                 var r = await d.DetectInstallationsAsync(cancellationToken);
                 if (r.Success)

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationDetectionOrchestrator.cs
@@ -54,7 +54,7 @@ namespace GenHub.Features.GameInstallations
             CancellationToken cancellationToken = default)
         {
             var r = await DetectAllInstallationsAsync(cancellationToken);
-            return r.Success ? r.Items : new List<GameInstallation>();
+            return r.Success ? r.Items.ToList() : new List<GameInstallation>();
         }
     }
 }

--- a/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Interfaces.GameInstallations;
@@ -52,7 +52,7 @@ namespace GenHub.Features.GameVersions
             CancellationToken cancellationToken = default)
         {
             var vres = await DetectAllVersionsAsync(cancellationToken);
-            return vres.Success ? vres.Items : new List<GameVersion>();
+            return vres.Success ? vres.Items.ToList() : new List<GameVersion>();
         }
     }
 }

--- a/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GameVersions;
+using GenHub.Core.Models.GameVersions;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Features.GameVersions
+{
+    /// <summary>
+    /// Orchestrates installation detection and version detection.
+    /// </summary>
+    public class GameVersionDetectionOrchestrator : IGameVersionDetectionOrchestrator
+    {
+        private readonly IGameInstallationDetectionOrchestrator _instOrchestrator;
+        private readonly IGameVersionDetector _verDetector;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GameVersionDetectionOrchestrator"/> class.
+        /// </summary>
+        /// <param name="instOrchestrator">The installation orchestrator.</param>
+        /// <param name="verDetector">The version detector.</param>
+        public GameVersionDetectionOrchestrator(
+            IGameInstallationDetectionOrchestrator instOrchestrator,
+            IGameVersionDetector verDetector)
+        {
+            _instOrchestrator = instOrchestrator;
+            _verDetector = verDetector;
+        }
+
+        /// <inheritdoc/>
+        public async Task<DetectionResult<GameVersion>> DetectAllVersionsAsync(
+            CancellationToken cancellationToken = default)
+        {
+            // 1) detect installations
+            var instRes = await _instOrchestrator.DetectAllInstallationsAsync(cancellationToken);
+            if (!instRes.Success)
+            {
+                return DetectionResult<GameVersion>.Failed(
+                    "Install detection errors: " + string.Join("; ", instRes.Errors));
+            }
+
+            // 2) detect versions from those installs
+            return await _verDetector.DetectVersionsFromInstallationsAsync(
+                instRes.Items, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<GameVersion>> GetDetectedVersionsAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var vres = await DetectAllVersionsAsync(cancellationToken);
+            return vres.Success ? vres.Items : new List<GameVersion>();
+        }
+    }
+}

--- a/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
@@ -12,7 +12,7 @@ namespace GenHub.Features.GameVersions
     /// <summary>
     /// Orchestrates installation detection and version detection.
     /// </summary>
-    public class GameVersionDetectionOrchestrator : IGameVersionDetectionOrchestrator
+    public sealed class GameVersionDetectionOrchestrator : IGameVersionDetectionOrchestrator
     {
         private readonly IGameInstallationDetectionOrchestrator _instOrchestrator;
         private readonly IGameVersionDetector _verDetector;

--- a/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameVersions/GameVersionDetectionOrchestrator.cs
@@ -51,8 +51,8 @@ namespace GenHub.Features.GameVersions
         public async Task<List<GameVersion>> GetDetectedVersionsAsync(
             CancellationToken cancellationToken = default)
         {
-            var vres = await DetectAllVersionsAsync(cancellationToken);
-            return vres.Success ? vres.Items.ToList() : new List<GameVersion>();
+            var result = await DetectAllVersionsAsync(cancellationToken);
+            return result.Success ? result.Items.ToList() : new List<GameVersion>();
         }
     }
 }


### PR DESCRIPTION
This PR introduces two detection interfaces and corresponding orchestrator services:

1. IGameInstallationDetector + IGameInstallationOrchestrator:
   - Detect “official” retail installs (Steam, EA App, Origin, CD, etc.)
   - Orchestrator aggregates all detectors and returns DetectionResult<GameInstallation>.

2. IGameVersionDetector + IGameVersionOrchestrator:
   - Orchestrator chains installation detection → version detection.

No existing platform‐specific code is modified—this simply defines the contracts and high‐level glue.
Unit tests verify that orchestrators correctly combine detector results.