### PR TITLE
Refactor(ci): Fix windows tests not failing ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
             foreach ($testProject in $testProjects) {
               Write-Host "Testing $($testProject.FullName)"
               dotnet test $testProject.FullName -c $env:BUILD_CONFIGURATION
+                if ($LASTEXITCODE -ne 0) {
+                    throw "Test failed for $($testProject.FullName)"
+                }
             }
           } else {
             Write-Host "No test projects found."


### PR DESCRIPTION
PowerShell doesn't automatically treat non-zero exit codes from external commands (dotnet test) as terminating errors.

This PR fixes this bug in the `ci.yml` workflow file by adding a `$LASTEXITCODE ` check.