### PR TITLE
Add C&C Labs search crawler to extract map entries with details page links

### DIFF
--- a/GenHub/Directory.Packages.props
+++ b/GenHub/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <!-- Avalonia packages -->
     <!-- Important: keep version in sync! -->
+    <PackageVersion Include="AngleSharp" Version="1.3.0" />
     <PackageVersion Include="Avalonia" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Desktop" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.7" />

--- a/GenHub/Directory.Packages.props
+++ b/GenHub/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.55.0" />
     <PackageVersion Include="ReactiveUI" Version="19.6.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <!-- Test packages -->

--- a/GenHub/GenHub.Core/Constants/CncLabsConstants.cs
+++ b/GenHub/GenHub.Core/Constants/CncLabsConstants.cs
@@ -1,0 +1,236 @@
+﻿namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Constants specific to CNC Labs and its content pipeline components.
+/// </summary>
+public static class CNCLabsConstants
+{
+    /// <summary>
+    /// CSS selector for search result containers on CNC Labs.
+    /// </summary>
+    public const string ResultSelector = "#search-results div.gsc-webResult.gsc-result";
+
+    /// <summary>
+    /// CSS selector for map title links within search results.
+    /// </summary>
+    public const string LinkSelector = "div.gs-webResult.gs-result div.gsc-thumbnail-inside div.gs-title a.gs-title";
+
+    /// <summary>
+    /// Attribute name for canonical href in CNC Labs search results.
+    /// </summary>
+    public const string CanonicalHrefAttr = "data-ctorig";
+
+    /// <summary>
+    /// Path marker for details pages on CNC Labs.
+    /// </summary>
+    public const string DetailsPathMarker = "details.aspx";
+
+    /// <summary>
+    /// Path marker for Generals maps on CNC Labs.
+    /// </summary>
+    public const string GeneralsPathMarker = "maps/generals";
+
+    /// <summary>
+    /// Default author name for CNC Labs content.
+    /// </summary>
+    public const string AuthorName = "C&C Labs";
+
+    /// <summary>
+    /// Base URL for CNC Labs search.
+    /// </summary>
+    public const string SearchUrlBase = "http://search.cnclabs.com/?cse=labs&q=";
+
+    /// <summary>
+    /// Base URL for CNC Labs search.
+    /// </summary>
+    public const string SearchMapsUrlBase = "https://www.cnclabs.com/maps/generals/";
+
+    /// <summary>
+    /// Source name for CNC Labs map discoverer.
+    /// </summary>
+    public const string SourceName = "CNC Labs Maps";
+
+    /// <summary>
+    /// Description for CNC Labs map discoverer.
+    /// </summary>
+    public const string Description = "Discovers maps from CNC Labs website";
+
+    /// <summary>
+    /// Resolver ID for CNC Labs maps.
+    /// </summary>
+    public const string ResolverId = "CNCLabsMap";
+
+    /// <summary>
+    /// Metadata key for map ID.
+    /// </summary>
+    public const string MapIdMetadataKey = "mapId";
+
+    /// <summary>
+    /// Error message for null query.
+    /// </summary>
+    public const string QueryNullErrorMessage = "Query cannot be null";
+
+    /// <summary>
+    /// Template for map description.
+    /// </summary>
+    public const string MapDescriptionTemplate = "Map from CNC Labs - full details available after resolution";
+
+    /// <summary>
+    /// Template for discovery failure error.
+    /// </summary>
+    public const string DiscoveryFailedErrorTemplate = "Discovery failed: {0}";
+
+    /// <summary>
+    /// Log message for discovery failure.
+    /// </summary>
+    public const string DiscoveryFailureLogMessage = "Failed to discover maps from CNC Labs";
+
+    /// <summary>
+    /// Format for CNC Labs map ID.
+    /// </summary>
+    public const string MapIdFormat = "cnclabs.map.{0}";
+
+    /// <summary>
+    /// Error message used when a provided URL string
+    /// fails validation as a valid absolute URI.
+    /// </summary>
+    public const string InvalidAbsoluteUri = "The provided URL is not a valid absolute URI.";
+
+    /// <summary>
+    /// Attribute name for anchor element href values within search results.
+    /// </summary>
+    public const string HrefAttribute = "href";
+
+    /// <summary>
+    /// Query string parameter name for the ID.
+    /// </summary>
+    public const string QueryStringIdParameter = "id";
+
+    /// <summary>
+    /// CSS selector for a single downloadable item container on list pages.
+    /// </summary>
+    public const string ListItemSelector = "div.DownloadItem";
+
+    /// <summary>
+    /// CSS selector for the hidden input that carries the map's numeric File Id.
+    /// </summary>
+    public const string FileIdHiddenSelector = "input[type='hidden'][id$='FileIdField']";
+
+    /// <summary>
+    /// CSS selector for the anchor with the display name of the map.
+    /// </summary>
+    public const string DisplayNameAnchorSelector = "a.DisplayName";
+
+    /// <summary>
+    /// CSS selector for the element that contains the short description.
+    /// </summary>
+    public const string DescriptionSelector = "span[id$='DescriptionLabel']";
+
+    /// <summary>
+    /// CSS selector for bold labels inside the item description cell (used to locate the "Author:" label).
+    /// </summary>
+    public const string DescriptionCellStrongSelector = ".DescriptionCell strong";
+
+    /// <summary>
+    /// Literal text appearing in the UI preceding the author value.
+    /// </summary>
+    public const string AuthorLabelText = "Author:";
+
+    /// <summary>
+    /// Default author name used when an author cannot be parsed from the page.
+    /// </summary>
+    public const string DefaultAuthorName = "Unknown";
+
+    /// <summary>
+    /// Error message used when <c>ContentSearchQuery.SearchTerm</c> is null, empty, or whitespace.
+    /// </summary>
+    public const string SearchTermEmptyErrorMessage = "Search term must be non-empty.";
+
+    /// <summary>
+    /// Standard HTML attribute name used to read an element's value.
+    /// </summary>
+    public const string ValueAttribute = "value";
+
+    /// <summary>
+    /// Relative path for the Command &amp; Conquer: Generals maps list page.
+    /// </summary>
+    public const string MapsPagePath = "maps.aspx";
+
+    /// <summary>
+    /// Relative path for the Command &amp; Conquer: Generals missions list page.
+    /// </summary>
+    public const string MissionsPagePath = "missions.aspx";
+
+    /// <summary>
+    /// Relative path for the Command &amp; Conquer: Zero Hour maps list page.
+    /// </summary>
+    public const string ZeroHourMapsPagePath = "zerohour-maps.aspx";
+
+    /// <summary>
+    /// Relative path for the Command &amp; Conquer: Zero Hour missions list page.
+    /// </summary>
+    public const string ZeroHourMissionsPagePath = "zerohour-missions.aspx";
+
+    /// <summary>
+    /// Query parameter name for the page index (1-based).
+    /// </summary>
+    public const string PageQueryParam = "page";
+
+    /// <summary>
+    /// Query parameter name for filtering by number of players.
+    /// </summary>
+    public const string PlayersQueryParam = "players";
+
+    /// <summary>
+    /// Query parameter name for filtering by tags (comma-separated).
+    /// </summary>
+    public const string TagsQueryParam = "tags";
+
+    /// <summary>
+    /// Separator used when joining multiple tag values for the <see cref="TagsQueryParam"/> parameter.
+    /// </summary>
+    public const string CommaSeparator = ",";
+
+    /// <summary>
+    /// CSS selector for the map title on the details page.
+    /// Example element: <c>&lt;span class="DisplayName"&gt;…&lt;/span&gt;</c>.
+    /// </summary>
+    public const string NameSelector = ".DownloadItem .DisplayName";
+
+    /// <summary>
+    /// CSS selector for the breadcrumb/header element that contains the full trail
+    /// (used as a fallback source for the name if <see cref="NameSelector"/> is missing).
+    /// </summary>
+    public const string BreadcrumbHeaderSelector = "h1";
+
+    /// <summary>
+    /// The character used by the site to separate parts of the breadcrumb trail in the
+    /// <see cref="BreadcrumbHeaderSelector"/> (we take the last segment as the map name).
+    /// </summary>
+    public const char BreadcrumbSeparator = '»';
+
+    /// <summary>
+    /// CSS selector for the description span whose id ends with <c>_DescriptionLabel</c>.
+    /// This is the raw HTML we pass to <c>CNCLabsHelper.FormatDescription</c> to normalize.
+    /// </summary>
+    public const string DetailsPageDescriptionSelector = ".DownloadItem span[id$='DescriptionLabel']";
+
+    /// <summary>
+    /// CSS selector that finds all <c>&lt;strong&gt;</c> nodes within the description cell.
+    /// We search these for a node whose text is equal to <see cref="AuthorLabelText"/>.
+    /// </summary>
+    public const string AuthorLabelContainerSelector = ".DownloadItem .DescriptionCell strong";
+
+    /// <summary>
+    /// Error message thrown when the caller provides a null/empty details page URL.
+    /// </summary>
+    public const string UrlRequiredMessage = "The details page URL must not be null or empty.";
+
+    /// <summary>Zero-based index of the “category” item in the breadcrumb (Downloads=0, CNC Generals=1, Category=2, Name=3).</summary>
+    public const int BreadcrumbCategoryIndex = 2;
+
+    /// <summary>
+    /// Query parameter name for sorting by selected value.
+    /// </summary>
+    public const string Sort = "sort";
+}

