### PR TITLE
Move native win32 commands to a NativeMethods class to make stylecop happy

### DIFF
--- a/GenHub/GenHub.Windows/NativeMethods.cs
+++ b/GenHub/GenHub.Windows/NativeMethods.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GenHub.Windows;
+
+/// <summary>
+/// Contains Win32 API constants and methods for interop.
+/// </summary>
+internal static class NativeMethods
+{
+    /// <summary>
+    /// The command to restore a window.
+    /// </summary>
+    internal const int SW_RESTORE = 9;
+
+    /// <summary>
+    /// Brings the specified window to the foreground and activates it.
+    /// </summary>
+    /// <remarks>This method is a wrapper for the native Windows API function in user32.dll. The ability to
+    /// bring a window to the foreground may be restricted by the system's user interface privilege level.</remarks>
+    /// <param name="hWnd">A handle to the window that should be brought to the foreground.</param>
+    /// <returns><see langword="true"/> if the window was successfully brought to the foreground; otherwise, <see
+    /// langword="false"/>.</returns>
+    [DllImport("user32.dll")]
+    internal static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    /// <summary>
+    /// Sets the specified window's show state.
+    /// </summary>
+    /// <remarks>
+    /// This method is a wrapper for the native Windows API function in user32.dll. It can be used to minimize, maximize, restore, or hide a window.
+    /// </remarks>
+    /// <param name="hWnd">A handle to the window.</param>
+    /// <param name="nCmdShow">Controls how the window is to be shown. For example, use <see cref="SW_RESTORE"/> to restore a minimized or maximized window.</param>
+    /// <returns><see langword="true"/> if the window was previously visible; otherwise, <see langword="false"/>.</returns>
+    [DllImport("user32.dll")]
+    internal static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+}

--- a/GenHub/GenHub.Windows/Program.cs
+++ b/GenHub/GenHub.Windows/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia;
 using GenHub.Infrastructure.DependencyInjection;
@@ -16,7 +15,6 @@ namespace GenHub.Windows;
 public class Program
 {
     private const string MutexName = "Global\\GenHub";
-    private const int SW_RESTORE = 9; // Windows API constant to restore a window
     private static Mutex? mutex;
 
     /// <summary>
@@ -77,12 +75,6 @@ public class Program
             .WithInterFont()
             .LogToTrace();
 
-    [DllImport("user32.dll")]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
-
-    [DllImport("user32.dll")]
-    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-
     /// <summary>
     /// Checks if another instance is already running by attempting to acquire a named <see cref="Mutex" />.
     /// </summary>
@@ -107,7 +99,7 @@ public class Program
 
         // Restore the window if minimized and bring it to the foreground
         var windowHandle = process.MainWindowHandle;
-        ShowWindow(windowHandle, SW_RESTORE);
-        SetForegroundWindow(windowHandle);
+        NativeMethods.ShowWindow(windowHandle, NativeMethods.SW_RESTORE);
+        NativeMethods.SetForegroundWindow(windowHandle);
     }
 }


### PR DESCRIPTION
It is a good convention to add native win32 methods into a NativeMethods class, per Stylecops suggestion.
If we don't want this, we will have to suppress a number of Stylecop warnings.