### PR TITLE
refactor: HttpcontentDeliverer

### DIFF
--- a/GenHub/GenHub.Core/Constants/ContentSourceNames.cs
+++ b/GenHub/GenHub.Core/Constants/ContentSourceNames.cs
@@ -57,9 +57,19 @@ public static class ContentSourceNames
     // Deliverers
 
     /// <summary>
+    /// Source name for GitHub content deliverer.
+    /// </summary>
+    public const string GitHubDeliverer = "GitHub Content Deliverer";
+
+    /// <summary>
     /// Source name for HTTP content deliverer.
     /// </summary>
     public const string HttpDeliverer = "HTTP Content Deliverer";
+
+    /// <summary>
+    /// Description for HTTP content deliverer.
+    /// </summary>
+    public const string HttpDelivererDescription = "Delivers content from HTTP/HTTPS URLs";
 
     /// <summary>
     /// Source name for local file system deliverer.

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.Manifest;
@@ -25,10 +26,10 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
     private readonly ILogger<HttpContentDeliverer> _logger = logger;
 
     /// <inheritdoc />
-    public string SourceName => "HTTP Content Deliverer";
+    public string SourceName => ContentSourceNames.HttpDeliverer;
 
     /// <inheritdoc />
-    public string Description => "Delivers content from HTTP/HTTPS URLs";
+    public string Description => ContentSourceNames.HttpDelivererDescription;
 
     /// <inheritdoc />
     public bool IsEnabled => true;
@@ -55,10 +56,13 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
     {
         try
         {
-            // Use builder to create delivered manifest
+            // Extract publisher from the manifest ID (3rd segment)
+            var idSegments = packageManifest.Id.Value.Split('.');
+            var publisherId = idSegments.Length >= 3 ? idSegments[2] : "unknown";
+
             var manifestVersionInt = int.TryParse(packageManifest.Version, out var parsedVersion) ? parsedVersion : 0;
             var deliveredManifest = _manifestBuilder
-                .WithBasicInfo(packageManifest.Id, packageManifest.Name, manifestVersionInt)
+                .WithBasicInfo(publisherId, packageManifest.Name, manifestVersionInt)
                 .WithContentType(packageManifest.ContentType, packageManifest.TargetGame)
                 .WithPublisher(
                     packageManifest.Publisher?.Name ?? string.Empty,

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/LocalManifestResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/LocalManifestResolver.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
@@ -18,7 +19,7 @@ public class LocalManifestResolver(ILogger<LocalManifestResolver> logger) : ICon
     /// <summary>
     /// Gets the resolver ID for local manifest content.
     /// </summary>
-    public string ResolverId => "LocalManifest";
+    public string ResolverId => ContentSourceNames.LocalResolverId;
 
     /// <summary>
     /// Resolves the manifest for discovered local content asynchronously.


### PR DESCRIPTION
This PR simply refactors the `HttpContentDeliverer` to make use of the constants in `ContentSourceNames` and passes the publisher (3rd segment in manifestID) )to the manifest builder