--- a/GenHub/GenHub.Core/Models/Content/ContentSearchQuery.cs
+++ b/GenHub/GenHub.Core/Models/Content/ContentSearchQuery.cs
@@ -63,4 +63,19 @@ public class ContentSearchQuery
     /// Gets or sets a value indicating whether to include already installed content in the results.
     /// </summary>
     public bool IncludeInstalled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets number of players filter by.
+    /// </summary>
+    public int? NumberOfPlayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets page number.
+    /// </summary>
+    public int? Page { get; set; }
+
+    /// <summary>
+    /// Gets or sets sort value.
+    /// </summary>
+    public string Sort { get; set; } = string.Empty;
 }

--- a/GenHub/GenHub.Core/Models/Enums/ContentType.cs
+++ b/GenHub/GenHub.Core/Models/Enums/ContentType.cs
@@ -40,4 +40,13 @@ public enum ContentType
 
     /// <summary>Link to specific content.</summary>
     ContentReferral,
+
+    /// <summary>Story-driven gameplay with objectives.</summary>
+    Mission,
+
+    /// <summary>Free-play or skirmish mode on a map.</summary>
+    Map,
+
+    /// <summary>Unknown content type</summary>
+    UnknownContentType,
 }

--- a/GenHub/GenHub.Core/Models/Enums/GameType.cs
+++ b/GenHub/GenHub.Core/Models/Enums/GameType.cs
@@ -14,4 +14,9 @@ public enum GameType
     /// Command and Conquer: Generals – Zero Hour.
     /// </summary>
     ZeroHour,
+
+    /// <summary>
+    /// Unknown game type.
+    /// </summary>
+    Unknown,
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
@@ -1,136 +1,303 @@
-﻿using GenHub.Core.Interfaces.Content;
-using GenHub.Core.Interfaces.Manifest;
+﻿using GenHub.Core.Constants;
 using GenHub.Core.Models.Content;
-using GenHub.Core.Models.Manifest;
-using GenHub.Core.Models.Results;
-using GenHub.Core.Models.Validation;
-using GenHub.Features.Content.Services.ContentProviders;
+using GenHub.Core.Models.Enums;
+using GenHub.Features.Content.Services.ContentDiscoverers;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Net;
 
