### PR TITLE
feat(manifest): add GitHub content ID generation method with version extraction

### DIFF
--- a/GenHub/GenHub.Core/Models/Manifest/ManifestIdGenerator.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ManifestIdGenerator.cs
@@ -207,11 +207,8 @@ public static class ManifestIdGenerator
         if (string.IsNullOrWhiteSpace(tag) || tag.Equals("latest", StringComparison.OrdinalIgnoreCase))
             return 0;
 
-        // Remove common prefixes
-        var cleaned = tag.TrimStart('v', 'V', 'r', 'R');
-
         // Extract all digits and concatenate
-        var digits = Regex.Replace(cleaned, @"[^\d]", string.Empty);
+        var digits = Regex.Replace(tag, @"[^\d]", string.Empty);
 
         if (string.IsNullOrEmpty(digits))
             return 0;


### PR DESCRIPTION
This PR adds a static method to the `ManifestIdGenerator` in order to generate a manifest ID derived from GitHub