### PR TITLE
refactor: change download result createfailure method

### DIFF
--- a/GenHub/GenHub.Core/Models/Results/Download/DownloadResult.cs
+++ b/GenHub/GenHub.Core/Models/Results/Download/DownloadResult.cs
@@ -1,29 +1,73 @@
 namespace GenHub.Core.Models.Results;
 
-/// <summary>Result of a file download operation.</summary>
-public class DownloadResult(bool success, string? filePath = null, long bytesDownloaded = 0, string? errorMessage = null, TimeSpan? elapsed = null, bool hashVerified = false)
-    : ResultBase(success, errorMessage, elapsed ?? TimeSpan.Zero)
+/// <summary>
+/// Result of a file download operation.
+/// </summary>
+public class DownloadResult : ResultBase
 {
-    /// <summary>Gets the path to the downloaded file.</summary>
-    public string? FilePath { get; } = filePath;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DownloadResult"/> class.
+    /// Initializes a new instance of the DownloadResult class.
+    /// </summary>
+    /// <param name="success">Indicates if the operation was successful.</param>
+    /// <param name="filePath">The path to the downloaded file.</param>
+    /// <param name="bytesDownloaded">The number of bytes downloaded.</param>
+    /// <param name="elapsed">The elapsed time.</param>
+    /// <param name="hashVerified">Whether the hash was verified.</param>
+    /// <param name="averageSpeedBytesPerSecond">The average speed.</param>
+    /// <param name="errors">The errors.</param>
+    protected DownloadResult(
+        bool success,
+        string? filePath,
+        long bytesDownloaded,
+        TimeSpan elapsed,
+        bool hashVerified,
+        double averageSpeedBytesPerSecond,
+        IEnumerable<string>? errors = null)
+        : base(success, errors, elapsed)
+    {
+        FilePath = filePath;
+        BytesDownloaded = bytesDownloaded;
+        HashVerified = hashVerified;
+        AverageSpeedBytesPerSecond = averageSpeedBytesPerSecond;
+        FormattedBytesDownloaded = FormatBytes(bytesDownloaded);
+        FormattedSpeed = FormatSpeed(averageSpeedBytesPerSecond);
+    }
 
-    /// <summary>Gets the number of bytes downloaded.</summary>
-    public long BytesDownloaded { get; } = bytesDownloaded;
+    /// <summary>
+    /// Gets the path to the downloaded file.
+    /// </summary>
+    public string? FilePath { get; }
 
-    /// <summary>Gets a value indicating whether hash verification passed.</summary>
-    public bool HashVerified { get; } = hashVerified;
+    /// <summary>
+    /// Gets the number of bytes downloaded.
+    /// </summary>
+    public long BytesDownloaded { get; }
 
-    /// <summary>Gets the average download speed in bytes per second.</summary>
-    public long AverageSpeedBytesPerSecond =>
-        Elapsed.TotalSeconds > 0 ? (long)(BytesDownloaded / Elapsed.TotalSeconds) : 0;
+    /// <summary>
+    /// Gets a value indicating whether the hash verification passed.
+    /// </summary>
+    public bool HashVerified { get; }
 
-    /// <summary>Gets the formatted bytes downloaded (e.g. "1.2 MB").</summary>
-    public string FormattedBytesDownloaded => FormatBytes(BytesDownloaded);
+    /// <summary>
+    /// Gets the average download speed in bytes per second.
+    /// </summary>
+    public double AverageSpeedBytesPerSecond { get; }
 
-    /// <summary>Gets the formatted average download speed (e.g. "1.2 MB/s").</summary>
-    public string FormattedSpeed => FormatBytes(AverageSpeedBytesPerSecond) + "/s";
+    /// <summary>
+    /// Gets the formatted bytes downloaded (e.g., "1.2 MB").
+    /// </summary>
+    public string FormattedBytesDownloaded { get; private set; } = string.Empty;
 
-    /// <summary>Gets the error message if the download failed.</summary>
+    /// <summary>
+    /// Gets the formatted average download speed (e.g., "1.2 MB/s").
+    /// </summary>
+    public string FormattedSpeed { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the error message if the download failed.
+    /// </summary>
+    [Obsolete("Use FirstError instead. This property will be removed in a future version.")]
     public string? ErrorMessage => FirstError;
 
     /// <summary>
@@ -38,23 +82,30 @@ public class DownloadResult(bool success, string? filePath = null, long bytesDow
         string filePath,
         long bytesDownloaded,
         TimeSpan elapsed,
-        bool hashVerified = false) =>
-        new(true, filePath, bytesDownloaded, null, elapsed, hashVerified);
+        bool hashVerified = false)
+    {
+        var averageSpeed = elapsed.TotalSeconds > 0 ? bytesDownloaded / elapsed.TotalSeconds : 0;
+        return new DownloadResult(true, filePath, bytesDownloaded, elapsed, hashVerified, averageSpeed);
+    }
 
     /// <summary>
     /// Creates a failed download result.
     /// </summary>
     /// <param name="errorMessage">The error message.</param>
-    /// <param name="bytesDownloaded">The number of bytes downloaded before failure.</param>
+    /// <param name="bytesDownloaded">The bytes downloaded before failure.</param>
     /// <param name="elapsed">Time taken before failure.</param>
     /// <returns>A failed download result.</returns>
-    public static DownloadResult CreateFailed(
+    public static DownloadResult CreateFailure(
         string errorMessage,
         long bytesDownloaded = 0,
-        TimeSpan? elapsed = null) =>
-        new(false, null, bytesDownloaded, errorMessage, elapsed);
+        TimeSpan elapsed = default)
+    {
+        return new DownloadResult(false, null, bytesDownloaded, elapsed, false, 0, new[] { errorMessage });
+    }
 
-    /// <summary>Formats bytes into a human-readable string.</summary>
+    /// <summary>
+    /// Formats bytes into a human-readable string.
+    /// </summary>
     private static string FormatBytes(long bytes)
     {
         string[] sizes = { "B", "KB", "MB", "GB", "TB" };
@@ -66,6 +117,14 @@ public class DownloadResult(bool success, string? filePath = null, long bytesDow
             len = len / 1024;
         }
 
-        return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0} {1}", len, sizes[order]);
+        return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.##} {1}", len, sizes[order]);
+    }
+
+    /// <summary>
+    /// Formats bytes per second into a human-readable speed string.
+    /// </summary>
+    private static string FormatSpeed(double bytesPerSecond)
+    {
+        return FormatBytes((long)bytesPerSecond) + "/s";
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/UpdateInstallerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/UpdateInstallerTests.cs
@@ -133,7 +133,7 @@ public class UpdateInstallerTests : IDisposable
                 It.IsAny<DownloadConfiguration>(),
                 It.IsAny<IProgress<DownloadProgress>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(DownloadResult.CreateFailed("Download failed"));
+            .ReturnsAsync(DownloadResult.CreateFailure("Download failed"));
 
         using var installer = new TestUpdateInstaller(_mockDownloadService.Object, _mockLogger.Object);
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -230,7 +230,7 @@ public class FileOperationsServiceTests : IDisposable
             It.IsAny<DownloadConfiguration>(),
             It.IsAny<IProgress<DownloadProgress>>(),
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync(DownloadResult.CreateFailed("Failed"));
+            .ReturnsAsync(DownloadResult.CreateFailure("Failed"));
 
         var loggerMock = new Mock<ILogger<FileOperationsService>>();
         var fileOps = new FileOperationsService(loggerMock.Object, downloadServiceMock.Object, _casService.Object);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Results/DownloadResultTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Results/DownloadResultTests.cs
@@ -70,7 +70,7 @@ public class DownloadResultTests
         var elapsed = TimeSpan.FromSeconds(0.5);
 
         // Act
-        var result = DownloadResult.CreateFailed(error, bytesDownloaded, elapsed);
+        var result = DownloadResult.CreateFailure(error, bytesDownloaded, elapsed);
 
         // Assert
         Assert.False(result.Success);
@@ -94,7 +94,7 @@ public class DownloadResultTests
         var error = "Network error";
 
         // Act
-        var result = DownloadResult.CreateFailed(error);
+        var result = DownloadResult.CreateFailure(error);
 
         // Assert
         Assert.False(result.Success);
@@ -135,12 +135,12 @@ public class DownloadResultTests
     /// <param name="bytes">The number of bytes to format.</param>
     /// <param name="expected">The expected formatted string.</param>
     [Theory]
-    [InlineData(0, "0.0 B")]
-    [InlineData(1023, "1023.0 B")]
-    [InlineData(1024, "1.0 KB")]
+    [InlineData(0, "0 B")]
+    [InlineData(1023, "1023 B")]
+    [InlineData(1024, "1 KB")]
     [InlineData(1536, "1.5 KB")]
-    [InlineData(1048576, "1.0 MB")]
-    [InlineData(1073741824, "1.0 GB")]
+    [InlineData(1048576, "1 MB")]
+    [InlineData(1073741824, "1 GB")]
     public void FormattedBytesDownloaded_FormatsCorrectly(long bytes, string expected)
     {
         // Arrange
@@ -160,9 +160,9 @@ public class DownloadResultTests
     /// <param name="seconds">The elapsed time in seconds.</param>
     /// <param name="expected">The expected formatted speed string.</param>
     [Theory]
-    [InlineData(1024, 1, "1.0 KB/s")]
-    [InlineData(1048576, 2, "512.0 KB/s")]
-    [InlineData(0, 1, "0.0 B/s")]
+    [InlineData(1024, 1, "1 KB/s")]
+    [InlineData(1048576, 2, "512 KB/s")]
+    [InlineData(0, 1, "0 B/s")]
     public void FormattedSpeed_FormatsCorrectly(long bytesDownloaded, double seconds, string expected)
     {
         // Arrange

--- a/GenHub/GenHub/Common/Services/DownloadService.cs
+++ b/GenHub/GenHub/Common/Services/DownloadService.cs
@@ -109,12 +109,12 @@ public class DownloadService(
                         errorMessage += $": {lastException.Message}";
                     }
 
-                    return DownloadResult.CreateFailed(errorMessage);
+                    return DownloadResult.CreateFailure(errorMessage);
                 }
             }
         }
 
-        return DownloadResult.CreateFailed($"Download failed after {configuration.MaxRetryAttempts} attempts (unexpected error)");
+        return DownloadResult.CreateFailure($"Download failed after {configuration.MaxRetryAttempts} attempts (unexpected error)");
     }
 
     private async Task<DownloadResult> PerformDownloadAsync(
@@ -180,7 +180,7 @@ public class DownloadService(
                     logger.LogWarning("Failed to delete corrupted file: {FilePath}", configuration.DestinationPath);
                 }
 
-                return DownloadResult.CreateFailed($"Hash verification failed. Expected: {configuration.ExpectedHash}, Actual: {actualHash}", downloadedBytes, stopwatch.Elapsed);
+                return DownloadResult.CreateFailure($"Hash verification failed. Expected: {configuration.ExpectedHash}, Actual: {actualHash}", downloadedBytes, stopwatch.Elapsed);
             }
         }
 


### PR DESCRIPTION
This PR updates the downloadResult class and refactors the `CreateFailed()` method to `CreateFailure()` in order to be consistent with other result classes