-namespace GenHub.Tests.Core.Features.Content
+namespace GenHub.Tests.Core.Features.Content;
+
+/// <summary>
+/// Unit tests for <see cref="CNCLabsMapDiscoverer"/>.
+/// </summary>
+public class CNCLabsMapDiscovererTests
 {
     /// <summary>
-    /// Unit tests for the <see cref="CNCLabsContentProvider"/> integration
-    /// with a CNCLabs-style map discoverer/resolver pipeline.
-    /// <para>
-    /// This test is fully offline: it mocks the discoverer, resolver,
-    /// deliverer, and validator so that CI remains deterministic.
-    /// </para>
+    /// Backing mock for verifying <see cref="ILogger{TCategoryName}"/> calls.
     /// </summary>
-    public class CNCLabsMapDiscovererTests
+    private readonly Mock<ILogger<CNCLabsMapDiscoverer>> _loggerMock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CNCLabsMapDiscovererTests"/> class.
+    /// </summary>
+    public CNCLabsMapDiscovererTests()
     {
-        /// <summary>Mock for the discovery layer that lists candidate items.</summary>
-        private readonly Mock<IContentDiscoverer> _discovererMock;
+        _loggerMock = new Mock<ILogger<CNCLabsMapDiscoverer>>();
+    }
 
-        /// <summary>Mock for the resolution layer that turns a discovered item into a full manifest.</summary>
-        private readonly Mock<IContentResolver> _resolverMock;
+    /// <summary>
+    /// Verifies that <see cref="CNCLabsMapDiscoverer.DiscoverAsync(ContentSearchQuery, CancellationToken)"/> returns a failure result
+    /// when the query is <see langword="null"/>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverAsync_NullQuery_ReturnsFailure()
+    {
+        // Arrange
+        using var http = CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var sut = CreateSut(http);
 
-        /// <summary>Mock for the delivery layer (kept for provider contract completeness).</summary>
-        private readonly Mock<IContentDeliverer> _delivererMock;
+        // Act
+        var result = await sut.DiscoverAsync(null!);
 
-        /// <summary>Mock for validating the resolved manifest.</summary>
-        private readonly Mock<IContentValidator> _validatorMock;
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains(CNCLabsConstants.QueryNullErrorMessage, result.AllErrors ?? string.Empty);
+    }
 
-        /// <summary>Mock for a content-manifest builder (kept for potential provider needs).</summary>
-        private readonly Mock<IContentManifestBuilder> _contentManifestBuilderMock;
+    /// <summary>
+    /// Verifies that discovery fails when both a search term and the required filters are missing
+    /// (i.e., neither <see cref="ContentSearchQuery.SearchTerm"/> nor both
+    /// <see cref="ContentSearchQuery.TargetGame"/> and <see cref="ContentSearchQuery.ContentType"/> are provided).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverAsync_MissingSearchTermAndFilters_ReturnsFailure()
+    {
+        // Arrange: neither SearchTerm nor both TargetGame & ContentType
+        var query = new ContentSearchQuery
+        {
+            SearchTerm = string.Empty,
+            TargetGame = null,
+            ContentType = null,
+        };
 
-        /// <summary>Logger mock for the provider.</summary>
-        private readonly Mock<ILogger<CNCLabsContentProvider>> _loggerMock;
+        using var http = CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var sut = CreateSut(http);
 
-        /// <summary>The provider under test, wired with mocked dependencies.</summary>
-        private readonly CNCLabsContentProvider _provider;
+        // Act
+        var result = await sut.DiscoverAsync(query);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains(CNCLabsConstants.QueryNullErrorMessage, result.AllErrors ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Verifies that a canceled operation results in a failure and is logged appropriately.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverAsync_CancellationRequested_ReturnsFailure()
+    {
+        // Arrange
+        var query = new ContentSearchQuery
+        {
+            TargetGame = GameType.ZeroHour,
+            ContentType = GenHub.Core.Models.Enums.ContentType.Mission,
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        using var http = CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var sut = CreateSut(http, _loggerMock);
+
+        // Act
+        var result = await sut.DiscoverAsync(query, cts.Token);
+
+        // Assert: class converts exceptions to OperationResult failure and logs them
+        Assert.False(result.Success);
+        _loggerMock.VerifyLogErrorCalled();
+    }
+
+    /// <summary>
+    /// Verifies that HTTP exceptions are surfaced as a failure result and that they are logged.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverAsync_HttpThrows_ReturnsFailure_AndLogs()
+    {
+        // Arrange - any request throws
+        using var http = new HttpClient(new ThrowingHandler(new HttpRequestException("boom")));
+        var sut = CreateSut(http, _loggerMock);
+
+        var query = new ContentSearchQuery
+        {
+            TargetGame = GameType.Generals,
+            ContentType = GenHub.Core.Models.Enums.ContentType.Map,
+        };
+
+        // Act
+        var result = await sut.DiscoverAsync(query);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("boom", result.AllErrors ?? string.Empty);
+        _loggerMock.VerifyLogErrorCalled();
+    }
+
+    /// <summary>
+    /// (Template) “happy path” test for the structured filters branch.
+    /// Uses a small HTML snippet expected to match the CNCLabs selectors.
+    /// Adjust the HTML to mirror your <see cref="CNCLabsConstants"/> selectors if they differ.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverAsync_WithFilters_ParsesListAndProjectsResults()
+    {
+        // Arrange
+        var query = new ContentSearchQuery
+        {
+            TargetGame = GameType.Generals,
+            ContentType = GenHub.Core.Models.Enums.ContentType.Map,
+        };
+
+        // IMPORTANT: Adjust this HTML to match your CNCLabsConstants.* selectors.
+        // The idea is: each list item has a hidden input for the id AND a link with name + href.
+        var listHtml = @"
+<html><body>
+  <div class=""DownloadItem"">
+    <input type=""hidden"" name=""ctl00$Main$DownloadsView$ItemRepeater$ctl00$ctl00$FileIdField"" id=""ctl00_Main_DownloadsView_ItemRepeater_ctl00_ctl00_FileIdField"" value=""3239"">
+    <a class=""DisplayName"" href=""/downloads/details.aspx?id=3239"">
+      COOP GLA vs CHI - Call of Dragon
+    </a>
+    <div class=""DescriptionCell"">
+      <span id=""x_DescriptionLabel"">This is another custom scripted co-op mission map. 1 or 2 humans players as GLA against 1 China…</span>
+      <strong>Author:</strong> El_Chapo
+    </div>
+  </div>
+</body></html>";
+
+        // We return the list page HTML for the search URL
+        using var http = CreateHttpClient(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(listHtml),
+            });
+
+        var sut = CreateSut(http);
+
+        // Act
+        var result = await sut.DiscoverAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data!.ToList();
+
+        Assert.Single(items);
+        var item = items[0];
+
+        Assert.Equal(string.Format(CNCLabsConstants.MapIdFormat, 3239), item.Id);
+        Assert.Equal("COOP GLA vs CHI - Call of Dragon", item.Name);
+        Assert.Equal(CNCLabsConstants.MapDescriptionTemplate, item.Description);
+        Assert.Equal("El_Chapo", item.AuthorName);
+        Assert.Equal(GenHub.Core.Models.Enums.ContentType.Map, item.ContentType);
+        Assert.Equal(GameType.Generals, item.TargetGame);
+        Assert.Equal(CNCLabsConstants.ResolverId, item.ResolverId);
+        Assert.True(item.RequiresResolution);
+        Assert.Equal(CNCLabsConstants.SourceName, item.ProviderName);
+        Assert.Equal("/downloads/details.aspx?id=3239", item.SourceUrl);
+        Assert.True(item.ResolverMetadata.ContainsKey(CNCLabsConstants.MapIdMetadataKey));
+        Assert.Equal("3239", item.ResolverMetadata[CNCLabsConstants.MapIdMetadataKey]);
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose responses are controlled by the provided <paramref name="responder"/>.
+    /// </summary>
+    /// <param name="responder">A delegate that receives the outgoing <see cref="HttpRequestMessage"/> and returns the response.</param>
+    /// <returns>An <see cref="HttpClient"/> configured to use the responder.</returns>
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var handler = new DelegateHandler((req, ct) => Task.FromResult(responder(req)));
+        return new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(5),
+        };
+    }
+
+    /// <summary>
+    /// Creates the system under test (SUT): an instance of <see cref="CNCLabsMapDiscoverer"/>.
+    /// </summary>
+    /// <param name="http">The <see cref="HttpClient"/> to be used by the discoverer.</param>
+    /// <param name="loggerMock">An optional mock logger. If <see langword="null"/>, a new mock is created.</param>
+    /// <returns>An initialized <see cref="CNCLabsMapDiscoverer"/>.</returns>
+    private static CNCLabsMapDiscoverer CreateSut(HttpClient http, Mock<ILogger<CNCLabsMapDiscoverer>>? loggerMock = null)
+    {
+        var logger = (loggerMock ?? new Mock<ILogger<CNCLabsMapDiscoverer>>()).Object;
+        return new CNCLabsMapDiscoverer(http, logger);
+    }
+
+    // ---- test doubles ----------------------------------------------------
+
+    /// <summary>
+    /// An <see cref="HttpMessageHandler"/> that delegates sending to a provided function.
+    /// Useful for crafting deterministic HTTP responses in tests.
+    /// </summary>
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _impl;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CNCLabsMapDiscovererTests"/> class.
-        /// Sets up all required mocks and constructs the provider using those mocks.
+        /// Initializes a new instance of the <see cref="DelegateHandler"/> class from a synchronous responder.
         /// </summary>
-        public CNCLabsMapDiscovererTests()
+        /// <param name="impl">The synchronous delegate that returns an <see cref="HttpResponseMessage"/>.</param>
+        public DelegateHandler(Func<HttpRequestMessage, HttpResponseMessage> impl)
+            : this((r, _) => Task.FromResult(impl(r)))
         {
-            _discovererMock = new Mock<IContentDiscoverer>();
-            _resolverMock = new Mock<IContentResolver>();
-            _delivererMock = new Mock<IContentDeliverer>();
-            _validatorMock = new Mock<IContentValidator>();
-            _contentManifestBuilderMock = new Mock<IContentManifestBuilder>();
-            _loggerMock = new Mock<ILogger<CNCLabsContentProvider>>();
-
-            // Provider relies on these metadata properties for wiring and reporting.
-            // These string values are chosen to match the test case expectations.
-            _discovererMock.SetupGet(d => d.SourceName).Returns("CNC Labs Maps");
-            _resolverMock.SetupGet(r => r.ResolverId).Returns("CNCLabsMap");
-            _delivererMock.SetupGet(d => d.SourceName).Returns("HTTP");
-
-            _provider = new CNCLabsContentProvider(
-                new[] { _discovererMock.Object },
-                new[] { _resolverMock.Object },
-                new[] { _delivererMock.Object },
-                _loggerMock.Object,
-                _validatorMock.Object
-            );
         }
 
         /// <summary>
-        /// Verifies that a search request flows through the discovery, resolution,
-        /// and validation stages, resulting in a successful, resolved search result
-        /// with an embedded <see cref="ContentManifest"/>.
+        /// Initializes a new instance of the <see cref="DelegateHandler"/> class.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task SearchAsync()
+        /// <param name="impl">The asynchronous delegate that returns an <see cref="HttpResponseMessage"/>.</param>
+        public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> impl)
         {
-            // ---------- Arrange ----------
-            // Input query: matches a typical CNCLabs map search term.
-            var query = new ContentSearchQuery { SearchTerm = "art of war" };
-
-            // Discovered item: Requires resolution and is handled by the "CNCLabsMap" resolver.
-            var discoveredItem = new ContentSearchResult
-            {
-                Id = "1.0.gh.test.publisher.mod",
-                Name = "Art of War",
-                SourceUrl = "https://www.cnclabs.com/downloads/details.aspx?id=1462",
-                ResolverId = "CNCLabsMap",
-                RequiresResolution = true,
-            };
-
-            // Final resolved manifest returned by the resolver.
-            var resolvedManifest = new ContentManifest
-            {
-                Id = "1.0.gh.test.publisher.mod",
-                Name = "Resolved Test Mod",
-            };
-
-            // Discovery returns a single candidate item.
-            _discovererMock
-                .Setup(d => d.DiscoverAsync(query, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>
-                    .CreateSuccess(new[] { discoveredItem }));
-
-            // Resolver turns that discovered item into a manifest.
-            _resolverMock
-                .Setup(r => r.ResolveAsync(discoveredItem, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(resolvedManifest));
-
-            // Validator accepts the manifest with no issues.
-            _validatorMock
-                .Setup(v => v.ValidateManifestAsync(resolvedManifest, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ValidationResult(resolvedManifest.Id, new List<ValidationIssue>()));
-
-            // ---------- Act ----------
-            var result = await _provider.SearchAsync(query);
-
-            // ---------- Assert ----------
-            Assert.True(result.Success);
-
-            // There should be exactly one result and it should be resolved and enriched.
-            var searchResult = Assert.Single(result.Data ?? Enumerable.Empty<ContentSearchResult>());
-            Assert.Equal("Resolved Test Mod", searchResult.Name);
-            Assert.False(searchResult.RequiresResolution); // Provider should mark it as resolved.
-            Assert.NotNull(searchResult.GetData<ContentManifest>()); // Manifest embedded in the result.
-
-            // Verify call flow.
-            _discovererMock.Verify(d => d.DiscoverAsync(query, It.IsAny<CancellationToken>()), Times.Once);
-            _resolverMock.Verify(r => r.ResolveAsync(discoveredItem, It.IsAny<CancellationToken>()), Times.Once);
-            _validatorMock.Verify(v => v.ValidateManifestAsync(resolvedManifest, It.IsAny<CancellationToken>()), Times.Once);
+            _impl = impl;
         }
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _impl(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// An <see cref="HttpMessageHandler"/> that always throws the provided exception.
+    /// Useful for simulating transport-layer failures.
+    /// </summary>
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        private readonly Exception _ex;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThrowingHandler"/> class.
+        /// </summary>
+        /// <param name="ex">The exception to throw when a request is sent.</param>
+        public ThrowingHandler(Exception ex)
+        {
+            _ex = ex;
+        }
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromException<HttpResponseMessage>(_ex);
+    }
+}
+
+// ---- Moq logger helpers ---------------------------------------------------
+
+/// <summary>
+/// Extensions for verifying that logging occurred using <see cref="Moq.Mock{T}"/>.
+/// </summary>
+internal static class LoggerVerifyExtensions
+{
+    /// <summary>
+    /// Verifies that an error-level log entry was written at least once.
+    /// </summary>
+    /// <typeparam name="T">The logger category type.</typeparam>
+    /// <param name="mock">The mocked logger.</param>
+    public static void VerifyLogErrorCalled<T>(this Mock<ILogger<T>> mock)
+    {
+        mock.Verify(
+            x => x.Log(
+                It.Is<LogLevel>(l => l == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((_, __) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
@@ -4,7 +4,6 @@ using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
 using GenHub.Core.Models.Validation;
-using GenHub.Features.Content.Services.ContentDiscoverers;
 using GenHub.Features.Content.Services.ContentProviders;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -12,21 +11,39 @@ using Moq;
 namespace GenHub.Tests.Core.Features.Content
 {
     /// <summary>
-    /// CNCLabsMapDiscovererTests class.
+    /// Unit tests for the <see cref="CNCLabsContentProvider"/> integration
+    /// with a CNCLabs-style map discoverer/resolver pipeline.
+    /// <para>
+    /// This test is fully offline: it mocks the discoverer, resolver,
+    /// deliverer, and validator so that CI remains deterministic.
+    /// </para>
     /// </summary>
     public class CNCLabsMapDiscovererTests
     {
+        /// <summary>Mock for the discovery layer that lists candidate items.</summary>
         private readonly Mock<IContentDiscoverer> _discovererMock;
+
+        /// <summary>Mock for the resolution layer that turns a discovered item into a full manifest.</summary>
         private readonly Mock<IContentResolver> _resolverMock;
+
+        /// <summary>Mock for the delivery layer (kept for provider contract completeness).</summary>
         private readonly Mock<IContentDeliverer> _delivererMock;
+
+        /// <summary>Mock for validating the resolved manifest.</summary>
         private readonly Mock<IContentValidator> _validatorMock;
+
+        /// <summary>Mock for a content-manifest builder (kept for potential provider needs).</summary>
         private readonly Mock<IContentManifestBuilder> _contentManifestBuilderMock;
+
+        /// <summary>Logger mock for the provider.</summary>
         private readonly Mock<ILogger<CNCLabsContentProvider>> _loggerMock;
 
+        /// <summary>The provider under test, wired with mocked dependencies.</summary>
         private readonly CNCLabsContentProvider _provider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CNCLabsMapDiscovererTests"/> class.
+        /// Sets up all required mocks and constructs the provider using those mocks.
         /// </summary>
         public CNCLabsMapDiscovererTests()
         {
@@ -34,58 +51,86 @@ namespace GenHub.Tests.Core.Features.Content
             _resolverMock = new Mock<IContentResolver>();
             _delivererMock = new Mock<IContentDeliverer>();
             _validatorMock = new Mock<IContentValidator>();
-            _contentManifestBuilderMock = new Mock<IContentManifestBuilder>(); // kept in case provider needs it elsewhere
+            _contentManifestBuilderMock = new Mock<IContentManifestBuilder>();
             _loggerMock = new Mock<ILogger<CNCLabsContentProvider>>();
 
-            // Provider requires a deliverer SourceName (used in results)
-            _discovererMock.Setup(d => d.SourceName).Returns("CNC Labs");
-            _resolverMock.Setup(d => d.ResolverId).Returns("CNCLabsMap");
-            _delivererMock.Setup(d => d.SourceName).Returns("HTTP");
-
-            var httpClient = new HttpClient();
-
-            var realDiscoverer = new CNCLabsMapDiscoverer(httpClient, Mock.Of<ILogger<CNCLabsMapDiscoverer>>());
+            // Provider relies on these metadata properties for wiring and reporting.
+            // These string values are chosen to match the test case expectations.
+            _discovererMock.SetupGet(d => d.SourceName).Returns("CNC Labs Maps");
+            _resolverMock.SetupGet(r => r.ResolverId).Returns("CNCLabsMap");
+            _delivererMock.SetupGet(d => d.SourceName).Returns("HTTP");
 
             _provider = new CNCLabsContentProvider(
-                new[] { realDiscoverer },              // real discoverer
+                new[] { _discovererMock.Object },
                 new[] { _resolverMock.Object },
                 new[] { _delivererMock.Object },
                 _loggerMock.Object,
                 _validatorMock.Object
             );
-
         }
 
         /// <summary>
-        ///
+        /// Verifies that a search request flows through the discovery, resolution,
+        /// and validation stages, resulting in a successful, resolved search result
+        /// with an embedded <see cref="ContentManifest"/>.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         public async Task SearchAsync()
         {
-            // Arrange
+            // ---------- Arrange ----------
+            // Input query: matches a typical CNCLabs map search term.
             var query = new ContentSearchQuery { SearchTerm = "art of war" };
 
-            // Make sure the resolver is "found" for that item
-            _resolverMock.Setup(r => r.ResolverId).Returns("CNCLabsMap");
+            // Discovered item: Requires resolution and is handled by the "CNCLabsMap" resolver.
+            var discoveredItem = new ContentSearchResult
+            {
+                Id = "1.0.gh.test.publisher.mod",
+                Name = "Art of War",
+                SourceUrl = "https://www.cnclabs.com/downloads/details.aspx?id=1462",
+                ResolverId = "CNCLabsMap",
+                RequiresResolution = true,
+            };
 
-            // What resolution returns
+            // Final resolved manifest returned by the resolver.
             var resolvedManifest = new ContentManifest
             {
                 Id = "1.0.gh.test.publisher.mod",
-                Name = "Resolved Test Mod"
+                Name = "Resolved Test Mod",
             };
 
+            // Discovery returns a single candidate item.
+            _discovererMock
+                .Setup(d => d.DiscoverAsync(query, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>
+                    .CreateSuccess(new[] { discoveredItem }));
+
+            // Resolver turns that discovered item into a manifest.
             _resolverMock
-                .Setup(r => r.ResolveAsync(It.IsAny<ContentSearchResult>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.ResolveAsync(discoveredItem, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(resolvedManifest));
 
+            // Validator accepts the manifest with no issues.
             _validatorMock
                 .Setup(v => v.ValidateManifestAsync(resolvedManifest, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ValidationResult(resolvedManifest.Id, new List<ValidationIssue>()));
 
+            // ---------- Act ----------
             var result = await _provider.SearchAsync(query);
+
+            // ---------- Assert ----------
             Assert.True(result.Success);
+
+            // There should be exactly one result and it should be resolved and enriched.
+            var searchResult = Assert.Single(result.Data ?? Enumerable.Empty<ContentSearchResult>());
+            Assert.Equal("Resolved Test Mod", searchResult.Name);
+            Assert.False(searchResult.RequiresResolution); // Provider should mark it as resolved.
+            Assert.NotNull(searchResult.GetData<ContentManifest>()); // Manifest embedded in the result.
+
+            // Verify call flow.
+            _discovererMock.Verify(d => d.DiscoverAsync(query, It.IsAny<CancellationToken>()), Times.Once);
+            _resolverMock.Verify(r => r.ResolveAsync(discoveredItem, It.IsAny<CancellationToken>()), Times.Once);
+            _validatorMock.Verify(v => v.ValidateManifestAsync(resolvedManifest, It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
@@ -1,0 +1,91 @@
+﻿using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Core.Models.Validation;
+using GenHub.Features.Content.Services.ContentDiscoverers;
+using GenHub.Features.Content.Services.ContentProviders;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GenHub.Tests.Core.Features.Content
+{
+    /// <summary>
+    /// CNCLabsMapDiscovererTests class.
+    /// </summary>
+    public class CNCLabsMapDiscovererTests
+    {
+        private readonly Mock<IContentDiscoverer> _discovererMock;
+        private readonly Mock<IContentResolver> _resolverMock;
+        private readonly Mock<IContentDeliverer> _delivererMock;
+        private readonly Mock<IContentValidator> _validatorMock;
+        private readonly Mock<IContentManifestBuilder> _contentManifestBuilderMock;
+        private readonly Mock<ILogger<CNCLabsContentProvider>> _loggerMock;
+
+        private readonly CNCLabsContentProvider _provider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CNCLabsMapDiscovererTests"/> class.
+        /// </summary>
+        public CNCLabsMapDiscovererTests()
+        {
+            _discovererMock = new Mock<IContentDiscoverer>();
+            _resolverMock = new Mock<IContentResolver>();
+            _delivererMock = new Mock<IContentDeliverer>();
+            _validatorMock = new Mock<IContentValidator>();
+            _contentManifestBuilderMock = new Mock<IContentManifestBuilder>(); // kept in case provider needs it elsewhere
+            _loggerMock = new Mock<ILogger<CNCLabsContentProvider>>();
+
+            // Provider requires a deliverer SourceName (used in results)
+            _discovererMock.Setup(d => d.SourceName).Returns("CNC Labs");
+            _resolverMock.Setup(d => d.ResolverId).Returns("CNCLabsMap");
+            _delivererMock.Setup(d => d.SourceName).Returns("HTTP");
+
+            var httpClient = new HttpClient();
+
+            var realDiscoverer = new CNCLabsMapDiscoverer(httpClient, Mock.Of<ILogger<CNCLabsMapDiscoverer>>());
+
+            _provider = new CNCLabsContentProvider(
+                new[] { realDiscoverer },              // real discoverer
+                new[] { _resolverMock.Object },
+                new[] { _delivererMock.Object },
+                _loggerMock.Object,
+                _validatorMock.Object
+            );
+
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task SearchAsync()
+        {
+            // Arrange
+            var query = new ContentSearchQuery { SearchTerm = "art of war" };
+
+            // Make sure the resolver is "found" for that item
+            _resolverMock.Setup(r => r.ResolverId).Returns("CNCLabsMap");
+
+            // What resolution returns
+            var resolvedManifest = new ContentManifest
+            {
+                Id = "1.0.gh.test.publisher.mod",
+                Name = "Resolved Test Mod"
+            };
+
+            _resolverMock
+                .Setup(r => r.ResolveAsync(It.IsAny<ContentSearchResult>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(resolvedManifest));
+
+            _validatorMock
+                .Setup(v => v.ValidateManifestAsync(resolvedManifest, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ValidationResult(resolvedManifest.Id, new List<ValidationIssue>()));
+
+            var result = await _provider.SearchAsync(query);
+            Assert.True(result.Success);
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
@@ -1,14 +1,18 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
+
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Results;
 using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
 
 namespace GenHub.Features.Content.Services.ContentDiscoverers;
 
@@ -60,9 +64,9 @@ public class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabsMapDisco
                 return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(Enumerable.Empty<ContentSearchResult>());
             }
 
-            var searchUrl = $"https://search.cnclabs.com/?cse=labs&q={Uri.EscapeDataString(query.SearchTerm ?? string.Empty)}";
-            var response = await _httpClient.GetStringAsync(searchUrl, cancellationToken);
-            var discoveredMaps = ParseMapListPage(response);
+
+            var searchUrl = $"http://search.cnclabs.com/?cse=labs&q={Uri.EscapeDataString(query.SearchTerm ?? string.Empty)}";
+            var discoveredMaps = await CNCLabSearchAsync(searchUrl);
             var results = discoveredMaps.Select(map => new ContentSearchResult
             {
                 Id = $"cnclabs.map.{map.id}",
@@ -87,14 +91,119 @@ public class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabsMapDisco
     }
 
     /// <summary>
-    /// Parses the HTML response from CNC Labs to extract map list items.
+    /// Crawls the C&amp;C Labs search results page and extracts map entries linking to a details page.
     /// </summary>
-    /// <param name="html">The HTML content to parse.</param>
-    /// <returns>A list of map list items.</returns>
-    private List<MapListItem> ParseMapListPage(string html)
+    /// <param name="url">
+    /// Absolute URL of the C&amp;C Labs search results page to parse (e.g., a Google CSE results page on cnc-labs).
+    /// </param>
+    /// <param name="cancellationToken">A token to observe while awaiting the task.</param>
+    /// <returns>
+    /// A list of <see cref="MapListItem"/> entries discovered on the page. Only items that resolve to a
+    /// details URL with a valid <c>id</c> query parameter are included.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="url"/> is null or empty.</exception>
+    /// <exception cref="UriFormatException">Thrown if <paramref name="url"/> is not a valid absolute URI.</exception>
+    /// <remarks>
+    /// This method launches a headless Chromium instance via Playwright, navigates to the specified URL,
+    /// and queries DOM nodes under <c>#search-results div.gsc-webResult.gsc-result</c>. It looks for anchors
+    /// matching <c>div.gs-webResult.gs-result div.gsc-thumbnail-inside div.gs-title a.gs-title</c> and attempts
+    /// to extract the canonical destination from the <c>data-ctorig</c> attribute. If the destination resembles
+    /// <c>details.aspx?id=123</c>, the numeric <c>id</c> is parsed and used to construct a <see cref="MapListItem"/>.
+    /// </remarks>          
+    private async Task<List<MapListItem>> CNCLabSearchAsync(
+        string url,
+        CancellationToken cancellationToken = default)
     {
-        // TODO: Implement actual HTML parsing logic
-        return new List<MapListItem>();
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentNullException(nameof(url));
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var _))
+            throw new UriFormatException("The provided URL is not a valid absolute URI.");
+
+        var mapList = new List<MapListItem>();
+
+        // Selectors kept as constants for maintainability.
+        const string ResultSelector = "#search-results div.gsc-webResult.gsc-result";
+        const string LinkSelector = "div.gs-webResult.gs-result div.gsc-thumbnail-inside div.gs-title a.gs-title";
+        const string CanonicalHrefAttr = "data-ctorig";
+        const string DetailsPathMarker = "details.aspx";
+        const string GeneralsPathMarker = "maps/generals";
+
+        // Playwright setup and navigation.
+        using var playwright = await Playwright.CreateAsync().ConfigureAwait(false);
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true,
+        }).ConfigureAwait(false);
+
+        var context = await browser.NewContextAsync().ConfigureAwait(false);
+        var page = await context.NewPageAsync().ConfigureAwait(false);
+
+        // A sensible navigation timeout; adjust if the site is slow.
+        page.SetDefaultNavigationTimeout(30_000);
+
+        await page.GotoAsync(url).ConfigureAwait(false);
+
+        // Grab all result containers.
+        var results = await page.QuerySelectorAllAsync(ResultSelector).ConfigureAwait(false);
+
+        foreach (var result in results)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Find the anchor that holds the title and canonical link.
+            var linkHandle = await result.QuerySelectorAsync(LinkSelector).ConfigureAwait(false);
+            if (linkHandle is null) continue;
+
+            // Prefer the canonical target (data-ctorig) if present.
+            var detailUrl = await linkHandle.GetAttributeAsync(CanonicalHrefAttr).ConfigureAwait(false)
+                           ?? await linkHandle.GetAttributeAsync("href").ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(detailUrl))
+                continue;
+
+            var name = (await linkHandle.InnerTextAsync().ConfigureAwait(false))?.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            // C&C Labs is the known author for these search results.
+            const string author = "C&C Labs";
+
+            // Try to extract numeric id from URLs like .../details.aspx?id=123
+            if (TryExtractId(detailUrl, DetailsPathMarker, out var id))
+            {
+                mapList.Add(new MapListItem(id, name, author, detailUrl));
+            }
+            else
+            {
+                // For non-details results, you can branch based on path for future handling.
+                var lower = detailUrl.ToLowerInvariant();
+                if (lower.Contains(GeneralsPathMarker))
+                {
+                    // NOTE: This URL redirects to the Generals maps page (list view). If needed,
+                    // call a dedicated extractor (e.g., ExtractMapsPageResultAsync) to harvest items.
+                }
+            }
+        }
+
+        return mapList;
+
+        // ------- local helpers --------
+        static bool TryExtractId(string targetUrl, string detailsMarker, out int id)
+        {
+            id = default;
+
+            if (!Uri.TryCreate(targetUrl, UriKind.Absolute, out var uri))
+                return false;
+
+            // Quick path check to reduce false positives.
+            if (!uri.AbsolutePath.ToLower(CultureInfo.InvariantCulture).Contains(detailsMarker))
+                return false;
+
+            var query = HttpUtility.ParseQueryString(uri.Query);
+            var idValue = query.Get("id");
+            return int.TryParse(idValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out id);
+        }
     }
 
     private record MapListItem(int id, string name, string author, string detailUrl);

--- a/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
@@ -1,18 +1,18 @@
-
+using AngleSharp;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Results;
+using GenHub.Features.Content.Services.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace GenHub.Features.Content.Services.ContentDiscoverers;
 
@@ -27,12 +27,12 @@ public class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabsMapDisco
     /// <summary>
     /// Gets the source name for this discoverer.
     /// </summary>
-    public string SourceName => "CNC Labs Maps";
+    public string SourceName => CNCLabsConstants.SourceName;
 
     /// <summary>
     /// Gets the description for this discoverer.
     /// </summary>
-    public string Description => "Discovers maps from CNC Labs website";
+    public string Description => CNCLabsConstants.Description;
 
     /// <summary>
     /// Gets a value indicating whether this discoverer is enabled.
@@ -45,166 +45,289 @@ public class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabsMapDisco
     public ContentSourceCapabilities Capabilities => ContentSourceCapabilities.RequiresDiscovery;
 
     /// <summary>
-    /// Discovers maps from CNC Labs based on the search query.
+    /// Discovers maps from CNC Labs using either a free-text search or structured query
+    /// (game/content type). If <paramref name="query"/> is null, or contains neither
+    /// a <see cref="ContentSearchQuery.SearchTerm"/> nor both <see cref="ContentSearchQuery.TargetGame"/>
+    /// and <see cref="ContentSearchQuery.ContentType"/>, a failure result is returned.
     /// </summary>
-    /// <param name="query">The search criteria.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A <see cref="T:GenHub.Core.Models.Results.OperationResult"/> containing discovered maps.</returns>
-    public async Task<OperationResult<IEnumerable<ContentSearchResult>>> DiscoverAsync(ContentSearchQuery query, CancellationToken cancellationToken = default)
+    /// <param name="query">Search criteria.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// An operation result containing <see cref="ContentSearchResult"/> items on success;
+    /// otherwise, a failure with a message describing the error.
+    /// </returns>
+    /// <exception cref="OperationCanceledException">Thrown if the operation is canceled.</exception>
+    public async Task<OperationResult<IEnumerable<ContentSearchResult>>> DiscoverAsync(
+        ContentSearchQuery query,
+        CancellationToken cancellationToken = default)
     {
         try
         {
-            if (query == null)
+            if (query is null || (string.IsNullOrWhiteSpace(query.SearchTerm) && (!query.TargetGame.HasValue || !query.ContentType.HasValue)))
             {
-                return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure("Query cannot be null");
+                return OperationResult<IEnumerable<ContentSearchResult>>
+                    .CreateFailure(CNCLabsConstants.QueryNullErrorMessage);
             }
 
-            if (string.IsNullOrWhiteSpace(query.SearchTerm))
-            {
-                return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(Enumerable.Empty<ContentSearchResult>());
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
+            List<MapListItem> discoveredMaps =
+                   !string.IsNullOrWhiteSpace(query.SearchTerm)
+                       ? await SearchByTextAsync(query.SearchTerm, cancellationToken).ConfigureAwait(false)
+                       : await SearchByFiltersAsync(query, cancellationToken).ConfigureAwait(false);
 
-            var searchUrl = $"http://search.cnclabs.com/?cse=labs&q={Uri.EscapeDataString(query.SearchTerm ?? string.Empty)}";
-            var discoveredMaps = await CNCLabSearchAsync(searchUrl);
             var results = discoveredMaps.Select(map => new ContentSearchResult
             {
-                Id = $"cnclabs.map.{map.id}",
+                Id = string.Format(CNCLabsConstants.MapIdFormat, map.id),
                 Name = map.name,
-                Description = "Map from CNC Labs - full details available after resolution",
+                Description = CNCLabsConstants.MapDescriptionTemplate,
                 AuthorName = map.author,
-                ContentType = ContentType.MapPack,
-                TargetGame = GameType.ZeroHour,
+                ContentType = map.contentType ?? ContentType.UnknownContentType,
+                TargetGame = map.targetGame ?? GameType.Unknown,
                 ProviderName = SourceName,
                 RequiresResolution = true,
-                ResolverId = "CNCLabsMap",
+                ResolverId = CNCLabsConstants.ResolverId,
                 SourceUrl = map.detailUrl,
-                ResolverMetadata = { ["mapId"] = map.id.ToString(), },
+                ResolverMetadata =
+                {
+                    [CNCLabsConstants.MapIdMetadataKey] = map.id.ToString(),
+                },
             });
             return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(results);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to discover maps from CNC Labs");
-            return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure($"Discovery failed: {ex.Message}");
+            _logger.LogError(ex, CNCLabsConstants.DiscoveryFailureLogMessage);
+            return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure(string.Format(CNCLabsConstants.DiscoveryFailedErrorTemplate, ex.Message));
         }
     }
 
     /// <summary>
-    /// Crawls the C&amp;C Labs search results page and extracts map entries linking to a details page.
+    /// Performs a text-based search using Playwright, parsing the results list for detail links and names.
     /// </summary>
-    /// <param name="url">
-    /// Absolute URL of the C&amp;C Labs search results page to parse (e.g., a Google CSE results page on cnc-labs).
-    /// </param>
-    /// <param name="cancellationToken">A token to observe while awaiting the task.</param>
-    /// <returns>
-    /// A list of <see cref="MapListItem"/> entries discovered on the page. Only items that resolve to a
-    /// details URL with a valid <c>id</c> query parameter are included.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="url"/> is null or empty.</exception>
-    /// <exception cref="UriFormatException">Thrown if <paramref name="url"/> is not a valid absolute URI.</exception>
-    /// <remarks>
-    /// This method launches a headless Chromium instance via Playwright, navigates to the specified URL,
-    /// and queries DOM nodes under <c>#search-results div.gsc-webResult.gsc-result</c>. It looks for anchors
-    /// matching <c>div.gs-webResult.gs-result div.gsc-thumbnail-inside div.gs-title a.gs-title</c> and attempts
-    /// to extract the canonical destination from the <c>data-ctorig</c> attribute. If the destination resembles
-    /// <c>details.aspx?id=123</c>, the numeric <c>id</c> is parsed and used to construct a <see cref="MapListItem"/>.
-    /// </remarks>          
-    private async Task<List<MapListItem>> CNCLabSearchAsync(
-        string url,
+    /// <param name="searchTerm">User-entered search term.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of minimally populated map list items.</returns>
+    private async Task<List<MapListItem>> SearchByTextAsync(
+        string searchTerm,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(url))
-            throw new ArgumentNullException(nameof(url));
+        if (string.IsNullOrWhiteSpace(searchTerm))
+        {
+            throw new ArgumentException(CNCLabsConstants.SearchTermEmptyErrorMessage, nameof(searchTerm));
+        }
 
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var _))
-            throw new UriFormatException("The provided URL is not a valid absolute URI.");
+        var url = $"{CNCLabsConstants.SearchUrlBase}{Uri.EscapeDataString(searchTerm)}";
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            throw new UriFormatException(CNCLabsConstants.InvalidAbsoluteUri);
+        }
 
         var mapList = new List<MapListItem>();
 
-        // Selectors kept as constants for maintainability.
-        const string ResultSelector = "#search-results div.gsc-webResult.gsc-result";
-        const string LinkSelector = "div.gs-webResult.gs-result div.gsc-thumbnail-inside div.gs-title a.gs-title";
-        const string CanonicalHrefAttr = "data-ctorig";
-        const string DetailsPathMarker = "details.aspx";
-        const string GeneralsPathMarker = "maps/generals";
-
-        // Playwright setup and navigation.
+        // Playwright setup & navigation
         using var playwright = await Playwright.CreateAsync().ConfigureAwait(false);
-        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = true,
-        }).ConfigureAwait(false);
+        await using var browser = await playwright.Chromium.LaunchAsync(
+            new BrowserTypeLaunchOptions { Headless = true }).ConfigureAwait(false);
 
         var context = await browser.NewContextAsync().ConfigureAwait(false);
         var page = await context.NewPageAsync().ConfigureAwait(false);
-
-        // A sensible navigation timeout; adjust if the site is slow.
         page.SetDefaultNavigationTimeout(30_000);
 
         await page.GotoAsync(url).ConfigureAwait(false);
 
-        // Grab all result containers.
-        var results = await page.QuerySelectorAllAsync(ResultSelector).ConfigureAwait(false);
+        var results = await page.QuerySelectorAllAsync(CNCLabsConstants.ResultSelector).ConfigureAwait(false);
 
         foreach (var result in results)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Find the anchor that holds the title and canonical link.
-            var linkHandle = await result.QuerySelectorAsync(LinkSelector).ConfigureAwait(false);
-            if (linkHandle is null) continue;
+            var linkHandle = await result.QuerySelectorAsync(CNCLabsConstants.LinkSelector).ConfigureAwait(false);
+            if (linkHandle is null)
+            {
+                continue;
+            }
 
-            // Prefer the canonical target (data-ctorig) if present.
-            var detailUrl = await linkHandle.GetAttributeAsync(CanonicalHrefAttr).ConfigureAwait(false)
-                           ?? await linkHandle.GetAttributeAsync("href").ConfigureAwait(false);
+            var detailUrl =
+                await linkHandle.GetAttributeAsync(CNCLabsConstants.CanonicalHrefAttr).ConfigureAwait(false)
+                ?? await linkHandle.GetAttributeAsync(CNCLabsConstants.HrefAttribute).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(detailUrl))
+            {
                 continue;
+            }
 
-            var name = (await linkHandle.InnerTextAsync().ConfigureAwait(false))?.Trim();
-            if (string.IsNullOrWhiteSpace(name))
+            var checkName = (await linkHandle.InnerTextAsync().ConfigureAwait(false))?.Trim();
+            if (string.IsNullOrWhiteSpace(checkName))
+            {
                 continue;
-
-            // C&C Labs is the known author for these search results.
-            const string author = "C&C Labs";
+            }
 
             // Try to extract numeric id from URLs like .../details.aspx?id=123
-            if (TryExtractId(detailUrl, DetailsPathMarker, out var id))
+            if (CNCLabsHelper.TryExtractMapIdFromUrl(detailUrl, CNCLabsConstants.DetailsPathMarker, out var id))
             {
-                mapList.Add(new MapListItem(id, name, author, detailUrl));
+                var map = await GetMapDetailsAsync(id, detailUrl, cancellationToken);
+                mapList.Add(map);
             }
             else
             {
-                // For non-details results, you can branch based on path for future handling.
+                // Non-details results: preserve a hook for future handling (e.g., list pages).
                 var lower = detailUrl.ToLowerInvariant();
-                if (lower.Contains(GeneralsPathMarker))
-                {
-                    // NOTE: This URL redirects to the Generals maps page (list view). If needed,
-                    // call a dedicated extractor (e.g., ExtractMapsPageResultAsync) to harvest items.
-                }
+                _ = lower.Contains(CNCLabsConstants.GeneralsPathMarker);
             }
         }
 
         return mapList;
-
-        // ------- local helpers --------
-        static bool TryExtractId(string targetUrl, string detailsMarker, out int id)
-        {
-            id = default;
-
-            if (!Uri.TryCreate(targetUrl, UriKind.Absolute, out var uri))
-                return false;
-
-            // Quick path check to reduce false positives.
-            if (!uri.AbsolutePath.ToLower(CultureInfo.InvariantCulture).Contains(detailsMarker))
-                return false;
-
-            var query = HttpUtility.ParseQueryString(uri.Query);
-            var idValue = query.Get("id");
-            return int.TryParse(idValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out id);
-        }
     }
 
-    private record MapListItem(int id, string name, string author, string detailUrl);
+    /// <summary>
+    /// Performs a structured search using server-rendered list pages (no headless browser).
+    /// </summary>
+    /// <param name="query">Structured query containing target game and content type.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of map list items parsed from the list page.</returns>
+    private async Task<List<MapListItem>> SearchByFiltersAsync(
+        ContentSearchQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var url = CNCLabsHelper.BuildSearchUrl(query);
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            throw new ArgumentNullException(nameof(url));
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            throw new UriFormatException(CNCLabsConstants.InvalidAbsoluteUri);
+        }
+
+        var mapList = new List<MapListItem>();
+
+        var html = await _httpClient.GetStringAsync(url, cancellationToken).ConfigureAwait(false);
+
+        var context = BrowsingContext.New(Configuration.Default);
+        var document = await context.OpenAsync(req => req.Content(html), cancellationToken).ConfigureAwait(false);
+
+        var results = document.QuerySelectorAll(CNCLabsConstants.ListItemSelector);
+
+        foreach (var item in results)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var idValue = item.QuerySelector(CNCLabsConstants.FileIdHiddenSelector)?.GetAttribute(CNCLabsConstants.ValueAttribute);
+            if (!string.IsNullOrWhiteSpace(idValue) && int.TryParse(idValue, out var id))
+            {
+                var nameAnchor = item.QuerySelector(CNCLabsConstants.DisplayNameAnchorSelector);
+                var name = nameAnchor?.TextContent?.Trim();
+                var detailsHref = nameAnchor?.GetAttribute(CNCLabsConstants.HrefAttribute);
+
+                string? description = null;
+                var descEl = item.QuerySelector(CNCLabsConstants.DescriptionSelector);
+                if (descEl != null)
+                {
+                    var htmlDesc = descEl.InnerHtml;
+                    description = CNCLabsHelper.NormalizeHtmlDescription(htmlDesc);
+                }
+
+                var authorStrong = item.QuerySelectorAll(CNCLabsConstants.DescriptionCellStrongSelector)
+                    .FirstOrDefault(s => string.Equals(
+                        s.TextContent?.Trim(),
+                        CNCLabsConstants.AuthorLabelText,
+                        StringComparison.OrdinalIgnoreCase));
+
+                var author = CNCLabsHelper.GetNextNonEmptyTextSibling(authorStrong);
+
+                mapList.Add(new MapListItem(id, name ?? string.Empty, description ?? string.Empty, author ?? CNCLabsConstants.DefaultAuthorName, detailsHref ?? string.Empty, query.TargetGame, query.ContentType));
+            }
+        }
+
+        return mapList;
+    }
+
+    /// <summary>
+    /// Downloads a C&amp;C Labs map details page and extracts the map's
+    /// <c>Name</c>, <c>Description</c>, and <c>Author</c>.
+    /// </summary>
+    /// <param name="id">Map numeric identifier.</param>
+    /// <param name="detailsPageUrl">
+    /// Absolute (or resolvable) URL to the map details page,
+    /// e.g. <c>https://www.cnclabs.com/downloads/details.aspx?id=3238</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token for the HTTP fetch and parsing work.</param>
+    /// <returns>
+    /// A tuple <c>(Name, Description, Author)</c>. If a field cannot be found,
+    /// an empty string is returned for that field (never <c>null</c>).
+    /// </returns>
+    /// <remarks>
+    /// Parsing strategy:
+    /// <list type="number">
+    /// <item><description>
+    /// Name: try <see cref="CNCLabsConstants.NameSelector"/>; if missing,
+    /// fall back to the last segment of <see cref="CNCLabsConstants.BreadcrumbHeaderSelector"/>
+    /// split by <see cref="CNCLabsConstants.BreadcrumbSeparator"/>.
+    /// </description></item>
+    /// <item><description>
+    /// Description: take the HTML from <see cref="CNCLabsConstants.DescriptionSelector"/>
+    /// and normalize it with <c>CNCLabsHelper.NormalizeHtmlDescription</c>.
+    /// </description></item>
+    /// <item><description>
+    /// Author: find a <c>&lt;strong&gt;</c> with text <see cref="CNCLabsConstants.AuthorLabelText"/>
+    /// inside <see cref="CNCLabsConstants.AuthorLabelContainerSelector"/>, then read the next
+    /// non-empty text node via <c>CNCLabsHelper.GetNextNonEmptyTextSibling</c>.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    private async Task<MapListItem> GetMapDetailsAsync(int id, string detailsPageUrl, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(detailsPageUrl))
+            throw new ArgumentException(CNCLabsConstants.UrlRequiredMessage, nameof(detailsPageUrl));
+
+        var html = await _httpClient.GetStringAsync(detailsPageUrl, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var context = BrowsingContext.New(Configuration.Default);
+        var document = await context.OpenAsync(req => req.Content(html), cancellationToken).ConfigureAwait(false);
+
+        // 1) Name (primary selector, then fallback to last breadcrumb segment)
+        var name =
+            document.QuerySelector(CNCLabsConstants.NameSelector)?.TextContent?.Trim()
+            ?? document.QuerySelector(CNCLabsConstants.BreadcrumbHeaderSelector)
+                       ?.TextContent?
+                       .Split(CNCLabsConstants.BreadcrumbSeparator)
+                       .LastOrDefault()?
+                       .Trim()
+            ?? string.Empty;
+
+        // 2) Description (span id ends with _DescriptionLabel)
+        var descEl = document.QuerySelector(CNCLabsConstants.DescriptionSelector);
+        var description = descEl is null
+            ? string.Empty
+            : CNCLabsHelper.NormalizeHtmlDescription(descEl.InnerHtml) ?? string.Empty;
+
+        // 3) Author (text node immediately after <strong>Author:</strong>)
+        var authorStrong = document.QuerySelectorAll(CNCLabsConstants.AuthorLabelContainerSelector)
+                                   .FirstOrDefault(s => string.Equals(
+                                       s.TextContent?.Trim(),
+                                       CNCLabsConstants.AuthorLabelText,
+                                       StringComparison.OrdinalIgnoreCase));
+
+        var author = CNCLabsHelper.GetNextNonEmptyTextSibling(authorStrong) ?? string.Empty;
+
+        var (gameType, contentType) = CNCLabsHelper.ExtractBreadcrumbCategory(document);
+
+        return new MapListItem(id, name, description, string.IsNullOrEmpty(author) ? CNCLabsConstants.DefaultAuthorName : author, detailsPageUrl, gameType, contentType);
+    }
+
+    /// <summary>
+    /// Small immutable record used internally to shuttle minimal map info between parsing and projection.
+    /// </summary>
+    /// <param name="id">Map numeric identifier.</param>
+    /// <param name="name">Map display name.</param>
+    /// <param name="description">Short description text.</param>
+    /// <param name="author">Author display name.</param>
+    /// <param name="detailUrl">Absolute detail page URL.</param>
+    /// <param name="targetGame">Target game.</param>
+    /// <param name="contentType">Content type.</param>
+    private sealed record MapListItem(int id, string name, string description, string author, string detailUrl, GameType? targetGame, ContentType? contentType);
 }

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/CNCLabsContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/CNCLabsContentProvider.cs
@@ -38,7 +38,7 @@ public class CNCLabsContentProvider : BaseContentProvider
         IContentValidator contentValidator)
         : base(contentValidator, logger)
     {
-        _cncLabsDiscoverer = discoverers.FirstOrDefault(d => d.SourceName?.Equals("CNC Labs", StringComparison.OrdinalIgnoreCase) == true)
+        _cncLabsDiscoverer = discoverers.FirstOrDefault(d => d.SourceName?.Equals("CNC Labs Maps", StringComparison.OrdinalIgnoreCase) == true)
             ?? throw new ArgumentException("CNC Labs discoverer not found", nameof(discoverers));
         _cncLabsResolver = resolvers.FirstOrDefault(r => r.ResolverId?.Equals("CNCLabsMap", StringComparison.OrdinalIgnoreCase) == true)
             ?? throw new ArgumentException("CNC Labs resolver not found", nameof(resolvers));

--- a/GenHub/GenHub/Features/Content/Services/Helpers/CNCLabsHelper.cs
+++ b/GenHub/GenHub/Features/Content/Services/Helpers/CNCLabsHelper.cs
@@ -1,0 +1,311 @@
+﻿using AngleSharp.Dom;
+using GenHub.Core.Constants;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+
+namespace GenHub.Features.Content.Services.Helpers;
+
+/// <summary>
+/// Helper utilities for building CNC Labs URLs and parsing document fragments.
+/// </summary>
+public static partial class CNCLabsHelper
+{
+    /// <summary>
+    /// Tries to extract a numeric content identifier from a CNC Labs details URL.
+    /// The method first ensures the URL is absolute and that its path contains the expected
+    /// details marker (e.g., <c>/details.aspx</c>), then reads the <c>id</c> query parameter.
+    /// </summary>
+    /// <param name="targetUrl">The absolute URL to inspect.</param>
+    /// <param name="detailsPathMarker">
+    /// A case-insensitive path marker that must appear in the URL for the extraction to proceed
+    /// (for CNC Labs, typically <see cref="CNCLabsConstants.DetailsPathMarker"/>).
+    /// </param>
+    /// <param name="id">When this method returns, contains the parsed numeric identifier if successful; otherwise 0.</param>
+    /// <returns><see langword="true"/> if an <c>id</c> value was found and parsed; otherwise, <see langword="false"/>.</returns>
+    public static bool TryExtractMapIdFromUrl(string targetUrl, string detailsPathMarker, out int id)
+    {
+        id = default;
+
+        if (!Uri.TryCreate(targetUrl, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        // Quick path check to reduce false positives.
+        if (!uri.AbsolutePath.Contains(detailsPathMarker, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var query = HttpUtility.ParseQueryString(uri.Query);
+        var idValue = query.Get(CNCLabsConstants.QueryStringIdParameter);
+
+        return int.TryParse(idValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out id);
+    }
+
+    /// <summary>
+    /// Builds a CNC Labs list URL based on the structured <paramref name="query"/> (game, content type, etc.).
+    /// The result is a fully composed absolute URL including applicable query parameters.
+    /// </summary>
+    /// <param name="query">Search input containing <see cref="ContentSearchQuery.TargetGame"/>, <see cref="ContentSearchQuery.ContentType"/> and optional filters.</param>
+    /// <returns>A fully-formed absolute URL string pointing to the relevant CNC Labs listing page.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="query"/> is <see langword="null"/>.</exception>
+    /// <exception cref="UriFormatException">Thrown if the resulting URL is not a valid absolute URI.</exception>
+    public static string BuildSearchUrl(ContentSearchQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        // Base + page path (depends on game + content type)
+        var sb = new StringBuilder(CNCLabsConstants.SearchMapsUrlBase);
+        sb.Append(ResolveListingPath(query.TargetGame, query.ContentType));
+
+        // Query parameters
+        var pageIndex = (query.Page.HasValue && query.Page.Value > 0) ? query.Page.Value : 1;
+
+        sb.Append('?')
+          .Append(CNCLabsConstants.PageQueryParam)
+          .Append('=')
+          .Append(pageIndex.ToString(CultureInfo.InvariantCulture));
+
+        if (query.NumberOfPlayers.HasValue && query.NumberOfPlayers.Value > 0)
+        {
+            sb.Append('&')
+              .Append(CNCLabsConstants.PlayersQueryParam)
+              .Append('=')
+              .Append(query.NumberOfPlayers.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (!string.IsNullOrEmpty(query.Sort))
+        {
+            sb.Append('&')
+              .Append(CNCLabsConstants.Sort)
+              .Append('=')
+              .Append(query.Sort);
+        }
+
+        if (query.Tags != null && query.Tags.Any())
+        {
+            sb.Append('&')
+              .Append(CNCLabsConstants.TagsQueryParam)
+              .Append('=')
+              .Append(string.Join(CNCLabsConstants.CommaSeparator, query.Tags));
+        }
+
+        var url = sb.ToString();
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            throw new UriFormatException(CNCLabsConstants.InvalidAbsoluteUri);
+        }
+
+        return url;
+    }
+
+    /// <summary>
+    /// Returns the next sibling text node that has non-whitespace content for the specified <paramref name="node"/>.
+    /// Useful when labels like <c>&lt;strong&gt;Author:&lt;/strong&gt;</c> are followed by text nodes.
+    /// </summary>
+    /// <param name="node">The starting node whose siblings are examined.</param>
+    /// <returns>The trimmed text content of the next non-empty text sibling, or <see langword="null"/> if none exist.</returns>
+    public static string? GetNextNonEmptyTextSibling(INode? node)
+    {
+        for (var n = node?.NextSibling; n is not null; n = n.NextSibling)
+        {
+            // Text node
+            if (n is IText t)
+            {
+                var text = t.Text?.Trim();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    return text;
+                }
+            }
+
+            // If another element appears (like <br>), keep scanning in case of whitespace-only nodes.
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts a small HTML description fragment into normalized plain text:
+    /// - Converts &lt;br&gt; tags to line breaks
+    /// - HTML-decodes entities (e.g., &amp;gt; → &gt;, &amp;nbsp; → non-breaking space)
+    /// - Replaces non-breaking spaces with regular spaces
+    /// - Normalizes newlines and trims messy whitespace
+    /// - Collapses excessive blank lines.
+    /// </summary>
+    /// <param name="htmlFragment">The HTML fragment to normalize (e.g., the InnerHtml of the description span).</param>
+    /// <returns>Readable, normalized plain text using <see cref="Environment.NewLine"/> line separators.</returns>
+    public static string NormalizeHtmlDescription(string? htmlFragment)
+    {
+        if (string.IsNullOrWhiteSpace(htmlFragment))
+            return string.Empty;
+
+        // 1) Convert <br> tags to '\n' so we can normalize consistently
+        var text = BrTagRegex().Replace(htmlFragment, "\n");
+
+        // 2) Decode HTML entities (&nbsp;, &gt;, etc.)
+        text = WebUtility.HtmlDecode(text);
+
+        // 3) Normalize spaces/newlines
+        text = text.Replace('\u00A0', ' ');       // NBSP → regular space
+        text = text.Replace("\r\n", "\n")
+                   .Replace("\r", "\n");          // unify to '\n'
+
+        // 4) Tidy whitespace & collapse excessive blank lines
+        text = TrailingWhitespaceBeforeNewlineRegex().Replace(text, "\n");
+        text = ExcessBlankLinesRegex().Replace(text, "\n\n");
+
+        // 5) Trim and convert to platform newline
+        text = text.Trim();
+        text = text.Replace("\n", Environment.NewLine);
+
+        return text;
+    }
+
+    /// <summary>
+    /// Extracts and canonicalizes the category from the breadcrumb navigation of a document.
+    /// </summary>
+    /// <param name="document">
+    /// The <see cref="IDocument"/> instance to parse. The method searches within the
+    /// element specified by <c>CNCLabsConstants.BreadcrumbHeaderSelector</c>.
+    /// </param>
+    /// <returns>
+    /// A tuple of (<see cref="GameType"/>, <see cref="ContentType"/>):
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///     (<see cref="GameType.Generals"/>, <see cref="ContentType.Map"/>) if the
+    ///     breadcrumb contains "Generals Maps".
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     (<see cref="GameType.Generals"/>, <see cref="ContentType.Mission"/>) if the
+    ///     breadcrumb contains "Generals Missions".
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     (<see cref="GameType.ZeroHour"/>, <see cref="ContentType.Map"/>) if the
+    ///     breadcrumb contains "Zero Hour Maps".
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     (<see cref="GameType.ZeroHour"/>, <see cref="ContentType.Mission"/>) if the
+    ///     breadcrumb contains "Zero Hour Missions".
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     (<see cref="GameType.Unknown"/>, <see cref="ContentType.UnknownContentType"/>)
+    ///     if the breadcrumb header is missing, has fewer than the expected number of parts,
+    ///     or does not match any of the recognized categories.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The method inspects the breadcrumb text, splits it by the defined
+    /// <c>CNCLabsConstants.BreadcrumbSeparator</c>, normalizes whitespace,
+    /// and canonicalizes the category name in a case-insensitive manner.
+    /// </para>
+    /// <para>
+    /// Only four breadcrumb categories are recognized. Any unexpected or malformed
+    /// category results in the Unknown tuple.
+    /// </para>
+    /// </remarks>
+    public static (GameType, ContentType) ExtractBreadcrumbCategory(IDocument document)
+    {
+        var header = document.QuerySelector(CNCLabsConstants.BreadcrumbHeaderSelector);
+        if (header == null) return (GameType.Unknown, ContentType.UnknownContentType);
+
+        var parts = header.TextContent
+            .Split(CNCLabsConstants.BreadcrumbSeparator)
+            .Select(s => s.Replace('\u00A0', ' ').Trim())
+            .Where(s => s.Length > 0)
+            .ToArray();
+
+        if (parts.Length <= CNCLabsConstants.BreadcrumbCategoryIndex)
+            return (GameType.Unknown, ContentType.UnknownContentType);
+
+        var raw = parts[CNCLabsConstants.BreadcrumbCategoryIndex];
+
+        // Canonicalize to the four allowed values (case/spacing tolerant).
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "generals maps" => (GameType.Generals, ContentType.Map),
+            "generals missions" => (GameType.Generals, ContentType.Mission),
+            "zero hour maps" => (GameType.ZeroHour, ContentType.Map),
+            "zero hour missions" => (GameType.ZeroHour, ContentType.Mission),
+            _ => (GameType.Unknown, ContentType.UnknownContentType)
+        };
+    }
+
+    /// <summary>
+    /// Regex that matches HTML &lt;br&gt; tag variants (e.g., &lt;br&gt;, &lt;br/&gt;, &lt;br /&gt;).
+    /// Replaced with a single newline during normalization.
+    /// </summary>
+    [GeneratedRegex(@"<br\s*/?>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex BrTagRegex();
+
+    /// <summary>
+    /// Regex that trims trailing spaces/tabs immediately before a newline to avoid ragged line ends.
+    /// </summary>
+    [GeneratedRegex(@"[ \t]+\r?\n", RegexOptions.CultureInvariant)]
+    private static partial Regex TrailingWhitespaceBeforeNewlineRegex();
+
+    /// <summary>
+    /// Regex that collapses runs of 3+ blank lines down to exactly two blank lines for readability.
+    /// </summary>
+    [GeneratedRegex(@"(?:\r?\n){3,}", RegexOptions.CultureInvariant)]
+    private static partial Regex ExcessBlankLinesRegex();
+
+    /// <summary>
+    /// Resolves the correct list page path for the given game and content type.
+    /// </summary>
+    /// <param name="game">The target game.</param>
+    /// <param name="contentType">The type of content to list.</param>
+    /// <returns>A relative page path (e.g., <c>maps.aspx</c>).</returns>
+    private static string ResolveListingPath(GameType? game, ContentType? contentType)
+    {
+        // Default to Generals/Maps if unspecified — caller validation controls when this is allowed.
+        if (!game.HasValue || !contentType.HasValue)
+        {
+            return CNCLabsConstants.MapsPagePath;
+        }
+
+        if (game == GameType.Generals && contentType == ContentType.Map)
+        {
+            return CNCLabsConstants.MapsPagePath;
+        }
+
+        if (game == GameType.Generals && contentType == ContentType.Mission)
+        {
+            return CNCLabsConstants.MissionsPagePath;
+        }
+
+        if (game == GameType.ZeroHour && contentType == ContentType.Map)
+        {
+            return CNCLabsConstants.ZeroHourMapsPagePath;
+        }
+
+        if (game == GameType.ZeroHour && contentType == ContentType.Mission)
+        {
+            return CNCLabsConstants.ZeroHourMissionsPagePath;
+        }
+
+        // Fallback: maps list.
+        return CNCLabsConstants.MapsPagePath;
+    }
+}

--- a/GenHub/GenHub/GenHub.csproj
+++ b/GenHub/GenHub/GenHub.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+        <PackageReference Include="Microsoft.Playwright" />
         <PackageReference Include="Octokit" />
         <PackageReference Include="ReactiveUI" />
         <PackageReference Include="StyleCop.Analyzers" />

--- a/GenHub/GenHub/GenHub.csproj
+++ b/GenHub/GenHub/GenHub.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AngleSharp" />
         <PackageReference Include="Avalonia" />
         <PackageReference Include="Avalonia.Desktop" />
         <PackageReference Include="Avalonia.Themes.Fluent" />


### PR DESCRIPTION
Adds CNCLabSearchAsync, an async method that crawls the C&C Labs search results page and extracts valid map entries linking to details.aspx?id=....

Uses Playwright (headless Chromium) to parse DOM results.

Collect map details.

Adds unit tests (CNCLabsMapDiscovererTests) to validate search .

### Commit 3 Refactors CNCLabsMapDiscoverer to improve maintainability, consistency, and test coverage.
### Key Changes

- Refactor discoverer

- Replaced hardcoded strings with CNCLabsConstants.
- Added CNCLabsHelper for URL building, description normalization, author extraction, and breadcrumb parsing.
- Added support for both text-based search (Playwright) and structured filter search (AngleSharp).
- Enriched map parsing with detail-page metadata (name, description, author, game, content type).
### Testing improvements

- Replaced provider integration tests with focused unit tests on CNCLabsMapDiscoverer.
- Introduced deterministic HTTP handler test doubles (DelegateHandler, ThrowingHandler).
- Added error logging verification.
- Added “happy path” HTML parsing test coverage.

### Breaking Change ⚠️

- CNCLabsMapDiscoverer behavior and its internal MapListItem contract have changed.
- Any dependent code/tests that relied on the old discovery flow or item shape must be updated to use the new constants, helpers, and enriched parsing logic.
### Motivation

- Improve readability and maintainability.
- Standardize selectors and error messages via constants.
- Support structured queries and richer metadata extraction.
- Provide deterministic and maintainable test coverage.

(#112)