### PR TITLE
feat(publisher): implement publisher manifest factory

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/Content/IPublisherManifestFactory.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IPublisherManifestFactory.cs
@@ -1,0 +1,44 @@
+using GenHub.Core.Models.Manifest;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Interface for publisher-specific manifest factories that handle content extraction,
+/// manifest generation, and multi-variant support for GitHub releases.
+/// </summary>
+public interface IPublisherManifestFactory
+{
+    /// <summary>
+    /// Gets the publisher identifier this factory handles (e.g., "thesuperhackers", "generalsonline").
+    /// </summary>
+    string PublisherId { get; }
+
+    /// <summary>
+    /// Determines if this factory can handle the given manifest based on publisher and content type.
+    /// </summary>
+    /// <param name="manifest">The manifest to check.</param>
+    /// <returns>True if this factory can handle the manifest.</returns>
+    bool CanHandle(ContentManifest manifest);
+
+    /// <summary>
+    /// Creates manifests from extracted GitHub release content.
+    /// May return multiple manifests for multi-variant releases (e.g., Generals + Zero Hour).
+    /// </summary>
+    /// <param name="originalManifest">The original manifest from GitHub resolution.</param>
+    /// <param name="extractedDirectory">The directory containing extracted files.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of content manifests (one or more depending on variants detected).</returns>
+    Task<List<ContentManifest>> CreateManifestsFromExtractedContentAsync(
+        ContentManifest originalManifest,
+        string extractedDirectory,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the subdirectory for a specific manifest variant.
+    /// Used to determine where files should be stored for each variant.
+    /// </summary>
+    /// <param name="manifest">The manifest to get the directory for.</param>
+    /// <param name="extractedDirectory">The root extracted directory.</param>
+    /// <returns>The subdirectory path for this manifest's files.</returns>
+    string GetManifestDirectory(ContentManifest manifest, string extractedDirectory);
+}

--- a/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
@@ -1,0 +1,42 @@
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Manifest;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GenHub.Features.Content.Services.Publishers;
+
+/// <summary>
+/// Resolves the appropriate publisher-specific manifest factory for a given manifest.
+/// </summary>
+public class PublisherManifestFactoryResolver(IEnumerable<IPublisherManifestFactory> factories, ILogger<PublisherManifestFactoryResolver> logger)
+{
+    /// <summary>
+    /// Resolves the appropriate factory for the given manifest.
+    /// </summary>
+    /// <param name="manifest">The manifest to resolve a factory for.</param>
+    /// <returns>The appropriate publisher-specific factory, or null if no factory can handle the manifest.</returns>
+    public IPublisherManifestFactory? ResolveFactory(ContentManifest manifest)
+    {
+        // Try to find a specialized factory that can handle this manifest
+        var factory = factories.FirstOrDefault(f => f.CanHandle(manifest));
+
+        if (factory != null)
+        {
+            logger.LogInformation(
+                "Resolved {FactoryType} for manifest {ManifestId} (Publisher: {Publisher})",
+                factory.GetType().Name,
+                manifest.Id,
+                manifest.Publisher?.PublisherType ?? "Unknown");
+            return factory;
+        }
+
+        logger.LogWarning(
+            "No factory found for manifest {ManifestId} (Publisher: {Publisher}, ContentType: {ContentType})",
+            manifest.Id,
+            manifest.Publisher?.PublisherType ?? "Unknown",
+            manifest.ContentType);
+
+        return null;
+    }
+}


### PR DESCRIPTION
This PR introduces a `IPublisherManifestFactory` interface that publishers can use to create factory implementations like for example `SuperHackersManifestFactory`, `GeneralsOnlineManifestFactory`, `CommunityOutpostManifestFactory` for generating `ContentManifests`.