### PR TITLE
Fixing a variety of warning messages

### DIFF
--- a/GenHub/GenHub.Linux/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Linux/GlobalSuppressions.cs
@@ -3,12 +3,12 @@
 //  This file contains code analysis suppression attributes for the entire project.
 //  For more information on suppressing warnings, see the .NET documentation.
 //
-//  Please keep suppressions well-documented and justified. 
+//  Please keep suppressions well-documented and justified.
 //  When adding a new suppression, include a comment explaining the rationale.
 //
 //  See CONTRIBUTIONS.md for contribution guidelines.
 //
-//  Version: 2025-06-17
+//  Version: 2025-06-30
 // -----------------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
@@ -57,3 +57,13 @@ using System.Diagnostics.CodeAnalysis;
     "StyleCop.CSharp.DocumentationRules",
     "SA1633:File should have header",
     Justification = "Licensing and other information is provided in seperate files.")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.SpacingRules",
+    "SA1011:Closing square brackets should be spaced correctly",
+    Justification = "Conflicts with SA1018")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.SpacingRules",
+    "SA1009:Closing parenthesis should be spaced correctly",
+    Justification = "Conflicts with null-forgiving operator usage.")]

--- a/GenHub/GenHub.Windows/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Windows/GlobalSuppressions.cs
@@ -3,12 +3,12 @@
 //  This file contains code analysis suppression attributes for the entire project.
 //  For more information on suppressing warnings, see the .NET documentation.
 //
-//  Please keep suppressions well-documented and justified. 
+//  Please keep suppressions well-documented and justified.
 //  When adding a new suppression, include a comment explaining the rationale.
 //
 //  See CONTRIBUTIONS.md for contribution guidelines.
 //
-//  Version: 2025-06-17
+//  Version: 2025-06-30
 // -----------------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
@@ -62,3 +62,13 @@ using System.Diagnostics.CodeAnalysis;
     "StyleCop.CSharp.DocumentationRules",
     "SA1633:File should have header",
     Justification = "Licensing and other information is provided in seperate files.")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.SpacingRules",
+    "SA1011:Closing square brackets should be spaced correctly",
+    Justification = "Conflicts with SA1018")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.SpacingRules",
+    "SA1009:Closing parenthesis should be spaced correctly",
+    Justification = "Conflicts with null-forgiving operator usage.")]

--- a/GenHub/GenHub.Windows/Installations/SteamInstallation.cs
+++ b/GenHub/GenHub.Windows/Installations/SteamInstallation.cs
@@ -52,7 +52,7 @@ public class SteamInstallation : IGameInstallation
         if(!TryGetSteamLibraries(out var libraryPaths))
             return;
 
-        foreach (var lib in libraryPaths)
+        foreach (var lib in libraryPaths!)
         {
             if(string.IsNullOrEmpty(lib))
                 continue;

--- a/GenHub/GenHub.Windows/Program.cs
+++ b/GenHub/GenHub.Windows/Program.cs
@@ -79,9 +79,9 @@ public class Program
     private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
     /// <summary>
-    /// Checks if another instance is already running by attempting to acquire a named <see cref="Mutex">.
+    /// Checks if another instance is already running by attempting to acquire a named <see cref="Mutex" />.
     /// </summary>
-    /// <returns>True if another instance already owns the <see cref="Mutex">.</returns>
+    /// <returns>True if another instance already owns the <see cref="Mutex" />.</returns>
     private static bool IsAnotherInstanceRunning()
     {
         mutex = new Mutex(true, MutexName, out bool createdNew);

--- a/GenHub/GenHub/GlobalSuppressions.cs
+++ b/GenHub/GenHub/GlobalSuppressions.cs
@@ -3,12 +3,12 @@
 //  This file contains code analysis suppression attributes for the entire project.
 //  For more information on suppressing warnings, see the .NET documentation.
 //
-//  Please keep suppressions well-documented and justified. 
+//  Please keep suppressions well-documented and justified.
 //  When adding a new suppression, include a comment explaining the rationale.
 //
 //  See CONTRIBUTIONS.md for contribution guidelines.
 //
-//  Version: 2025-06-17
+//  Version: 2025-06-30
 // -----------------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
@@ -57,3 +57,13 @@ using System.Diagnostics.CodeAnalysis;
     "StyleCop.CSharp.DocumentationRules",
     "SA1633:File should have header",
     Justification = "Licensing and other information is provided in seperate files.")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.SpacingRules",
+    "SA1011:Closing square brackets should be spaced correctly",
+    Justification = "Conflicts with SA1018")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.SpacingRules",
+    "SA1009:Closing parenthesis should be spaced correctly",
+    Justification = "Conflicts with null-forgiving operator usage.")]

--- a/GenHub/GenHub/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/ViewModels/MainViewModel.cs
@@ -24,7 +24,8 @@ public partial class MainViewModel(GameDetectionService gameDetectionService)
     /// </summary>
     public MainViewModel()
         : this(new GameDetectionService(new DummyGameDetector()))
-    { }
+    {
+    }
 
     [RelayCommand]
     private void Detect()

--- a/GenHub/GenHub/ViewModels/ViewModelBase.cs
+++ b/GenHub/GenHub/ViewModels/ViewModelBase.cs
@@ -6,4 +6,5 @@ namespace GenHub.ViewModels;
 /// Base class for ViewModels.
 /// </summary>
 public class ViewModelBase : ObservableObject
-{ }
+{
+}


### PR DESCRIPTION
- Partially resolves #8 

Resolves:
- Issues with spacing between parenthesis and the ? and ! operator. These warnings are ignored now.
- Missing closing tags in documentation
- Unnecessary spaces
- Incorrect detection of a possible null reference
- Incorrect use of brackets.
