### PR TITLE
feat(generals-online): add content pipeline implementation for generalsonline

### DIFF
--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -1,0 +1,107 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Constants specific to Generals Online content provider and multiplayer service.
+/// </summary>
+public static class GeneralsOnlineConstants
+{
+    // ===== API Endpoints =====
+
+    /// <summary>Base URL for Generals Online CDN.</summary>
+    public const string CdnBaseUrl = "https://cdn.playgenerals.online";
+
+    /// <summary>API endpoint for JSON manifest with full release information.</summary>
+    public const string ManifestApiUrl = "https://cdn.playgenerals.online/manifest.json";
+
+    /// <summary>Endpoint for latest version information (plain text version string).</summary>
+    public const string LatestVersionUrl = "https://cdn.playgenerals.online/latest.txt";
+
+    /// <summary>Base URL for release downloads.</summary>
+    public const string ReleasesUrl = "https://cdn.playgenerals.online/releases";
+
+    // ===== Web URLs =====
+
+    /// <summary>Official Generals Online website.</summary>
+    public const string WebsiteUrl = "https://www.playgenerals.online/";
+
+    /// <summary>Download page URL.</summary>
+    public const string DownloadPageUrl = "https://www.playgenerals.online/#download";
+
+    /// <summary>Support/discord URL.</summary>
+    public const string SupportUrl = "https://discord.playgenerals.online/";
+
+    // ===== Content Metadata =====
+
+    /// <summary>Publisher name for manifests.</summary>
+    public const string PublisherName = "Generals Online Team";
+
+    /// <summary>Content name for manifests.</summary>
+    public const string ContentName = "Generals Online";
+
+    /// <summary>Full content description.</summary>
+    public const string Description = "Community-driven multiplayer service for C&C Generals Zero Hour. Features 60Hz tick rate, automatic updates, and improved stability.";
+
+    /// <summary>Short content description.</summary>
+    public const string ShortDescription = "Community-driven multiplayer service for C&C Generals Zero Hour";
+
+    /// <summary>Content icon URL.</summary>
+    public const string IconUrl = "https://www.playgenerals.online/logo.png";
+
+    // ===== Version Parsing =====
+
+    /// <summary>Format for parsing version dates (DDMMYY).</summary>
+    public const string VersionDateFormat = "ddMMyy";
+
+    /// <summary>Separator between date and QFE number in versions.</summary>
+    public const string QfeSeparator = "_QFE";
+
+    // ===== File Extensions =====
+
+    /// <summary>File extension for portable downloads.</summary>
+    public const string PortableExtension = ".zip";
+
+    // ===== Default File Sizes =====
+
+    /// <summary>
+    /// Default portable ZIP file size (38MB) - placeholder until actual size is known.
+    /// </summary>
+    public const long DefaultPortableSize = 38_000_000;
+
+    // ===== Update Intervals =====
+
+    /// <summary>Hours between update checks.</summary>
+    public const int UpdateCheckIntervalHours = 24;
+
+    // ===== Manifest Generation =====
+
+    /// <summary>Publisher type identifier for GeneralsOnline.</summary>
+    public const string PublisherType = "generalsonline";
+
+    /// <summary>Content type for GeneralsOnline game clients.</summary>
+    public const string ContentType = "gameclient";
+
+    /// <summary>Manifest name suffix for 30Hz variant.</summary>
+    public const string Variant30HzSuffix = "30hz";
+
+    /// <summary>Manifest name suffix for 60Hz variant.</summary>
+    public const string Variant60HzSuffix = "60hz";
+
+    // ===== Component Identifiers =====
+
+    /// <summary>Source name for Generals Online discoverer.</summary>
+    public const string DiscovererSourceName = PublisherType;
+
+    /// <summary>Resolver ID for Generals Online resolver.</summary>
+    public const string ResolverId = "GeneralsOnline";
+
+    /// <summary>Source name for Generals Online deliverer.</summary>
+    public const string DelivererSourceName = "Generals Online Deliverer";
+
+    /// <summary>Description for Generals Online deliverer.</summary>
+    public const string DelivererDescription = "Delivers Generals Online content via ZIP extraction and CAS storage";
+
+    // ===== Content Tags =====
+
+    /// <summary>Content tags for search and categorization.</summary>
+    public static readonly string[] Tags = new[] { "multiplayer", "online", "community", "enhancement" };
+}

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -60,13 +60,6 @@ public static class GeneralsOnlineConstants
     /// <summary>File extension for portable downloads.</summary>
     public const string PortableExtension = ".zip";
 
-    // ===== Default File Sizes =====
-
-    /// <summary>
-    /// Default portable ZIP file size (38MB) - placeholder until actual size is known.
-    /// </summary>
-    public const long DefaultPortableSize = 38_000_000;
-
     // ===== Update Intervals =====
 
     /// <summary>Hours between update checks.</summary>

--- a/GenHub/GenHub.Core/Interfaces/Content/IContentUpdateService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IContentUpdateService.cs
@@ -1,7 +1,9 @@
 namespace GenHub.Core.Interfaces.Content;
 
+using GenHub.Core.Models.Results.Content;
+
 /// <summary>
