### PR TITLE
feat(global-suppressions): add suppression for StyleCop ordering rules due to record declarations bug

### DIFF
--- a/GenHub/GenHub.Core/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Core/GlobalSuppressions.cs
@@ -39,6 +39,11 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Using directives are sorted alphabetically, which coincides with Visual Studio's Sort & Remove")]
 
 [assembly: SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
+    "SA1201:ElementsMustAppearInTheCorrectOrder",
+    Justification = "Known StyleCop bug with .NET 8+ record declarations; does not affect code order.")]
+
+[assembly: SuppressMessage(
     "StyleCop.CSharp.NamingRules",
     "SA1300:Element should begin with upper-case letter",
     Justification = "Microsoft guidelines allow underscores in certain cases, such as test methods.")]

--- a/GenHub/GenHub.Linux/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Linux/GlobalSuppressions.cs
@@ -39,6 +39,11 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Using directives are sorted alphabetically, which coincides with Visual Studio's Sort & Remove")]
 
 [assembly: SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
+    "SA1201:ElementsMustAppearInTheCorrectOrder",
+    Justification = "Known StyleCop bug with .NET 8+ record declarations; does not affect code order.")]
+
+[assembly: SuppressMessage(
     "StyleCop.CSharp.NamingRules",
     "SA1300:Element should begin with upper-case letter",
     Justification = "Microsoft guidelines allow underscores in certain cases, such as test methods.")]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/GlobalSuppressions.cs
@@ -39,6 +39,11 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Using directives are sorted alphabetically, which coincides with Visual Studio's Sort & Remove")]
 
 [assembly: SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
+    "SA1201:ElementsMustAppearInTheCorrectOrder",
+    Justification = "Known StyleCop bug with .NET 8+ record declarations; does not affect code order.")]
+
+[assembly: SuppressMessage(
     "StyleCop.CSharp.NamingRules",
     "SA1300:Element should begin with upper-case letter",
     Justification = "Microsoft guidelines allow underscores in certain cases, such as test methods.")]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Linux/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Linux/GlobalSuppressions.cs
@@ -35,6 +35,11 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage(
     "StyleCop.CSharp.OrderingRules",
+    "SA1201:ElementsMustAppearInTheCorrectOrder",
+    Justification = "Known StyleCop bug with .NET 8+ record declarations; does not affect code order.")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
     "SA1208:System using directives should be placed before other using directives",
     Justification = "Using directives are sorted alphabetically, which coincides with Visual Studio's Sort & Remove")]
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Windows/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Windows/GlobalSuppressions.cs
@@ -39,6 +39,11 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Using directives are sorted alphabetically, which coincides with Visual Studio's Sort & Remove")]
 
 [assembly: SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
+    "SA1201:ElementsMustAppearInTheCorrectOrder",
+    Justification = "Known StyleCop bug with .NET 8+ record declarations; does not affect code order.")]
+
+[assembly: SuppressMessage(
     "StyleCop.CSharp.NamingRules",
     "SA1300:Element should begin with upper-case letter",
     Justification = "Microsoft guidelines allow underscores in certain cases, such as test methods.")]

--- a/GenHub/GenHub.Windows/GlobalSuppressions.cs
+++ b/GenHub/GenHub.Windows/GlobalSuppressions.cs
@@ -72,3 +72,8 @@ using System.Diagnostics.CodeAnalysis;
     "StyleCop.CSharp.SpacingRules",
     "SA1009:Closing parenthesis should be spaced correctly",
     Justification = "Conflicts with null-forgiving operator usage.")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
+    "SA1201:ElementsMustAppearInTheCorrectOrder",
+    Justification = "Known StyleCop bug with .NET 8+ record declarations; does not affect code order.")]

--- a/GenHub/GenHub/GlobalSuppressions.cs
+++ b/GenHub/GenHub/GlobalSuppressions.cs
@@ -35,6 +35,11 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage(
     "StyleCop.CSharp.OrderingRules",
+    "SA1201:ElementsMustAppearInTheCorrectOrder",
+    Justification = "Known StyleCop bug with .NET 8+ record declarations; does not affect code order.")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
     "SA1208:System using directives should be placed before other using directives",
     Justification = "Using directives are sorted alphabetically, which coincides with Visual Studio's Sort & Remove")]
 


### PR DESCRIPTION
This PR adds the `GlobalSuppressions.cs` files in order to suppress the record declaration warnings thrown by the stylecop analyzer.