### PR TITLE
feat(tools): Add tools management feature with registry and view models

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/Tools/ITool.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ITool.cs
@@ -1,0 +1,27 @@
+using GenHub.Core.Models.Tools;
+
+namespace GenHub.Core.Interfaces.Tools;
+
+/// <summary>
+/// Represents a tool that can be registered and displayed in the Tools tab.
+/// </summary>
+public interface ITool
+{
+    /// <summary>
+    /// Gets the metadata describing this tool.
+    /// </summary>
+    ToolMetadata Metadata { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this tool is currently enabled.
+    /// Tools can be disabled based on application state or user settings.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Creates a new instance of the view model for this tool.
+    /// This is called when the tool is selected by the user.
+    /// </summary>
+    /// <returns>A new view model instance for this tool.</returns>
+    IToolViewModel CreateViewModel();
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/IToolRegistry.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/IToolRegistry.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace GenHub.Core.Interfaces.Tools;
+
+/// <summary>
+/// Registry for managing and discovering available tools.
+/// </summary>
+public interface IToolRegistry
+{
+    /// <summary>
+    /// Gets all registered tools.
+    /// </summary>
+    /// <returns>Collection of all registered tools.</returns>
+    IReadOnlyCollection<ITool> GetAllTools();
+
+    /// <summary>
+    /// Gets all enabled tools.
+    /// </summary>
+    /// <returns>Collection of enabled tools.</returns>
+    IReadOnlyCollection<ITool> GetEnabledTools();
+
+    /// <summary>
+    /// Gets a tool by its unique identifier.
+    /// </summary>
+    /// <param name="id">The tool's unique identifier.</param>
+    /// <returns>The tool if found; otherwise, null.</returns>
+    ITool? GetToolById(string id);
+
+    /// <summary>
+    /// Registers a tool with the registry.
+    /// </summary>
+    /// <param name="tool">The tool to register.</param>
+    void RegisterTool(ITool tool);
+
+    /// <summary>
+    /// Gets tools organized by category.
+    /// </summary>
+    /// <returns>Dictionary of categories and their associated tools.</returns>
+    IReadOnlyDictionary<string, IReadOnlyCollection<ITool>> GetToolsByCategory();
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/IToolViewModel.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/IToolViewModel.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+
+namespace GenHub.Core.Interfaces.Tools;
+
+/// <summary>
+/// Base interface for tool view models.
+/// All tool view models must implement this interface.
+/// </summary>
+public interface IToolViewModel
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether this tool is currently active/visible.
+    /// </summary>
+    bool IsActive { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the tool is currently busy performing an operation.
+    /// </summary>
+    bool IsBusy { get; }
+
+    /// <summary>
+    /// Initializes the tool view model.
+    /// Called when the tool is first activated.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task InitializeAsync();
+
+    /// <summary>
+    /// Activates the tool view model.
+    /// Called when the user selects this tool.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task ActivateAsync();
+
+    /// <summary>
+    /// Deactivates the tool view model.
+    /// Called when the user navigates away from this tool.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task DeactivateAsync();
+
+    /// <summary>
+    /// Refreshes the tool's data.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RefreshAsync();
+}

--- a/GenHub/GenHub.Core/Models/Enums/NavigationTab.cs
+++ b/GenHub/GenHub.Core/Models/Enums/NavigationTab.cs
@@ -21,6 +21,11 @@ public enum NavigationTab
     Downloads,
 
     /// <summary>
+    /// Tools and utilities.
+    /// </summary>
+    Tools,
+
+    /// <summary>
     /// Application settings and configuration.
     /// </summary>
     Settings,

--- a/GenHub/GenHub.Core/Models/Tools/ToolMetadata.cs
+++ b/GenHub/GenHub.Core/Models/Tools/ToolMetadata.cs
@@ -1,0 +1,62 @@
+namespace GenHub.Core.Models.Tools;
+
+/// <summary>
+/// Metadata describing a tool.
+/// </summary>
+public sealed class ToolMetadata
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolMetadata"/> class.
+    /// </summary>
+    /// <param name="id">Unique identifier for the tool.</param>
+    /// <param name="name">Display name of the tool.</param>
+    /// <param name="description">Brief description of what the tool does.</param>
+    /// <param name="category">Category for grouping related tools.</param>
+    /// <param name="iconPath">Optional path to the tool's icon.</param>
+    /// <param name="order">Sort order for display (lower numbers appear first).</param>
+    public ToolMetadata(
+        string id,
+        string name,
+        string description,
+        string category = "General",
+        string? iconPath = null,
+        int order = 0)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+        Category = category;
+        IconPath = iconPath;
+        Order = order;
+    }
+
+    /// <summary>
+    /// Gets the unique identifier for the tool.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets the display name of the tool.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the description of what the tool does.
+    /// </summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Gets the category for grouping related tools.
+    /// </summary>
+    public string Category { get; }
+
+    /// <summary>
+    /// Gets the path to the tool's icon (optional).
+    /// </summary>
+    public string? IconPath { get; }
+
+    /// <summary>
+    /// Gets the sort order for display (lower numbers appear first).
+    /// </summary>
+    public int Order { get; }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Converters/NavigationTabConverterTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Converters/NavigationTabConverterTests.cs
@@ -54,7 +54,8 @@ public class NavigationTabConverterTests
     [InlineData(0, NavigationTab.Home)]
     [InlineData(1, NavigationTab.GameProfiles)]
     [InlineData(2, NavigationTab.Downloads)]
-    [InlineData(3, NavigationTab.Settings)]
+    [InlineData(3, NavigationTab.Tools)]
+    [InlineData(4, NavigationTab.Settings)]
     public void ConvertBack_WithValidIndex_ReturnsTab(int value, NavigationTab expected)
     {
         var result = NavigationTabConverter.Instance.ConvertBack(value, typeof(NavigationTab), null, null);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/NavigationTabTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/NavigationTabTests.cs
@@ -15,7 +15,7 @@ public class NavigationTabTests
     public void NavigationTab_AllValuesAreDefined()
     {
         var values = Enum.GetValues<NavigationTab>();
-        Assert.Equal(4, values.Length);
+        Assert.Equal(5, values.Length);
         Assert.Contains(NavigationTab.Home, values);
         Assert.Contains(NavigationTab.GameProfiles, values);
         Assert.Contains(NavigationTab.Downloads, values);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/ViewModels/MainViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/ViewModels/MainViewModelTests.cs
@@ -2,11 +2,13 @@ using GenHub.Common.ViewModels;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameProfiles;
+using GenHub.Core.Interfaces.Tools;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
 using GenHub.Features.Downloads.ViewModels;
 using GenHub.Features.GameProfiles.ViewModels;
 using GenHub.Features.Settings.ViewModels;
+using GenHub.Features.Tools.ViewModels;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -34,6 +36,7 @@ public class MainViewModelTests
         var vm = new MainViewModel(
             new GameProfileLauncherViewModel(),
             new DownloadsViewModel(),
+            CreateToolsVm(),
             settingsVm,
             mockOrchestrator.Object,
             configProvider,
@@ -65,6 +68,7 @@ public class MainViewModelTests
         var vm = new MainViewModel(
             new GameProfileLauncherViewModel(),
             new DownloadsViewModel(),
+            CreateToolsVm(),
             settingsVm,
             mockOrchestrator.Object,
             configProvider,
@@ -92,6 +96,7 @@ public class MainViewModelTests
         var viewModel = new MainViewModel(
             new GameProfileLauncherViewModel(),
             new DownloadsViewModel(),
+            CreateToolsVm(),
             settingsVm,
             mockOrchestrator.Object,
             configProvider,
@@ -120,6 +125,7 @@ public class MainViewModelTests
         var vm = new MainViewModel(
             new GameProfileLauncherViewModel(),
             new DownloadsViewModel(),
+            CreateToolsVm(),
             settingsVm,
             mockOrchestrator.Object,
             configProvider,
@@ -151,6 +157,7 @@ public class MainViewModelTests
         var vm = new MainViewModel(
             new GameProfileLauncherViewModel(),
             new DownloadsViewModel(),
+            CreateToolsVm(),
             settingsVm,
             mockOrchestrator.Object,
             configProvider,
@@ -189,6 +196,17 @@ public class MainViewModelTests
         var mockLogger = new Mock<ILogger<SettingsViewModel>>();
         var settingsVm = new SettingsViewModel(mockUserSettings.Object, mockLogger.Object);
         return (settingsVm, mockUserSettings);
+    }
+
+    /// <summary>
+    /// Creates a default ToolsViewModel with mocked services for reuse.
+    /// </summary>
+    private static ToolsViewModel CreateToolsVm()
+    {
+        var mockToolRegistry = new Mock<IToolRegistry>();
+        mockToolRegistry.Setup(x => x.GetAllTools()).Returns(new System.Collections.Generic.List<ITool>());
+        mockToolRegistry.Setup(x => x.GetEnabledTools()).Returns(new System.Collections.Generic.List<ITool>());
+        return new ToolsViewModel(mockToolRegistry.Object);
     }
 
     private static IConfigurationProviderService CreateConfigProviderMock()

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -11,6 +11,7 @@ using GenHub.Features.AppUpdate.Views;
 using GenHub.Features.Downloads.ViewModels;
 using GenHub.Features.GameProfiles.ViewModels;
 using GenHub.Features.Settings.ViewModels;
+using GenHub.Features.Tools.ViewModels;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.ObjectModel;
@@ -38,6 +39,7 @@ public partial class MainViewModel : ObservableObject
     /// </summary>
     /// <param name="gameProfilesViewModel">Game profiles view model.</param>
     /// <param name="downloadsViewModel">Downloads view model.</param>
+    /// <param name="toolsViewModel">Tools view model.</param>
     /// <param name="settingsViewModel">Settings view model.</param>
     /// <param name="gameInstallationDetectionOrchestrator">Game installation orchestrator.</param>
     /// <param name="configurationProvider">Configuration provider service.</param>
@@ -47,6 +49,7 @@ public partial class MainViewModel : ObservableObject
     public MainViewModel(
         GameProfileLauncherViewModel gameProfilesViewModel,
         DownloadsViewModel downloadsViewModel,
+        ToolsViewModel toolsViewModel,
         SettingsViewModel settingsViewModel,
         IGameInstallationDetectionOrchestrator gameInstallationDetectionOrchestrator,
         IConfigurationProviderService configurationProvider,
@@ -56,6 +59,7 @@ public partial class MainViewModel : ObservableObject
     {
         GameProfilesViewModel = gameProfilesViewModel;
         DownloadsViewModel = downloadsViewModel;
+        ToolsViewModel = toolsViewModel;
         SettingsViewModel = settingsViewModel;
         _gameInstallationDetectionOrchestrator = gameInstallationDetectionOrchestrator;
         _configurationProvider = configurationProvider;
@@ -94,6 +98,11 @@ public partial class MainViewModel : ObservableObject
     public DownloadsViewModel DownloadsViewModel { get; }
 
     /// <summary>
+    /// Gets the tools view model.
+    /// </summary>
+    public ToolsViewModel ToolsViewModel { get; }
+
+    /// <summary>
     /// Gets the settings view model.
     /// </summary>
     public SettingsViewModel SettingsViewModel { get; }
@@ -110,6 +119,7 @@ public partial class MainViewModel : ObservableObject
     {
         NavigationTab.GameProfiles,
         NavigationTab.Downloads,
+        NavigationTab.Tools,
         NavigationTab.Settings,
     };
 
@@ -120,6 +130,7 @@ public partial class MainViewModel : ObservableObject
     {
         NavigationTab.GameProfiles => GameProfilesViewModel,
         NavigationTab.Downloads => DownloadsViewModel,
+        NavigationTab.Tools => ToolsViewModel,
         NavigationTab.Settings => SettingsViewModel,
         _ => GameProfilesViewModel,
     };
@@ -133,6 +144,7 @@ public partial class MainViewModel : ObservableObject
     {
         NavigationTab.GameProfiles => "Game Profiles",
         NavigationTab.Downloads => "Downloads",
+        NavigationTab.Tools => "Tools",
         NavigationTab.Settings => "Settings",
         _ => tab.ToString(),
     };
@@ -145,6 +157,7 @@ public partial class MainViewModel : ObservableObject
     {
         await GameProfilesViewModel.InitializeAsync();
         await DownloadsViewModel.InitializeAsync();
+        await ToolsViewModel.InitializeAsync();
         _logger?.LogInformation("MainViewModel initialized");
         await Task.CompletedTask;
     }

--- a/GenHub/GenHub/Common/Views/MainView.axaml
+++ b/GenHub/GenHub/Common/Views/MainView.axaml
@@ -10,6 +10,8 @@
              xmlns:profileViews="clr-namespace:GenHub.Features.GameProfiles.Views"
              xmlns:downloadsVM="clr-namespace:GenHub.Features.Downloads.ViewModels"
              xmlns:downloadsViews="clr-namespace:GenHub.Features.Downloads.Views"
+             xmlns:toolsVM="clr-namespace:GenHub.Features.Tools.ViewModels"
+             xmlns:toolsViews="clr-namespace:GenHub.Features.Tools.Views"
              xmlns:settingsVM="clr-namespace:GenHub.Features.Settings.ViewModels"
              xmlns:settingsViews="clr-namespace:GenHub.Features.Settings.Views"
              xmlns:system="clr-namespace:System;assembly=System.Runtime"
@@ -140,6 +142,9 @@
         <DataTemplate DataType="downloadsVM:DownloadsViewModel">
             <downloadsViews:DownloadsView />
         </DataTemplate>
+        <DataTemplate DataType="toolsVM:ToolsViewModel">
+            <toolsViews:ToolsView />
+        </DataTemplate>
         <DataTemplate DataType="settingsVM:SettingsViewModel">
             <settingsViews:SettingsView />
         </DataTemplate>
@@ -169,11 +174,17 @@
                         Content="Downloads"
                         Name="Tab1Button" />
                     <Button Classes="modern-tab"
+                        Classes.active="{Binding SelectedTab, Converter={x:Static conv:NavigationTabConverter.Instance}, ConverterParameter={x:Static enums:NavigationTab.Tools}}"
+                        Command="{Binding SelectTabCommand}"
+                        CommandParameter="{x:Static enums:NavigationTab.Tools}"
+                        Content="Tools"
+                        Name="Tab2Button" />
+                    <Button Classes="modern-tab"
                         Classes.active="{Binding SelectedTab, Converter={x:Static conv:NavigationTabConverter.Instance}, ConverterParameter={x:Static enums:NavigationTab.Settings}}"
                         Command="{Binding SelectTabCommand}"
                         CommandParameter="{x:Static enums:NavigationTab.Settings}"
                         Content="Settings"
-                        Name="Tab2Button" />    
+                        Name="Tab3Button" />    
                 </StackPanel>
                 <!-- branding and update button - Right side -->
                 <Grid Grid.Column="2" ColumnDefinitions="Auto,Auto" VerticalAlignment="Center">

--- a/GenHub/GenHub/Features/Tools/Services/ToolRegistry.cs
+++ b/GenHub/GenHub/Features/Tools/Services/ToolRegistry.cs
@@ -1,0 +1,81 @@
+using GenHub.Core.Interfaces.Tools;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GenHub.Features.Tools.Services;
+
+/// <summary>
+/// Registry for managing and discovering available tools.
+/// </summary>
+public sealed class ToolRegistry : IToolRegistry
+{
+    private readonly ILogger<ToolRegistry>? _logger;
+    private readonly Dictionary<string, ITool> _tools = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolRegistry"/> class.
+    /// </summary>
+    /// <param name="logger">Logger instance.</param>
+    public ToolRegistry(ILogger<ToolRegistry>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<ITool> GetAllTools()
+    {
+        return _tools.Values
+            .OrderBy(t => t.Metadata.Order)
+            .ThenBy(t => t.Metadata.Name)
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<ITool> GetEnabledTools()
+    {
+        return _tools.Values
+            .Where(t => t.IsEnabled)
+            .OrderBy(t => t.Metadata.Order)
+            .ThenBy(t => t.Metadata.Name)
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public ITool? GetToolById(string id)
+    {
+        _tools.TryGetValue(id, out var tool);
+        return tool;
+    }
+
+    /// <inheritdoc/>
+    public void RegisterTool(ITool tool)
+    {
+        if (_tools.ContainsKey(tool.Metadata.Id))
+        {
+            _logger?.LogWarning(
+                "Tool with ID '{ToolId}' is already registered. Skipping.",
+                tool.Metadata.Id);
+            return;
+        }
+
+        _tools[tool.Metadata.Id] = tool;
+        _logger?.LogInformation(
+            "Registered tool: {ToolName} (ID: {ToolId})",
+            tool.Metadata.Name,
+            tool.Metadata.Id);
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<ITool>> GetToolsByCategory()
+    {
+        return _tools.Values
+            .GroupBy(t => t.Metadata.Category)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyCollection<ITool>)g
+                    .OrderBy(t => t.Metadata.Order)
+                    .ThenBy(t => t.Metadata.Name)
+                    .ToList());
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ViewModels/ToolViewModelBase.cs
+++ b/GenHub/GenHub/Features/Tools/ViewModels/ToolViewModelBase.cs
@@ -1,0 +1,103 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using GenHub.Core.Interfaces.Tools;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Tools.ViewModels;
+
+/// <summary>
+/// Abstract base class for tool view models.
+/// Provides common functionality for all tools.
+/// </summary>
+public abstract partial class ToolViewModelBase : ObservableObject, IToolViewModel
+{
+    private readonly ILogger? _logger;
+
+    [ObservableProperty]
+    private bool _isActive;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolViewModelBase"/> class.
+    /// </summary>
+    /// <param name="logger">Logger instance.</param>
+    protected ToolViewModelBase(ILogger? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task InitializeAsync()
+    {
+        _logger?.LogDebug("Initializing tool: {ToolType}", GetType().Name);
+        await Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task ActivateAsync()
+    {
+        _logger?.LogDebug("Activating tool: {ToolType}", GetType().Name);
+        IsActive = true;
+        await Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task DeactivateAsync()
+    {
+        _logger?.LogDebug("Deactivating tool: {ToolType}", GetType().Name);
+        IsActive = false;
+        await Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task RefreshAsync()
+    {
+        _logger?.LogDebug("Refreshing tool: {ToolType}", GetType().Name);
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Sets the busy state and executes an action.
+    /// </summary>
+    /// <param name="action">The async action to execute.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    protected async Task ExecuteWithBusyStateAsync(System.Func<Task> action)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            await action();
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Logs an error message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="args">Message format arguments.</param>
+    protected void LogError(string message, params object[] args)
+    {
+        _logger?.LogError(message, args);
+    }
+
+    /// <summary>
+    /// Logs an information message.
+    /// </summary>
+    /// <param name="message">The information message.</param>
+    /// <param name="args">Message format arguments.</param>
+    protected void LogInformation(string message, params object[] args)
+    {
+        _logger?.LogInformation(message, args);
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ViewModels/ToolsViewModel.cs
+++ b/GenHub/GenHub/Features/Tools/ViewModels/ToolsViewModel.cs
@@ -1,0 +1,131 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GenHub.Core.Interfaces.Tools;
+using Microsoft.Extensions.Logging;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Tools.ViewModels;
+
+/// <summary>
+/// View model for the Tools tab.
+/// </summary>
+public partial class ToolsViewModel : ObservableObject
+{
+    private readonly ILogger<ToolsViewModel>? _logger;
+    private readonly IToolRegistry _toolRegistry;
+
+    [ObservableProperty]
+    private ITool? _selectedTool;
+
+    [ObservableProperty]
+    private IToolViewModel? _selectedToolViewModel;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolsViewModel"/> class.
+    /// </summary>
+    /// <param name="toolRegistry">The tool registry service.</param>
+    /// <param name="logger">Logger instance.</param>
+    public ToolsViewModel(
+        IToolRegistry toolRegistry,
+        ILogger<ToolsViewModel>? logger = null)
+    {
+        _logger = logger;
+        _toolRegistry = toolRegistry;
+    }
+
+    /// <summary>
+    /// Gets the collection of available tools.
+    /// </summary>
+    public ObservableCollection<ITool> AvailableTools { get; } = new();
+
+    /// <summary>
+    /// Initializes the view model asynchronously.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task InitializeAsync()
+    {
+        _logger?.LogInformation("ToolsViewModel initialized");
+
+        // Load available tools from registry
+        LoadAvailableTools();
+
+        // Select the first tool by default if available
+        if (AvailableTools.Count > 0)
+        {
+            await SelectToolAsync(AvailableTools[0]);
+        }
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Handles the SelectedTool property change.
+    /// </summary>
+    /// <param name="value">The new selected tool.</param>
+    partial void OnSelectedToolChanged(ITool? value)
+    {
+        // Trigger selection asynchronously when tool changes
+        _ = SelectToolAsync(value);
+    }
+
+    /// <summary>
+    /// Selects a tool and creates its view model.
+    /// </summary>
+    /// <param name="tool">The tool to select.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [RelayCommand]
+    private async Task SelectToolAsync(ITool? tool)
+    {
+        if (tool == null)
+        {
+            return;
+        }
+
+        // Deactivate current tool
+        if (SelectedToolViewModel != null)
+        {
+            await SelectedToolViewModel.DeactivateAsync();
+        }
+
+        SelectedTool = tool;
+
+        // Create and initialize new tool view model
+        SelectedToolViewModel = tool.CreateViewModel();
+        await SelectedToolViewModel.InitializeAsync();
+        await SelectedToolViewModel.ActivateAsync();
+
+        _logger?.LogInformation("Selected tool: {ToolName}", tool.Metadata.Name);
+    }
+
+    /// <summary>
+    /// Refreshes the current tool.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [RelayCommand]
+    private async Task RefreshCurrentToolAsync()
+    {
+        if (SelectedToolViewModel != null)
+        {
+            await SelectedToolViewModel.RefreshAsync();
+            _logger?.LogInformation("Refreshed current tool");
+        }
+    }
+
+    /// <summary>
+    /// Loads available tools from the registry.
+    /// </summary>
+    private void LoadAvailableTools()
+    {
+        AvailableTools.Clear();
+
+        var tools = _toolRegistry.GetEnabledTools();
+        foreach (var tool in tools)
+        {
+            AvailableTools.Add(tool);
+        }
+
+        _logger?.LogInformation("Loaded {Count} tools", AvailableTools.Count);
+    }
+}

--- a/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml
+++ b/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml
@@ -1,0 +1,130 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:GenHub.Features.Tools.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="GenHub.Features.Tools.Views.ToolsView"
+             x:DataType="vm:ToolsViewModel">
+
+    <Design.DataContext>
+        <vm:ToolsViewModel />
+    </Design.DataContext>
+
+    <UserControl.Styles>
+        <!-- Tool list item style -->
+        <Style Selector="ListBoxItem">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="12,10" />
+            <Setter Property="Margin" Value="0,0,0,4" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+
+        <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2A2A2A" />
+        </Style>
+
+        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
+            <Setter Property="Background" Value="#3A3A3A" />
+        </Style>
+
+        <!-- Tool card style -->
+        <Style Selector="Border.tool-card">
+            <Setter Property="Background" Value="#2A2A2A" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="16" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="280" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <!-- Left sidebar - Tool list -->
+        <Border Grid.Column="0" Background="#1E1E1E" BorderBrush="#333333" BorderThickness="0,0,1,0" Padding="16">
+            <Grid RowDefinitions="Auto,Auto,*">
+                <!-- Header -->
+                <StackPanel Grid.Row="0" Margin="0,0,0,16">
+                    <TextBlock Text="Tools" FontSize="24" FontWeight="Bold" Foreground="White" />
+                    <TextBlock Text="Select a tool to use" FontSize="12" Foreground="#A0A0A0" Margin="0,4,0,0" />
+                </StackPanel>
+
+                <!-- Refresh button -->
+                <Button Grid.Row="1" 
+                        Command="{Binding RefreshCurrentToolCommand}"
+                        HorizontalAlignment="Stretch"
+                        Margin="0,0,0,12"
+                        Padding="8"
+                        Background="#2A2A2A"
+                        BorderBrush="#4A9EFF"
+                        BorderThickness="1"
+                        CornerRadius="6">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Text="🔄" FontSize="14" Margin="0,0,6,0" />
+                        <TextBlock Text="Refresh" FontSize="13" Foreground="White" />
+                    </StackPanel>
+                </Button>
+
+                <!-- Tool list -->
+                <ListBox Grid.Row="2"
+                         ItemsSource="{Binding AvailableTools}"
+                         SelectedItem="{Binding SelectedTool}"
+                         Background="Transparent"
+                         BorderThickness="0">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Border Classes="tool-card">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="{Binding Metadata.Name}" 
+                                               FontSize="14" 
+                                               FontWeight="SemiBold" 
+                                               Foreground="White" />
+                                    <TextBlock Text="{Binding Metadata.Description}" 
+                                               FontSize="11" 
+                                               Foreground="#B0B0B0" 
+                                               TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding Metadata.Category}" 
+                                               FontSize="10" 
+                                               Foreground="#808080" 
+                                               Margin="0,2,0,0" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+        </Border>
+
+        <!-- Right content area - Selected tool view -->
+        <Grid Grid.Column="1" Background="#1A1A1A" Margin="20">
+            <!-- Tool content -->
+            <ContentControl Content="{Binding SelectedToolViewModel}"
+                            IsVisible="{Binding SelectedToolViewModel, Converter={x:Static ObjectConverters.IsNotNull}}" />
+
+            <!-- Empty state -->
+            <Border IsVisible="{Binding SelectedToolViewModel, Converter={x:Static ObjectConverters.IsNull}}"
+                    Background="#2A2A2A" 
+                    CornerRadius="8" 
+                    Padding="40"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                <StackPanel Spacing="12" HorizontalAlignment="Center">
+                    <TextBlock Text="🔧" FontSize="48" HorizontalAlignment="Center" />
+                    <TextBlock Text="No Tool Selected" 
+                               FontSize="18" 
+                               FontWeight="SemiBold" 
+                               Foreground="White" 
+                               HorizontalAlignment="Center" />
+                    <TextBlock Text="Select a tool from the list to get started" 
+                               FontSize="14" 
+                               Foreground="#B0B0B0" 
+                               HorizontalAlignment="Center" />
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml.cs
+++ b/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+
+namespace GenHub.Features.Tools.Views;
+
+/// <summary>
+/// View for the Tools tab.
+/// </summary>
+public partial class ToolsView : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolsView"/> class.
+    /// </summary>
+    public ToolsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
@@ -2,11 +2,15 @@ using System;
 using GenHub.Common.ViewModels;
 using GenHub.Core;
 using GenHub.Core.Interfaces.GameProfiles;
+using GenHub.Core.Interfaces.Tools;
 using GenHub.Features.Downloads.ViewModels;
 using GenHub.Features.GameProfiles.Services;
 using GenHub.Features.GameProfiles.ViewModels;
 using GenHub.Features.Settings.ViewModels;
+using GenHub.Features.Tools.Services;
+using GenHub.Features.Tools.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace GenHub.Infrastructure.DependencyInjection;
 
@@ -28,12 +32,27 @@ public static class SharedViewModelModule
         // Register tab ViewModels
         services.AddSingleton<GameProfileLauncherViewModel>();
         services.AddSingleton<DownloadsViewModel>();
+        services.AddSingleton<ToolsViewModel>();
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<GameProfileSettingsViewModel>();
 
         // Register factory for GameProfileItemViewModel (has required constructor parameters)
         services.AddTransient<Func<IGameProfile, string, string, GameProfileItemViewModel>>(sp =>
             (profile, icon, cover) => new GameProfileItemViewModel(profile, icon, cover));
+
+        // Register and initialize tool registry
+        services.AddSingleton<IToolRegistry>(sp =>
+        {
+            var logger = sp.GetService<ILogger<ToolRegistry>>();
+            var registry = new ToolRegistry(logger);
+            var tools = sp.GetServices<ITool>();
+            foreach (var tool in tools)
+            {
+                registry.RegisterTool(tool);
+            }
+
+            return registry;
+        });
 
         return services;
     }

--- a/docs/dev/tools-framework.md
+++ b/docs/dev/tools-framework.md
@@ -1,0 +1,301 @@
+# Tools Framework Documentation
+
+## Overview
+
+The Tools framework provides a flexible, extensible architecture for adding utility tools to the GenHub application. Each tool is a self-contained component with its own view and view model that can interact with the main application's data and services.
+
+## Architecture
+
+### Core Components
+
+1. **ITool** - Interface that all tools must implement
+2. **IToolViewModel** - Interface for tool view models
+3. **ToolMetadata** - Metadata describing a tool (name, description, category, etc.)
+4. **IToolRegistry** - Registry for managing and discovering tools
+5. **ToolViewModelBase** - Abstract base class providing common functionality
+
+### Directory Structure
+
+```
+GenHub/Features/Tools/
+├── Models/
+│   └── GameInstallationInfoTool.cs         # Tool implementation
+├── Services/
+│   └── ToolRegistry.cs                     # Registry service
+├── ViewModels/
+│   ├── ToolsViewModel.cs                   # Main tools tab view model
+│   ├── ToolViewModelBase.cs                # Base class for tool VMs
+│   └── Tools/
+│       └── GameInstallationInfoToolViewModel.cs
+└── Views/
+    ├── ToolsView.axaml                     # Main tools tab view
+    └── Tools/
+        ├── GameInstallationInfoToolView.axaml
+        └── GameInstallationInfoToolView.axaml.cs
+```
+
+## Creating a New Tool
+
+### Step 1: Create the Tool Implementation
+
+Create a class that implements `ITool` in `GenHub/Features/Tools/Models/`:
+
+```csharp
+using GenHub.Core.Interfaces.Tools;
+using GenHub.Core.Models.Tools;
+using GenHub.Features.Tools.ViewModels.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace GenHub.Features.Tools.Models;
+
+public sealed class MyCustomTool : ITool
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public MyCustomTool(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+        Metadata = new ToolMetadata(
+            id: "my-custom-tool",
+            name: "My Custom Tool",
+            description: "Description of what this tool does",
+            category: "Utilities",
+            order: 10);
+    }
+
+    public ToolMetadata Metadata { get; }
+
+    public bool IsEnabled => true; // Or add logic to conditionally enable
+
+    public IToolViewModel CreateViewModel()
+    {
+        return _serviceProvider.GetRequiredService<MyCustomToolViewModel>();
+    }
+}
+```
+
+### Step 2: Create the Tool ViewModel
+
+Create a view model that inherits from `ToolViewModelBase` in `GenHub/Features/Tools/ViewModels/Tools/`:
+
+```csharp
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Tools.ViewModels.Tools;
+
+public partial class MyCustomToolViewModel : ToolViewModelBase
+{
+    // Inject any required services
+    private readonly ISomeService _someService;
+
+    [ObservableProperty]
+    private string _myProperty = "Initial value";
+
+    public MyCustomToolViewModel(
+        ISomeService someService,
+        ILogger<MyCustomToolViewModel>? logger = null)
+        : base(logger)
+    {
+        _someService = someService;
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        // Initialize your tool
+        await LoadDataAsync();
+    }
+
+    public override async Task RefreshAsync()
+    {
+        await base.RefreshAsync();
+        // Refresh logic
+        await LoadDataAsync();
+    }
+
+    [RelayCommand]
+    private async Task LoadDataAsync()
+    {
+        await ExecuteWithBusyStateAsync(async () =>
+        {
+            // Your logic here
+            LogInformation("Loading data...");
+        });
+    }
+}
+```
+
+### Step 3: Create the Tool View
+
+Create the XAML view in `GenHub/Features/Tools/Views/Tools/`:
+
+**MyCustomToolView.axaml:**
+```xml
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:GenHub.Features.Tools.ViewModels.Tools"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="500"
+             x:Class="GenHub.Features.Tools.Views.Tools.MyCustomToolView"
+             x:DataType="vm:MyCustomToolViewModel">
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="16" Margin="0">
+            <!-- Your UI here -->
+            <Border Background="#2A2A2A" CornerRadius="8" Padding="20">
+                <TextBlock Text="{Binding MyProperty}" 
+                           FontSize="14" 
+                           Foreground="White" />
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>
+```
+
+**MyCustomToolView.axaml.cs:**
+```csharp
+using Avalonia.Controls;
+
+namespace GenHub.Features.Tools.Views.Tools;
+
+public partial class MyCustomToolView : UserControl
+{
+    public MyCustomToolView()
+    {
+        InitializeComponent();
+    }
+}
+```
+
+### Step 4: Register in Dependency Injection
+
+Update `GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs`:
+
+```csharp
+// Register tool implementations
+services.AddSingleton<ITool, GameInstallationInfoTool>();
+services.AddSingleton<ITool, MyCustomTool>(); // Add this line
+
+// Register tool view models
+services.AddTransient<GameInstallationInfoToolViewModel>();
+services.AddTransient<MyCustomToolViewModel>(); // Add this line
+```
+
+### Step 5: Add DataTemplate Mapping
+
+Update `GenHub/Common/Views/MainView.axaml`:
+
+1. Add namespace:
+```xml
+xmlns:myToolVM="clr-namespace:GenHub.Features.Tools.ViewModels.Tools"
+xmlns:myToolViews="clr-namespace:GenHub.Features.Tools.Views.Tools"
+```
+
+2. Add DataTemplate:
+```xml
+<DataTemplate DataType="myToolVM:MyCustomToolViewModel">
+    <myToolViews:MyCustomToolView />
+</DataTemplate>
+```
+
+## Features Available to Tools
+
+### Base Functionality (from ToolViewModelBase)
+
+- **IsBusy** - Automatic busy state management
+- **IsActive** - Track if tool is currently active
+- **ExecuteWithBusyStateAsync()** - Execute operations with automatic busy state
+- **LogError()** / **LogInformation()** - Built-in logging
+- **InitializeAsync()** - Called once when tool is created
+- **ActivateAsync()** - Called when user selects the tool
+- **DeactivateAsync()** - Called when user navigates away
+- **RefreshAsync()** - Called when user clicks refresh
+
+### Accessing Application Services
+
+Tools can access any registered service through dependency injection:
+
+- **IGameInstallationDetectionOrchestrator** - Detect game installations
+- **IGameProfileService** - Manage game profiles
+- **IConfigurationProviderService** - Access configuration
+- **IUserSettingsService** - Access user settings
+- Any custom services registered in DI
+
+### Example: Accessing Game Data
+
+```csharp
+public partial class MyToolViewModel : ToolViewModelBase
+{
+    private readonly IGameProfileService _profileService;
+    private readonly IGameInstallationDetectionOrchestrator _installOrchestrator;
+
+    public MyToolViewModel(
+        IGameProfileService profileService,
+        IGameInstallationDetectionOrchestrator installOrchestrator,
+        ILogger<MyToolViewModel>? logger = null)
+        : base(logger)
+    {
+        _profileService = profileService;
+        _installOrchestrator = installOrchestrator;
+    }
+
+    private async Task LoadGameDataAsync()
+    {
+        var profiles = await _profileService.GetAllProfilesAsync();
+        var installations = await _installOrchestrator.DetectAllInstallationsAsync();
+        
+        // Process data...
+    }
+}
+```
+
+## Tool Categories
+
+Tools are organized by category in the UI. Standard categories include:
+
+- **Diagnostics** - System and game diagnostics
+- **Utilities** - General utilities
+- **Maintenance** - Maintenance and cleanup tools
+- **General** - Default category
+
+## Best Practices
+
+1. **Keep tools focused** - Each tool should do one thing well
+2. **Use ExecuteWithBusyStateAsync** - Always wrap long operations
+3. **Implement RefreshAsync** - Allow users to refresh data
+4. **Log important actions** - Use the built-in logging methods
+5. **Handle errors gracefully** - Show user-friendly error messages
+6. **Follow naming conventions** - Use consistent naming for files and classes
+7. **Test with DI** - Ensure all dependencies are properly registered
+
+## Example Tool Implementation
+
+See `GameInstallationInfoTool` for a complete working example that demonstrates:
+- Service injection
+- Data binding
+- Command implementation
+- Error handling
+- UI layout
+- Refresh functionality
+
+## Troubleshooting
+
+### Tool doesn't appear in the list
+- Check that the tool is registered in `SharedViewModelModule.cs`
+- Verify `IsEnabled` returns `true`
+- Check the registry initialization code runs
+
+### Tool view doesn't display
+- Ensure DataTemplate is registered in `MainView.axaml`
+- Verify namespace imports are correct
+- Check that `CreateViewModel()` returns the correct type
+
+### Can't access services
+- Verify services are registered in DI container
+- Check constructor parameters match registered types
+- Ensure tool view model is registered as Transient


### PR DESCRIPTION
Closes #68

# Overview
This pull request introduces a new Tools feature to the application, allowing tools to be registered, managed, and displayed in a dedicated Tools tab within the main UI. The changes include new interfaces and models for tool management, integration of the Tools tab into the navigation and main view, and the foundation for tool view models and registry services.

### Tools Feature Infrastructure

* Added core interfaces for tools: `ITool`, `IToolViewModel`, and `IToolRegistry`, enabling standardized registration, discovery, and lifecycle management of tools. (`GenHub.Core/Interfaces/Tools/ITool.cs`, `GenHub.Core/Interfaces/Tools/IToolViewModel.cs`, `GenHub.Core/Interfaces/Tools/IToolRegistry.cs`)
* Introduced the `ToolMetadata` model to describe each tool’s identity, category, and display properties. (`GenHub.Core/Models/Tools/ToolMetadata.cs`)
* Implemented the `ToolRegistry` service for managing tool registration, lookup, and categorization. (`GenHub.Features.Tools.Services/ToolRegistry.cs`)
* Created an abstract base class `ToolViewModelBase` for tool view models, providing common state management and logging functionality. (`GenHub.Features.Tools.ViewModels/ToolViewModelBase.cs`)

### UI & Navigation Integration

* Added a new `Tools` tab to the navigation enum and integrated it into the main view model, navigation logic, and initialization routines. (`GenHub.Core/Models/Enums/NavigationTab.cs`, `GenHub/Common/ViewModels/MainViewModel.cs`)
* Updated the main view (`MainView.axaml`) to include the Tools tab button and its corresponding view template. (`GenHub/Common/Views/MainView.axaml`)

These changes lay the groundwork for adding individual tools and utilities to the application, making it easier to extend functionality and provide a consistent user experience for tool-related features.