-/// Interface for content update checking services.
+/// Defines the contract for content update checking services.
 /// </summary>
 public interface IContentUpdateService
 {
@@ -9,6 +11,6 @@ public interface IContentUpdateService
     /// Checks for available content updates.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A tuple containing update availability, latest version, and current version.</returns>
-    Task<(bool UpdateAvailable, string? LatestVersion, string? CurrentVersion)> CheckForUpdatesAsync(CancellationToken cancellationToken = default);
+    /// <returns>A result containing update availability information.</returns>
+    Task<ContentUpdateCheckResult> CheckForUpdatesAsync(CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Core/Interfaces/Content/IContentUpdateService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IContentUpdateService.cs
@@ -1,0 +1,14 @@
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Interface for content update checking services.
+/// </summary>
+public interface IContentUpdateService
+{
+    /// <summary>
+    /// Checks for available content updates.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A tuple containing update availability, latest version, and current version.</returns>
+    Task<(bool UpdateAvailable, string? LatestVersion, string? CurrentVersion)> CheckForUpdatesAsync(CancellationToken cancellationToken = default);
+}

--- a/GenHub/GenHub.Core/Interfaces/Content/IPublisherManifestFactory.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IPublisherManifestFactory.cs
@@ -1,0 +1,44 @@
+using GenHub.Core.Models.Manifest;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Interface for publisher-specific manifest factories that handle content extraction,
+/// manifest generation, and multi-variant support for GitHub releases.
+/// </summary>
+public interface IPublisherManifestFactory
+{
+    /// <summary>
+    /// Gets the publisher identifier this factory handles (e.g., "thesuperhackers", "generalsonline").
+    /// </summary>
+    string PublisherId { get; }
+
+    /// <summary>
+    /// Determines if this factory can handle the given manifest based on publisher and content type.
+    /// </summary>
+    /// <param name="manifest">The manifest to check.</param>
+    /// <returns>True if this factory can handle the manifest.</returns>
+    bool CanHandle(ContentManifest manifest);
+
+    /// <summary>
+    /// Creates manifests from extracted GitHub release content.
+    /// May return multiple manifests for multi-variant releases (e.g., Generals + Zero Hour).
+    /// </summary>
+    /// <param name="originalManifest">The original manifest from GitHub resolution.</param>
+    /// <param name="extractedDirectory">The directory containing extracted files.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of content manifests (one or more depending on variants detected).</returns>
+    Task<List<ContentManifest>> CreateManifestsFromExtractedContentAsync(
+        ContentManifest originalManifest,
+        string extractedDirectory,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the subdirectory for a specific manifest variant.
+    /// Used to determine where files should be stored for each variant.
+    /// </summary>
+    /// <param name="manifest">The manifest to get the directory for.</param>
+    /// <param name="extractedDirectory">The root extracted directory.</param>
+    /// <returns>The subdirectory path for this manifest's files.</returns>
+    string GetManifestDirectory(ContentManifest manifest, string extractedDirectory);
+}

--- a/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineApiResponse.cs
+++ b/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineApiResponse.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace GenHub.Core.Models.GeneralsOnline;
+
+/// <summary>
+/// Represents the API response from Generals Online CDN manifest endpoint.
+/// </summary>
+public class GeneralsOnlineApiResponse
+{
+    /// <summary>
+    /// Gets or sets the version string (e.g., "111125_QFE2").
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the direct download URL for the portable release.
+    /// </summary>
+    [JsonPropertyName("download_url")]
+    public string DownloadUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file size in bytes.
+    /// </summary>
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets the release notes or changelog.
+    /// </summary>
+    [JsonPropertyName("release_notes")]
+    public string? ReleaseNotes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SHA256 hash for file verification.
+    /// </summary>
+    [JsonPropertyName("sha256")]
+    public string? Sha256 { get; set; }
+}

--- a/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineApiResponse.cs
+++ b/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineApiResponse.cs
@@ -8,7 +8,8 @@ namespace GenHub.Core.Models.GeneralsOnline;
 public class GeneralsOnlineApiResponse
 {
     /// <summary>
-    /// Gets or sets the version string (e.g., "111125_QFE2").
+    /// Gets or sets the version string (e.g., "111825_QFE2" for November 18, 2025).
+    /// Format: MMDDYY_QFE# where MM=month, DD=day, YY=year, #=QFE number.
     /// </summary>
     [JsonPropertyName("version")]
     public string Version { get; set; } = string.Empty;

--- a/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
+++ b/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
@@ -1,0 +1,41 @@
+namespace GenHub.Core.Models.GeneralsOnline;
+
+/// <summary>
+/// Represents a Generals Online release with version information and download URLs.
+/// This model represents release information from the Generals Online CDN.
+/// Currently uses hardcoded patterns and placeholder sizes until manifest.json API is available.
+/// </summary>
+public class GeneralsOnlineRelease
+{
+    /// <summary>
+    /// Gets version string in format: MMDDYY_QFE# (e.g., "101525_QFE5").
+    /// </summary>
+    required public string Version { get; init; }
+
+    /// <summary>
+    /// Gets date encoded in version (e.g., 101525 = October 15, 2025).
+    /// </summary>
+    public DateTime VersionDate { get; init; }
+
+    /// <summary>
+    /// Gets actual release date.
+    /// </summary>
+    public DateTime ReleaseDate { get; init; }
+
+    /// <summary>
+    /// Gets URL to portable ZIP.
+    /// This is the format GenHub uses for content delivery.
+    /// </summary>
+    required public string PortableUrl { get; init; }
+
+    /// <summary>
+    /// Gets size of portable ZIP in bytes.
+    /// NOTE: Currently a placeholder constant until manifest.json API is available.
+    /// </summary>
+    public long PortableSize { get; init; }
+
+    /// <summary>
+    /// Gets release changelog/notes.
+    /// </summary>
+    public string? Changelog { get; init; }
+}

--- a/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
+++ b/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
@@ -1,3 +1,5 @@
+using GenHub.Core.Constants;
+
 namespace GenHub.Core.Models.GeneralsOnline;
 
 /// <summary>
@@ -30,9 +32,9 @@ public class GeneralsOnlineRelease
 
     /// <summary>
     /// Gets size of portable ZIP in bytes.
-    /// NOTE: Currently a placeholder constant until manifest.json API is available.
+    /// Null when size is unknown (e.g., from latest.txt API).
     /// </summary>
-    public long PortableSize { get; init; }
+    public long? PortableSize { get; init; }
 
     /// <summary>
     /// Gets release changelog/notes.

--- a/GenHub/GenHub.Core/Models/Results/Content/ContentUpdateCheckResult.cs
+++ b/GenHub/GenHub.Core/Models/Results/Content/ContentUpdateCheckResult.cs
@@ -1,0 +1,164 @@
+namespace GenHub.Core.Models.Results.Content;
+
+/// <summary>
+/// Represents the result of a content update check operation.
+/// </summary>
+public class ContentUpdateCheckResult : ResultBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContentUpdateCheckResult"/> class.
+    /// </summary>
+    /// <param name="isUpdateAvailable">Whether an update is available.</param>
+    /// <param name="latestVersion">The latest version available.</param>
+    /// <param name="currentVersion">The currently installed version.</param>
+    /// <param name="releaseDate">The release date of the latest version.</param>
+    /// <param name="downloadUrl">The download URL for the update.</param>
+    /// <param name="changelog">The changelog or release notes.</param>
+    /// <param name="error">Error message if the check failed.</param>
+    /// <param name="elapsed">Time taken for the operation.</param>
+    private ContentUpdateCheckResult(
+        bool isUpdateAvailable,
+        string? latestVersion,
+        string? currentVersion,
+        DateTime? releaseDate = null,
+        string? downloadUrl = null,
+        string? changelog = null,
+        string? error = null,
+        TimeSpan elapsed = default)
+        : base(error == null, error, elapsed)
+    {
+        IsUpdateAvailable = isUpdateAvailable;
+        LatestVersion = latestVersion;
+        CurrentVersion = currentVersion;
+        ReleaseDate = releaseDate;
+        DownloadUrl = downloadUrl;
+        Changelog = changelog;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether an update is available.
+    /// </summary>
+    public bool IsUpdateAvailable { get; }
+
+    /// <summary>
+    /// Gets the latest version available.
+    /// </summary>
+    public string? LatestVersion { get; }
+
+    /// <summary>
+    /// Gets the currently installed version.
+    /// </summary>
+    public string? CurrentVersion { get; }
+
+    /// <summary>
+    /// Gets the release date of the latest version.
+    /// </summary>
+    public DateTime? ReleaseDate { get; }
+
+    /// <summary>
+    /// Gets the download URL for the update.
+    /// </summary>
+    public string? DownloadUrl { get; }
+
+    /// <summary>
+    /// Gets the changelog or release notes for the latest version.
+    /// </summary>
+    public string? Changelog { get; }
+
+    // -------------------------
+    // Factory Methods
+    // -------------------------
+
+    /// <summary>
+    /// Creates a successful result indicating an update is available.
+    /// </summary>
+    /// <param name="latestVersion">The latest version available.</param>
+    /// <param name="currentVersion">The currently installed version.</param>
+    /// <param name="releaseDate">The release date of the latest version.</param>
+    /// <param name="downloadUrl">The download URL for the update.</param>
+    /// <param name="changelog">The changelog or release notes.</param>
+    /// <param name="elapsed">Time taken for the operation.</param>
+    /// <returns>A <see cref="ContentUpdateCheckResult"/> indicating an update is available.</returns>
+    public static ContentUpdateCheckResult CreateUpdateAvailable(
+        string latestVersion,
+        string? currentVersion = null,
+        DateTime? releaseDate = null,
+        string? downloadUrl = null,
+        string? changelog = null,
+        TimeSpan elapsed = default)
+    {
+        return new ContentUpdateCheckResult(
+            isUpdateAvailable: true,
+            latestVersion: latestVersion,
+            currentVersion: currentVersion,
+            releaseDate: releaseDate,
+            downloadUrl: downloadUrl,
+            changelog: changelog,
+            elapsed: elapsed);
+    }
+
+    /// <summary>
+    /// Creates a successful result indicating no update is available.
+    /// </summary>
+    /// <param name="currentVersion">The currently installed version.</param>
+    /// <param name="latestVersion">The latest version checked (same as current).</param>
+    /// <param name="elapsed">Time taken for the operation.</param>
+    /// <returns>A <see cref="ContentUpdateCheckResult"/> indicating no update is available.</returns>
+    public static ContentUpdateCheckResult CreateNoUpdateAvailable(
+        string? currentVersion = null,
+        string? latestVersion = null,
+        TimeSpan elapsed = default)
+    {
+        return new ContentUpdateCheckResult(
+            isUpdateAvailable: false,
+            latestVersion: latestVersion ?? currentVersion,
+            currentVersion: currentVersion,
+            elapsed: elapsed);
+    }
+
+    /// <summary>
+    /// Creates a failed result indicating the update check encountered an error.
+    /// </summary>
+    /// <param name="error">The error message.</param>
+    /// <param name="currentVersion">The currently installed version, if known.</param>
+    /// <param name="elapsed">Time taken for the operation.</param>
+    /// <returns>A <see cref="ContentUpdateCheckResult"/> indicating the check failed.</returns>
+    public static ContentUpdateCheckResult CreateFailure(
+        string error,
+        string? currentVersion = null,
+        TimeSpan elapsed = default)
+    {
+        return new ContentUpdateCheckResult(
+            isUpdateAvailable: false,
+            latestVersion: null,
+            currentVersion: currentVersion,
+            error: error,
+            elapsed: elapsed);
+    }
+
+    /// <summary>
+    /// Creates a successful result for when no content is currently installed.
+    /// </summary>
+    /// <param name="latestVersion">The latest version available.</param>
+    /// <param name="releaseDate">The release date of the latest version.</param>
+    /// <param name="downloadUrl">The download URL.</param>
+    /// <param name="changelog">The changelog or release notes.</param>
+    /// <param name="elapsed">Time taken for the operation.</param>
+    /// <returns>A <see cref="ContentUpdateCheckResult"/> indicating content is available for first-time install.</returns>
+    public static ContentUpdateCheckResult CreateContentAvailable(
+        string latestVersion,
+        DateTime? releaseDate = null,
+        string? downloadUrl = null,
+        string? changelog = null,
+        TimeSpan elapsed = default)
+    {
+        return new ContentUpdateCheckResult(
+            isUpdateAvailable: true,
+            latestVersion: latestVersion,
+            currentVersion: null,
+            releaseDate: releaseDate,
+            downloadUrl: downloadUrl,
+            changelog: changelog,
+            elapsed: elapsed);
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/ContentUpdateServiceBase.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentUpdateServiceBase.cs
@@ -1,0 +1,106 @@
+using GenHub.Core.Interfaces.Content;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Content.Services;
+
+/// <summary>
+/// Abstract base class for content update services.
+/// Provides common background service implementation for periodic update checking.
+/// </summary>
+public abstract class ContentUpdateServiceBase(ILogger<ContentUpdateServiceBase> logger) : BackgroundService, IContentUpdateService
+{
+    /// <summary>
+    /// Gets the name of the update service for logging purposes.
+    /// </summary>
+    protected abstract string ServiceName { get; }
+
+    /// <summary>
+    /// Gets the interval between update checks.
+    /// </summary>
+    protected abstract TimeSpan UpdateCheckInterval { get; }
+
+    /// <inheritdoc />
+    public Task<(bool UpdateAvailable, string? LatestVersion, string? CurrentVersion)> CheckForUpdatesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return CheckForUpdatesImplAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Checks for available content updates (implementation-specific).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A tuple containing update availability, latest version, and current version.</returns>
+    protected abstract Task<(bool UpdateAvailable, string? LatestVersion, string? CurrentVersion)> CheckForUpdatesImplAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes the background service that periodically checks for updates.
+    /// </summary>
+    /// <param name="stoppingToken">Cancellation token for stopping the service.</param>
+    /// <returns>A task representing the background execution.</returns>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("[{ServiceName}] Update service started. Check interval: {Interval}", ServiceName, UpdateCheckInterval);
+
+        // Initial delay to allow application to fully start
+        await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                logger.LogDebug("[{ServiceName}] Starting update check", ServiceName);
+
+                var (updateAvailable, latestVersion, currentVersion) = await CheckForUpdatesImplAsync(stoppingToken);
+
+                if (updateAvailable)
+                {
+                    logger.LogInformation(
+                        "[{ServiceName}] Update available: {LatestVersion} (current: {CurrentVersion})",
+                        ServiceName,
+                        latestVersion ?? "unknown",
+                        currentVersion ?? "none");
+                }
+                else
+                {
+                    logger.LogDebug(
+                        "[{ServiceName}] No updates available. Current version: {CurrentVersion}",
+                        ServiceName,
+                        currentVersion ?? "none");
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Service is being stopped, exit gracefully
+                logger.LogInformation("[{ServiceName}] Update service stopped", ServiceName);
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "[{ServiceName}] Update check failed. Will retry in {Interval}",
+                    ServiceName,
+                    UpdateCheckInterval);
+            }
+
+            // Wait for the configured interval before next check
+            try
+            {
+                await Task.Delay(UpdateCheckInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Service is being stopped
+                logger.LogInformation("[{ServiceName}] Update service stopped", ServiceName);
+                break;
+            }
+        }
+
+        logger.LogInformation("[{ServiceName}] Update service shutdown complete", ServiceName);
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -1,0 +1,242 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Specialized deliverer for Generals Online content.
+/// Downloads ZIP packages, extracts files, and creates dual variant manifests (30Hz/60Hz).
+/// </summary>
+public class GeneralsOnlineDeliverer(
+   IDownloadService downloadService,
+   IContentManifestPool manifestPool,
+   GeneralsOnlineManifestFactory manifestFactory,
+   ILogger<GeneralsOnlineDeliverer> logger)
+   : IContentDeliverer
+{
+    /// <inheritdoc />
+    public string SourceName => GeneralsOnlineConstants.DelivererSourceName;
+
+    /// <inheritdoc />
+    public string Description => GeneralsOnlineConstants.DelivererDescription;
+
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
+    /// <inheritdoc />
+    public ContentSourceCapabilities Capabilities => ContentSourceCapabilities.SupportsPackageAcquisition;
+
+    /// <inheritdoc />
+    public bool CanDeliver(ContentManifest manifest)
+    {
+        // Can deliver if it's a Generals Online manifest with a portable ZIP URL
+        return manifest.Publisher?.Name?.Equals(GeneralsOnlineConstants.PublisherName, StringComparison.OrdinalIgnoreCase) == true &&
+               manifest.Files.Any(f => f.DownloadUrl?.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult<ContentManifest>> DeliverContentAsync(
+        ContentManifest packageManifest,
+        string targetDirectory,
+        IProgress<ContentAcquisitionProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogInformation("Starting Generals Online content delivery for {Version}", packageManifest.Version);
+
+            // Step 1: Download ZIP file
+            var zipFile = packageManifest.Files.FirstOrDefault(f => f.DownloadUrl?.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase) == true);
+            if (zipFile == null)
+            {
+                return OperationResult<ContentManifest>.CreateFailure("No ZIP file found in manifest");
+            }
+
+            var zipPath = Path.Combine(targetDirectory, "GeneralsOnline.zip");
+
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.Downloading,
+                ProgressPercentage = 10,
+                CurrentOperation = "Downloading Generals Online ZIP package",
+                CurrentFile = zipFile.RelativePath,
+            });
+
+            logger.LogDebug("Downloading ZIP from {Url} to {Path}", zipFile.DownloadUrl, zipPath);
+            var downloadResult = await downloadService.DownloadFileAsync(
+                zipFile.DownloadUrl!,
+                zipPath,
+                expectedHash: null,
+                progress: null,
+                cancellationToken);
+
+            if (!downloadResult.Success)
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Failed to download ZIP: {downloadResult.FirstError}");
+            }
+
+            // Step 2: Extract ZIP
+            var extractPath = Path.Combine(targetDirectory, "extracted");
+            Directory.CreateDirectory(extractPath);
+
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.Extracting,
+                ProgressPercentage = 40,
+                CurrentOperation = "Extracting Generals Online files",
+            });
+
+            logger.LogDebug("Extracting ZIP to {Path}", extractPath);
+            ZipFile.ExtractToDirectory(zipPath, extractPath, overwriteFiles: true);
+
+            // Step 3: Create both variant manifests using the factory
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.Copying,
+                ProgressPercentage = 50,
+                CurrentOperation = "Creating manifests for both variants",
+            });
+
+            logger.LogInformation("Creating dual manifests for GeneralsOnline variants");
+            var manifests = await manifestFactory.CreateManifestsFromExtractedContentAsync(
+                packageManifest,
+                extractPath,
+                cancellationToken);
+
+            if (manifests.Count != 2)
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Expected 2 manifests but got {manifests.Count}");
+            }
+
+            // Step 4: Register both variant manifests to CAS
+            // This ensures all files (including both executables) are stored before validation
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.Copying,
+                ProgressPercentage = 90,
+                CurrentOperation = "Registering both variant manifests to content library",
+            });
+
+            logger.LogInformation("Registering both variant manifests (30Hz and 60Hz) in pool");
+
+            // Register 30Hz manifest first
+            var hz30Manifest = manifests[0];
+            var add30Result = await manifestPool.AddManifestAsync(hz30Manifest, extractPath, cancellationToken);
+            if (!add30Result.Success)
+            {
+                logger.LogWarning(
+                    "Failed to register 30Hz manifest {ManifestId}: {Error}",
+                    hz30Manifest.Id,
+                    add30Result.FirstError);
+            }
+            else
+            {
+                logger.LogInformation("Successfully registered 30Hz manifest: {ManifestId}", hz30Manifest.Id);
+            }
+
+            // Register 60Hz manifest
+            var hz60Manifest = manifests[1];
+            var add60Result = await manifestPool.AddManifestAsync(hz60Manifest, extractPath, cancellationToken);
+            if (!add60Result.Success)
+            {
+                logger.LogWarning(
+                    "Failed to register 60Hz manifest {ManifestId}: {Error}",
+                    hz60Manifest.Id,
+                    add60Result.FirstError);
+            }
+            else
+            {
+                logger.LogInformation("Successfully registered 60Hz manifest: {ManifestId}", hz60Manifest.Id);
+            }
+
+            var parentDir = Directory.GetParent(extractPath)?.FullName;
+            if (parentDir != null)
+            {
+                logger.LogInformation("Moving extracted files from {ExtractPath} to parent {ParentDir}", extractPath, parentDir);
+                foreach (var file in Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories))
+                {
+                    var relativePath = Path.GetRelativePath(extractPath, file);
+                    var targetPath = Path.Combine(parentDir, relativePath);
+                    var targetDir = Path.GetDirectoryName(targetPath);
+                    if (!string.IsNullOrEmpty(targetDir))
+                    {
+                        Directory.CreateDirectory(targetDir);
+                    }
+
+                    File.Move(file, targetPath, overwrite: true);
+                }
+
+                try
+                {
+                    Directory.Delete(extractPath, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to delete extracted directory {ExtractPath}", extractPath);
+                }
+            }
+
+            try
+            {
+                File.Delete(zipPath);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to delete ZIP file {ZipPath}", zipPath);
+            }
+
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.Completed,
+                ProgressPercentage = 100,
+                CurrentOperation = "Generals Online content delivered successfully (both variants)",
+            });
+
+            var primaryManifest = manifests[0];
+            logger.LogInformation(
+                "Successfully delivered Generals Online content: 2 manifests created, both registered to pool");
+
+            return OperationResult<ContentManifest>.CreateSuccess(primaryManifest);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to deliver Generals Online content");
+            return OperationResult<ContentManifest>.CreateFailure($"Content delivery failed: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<OperationResult<bool>> ValidateContentAsync(
+        ContentManifest manifest,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var hasZipFile = manifest.Files.Any(f =>
+                !string.IsNullOrEmpty(f.DownloadUrl) &&
+                f.DownloadUrl.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
+
+            return Task.FromResult(OperationResult<bool>.CreateSuccess(hasZipFile));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Validation failed for Generals Online manifest {ManifestId}", manifest.Id);
+            return Task.FromResult(OperationResult<bool>.CreateFailure($"Validation failed: {ex.Message}"));
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDiscoverer.cs
@@ -1,0 +1,283 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GeneralsOnline;
+using GenHub.Core.Models.Results;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Discovers Generals Online releases by querying the CDN API or falling back to mock data.
+/// Supports both manifest.json API and latest.txt polling for release discovery.
+/// </summary>
+public class GeneralsOnlineDiscoverer : IContentDiscoverer
+{
+    private readonly ILogger<GeneralsOnlineDiscoverer> _logger;
+    private readonly HttpClient _httpClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeneralsOnlineDiscoverer"/> class.
+    /// </summary>
+    /// <param name="logger">The logger for diagnostic information.</param>
+    public GeneralsOnlineDiscoverer(ILogger<GeneralsOnlineDiscoverer> logger)
+    {
+        _logger = logger;
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+    }
+
+    /// <inheritdoc />
+    public string SourceName => GeneralsOnlineConstants.PublisherType;
+
+    /// <inheritdoc />
+    public string Description => "Discovers Generals Online releases from official CDN";
+
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
+    /// <inheritdoc />
+    public ContentSourceCapabilities Capabilities =>
+        ContentSourceCapabilities.RequiresDiscovery |
+        ContentSourceCapabilities.SupportsPackageAcquisition;
+
+    /// <summary>
+    /// Disposes resources used by the discoverer.
+    /// </summary>
+    public void Dispose()
+    {
+        _httpClient?.Dispose();
+    }
+
+    /// <summary>
+    /// Discovers Generals Online releases from CDN API or mock data.
+    /// Tries manifest.json first, then latest.txt, then falls back to mock release.
+    /// </summary>
+    /// <param name="query">The search query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result containing discovered content.</returns>
+    public async Task<OperationResult<IEnumerable<ContentSearchResult>>> DiscoverAsync(
+        ContentSearchQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Discovering Generals Online releases");
+
+        try
+        {
+            // Try to get release from API
+            var (release, cdnAvailable) = await TryGetReleaseFromApiAsync(cancellationToken);
+
+            // If CDN is unreachable, return failure
+            if (!cdnAvailable)
+            {
+                _logger.LogWarning("Generals Online CDN is currently unreachable");
+                return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure(
+                    "Generals Online CDN is currently unavailable. Please try again later.");
+            }
+
+            // CDN is reachable but has no releases
+            if (release == null)
+            {
+                _logger.LogInformation("No Generals Online releases available");
+                return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+                    Enumerable.Empty<ContentSearchResult>());
+            }
+
+            // Filter by search query if provided
+            if (!string.IsNullOrWhiteSpace(query.SearchTerm) &&
+                !release.Version.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) &&
+                !GeneralsOnlineConstants.ContentName.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase))
+            {
+                return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+                    Enumerable.Empty<ContentSearchResult>());
+            }
+
+            var searchResult = CreateSearchResult(release);
+
+            return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+                new[] { searchResult });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to discover Generals Online releases");
+            return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure(
+                $"Discovery failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Attempts to get release information from the Generals Online CDN API.
+    /// </summary>
+    /// <returns>Tuple of (release, cdnAvailable). Release is null if none found, cdnAvailable is false if CDN is unreachable.</returns>
+    private async Task<(GeneralsOnlineRelease? release, bool cdnAvailable)> TryGetReleaseFromApiAsync(
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            _logger.LogDebug("Attempting to query Generals Online CDN API");
+
+            // Try manifest.json first (full API response)
+            var manifestResponse = await _httpClient.GetAsync(
+                GeneralsOnlineConstants.ManifestApiUrl,
+                cancellationToken);
+
+            if (manifestResponse.IsSuccessStatusCode)
+            {
+                var json = await manifestResponse.Content.ReadAsStringAsync(cancellationToken);
+                var apiResponse = JsonSerializer.Deserialize<GeneralsOnlineApiResponse>(json);
+
+                if (apiResponse != null && !string.IsNullOrEmpty(apiResponse.Version))
+                {
+                    _logger.LogInformation("Retrieved release from manifest.json API: {Version}", apiResponse.Version);
+                    return (CreateReleaseFromApiResponse(apiResponse), true);
+                }
+            }
+
+            // Fall back to latest.txt (simple version polling)
+            var versionResponse = await _httpClient.GetAsync(
+                GeneralsOnlineConstants.LatestVersionUrl,
+                cancellationToken);
+
+            if (versionResponse.IsSuccessStatusCode)
+            {
+                var version = await versionResponse.Content.ReadAsStringAsync(cancellationToken);
+                version = version?.Trim();
+
+                if (!string.IsNullOrEmpty(version))
+                {
+                    _logger.LogInformation("Retrieved version from latest.txt: {Version}", version);
+                    return (CreateReleaseFromVersion(version), true);
+                }
+            }
+
+            // CDN responded but had no valid data (unlikely)
+            _logger.LogDebug("CDN responded but contains no release data");
+            return (null, true);
+        }
+        catch (HttpRequestException ex)
+        {
+            // Network error - CDN is unreachable
+            _logger.LogWarning(ex, "Generals Online CDN is unreachable");
+            return (null, false);
+        }
+        catch (Exception ex)
+        {
+            // Other errors (parsing, etc.) - treat as CDN issue
+            _logger.LogWarning(ex, "Failed to query Generals Online CDN");
+            return (null, false);
+        }
+    }
+
+    /// <summary>
+    /// Creates a GeneralsOnlineRelease from a full API response (manifest.json).
+    /// </summary>
+    /// <param name="apiResponse">The API response.</param>
+    /// <returns>A fully populated GeneralsOnlineRelease.</returns>
+    private GeneralsOnlineRelease CreateReleaseFromApiResponse(GeneralsOnlineApiResponse apiResponse)
+    {
+        var versionDate = ParseVersionDate(apiResponse.Version);
+
+        return new GeneralsOnlineRelease
+        {
+            Version = apiResponse.Version,
+            VersionDate = versionDate,
+            ReleaseDate = versionDate,
+            PortableUrl = apiResponse.DownloadUrl,
+            PortableSize = apiResponse.Size,
+            Changelog = apiResponse.ReleaseNotes ?? $"Generals Online {apiResponse.Version}",
+        };
+    }
+
+    /// <summary>
+    /// Creates a GeneralsOnlineRelease from a version string (latest.txt fallback).
+    /// Constructs URLs and uses default sizes since full API data is unavailable.
+    /// </summary>
+    /// <param name="version">The version string (e.g., "101525_QFE5").</param>
+    /// <returns>A GeneralsOnlineRelease with constructed URLs.</returns>
+    private GeneralsOnlineRelease CreateReleaseFromVersion(string version)
+    {
+        var versionDate = ParseVersionDate(version);
+
+        return new GeneralsOnlineRelease
+        {
+            Version = version,
+            VersionDate = versionDate,
+            ReleaseDate = versionDate,
+            PortableUrl = $"{GeneralsOnlineConstants.ReleasesUrl}/GeneralsOnline_portable_{version}{GeneralsOnlineConstants.PortableExtension}",
+            PortableSize = GeneralsOnlineConstants.DefaultPortableSize,
+            Changelog = $"Generals Online {version}",
+        };
+    }
+
+    /// <summary>
+    /// Parses a version string (MMDDYY_QFE#) to extract the date.
+    /// </summary>
+    /// <param name="version">The version string.</param>
+    /// <returns>The parsed date, or current date if parsing fails.</returns>
+    private DateTime ParseVersionDate(string version)
+    {
+        try
+        {
+            var parts = version.Split('_');
+            if (parts.Length < 1)
+            {
+                return DateTime.Now;
+            }
+
+            var datePart = parts[0];
+            if (datePart.Length != 6)
+            {
+                return DateTime.Now;
+            }
+
+            var month = int.Parse(datePart.Substring(0, 2));
+            var day = int.Parse(datePart.Substring(2, 2));
+            var year = 2000 + int.Parse(datePart.Substring(4, 2));
+
+            return new DateTime(year, month, day);
+        }
+        catch
+        {
+            return DateTime.Now;
+        }
+    }
+
+    private ContentSearchResult CreateSearchResult(GeneralsOnlineRelease release)
+    {
+        var searchResult = new ContentSearchResult
+        {
+            Id = $"GeneralsOnline_{release.Version}",
+            Name = GeneralsOnlineConstants.ContentName,
+            Description = release.Changelog ?? GeneralsOnlineConstants.Description,
+            Version = release.Version,
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            ProviderName = SourceName,
+            AuthorName = GeneralsOnlineConstants.PublisherName,
+            IconUrl = GeneralsOnlineConstants.IconUrl,
+            LastUpdated = release.ReleaseDate,
+            DownloadSize = release.PortableSize,
+            RequiresResolution = true,
+            ResolverId = GeneralsOnlineConstants.ResolverId,
+            SourceUrl = GeneralsOnlineConstants.DownloadPageUrl,
+        };
+
+        foreach (var tag in GeneralsOnlineConstants.Tags)
+        {
+            searchResult.Tags.Add(tag);
+        }
+
+        searchResult.SetData(release);
+
+        return searchResult;
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -77,9 +77,11 @@ public class GeneralsOnlineManifestFactory(ILogger<GeneralsOnlineManifestFactory
 
     /// <summary>
     /// Parses a Generals Online version string to extract a numeric user version for manifest IDs.
-    /// Converts versions like "101525_QFE5" to a numeric value like 1015255.
+    /// Converts versions like "111825_QFE2" (Nov 18, 2025) to a numeric value like 1118252.
+    /// NOTE: Format is dictated by Generals Online CDN API (MMDDYY_QFE#), not our choice.
+    /// This method converts it to a sortable numeric format.
     /// </summary>
-    /// <param name="version">The version string (e.g., "101525_QFE5").</param>
+    /// <param name="version">The version string (e.g., "111825_QFE2").</param>
     /// <returns>A numeric version suitable for manifest IDs.</returns>
     private static int ParseVersionForManifestId(string version)
     {
@@ -122,7 +124,7 @@ public class GeneralsOnlineManifestFactory(ILogger<GeneralsOnlineManifestFactory
             VersionDate = DateTime.Now,
             ReleaseDate = manifest.Metadata?.ReleaseDate ?? DateTime.Now,
             PortableUrl = zipFile?.DownloadUrl ?? string.Empty,
-            PortableSize = zipFile?.Size ?? GeneralsOnlineConstants.DefaultPortableSize,
+            PortableSize = zipFile?.Size, // Use actual file size, null if unknown
             Changelog = manifest.Metadata?.ChangelogUrl,
         };
     }
@@ -282,7 +284,7 @@ public class GeneralsOnlineManifestFactory(ILogger<GeneralsOnlineManifestFactory
                 {
                     RelativePath = Path.GetFileName(release.PortableUrl),
                     DownloadUrl = release.PortableUrl,
-                    Size = release.PortableSize,
+                    Size = release.PortableSize ?? 0, // Use 0 when size is unknown
                     SourceType = ContentSourceType.RemoteDownload,
                     Hash = string.Empty,
                 },

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -1,0 +1,301 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GeneralsOnline;
+using GenHub.Core.Models.Manifest;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Factory for creating and updating Generals Online content manifests.
+/// Creates separate manifests for each game client variant (30Hz and 60Hz).
+/// </summary>
+public class GeneralsOnlineManifestFactory(ILogger<GeneralsOnlineManifestFactory> logger) : IPublisherManifestFactory
+{
+    /// <inheritdoc />
+    public string PublisherId => PublisherTypeConstants.GeneralsOnline;
+
+    /// <inheritdoc />
+    public bool CanHandle(ContentManifest manifest)
+    {
+        var publisherMatches = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true;
+        var isGameClient = manifest.ContentType == ContentType.GameClient;
+        return publisherMatches && isGameClient;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ContentManifest>> CreateManifestsFromExtractedContentAsync(
+        ContentManifest originalManifest,
+        string extractedDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Creating GeneralsOnline manifests from extracted content in: {Directory}", extractedDirectory);
+
+        // Create release info from original manifest
+        var release = CreateReleaseFromManifest(originalManifest);
+
+        // Create both variant manifests
+        var manifests = CreateManifests(release);
+
+        // Update manifests with extracted files
+        return await UpdateManifestsWithExtractedFiles(manifests, extractedDirectory, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public string GetManifestDirectory(ContentManifest manifest, string extractedDirectory)
+    {
+        // GeneralsOnline uses the root extracted directory for all variants
+        return extractedDirectory;
+    }
+
+    /// <summary>
+    /// Creates two content manifests from a GeneralsOnline release - one for each variant (30Hz and 60Hz).
+    /// This creates the initial manifests with download URLs.
+    /// </summary>
+    /// <param name="release">The GeneralsOnlineRelease to create the manifests from.</param>
+    /// <returns>A list containing two ContentManifest instances (30Hz and 60Hz variants).</returns>
+    public List<ContentManifest> CreateManifests(GeneralsOnlineRelease release)
+    {
+        var manifests = new List<ContentManifest>();
+
+        // Create manifest for 30Hz variant
+        manifests.Add(CreateVariantManifest(release, GameClientConstants.GeneralsOnline30HzExecutable, GeneralsOnlineConstants.Variant30HzSuffix, GameClientConstants.GeneralsOnline30HzDisplayName));
+
+        // Create manifest for 60Hz variant
+        manifests.Add(CreateVariantManifest(release, GameClientConstants.GeneralsOnline60HzExecutable, GeneralsOnlineConstants.Variant60HzSuffix, GameClientConstants.GeneralsOnline60HzDisplayName));
+
+        return manifests;
+    }
+
+    /// <summary>
+    /// Parses a Generals Online version string to extract a numeric user version for manifest IDs.
+    /// Converts versions like "101525_QFE5" to a numeric value like 1015255.
+    /// </summary>
+    /// <param name="version">The version string (e.g., "101525_QFE5").</param>
+    /// <returns>A numeric version suitable for manifest IDs.</returns>
+    private static int ParseVersionForManifestId(string version)
+    {
+        try
+        {
+            var parts = version.Split(new[] { GeneralsOnlineConstants.QfeSeparator }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 2)
+            {
+                return 0;
+            }
+
+            var datePart = parts[0]; // "101525"
+            var qfePart = parts[1].Replace("QFE", string.Empty, StringComparison.OrdinalIgnoreCase);
+
+            if (!int.TryParse(datePart, out var dateValue) || !int.TryParse(qfePart, out var qfeValue))
+            {
+                return 0;
+            }
+
+            // Combine: 101525 * 10 + 5 = 1015255
+            return (dateValue * 10) + qfeValue;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Creates a release info object from a content manifest.
+    /// </summary>
+    private static GeneralsOnlineRelease CreateReleaseFromManifest(ContentManifest manifest)
+    {
+        var zipFile = manifest.Files.FirstOrDefault(f =>
+            f.DownloadUrl?.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase) == true);
+
+        return new GeneralsOnlineRelease
+        {
+            Version = manifest.Version ?? "unknown",
+            VersionDate = DateTime.Now,
+            ReleaseDate = manifest.Metadata?.ReleaseDate ?? DateTime.Now,
+            PortableUrl = zipFile?.DownloadUrl ?? string.Empty,
+            PortableSize = zipFile?.Size ?? GeneralsOnlineConstants.DefaultPortableSize,
+            Changelog = manifest.Metadata?.ChangelogUrl,
+        };
+    }
+
+    /// <summary>
+    /// Updates two manifests (30Hz and 60Hz) with extracted file information.
+    /// Computes SHA-256 hashes for all files for CAS integration.
+    /// Each variant gets only the files it needs plus shared files.
+    /// </summary>
+    /// <param name="manifests">The original content manifests to update (30Hz and 60Hz).</param>
+    /// <param name="extractPath">The path to the directory containing extracted files.</param>
+    /// <param name="cancellationToken">Token to cancel the operation if needed.</param>
+    /// <returns>Updated content manifests with file hashes and details.</returns>
+    private async Task<List<ContentManifest>> UpdateManifestsWithExtractedFiles(
+        List<ContentManifest> manifests,
+        string extractPath,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Updating manifests with extracted files from: {Path}", extractPath);
+
+        var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
+        logger.LogInformation("Processing {Count} files", allFiles.Length);
+
+        var filesWithHashes = new List<(string relativePath, FileInfo fileInfo, string hash)>();
+
+        foreach (var filePath in allFiles)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            var relativePath = Path.GetRelativePath(extractPath, filePath);
+            var fileInfo = new FileInfo(filePath);
+
+            string hash;
+            using (var stream = File.OpenRead(filePath))
+            {
+                var hashBytes = await SHA256.HashDataAsync(stream, cancellationToken);
+                hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+            }
+
+            filesWithHashes.Add((relativePath, fileInfo, hash));
+            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash})", relativePath, fileInfo.Length, hash[..8]);
+        }
+
+        var updatedManifests = new List<ContentManifest>();
+
+        foreach (var manifest in manifests)
+        {
+            var manifestFiles = new List<ManifestFile>();
+
+            var is30Hz = manifest.Name.Contains(GeneralsOnlineConstants.Variant30HzSuffix, StringComparison.OrdinalIgnoreCase);
+            var targetExecutable = is30Hz
+                ? GameClientConstants.GeneralsOnline30HzExecutable.ToLowerInvariant()
+                : GameClientConstants.GeneralsOnline60HzExecutable.ToLowerInvariant();
+
+            foreach (var (relativePath, fileInfo, hash) in filesWithHashes)
+            {
+                var fileName = Path.GetFileName(relativePath).ToLowerInvariant();
+                var isExecutable = false;
+
+                if (fileName == targetExecutable)
+                {
+                    isExecutable = true;
+                }
+                else if (fileName == GameClientConstants.GeneralsOnline30HzExecutable.ToLowerInvariant() ||
+                         fileName == GameClientConstants.GeneralsOnline60HzExecutable.ToLowerInvariant())
+                {
+                    continue;
+                }
+
+                manifestFiles.Add(new ManifestFile
+                {
+                    RelativePath = relativePath,
+                    Size = fileInfo.Length,
+                    Hash = hash,
+                    SourceType = ContentSourceType.ContentAddressable,
+                    SourcePath = fileInfo.FullName,
+                    IsExecutable = isExecutable,
+                });
+            }
+
+            logger.LogInformation("Manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
+
+            updatedManifests.Add(new ContentManifest
+            {
+                Id = manifest.Id,
+                Name = manifest.Name,
+                Version = manifest.Version,
+                ContentType = manifest.ContentType,
+                TargetGame = manifest.TargetGame,
+                Publisher = manifest.Publisher,
+                Metadata = manifest.Metadata,
+                Files = manifestFiles,
+                Dependencies = manifest.Dependencies,
+            });
+        }
+
+        return updatedManifests;
+    }
+
+    /// <summary>
+    /// Creates a content manifest for a specific Generals Online variant.
+    /// </summary>
+    /// <param name="release">The Generals Online release information.</param>
+    /// <param name="executableName">The executable filename for this variant.</param>
+    /// <param name="variantSuffix">The suffix for the manifest ID (e.g., "30hz").</param>
+    /// <param name="displayName">The display name for this variant (e.g., "GeneralsOnline 30Hz").</param>
+    /// <returns>A content manifest for the specified variant.</returns>
+    private ContentManifest CreateVariantManifest(
+        GeneralsOnlineRelease release,
+        string executableName,
+        string variantSuffix,
+        string displayName)
+    {
+        // Parse version to extract numeric version (remove dots and QFE markers)
+        var userVersion = ParseVersionForManifestId(release.Version);
+
+        // Content name for GeneralsOnline (publisher is "generalsonline", content is the variant)
+        // This will create IDs like: 1.1015255.generalsonline.gameclient.30hz
+        var contentName = variantSuffix;
+
+        var manifestId = ManifestId.Create(ManifestIdGenerator.GeneratePublisherContentId(
+            PublisherTypeConstants.GeneralsOnline,
+            ContentType.GameClient,
+            contentName,
+            userVersion));
+
+        return new ContentManifest
+        {
+            Id = manifestId,
+            Name = displayName,
+            Version = release.Version,
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            Publisher = new PublisherInfo
+            {
+                Name = GeneralsOnlineConstants.PublisherName,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+                Website = GeneralsOnlineConstants.WebsiteUrl,
+                SupportUrl = GeneralsOnlineConstants.SupportUrl,
+                ContentIndexUrl = GeneralsOnlineConstants.DownloadPageUrl,
+                UpdateCheckIntervalHours = GeneralsOnlineConstants.UpdateCheckIntervalHours,
+            },
+            Metadata = new ContentMetadata
+            {
+                Description = GeneralsOnlineConstants.ShortDescription,
+                ReleaseDate = release.ReleaseDate,
+                IconUrl = GeneralsOnlineConstants.IconUrl,
+                Tags = new List<string>(GeneralsOnlineConstants.Tags),
+                ChangelogUrl = release.Changelog,
+            },
+            Files = new List<ManifestFile>
+            {
+                new ManifestFile
+                {
+                    RelativePath = Path.GetFileName(release.PortableUrl),
+                    DownloadUrl = release.PortableUrl,
+                    Size = release.PortableSize,
+                    SourceType = ContentSourceType.RemoteDownload,
+                    Hash = string.Empty,
+                },
+            },
+            Dependencies = new List<ContentDependency>
+            {
+                new ContentDependency
+                {
+                    Name = GameClientConstants.ZeroHourInstallationDependencyName,
+                    DependencyType = ContentType.GameInstallation,
+                    MinVersion = ManifestConstants.ZeroHourManifestVersion,
+                },
+            },
+        };
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -1,0 +1,191 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Features.Content.Services.ContentProviders;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Content provider for Generals Online multiplayer service.
+/// Orchestrates discovery, resolution, and delivery through the content pipeline.
+/// </summary>
+public class GeneralsOnlineProvider(
+    IEnumerable<IContentDiscoverer> discoverers,
+    IEnumerable<IContentResolver> resolvers,
+    IEnumerable<IContentDeliverer> deliverers,
+    IContentValidator contentValidator,
+    IContentManifestPool manifestPool,
+    ILogger<GeneralsOnlineProvider> logger)
+    : BaseContentProvider(contentValidator, logger)
+{
+    /// <inheritdoc />
+    public override string SourceName => GeneralsOnlineConstants.PublisherType;
+
+    /// <inheritdoc />
+    public override string Description => GeneralsOnlineConstants.Description;
+
+    /// <inheritdoc />
+    public override bool IsEnabled => true;
+
+    /// <inheritdoc />
+    public override ContentSourceCapabilities Capabilities =>
+        ContentSourceCapabilities.RequiresDiscovery |
+        ContentSourceCapabilities.SupportsPackageAcquisition;
+
+    /// <inheritdoc />
+    protected override IContentDiscoverer Discoverer =>
+        discoverers.FirstOrDefault(d =>
+            d.SourceName.Equals(
+                GeneralsOnlineConstants.DiscovererSourceName,
+                StringComparison.OrdinalIgnoreCase))!;
+
+    /// <inheritdoc />
+    protected override IContentResolver Resolver =>
+        resolvers.FirstOrDefault(r =>
+            r.ResolverId.Equals(
+                GeneralsOnlineConstants.ResolverId,
+                StringComparison.OrdinalIgnoreCase))!;
+
+    /// <inheritdoc />
+    protected override IContentDeliverer Deliverer =>
+        deliverers.FirstOrDefault(d =>
+            d.SourceName.Equals(
+                GeneralsOnlineConstants.DelivererSourceName,
+                StringComparison.OrdinalIgnoreCase))!;
+
+    /// <inheritdoc />
+    public override async Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
+    string contentId,
+    CancellationToken cancellationToken = default)
+    {
+        Logger.LogInformation("Getting Generals Online manifest for: {ContentId}", contentId);
+
+        try
+        {
+            // ContentId format from discoverer: "GeneralsOnline_{Version}" (e.g., "GeneralsOnline_101525_QFE5")
+            // Manifest IDs in pool: "1.1015255.generalsonline.gameclient.30hz" or "1.1015255.generalsonline.gameclient.60hz"
+            if (!contentId.StartsWith("GeneralsOnline_", StringComparison.OrdinalIgnoreCase))
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Invalid contentId format: '{contentId}'. Expected format: 'GeneralsOnline_{{version}}'");
+            }
+
+            var version = contentId.Substring("GeneralsOnline_".Length);
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Invalid version in contentId: '{contentId}'");
+            }
+
+            // Check if already installed - search all manifests and filter in-memory
+            var allManifestsResult = await manifestPool.GetAllManifestsAsync(cancellationToken);
+
+            if (allManifestsResult.Success && allManifestsResult.Data != null)
+            {
+                // Find any GeneralsOnline manifest with matching version (30hz or 60hz)
+                var existing = allManifestsResult.Data.FirstOrDefault(m =>
+                    string.Equals(m.Version, version, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(m.Publisher?.PublisherType, GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase));
+
+                if (existing != null)
+                {
+                    Logger.LogInformation(
+                        "Found existing manifest for version {Version}: {ManifestId}",
+                        version,
+                        existing.Id);
+                    return OperationResult<ContentManifest>.CreateSuccess(existing);
+                }
+            }
+
+            // Not found - resolve new manifest
+            var searchResultObj = new ContentSearchResult
+            {
+                Id = contentId,
+                Name = GeneralsOnlineConstants.ContentName,
+                Version = version, // Use parsed version, not full contentId
+                ProviderName = SourceName,
+                RequiresResolution = true,
+                ResolverId = GeneralsOnlineConstants.ResolverId,
+            };
+
+            var manifestResult = await Resolver.ResolveAsync(searchResultObj, cancellationToken);
+            if (!manifestResult.Success || manifestResult.Data == null)
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Failed to resolve manifest: {manifestResult.FirstError}");
+            }
+
+            var validationResult = await ContentValidator.ValidateManifestAsync(
+                manifestResult.Data,
+                cancellationToken);
+
+            if (!validationResult.IsValid)
+            {
+                var errors = validationResult.Issues.Select(i => $"Validation failed: {i.Message}");
+                return OperationResult<ContentManifest>.CreateFailure(errors);
+            }
+
+            return manifestResult;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to get validated content for {ContentId}", contentId);
+            return OperationResult<ContentManifest>.CreateFailure(
+                $"Content validation failed: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        Logger.LogInformation("Preparing Generals Online content: {Version}", manifest.Version);
+
+        try
+        {
+            // Use the deliverer to handle content acquisition
+            if (!Deliverer.CanDeliver(manifest))
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Cannot deliver content for manifest {manifest.Id}");
+            }
+
+            var deliveryResult = await Deliverer.DeliverContentAsync(
+                manifest,
+                workingDirectory,
+                progress,
+                cancellationToken);
+            if (!deliveryResult.Success)
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Content delivery failed: {deliveryResult.FirstError}");
+            }
+
+            // Ensure we have valid data before validation
+            var resultManifest = deliveryResult.Data ?? manifest;
+
+            Logger.LogInformation("Successfully prepared Generals Online content {ManifestId}", manifest.Id);
+            return OperationResult<ContentManifest>.CreateSuccess(resultManifest);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to prepare Generals Online content");
+            return OperationResult<ContentManifest>.CreateFailure(
+                $"Content preparation failed: {ex.Message}");
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -38,30 +38,35 @@ public class GeneralsOnlineProvider(
     public override bool IsEnabled => true;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Capabilities:
+    /// - RequiresDiscovery: Provider queries CDN API to find available releases
+    /// - SupportsPackageAcquisition: Provider can download and install content packages.
+    /// </remarks>
     public override ContentSourceCapabilities Capabilities =>
         ContentSourceCapabilities.RequiresDiscovery |
         ContentSourceCapabilities.SupportsPackageAcquisition;
 
     /// <inheritdoc />
     protected override IContentDiscoverer Discoverer =>
-        discoverers.FirstOrDefault(d =>
+        discoverers.First(d =>
             d.SourceName.Equals(
                 GeneralsOnlineConstants.DiscovererSourceName,
-                StringComparison.OrdinalIgnoreCase))!;
+                StringComparison.OrdinalIgnoreCase));
 
     /// <inheritdoc />
     protected override IContentResolver Resolver =>
-        resolvers.FirstOrDefault(r =>
+        resolvers.First(r =>
             r.ResolverId.Equals(
                 GeneralsOnlineConstants.ResolverId,
-                StringComparison.OrdinalIgnoreCase))!;
+                StringComparison.OrdinalIgnoreCase));
 
     /// <inheritdoc />
     protected override IContentDeliverer Deliverer =>
-        deliverers.FirstOrDefault(d =>
+        deliverers.First(d =>
             d.SourceName.Equals(
                 GeneralsOnlineConstants.DelivererSourceName,
-                StringComparison.OrdinalIgnoreCase))!;
+                StringComparison.OrdinalIgnoreCase));
 
     /// <inheritdoc />
     public override async Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
@@ -147,6 +152,10 @@ public class GeneralsOnlineProvider(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// This is the internal implementation called by the base class's public PrepareContentAsync method.
+    /// The base class handles common validation and error handling, then delegates to this method.
+    /// </remarks>
     protected override async Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
         ContentManifest manifest,
         string workingDirectory,

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineResolver.cs
@@ -1,0 +1,65 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.GeneralsOnline;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Resolves Generals Online search results into ContentManifests.
+/// </summary>
+public class GeneralsOnlineResolver(GeneralsOnlineManifestFactory manifestFactory, ILogger<GeneralsOnlineResolver> logger) : IContentResolver
+{
+    /// <inheritdoc />
+    public string ResolverId => GeneralsOnlineConstants.ResolverId;
+
+    /// <summary>
+    /// Resolves a Generals Online search result into a content manifest.
+    /// Returns the 30Hz variant; deliverer will create and register both variants.
+    /// </summary>
+    /// <param name="searchResult">The search result to resolve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result containing the resolved manifest.</returns>
+    public async Task<OperationResult<ContentManifest>> ResolveAsync(
+        ContentSearchResult searchResult,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Resolving Generals Online manifest for: {Version}", searchResult.Version);
+
+        try
+        {
+            var release = searchResult.GetData<GeneralsOnlineRelease>();
+            if (release == null)
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    "Release information not found in search result");
+            }
+
+            var manifests = manifestFactory.CreateManifests(release);
+            var primaryManifest = manifests.FirstOrDefault();
+
+            if (primaryManifest == null)
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    "Failed to create manifests from release");
+            }
+
+            logger.LogInformation("Successfully resolved Generals Online manifest ({Variant})", primaryManifest.Name);
+
+            return await Task.FromResult(
+                OperationResult<ContentManifest>.CreateSuccess(primaryManifest));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to resolve Generals Online manifest");
+            return OperationResult<ContentManifest>.CreateFailure(
+                $"Resolution failed: {ex.Message}");
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateService.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateService.cs
@@ -1,0 +1,190 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Manifest;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Background service for checking Generals Online updates.
+/// Polls CDN for new releases and notifies when updates are available.
+/// </summary>
+public class GeneralsOnlineUpdateService : ContentUpdateServiceBase
+{
+    private readonly ILogger<GeneralsOnlineUpdateService> _logger;
+    private readonly IContentManifestPool _manifestPool;
+    private readonly HttpClient _httpClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeneralsOnlineUpdateService"/> class.
+    /// </summary>
+    /// <param name="logger">The logger for diagnostic information.</param>
+    /// <param name="manifestPool">The content manifest pool.</param>
+    public GeneralsOnlineUpdateService(
+        ILogger<GeneralsOnlineUpdateService> logger,
+        IContentManifestPool manifestPool)
+        : base(logger)
+    {
+        _logger = logger;
+        _manifestPool = manifestPool;
+        _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        _httpClient?.Dispose();
+        base.Dispose();
+    }
+
+    /// <inheritdoc />
+    protected override string ServiceName => GeneralsOnlineConstants.ContentName;
+
+    /// <inheritdoc />
+    protected override TimeSpan UpdateCheckInterval =>
+        TimeSpan.FromHours(GeneralsOnlineConstants.UpdateCheckIntervalHours);
+
+    /// <inheritdoc />
+    protected override async Task<(bool UpdateAvailable, string? LatestVersion, string? CurrentVersion)>
+        CheckForUpdatesImplAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Checking for Generals Online updates");
+
+        try
+        {
+            // Get current installed version
+            var currentVersion = await GetInstalledVersionAsync(cancellationToken);
+
+            // Get latest version from CDN
+            var latestVersion = await GetLatestVersionFromCdnAsync(cancellationToken);
+
+            if (string.IsNullOrEmpty(latestVersion))
+            {
+                _logger.LogWarning("Could not retrieve latest version from CDN");
+                return (false, null, currentVersion);
+            }
+
+            var updateAvailable = IsNewerVersion(latestVersion, currentVersion);
+
+            return (updateAvailable, latestVersion, currentVersion);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check for Generals Online updates");
+            throw;
+        }
+    }
+
+    private async Task<string?> GetInstalledVersionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var manifests = await _manifestPool.GetAllManifestsAsync(cancellationToken);
+            if (!manifests.Success || manifests.Data == null)
+            {
+                return null;
+            }
+
+            var goManifest = manifests.Data.FirstOrDefault(m =>
+                m.Publisher?.PublisherType?.Equals(GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase) == true);
+
+            return goManifest?.Version;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get installed Generals Online version");
+            return null;
+        }
+    }
+
+    private async Task<string?> GetLatestVersionFromCdnAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Try to get version from latest.txt
+            var response = await _httpClient.GetAsync(GeneralsOnlineConstants.LatestVersionUrl, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var version = await response.Content.ReadAsStringAsync(cancellationToken);
+                return version?.Trim();
+            }
+
+            _logger.LogWarning("latest.txt not available, status code: {StatusCode}", response.StatusCode);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get latest version from CDN");
+            return null;
+        }
+    }
+
+    private bool IsNewerVersion(string latestVersion, string? currentVersion)
+    {
+        if (string.IsNullOrEmpty(currentVersion))
+        {
+            return true; // Any version is newer than nothing
+        }
+
+        // Parse DDMMYY_QFE# format
+        var latest = ParseVersion(latestVersion);
+        var current = ParseVersion(currentVersion);
+
+        if (latest == null || current == null)
+        {
+            return false;
+        }
+
+        // Compare date first
+        if (latest.Value.date > current.Value.date)
+        {
+            return true;
+        }
+
+        if (latest.Value.date == current.Value.date)
+        {
+            // Same date, compare QFE number
+            return latest.Value.qfe > current.Value.qfe;
+        }
+
+        return false;
+    }
+
+    private (DateTime date, int qfe)? ParseVersion(string version)
+    {
+        try
+        {
+            // Format: DDMMYY_QFE#
+            var parts = version.Split('_');
+            if (parts.Length != 2)
+            {
+                return null;
+            }
+
+            var datePart = parts[0];
+            var qfePart = parts[1].Replace("QFE", string.Empty);
+
+            if (datePart.Length != 6 || !int.TryParse(qfePart, out var qfe))
+            {
+                return null;
+            }
+
+            var month = int.Parse(datePart.Substring(0, 2));
+            var day = int.Parse(datePart.Substring(2, 2));
+            var year = 2000 + int.Parse(datePart.Substring(4, 2));
+
+            var date = new DateTime(year, month, day);
+            return (date, qfe);
+        }
+        catch
+        {
+            _logger.LogWarning("Failed to parse version: {Version}", version);
+            return null;
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
@@ -1,0 +1,42 @@
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Manifest;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GenHub.Features.Content.Services.Publishers;
+
+/// <summary>
+/// Resolves the appropriate publisher-specific manifest factory for a given manifest.
+/// </summary>
+public class PublisherManifestFactoryResolver(IEnumerable<IPublisherManifestFactory> factories, ILogger<PublisherManifestFactoryResolver> logger)
+{
+    /// <summary>
+    /// Resolves the appropriate factory for the given manifest.
+    /// </summary>
+    /// <param name="manifest">The manifest to resolve a factory for.</param>
+    /// <returns>The appropriate publisher-specific factory, or null if no factory can handle the manifest.</returns>
+    public IPublisherManifestFactory? ResolveFactory(ContentManifest manifest)
+    {
+        // Try to find a specialized factory that can handle this manifest
+        var factory = factories.FirstOrDefault(f => f.CanHandle(manifest));
+
+        if (factory != null)
+        {
+            logger.LogInformation(
+                "Resolved {FactoryType} for manifest {ManifestId} (Publisher: {Publisher})",
+                factory.GetType().Name,
+                manifest.Id,
+                manifest.Publisher?.PublisherType ?? "Unknown");
+            return factory;
+        }
+
+        logger.LogWarning(
+            "No factory found for manifest {ManifestId} (Publisher: {Publisher}, ContentType: {ContentType})",
+            manifest.Id,
+            manifest.Publisher?.PublisherType ?? "Unknown",
+            manifest.ContentType);
+
+        return null;
+    }
+}

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -1,4 +1,5 @@
 using GenHub.Common.Services;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GitHub;
@@ -13,6 +14,7 @@ using GenHub.Features.Content.Services.Publishers;
 using GenHub.Features.GitHub.Services;
 using GenHub.Features.Manifest;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace GenHub.Infrastructure.DependencyInjection;
 
@@ -56,6 +58,12 @@ public static class ContentPipelineModule
 
         // Register HTTP client factory for content providers
         services.AddHttpClient();
+
+        // Register named HTTP client for Generals Online
+        services.AddHttpClient(GeneralsOnlineConstants.PublisherType, static httpClient =>
+        {
+            httpClient.Timeout = TimeSpan.FromSeconds(30);
+        });
 
         // Register core storage and manifest services
         services.AddSingleton<IContentStorageService, ContentStorageService>();

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -8,6 +8,8 @@ using GenHub.Features.Content.Services.ContentDeliverers;
 using GenHub.Features.Content.Services.ContentDiscoverers;
 using GenHub.Features.Content.Services.ContentProviders;
 using GenHub.Features.Content.Services.ContentResolvers;
+using GenHub.Features.Content.Services.GeneralsOnline;
+using GenHub.Features.Content.Services.Publishers;
 using GenHub.Features.GitHub.Services;
 using GenHub.Features.Manifest;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +28,24 @@ public static class ContentPipelineModule
     /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddContentPipelineServices(this IServiceCollection services)
     {
+        // Register core services
+        AddCoreServices(services);
+
+        // Register content pipelines
+        AddGitHubPipeline(services);
+        AddGeneralsOnlinePipeline(services);
+        AddCNCLabsPipeline(services);
+        AddLocalFileSystemPipeline(services);
+        AddSharedComponents(services);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers core services required by all pipelines.
+    /// </summary>
+    private static void AddCoreServices(IServiceCollection services)
+    {
         // Register core hash provider
         var hashProvider = new Sha256HashProvider();
         services.AddSingleton<IFileHashProvider>(hashProvider);
@@ -33,6 +53,9 @@ public static class ContentPipelineModule
 
         // Register memory cache
         services.AddMemoryCache();
+
+        // Register HTTP client factory for content providers
+        services.AddHttpClient();
 
         // Register core storage and manifest services
         services.AddSingleton<IContentStorageService, ContentStorageService>();
@@ -46,30 +69,90 @@ public static class ContentPipelineModule
 
         // Register GitHub API client
         services.AddSingleton<IGitHubApiClient, OctokitGitHubApiClient>();
+    }
 
-        // Register concrete content providers only
+    /// <summary>
+    /// Registers GitHub content pipeline services.
+    /// </summary>
+    private static void AddGitHubPipeline(IServiceCollection services)
+    {
+        // Register GitHub content provider
         services.AddTransient<IContentProvider, GitHubContentProvider>();
-        services.AddTransient<IContentProvider, CNCLabsContentProvider>();
 
-        // TODO: Implement ModDB discoverer and resolver
-        // services.AddTransient<IContentProvider, ModDBContentProvider>();
-        services.AddTransient<IContentProvider, LocalFileSystemContentProvider>();
-
-        // Register content discoverers
+        // Register GitHub discoverers
         services.AddTransient<IContentDiscoverer, GitHubDiscoverer>();
         services.AddTransient<IContentDiscoverer, GitHubReleasesDiscoverer>();
+
+        // Register GitHub resolver
+        services.AddTransient<IContentResolver, GitHubResolver>();
+    }
+
+    /// <summary>
+    /// Registers Generals Online content pipeline services.
+    /// </summary>
+    private static void AddGeneralsOnlinePipeline(IServiceCollection services)
+    {
+        // Register Generals Online provider
+        services.AddTransient<IContentProvider, GeneralsOnlineProvider>();
+
+        // Register Generals Online discoverer
+        services.AddTransient<IContentDiscoverer, GeneralsOnlineDiscoverer>();
+
+        // Register Generals Online resolver
+        services.AddTransient<IContentResolver, GeneralsOnlineResolver>();
+
+        // Register Generals Online deliverer
+        services.AddTransient<IContentDeliverer, GeneralsOnlineDeliverer>();
+
+        // Register Generals Online manifest factory
+        services.AddTransient<GeneralsOnlineManifestFactory>();
+
+        // Register Generals Online update service
+        services.AddSingleton<GeneralsOnlineUpdateService>();
+    }
+
+    /// <summary>
+    /// Registers CNCLabs content pipeline services.
+    /// </summary>
+    private static void AddCNCLabsPipeline(IServiceCollection services)
+    {
+        // Register CNCLabs content provider
+        services.AddTransient<IContentProvider, CNCLabsContentProvider>();
+
+        // Register CNCLabs discoverer
         services.AddTransient<IContentDiscoverer, CNCLabsMapDiscoverer>();
+
+        // Register CNCLabs resolver
+        services.AddTransient<IContentResolver, CNCLabsMapResolver>();
+    }
+
+    /// <summary>
+    /// Registers Local File System content pipeline services.
+    /// </summary>
+    private static void AddLocalFileSystemPipeline(IServiceCollection services)
+    {
+        // Register Local File System content provider
+        services.AddTransient<IContentProvider, LocalFileSystemContentProvider>();
+
+        // Register File System discoverer
         services.AddTransient<IContentDiscoverer, FileSystemDiscoverer>();
 
-        // Register content resolvers
-        services.AddTransient<IContentResolver, GitHubResolver>();
-        services.AddTransient<IContentResolver, CNCLabsMapResolver>();
+        // Register Local Manifest resolver
         services.AddTransient<IContentResolver, LocalManifestResolver>();
 
-        // Register content deliverers
-        services.AddTransient<IContentDeliverer, HttpContentDeliverer>();
+        // Register File System deliverer
         services.AddTransient<IContentDeliverer, FileSystemDeliverer>();
+    }
 
-        return services;
+    /// <summary>
+    /// Registers shared components used across multiple pipelines.
+    /// </summary>
+    private static void AddSharedComponents(IServiceCollection services)
+    {
+        // Register shared deliverers
+        services.AddTransient<IContentDeliverer, HttpContentDeliverer>();
+
+        // Register publisher manifest factory resolver
+        services.AddTransient<PublisherManifestFactoryResolver>();
     }
 }


### PR DESCRIPTION
* Merge after 
* #186 
* #188

This PR implements the content-pipeline service for generals online using the discoverer, resolver and deliverer components. See #177 for the full implementation wired up.

