### PR TITLE
Fixes remaining documentation warnings thrown by Stylecop

### DIFF
--- a/GenHub/GenHub.Core/GenHub.Core.csproj
+++ b/GenHub/GenHub.Core/GenHub.Core.csproj
@@ -3,6 +3,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="StyleCop.Analyzers" />

--- a/GenHub/GenHub.Core/Models/GameVersions/GameType.cs
+++ b/GenHub/GenHub.Core/Models/GameVersions/GameType.cs
@@ -1,17 +1,17 @@
 namespace GenHub.Core.Models.GameVersions;
 
 /// <summary>
-/// Represents the type of Command & Conquer game.
+/// Represents the type of Command and Conquer game.
 /// </summary>
 public enum GameType
 {
     /// <summary>
-    /// Command & Conquer: Generals.
+    /// Command and Conquer: Generals.
     /// </summary>
     Generals,
 
     /// <summary>
-    /// Command & Conquer: Generals – Zero Hour.
+    /// Command and Conquer: Generals – Zero Hour.
     /// </summary>
     ZeroHour,
 }

--- a/GenHub/GenHub.Linux/GenHub.Linux.csproj
+++ b/GenHub/GenHub.Linux/GenHub.Linux.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" />

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/GlobalSuppressions.cs
@@ -3,7 +3,7 @@
 //  This file contains code analysis suppression attributes for the entire project.
 //  For more information on suppressing warnings, see the .NET documentation.
 //
-//  Please keep suppressions well-documented and justified. 
+//  Please keep suppressions well-documented and justified.
 //  When adding a new suppression, include a comment explaining the rationale.
 //
 //  See CONTRIBUTIONS.md for contribution guidelines.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Linux/GenHub.Tests.Linux.csproj
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Linux/GenHub.Tests.Linux.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" />

--- a/GenHub/GenHub.Tests/GenHub.Tests.Windows/GenHub.Tests.Windows.csproj
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Windows/GenHub.Tests.Windows.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" />

--- a/GenHub/GenHub.Windows/GenHub.Windows.csproj
+++ b/GenHub/GenHub.Windows/GenHub.Windows.csproj
@@ -6,6 +6,7 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/GenHub/GenHub/App.axaml.cs
+++ b/GenHub/GenHub/App.axaml.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GenHub;
 
+/// <summary>
+/// Primary application class for GenHub.
+/// </summary>
 public partial class App : Application
 {
     /// <inheritdoc/>

--- a/GenHub/GenHub/AppLocator.cs
+++ b/GenHub/GenHub/AppLocator.cs
@@ -13,8 +13,6 @@ public static class AppLocator
     /// <summary>
     /// Gets or sets the service provider for dependency injection.
     /// </summary>
-    /// Gets or sets service provider for dependency injection.
-    /// </summary>
     public static IServiceProvider? Services { get; set; }
 
     /// <summary>

--- a/GenHub/GenHub/GenHub.csproj
+++ b/GenHub/GenHub/GenHub.csproj
@@ -3,6 +3,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/GameDetectionModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/GameDetectionModule.cs
@@ -1,5 +1,5 @@
-using GenHub.Services;
 using GenHub.Core;
+using GenHub.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GenHub.Infrastructure.DependencyInjection


### PR DESCRIPTION
Required to add `GenerateDocumentation` to each and every project, which yielded a number of additional documentation warnings.