### PR TITLE
feat(content-pipeline): Add TheSuperHackers Content Provider Support

### DIFF
--- a/GenHub/GenHub.Core/Constants/ContentSourceNames.cs
+++ b/GenHub/GenHub.Core/Constants/ContentSourceNames.cs
@@ -57,6 +57,11 @@ public static class ContentSourceNames
     // Deliverers
 
     /// <summary>
+    /// Source name for GitHub content deliverer.
+    /// </summary>
+    public const string GitHubDeliverer = "GitHub Content Deliverer";
+
+    /// <summary>
     /// Source name for HTTP content deliverer.
     /// </summary>
     public const string HttpDeliverer = "HTTP Content Deliverer";

--- a/GenHub/GenHub.Core/Constants/PublisherTypeConstants.cs
+++ b/GenHub/GenHub.Core/Constants/PublisherTypeConstants.cs
@@ -44,6 +44,9 @@ public static class PublisherTypeConstants
     /// <summary>Generals Online community client publisher.</summary>
     public const string GeneralsOnline = "generalsonline";
 
+    /// <summary>The Super Hackers community publisher.</summary>
+    public const string TheSuperHackers = "thesuperhackers";
+
     /// <summary>
     /// Maps GameInstallationType enum to publisher type string.
     /// </summary>

--- a/GenHub/GenHub.Core/Constants/SuperHackersConstants.cs
+++ b/GenHub/GenHub.Core/Constants/SuperHackersConstants.cs
@@ -1,0 +1,78 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Constants for TheSuperHackers content provider.
+/// </summary>
+public static class SuperHackersConstants
+{
+    /// <summary>
+    /// The publisher ID for TheSuperHackers.
+    /// </summary>
+    public const string PublisherId = "thesuperhackers";
+
+    /// <summary>
+    /// The display name for the publisher.
+    /// </summary>
+    public const string PublisherName = "TheSuperHackers";
+
+    /// <summary>
+    /// Description for the content provider.
+    /// </summary>
+    public const string ProviderDescription = "Weekly releases of Generals and Zero Hour game code from TheSuperHackers";
+
+    /// <summary>
+    /// Publisher icon color.
+    /// </summary>
+    public const string IconColor = "#FF9800";
+
+    /// <summary>
+    /// The resolver ID used for GitHub releases.
+    /// </summary>
+    public const string ResolverId = "GitHubRelease";
+
+    // ===== GitHub Repository =====
+
+    /// <summary>
+    /// The GitHub repository owner.
+    /// </summary>
+    public const string GeneralsGameCodeOwner = "thesuperhackers";
+
+    /// <summary>
+    /// The GitHub repository name.
+    /// </summary>
+    public const string GeneralsGameCodeRepo = "GeneralsGameCode";
+
+    // ===== Service Configuration =====
+
+    /// <summary>
+    /// Name of the update service.
+    /// </summary>
+    public const string ServiceName = "SuperHackers Release Monitor";
+
+    /// <summary>
+    /// Interval in hours between update checks.
+    /// </summary>
+    public const int UpdateCheckIntervalHours = 6;
+
+    // ===== Manifest Generation =====
+
+    /// <summary>
+    /// Suffix for Generals game type in manifest IDs.
+    /// </summary>
+    public const string GeneralsSuffix = "generals";
+
+    /// <summary>
+    /// Suffix for Zero Hour game type in manifest IDs.
+    /// </summary>
+    public const string ZeroHourSuffix = "zerohour";
+
+    /// <summary>
+    /// Display name for Generals variant.
+    /// </summary>
+    public const string GeneralsDisplayName = "Generals";
+
+    /// <summary>
+    /// Display name for Zero Hour variant.
+    /// </summary>
+    public const string ZeroHourDisplayName = "Zero Hour";
+}

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersManifestFactory.cs
@@ -1,0 +1,295 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Features.Content.Services.Publishers;
+
+/// <summary>
+/// Manifest factory for TheSuperHackers publisher.
+/// Handles multi-game releases with separate executables for Generals and Zero Hour.
+/// </summary>
+public class SuperHackersManifestFactory(ILogger<SuperHackersManifestFactory> logger, IFileHashProvider hashProvider) : IPublisherManifestFactory
+{
+    /// <summary>
+    /// Extracts version number from manifest ID.
+    /// </summary>
+    private static int ExtractVersionFromManifestId(string manifestId)
+    {
+        var parts = manifestId.Split('.');
+        if (parts.Length >= 2 && int.TryParse(parts[1], out int version))
+        {
+            return version;
+        }
+
+        return 0;
+    }
+
+    /// <inheritdoc />
+    public string PublisherId => PublisherTypeConstants.TheSuperHackers;
+
+    /// <inheritdoc />
+    public bool CanHandle(ContentManifest manifest)
+    {
+        // Only handle manifests with explicit thesuperhackers publisher type
+        var publisherMatches = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.TheSuperHackers, StringComparison.OrdinalIgnoreCase) == true;
+
+        // Only handle GameClient content type
+        var isGameClient = manifest.ContentType == ContentType.GameClient;
+
+        var canHandle = publisherMatches && isGameClient;
+
+        logger.LogDebug(
+            "CanHandle check for manifest {ManifestId}: Publisher={Publisher}, Type={PublisherType}, IsGameClient={IsGameClient}, Result={CanHandle}",
+            manifest.Id,
+            manifest.Publisher?.Name,
+            manifest.Publisher?.PublisherType,
+            isGameClient,
+            canHandle);
+
+        return canHandle;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ContentManifest>> CreateManifestsFromExtractedContentAsync(
+        ContentManifest originalManifest,
+        string extractedDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Creating SuperHackers manifests from extracted content in: {Directory}", extractedDirectory);
+
+        var detectedExecutables = DetectGameExecutables(extractedDirectory);
+
+        if (detectedExecutables.Count == 0)
+        {
+            logger.LogWarning("No SuperHackers game executables detected in {Directory}", extractedDirectory);
+            return new List<ContentManifest>();
+        }
+
+        logger.LogInformation("Detected {Count} game executables for SuperHackers release", detectedExecutables.Count);
+
+        var manifests = new List<ContentManifest>();
+
+        // Sort by game type to ensure consistent ordering (Generals first, then Zero Hour)
+        foreach (var (gameType, executablePath) in detectedExecutables.OrderBy(kv => kv.Key))
+        {
+            var manifest = await BuildManifestForGameTypeAsync(
+                originalManifest,
+                extractedDirectory,
+                gameType,
+                executablePath,
+                cancellationToken);
+
+            manifests.Add(manifest);
+
+            logger.LogInformation(
+                "Created SuperHackers {GameType} manifest {ManifestId} with {FileCount} files",
+                gameType,
+                manifest.Id,
+                manifest.Files.Count);
+        }
+
+        return manifests;
+    }
+
+    /// <inheritdoc />
+    public string GetManifestDirectory(ContentManifest manifest, string extractedDirectory)
+    {
+        // For SuperHackers, each game type has its own subdirectory based on the executable location
+        var executable = manifest.Files.FirstOrDefault(f => f.IsExecutable);
+        if (executable != null)
+        {
+            var executableFullPath = Path.Combine(extractedDirectory, executable.RelativePath);
+            var directory = Path.GetDirectoryName(executableFullPath);
+            return directory ?? extractedDirectory;
+        }
+
+        return extractedDirectory;
+    }
+
+    /// <summary>
+    /// Detects SuperHackers game executables in the extracted directory.
+    /// </summary>
+    private Dictionary<GameType, string> DetectGameExecutables(string directory)
+    {
+        var result = new Dictionary<GameType, string>();
+
+        if (!Directory.Exists(directory))
+            return result;
+
+        var allFiles = Directory.GetFiles(directory, "*.exe", SearchOption.AllDirectories);
+
+        foreach (var filePath in allFiles)
+        {
+            var fileName = Path.GetFileName(filePath).ToLowerInvariant();
+
+            // Check for SuperHackers executables
+            if (fileName == GameClientConstants.SuperHackersGeneralsExecutable.ToLowerInvariant())
+            {
+                result[GameType.Generals] = filePath;
+                logger.LogInformation("Detected SuperHackers Generals executable: {Path}", filePath);
+            }
+            else if (fileName == GameClientConstants.SuperHackersZeroHourExecutable.ToLowerInvariant())
+            {
+                result[GameType.ZeroHour] = filePath;
+                logger.LogInformation("Detected SuperHackers Zero Hour executable: {Path}", filePath);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds a manifest for a specific game type.
+    /// </summary>
+    private async Task<ContentManifest> BuildManifestForGameTypeAsync(
+        ContentManifest originalManifest,
+        string extractedDirectory,
+        GameType gameType,
+        string executablePath,
+        CancellationToken cancellationToken)
+    {
+        var files = new List<ManifestFile>();
+        var executableDirectory = Path.GetDirectoryName(executablePath) ?? extractedDirectory;
+
+        // Normalize the executable path for comparison
+        var normalizedExecutablePath = Path.GetFullPath(executablePath);
+        var executableFileName = Path.GetFileName(executablePath).ToLowerInvariant();
+
+        // Get the OTHER game's executable name to exclude it (and its .pdb file)
+        var otherGameExecutable = gameType == GameType.Generals
+            ? GameClientConstants.SuperHackersZeroHourExecutable.ToLowerInvariant()
+            : GameClientConstants.SuperHackersGeneralsExecutable.ToLowerInvariant();
+
+        // Also exclude the .pdb file for the other game
+        var otherGamePdb = Path.ChangeExtension(otherGameExecutable, ".pdb");
+
+        logger.LogInformation(
+            "Building {GameType} manifest: Main executable = {MainExe}, Excluding = {OtherExe} and {OtherPdb}",
+            gameType,
+            executableFileName,
+            otherGameExecutable,
+            otherGamePdb);
+
+        if (Directory.Exists(executableDirectory))
+        {
+            var allFiles = Directory.GetFiles(executableDirectory, "*", SearchOption.AllDirectories);
+            logger.LogInformation("Found {FileCount} files in {Directory} for {GameType} manifest", allFiles.Length, executableDirectory, gameType);
+
+            foreach (var filePath in allFiles)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                var fileName = Path.GetFileName(filePath).ToLowerInvariant();
+
+                // Skip the other game's executable and .pdb file
+                if (fileName == otherGameExecutable || fileName == otherGamePdb)
+                {
+                    logger.LogInformation("Excluding {FileName} from {GameType} manifest", fileName, gameType);
+                    continue;
+                }
+
+                // For GameClient manifests, only include the main executable and its PDB
+                // Exclude all development tools and other executables
+                if (originalManifest.ContentType == ContentType.GameClient)
+                {
+                    // Only include the main game executable and its PDB file
+                    if (fileName != executableFileName && fileName != Path.ChangeExtension(executableFileName, ".pdb"))
+                    {
+                        logger.LogDebug("Excluding development tool {FileName} from GameClient manifest", fileName);
+                        continue;
+                    }
+                }
+
+                var relativePath = Path.GetRelativePath(executableDirectory, filePath);
+                var fileInfo = new FileInfo(filePath);
+
+                // Check if this is the game executable by comparing normalized full paths
+                var normalizedFilePath = Path.GetFullPath(filePath);
+                bool isExecutable = string.Equals(normalizedFilePath, normalizedExecutablePath, StringComparison.OrdinalIgnoreCase);
+
+                if (isExecutable)
+                {
+                    logger.LogInformation("Marking {FileName} as executable for {GameType} manifest", fileName, gameType);
+                    logger.LogDebug("Path comparison - File: {FilePath}, Expected: {ExpectedPath}", normalizedFilePath, normalizedExecutablePath);
+                }
+                else if (fileName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Log why other executables are NOT being marked
+                    logger.LogDebug(
+                        "NOT marking {FileName} as executable - Path mismatch: File={FilePath}, Expected={ExpectedPath}",
+                        fileName,
+                        normalizedFilePath,
+                        normalizedExecutablePath);
+                }
+
+                // Compute hash for ContentAddressable storage
+                string fileHash = await hashProvider.ComputeFileHashAsync(filePath);
+
+                files.Add(new ManifestFile
+                {
+                    RelativePath = relativePath,
+                    Size = fileInfo.Length,
+                    Hash = fileHash,
+                    IsRequired = true,
+                    IsExecutable = isExecutable,
+                    SourceType = ContentSourceType.ContentAddressable,
+                    SourcePath = filePath,
+                });
+            }
+        }
+
+        // Generate manifest ID for this game type
+        var gameTypeSuffix = gameType == GameType.Generals ? SuperHackersConstants.GeneralsSuffix : SuperHackersConstants.ZeroHourSuffix;
+        var userVersion = ExtractVersionFromManifestId(originalManifest.Id.Value);
+
+        logger.LogInformation(
+            "Building manifest for {GameType}: Original ID = {OriginalId}, Extracted version = {Version}, Will use suffix = {Suffix}",
+            gameType,
+            originalManifest.Id,
+            userVersion,
+            gameTypeSuffix);
+
+        var manifestId = ManifestIdGenerator.GeneratePublisherContentId(
+            PublisherTypeConstants.TheSuperHackers,
+            ContentType.GameClient,
+            gameTypeSuffix,
+            userVersion: userVersion);
+
+        logger.LogInformation(
+            "Generated manifest ID for {GameType}: {ManifestId}",
+            gameType,
+            manifestId);
+
+        var gameTypeName = gameType == GameType.Generals ? SuperHackersConstants.GeneralsDisplayName : SuperHackersConstants.ZeroHourDisplayName;
+
+        var manifest = new ContentManifest
+        {
+            ManifestVersion = originalManifest.ManifestVersion,
+            Id = ManifestId.Create(manifestId),
+            Name = $"{originalManifest.Name} - {gameTypeName}",
+            Version = originalManifest.Version,
+            ContentType = ContentType.GameClient,
+            TargetGame = gameType,
+            Publisher = originalManifest.Publisher,
+            Metadata = originalManifest.Metadata,
+            Dependencies = originalManifest.Dependencies,
+            ContentReferences = originalManifest.ContentReferences,
+            KnownAddons = originalManifest.KnownAddons,
+            Files = files,
+            RequiredDirectories = originalManifest.RequiredDirectories,
+            InstallationInstructions = originalManifest.InstallationInstructions,
+        };
+
+        return await Task.FromResult(manifest);
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Features.Content.Services.ContentProviders;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Content.Services.Publishers;
+
+/// <summary>
+/// Content provider for TheSuperHackers publisher.
+/// Discovers and delivers game client releases from TheSuperHackers GitHub repositories.
+/// </summary>
+public class SuperHackersProvider(
+    IEnumerable<IContentDiscoverer> discoverers,
+    IEnumerable<IContentResolver> resolvers,
+    IEnumerable<IContentDeliverer> deliverers,
+    IContentValidator contentValidator,
+    ILogger<SuperHackersProvider> logger)
+    : BaseContentProvider(contentValidator, logger)
+{
+    private readonly IContentDiscoverer _discoverer = discoverers.FirstOrDefault(d =>
+            d.SourceName.Contains("GitHub", StringComparison.OrdinalIgnoreCase))
+        ?? throw new InvalidOperationException("No GitHub discoverer found for SuperHackers");
+
+    private readonly IContentResolver _resolver = resolvers.FirstOrDefault(r =>
+            r.ResolverId?.Equals(SuperHackersConstants.ResolverId, StringComparison.OrdinalIgnoreCase) == true)
+        ?? throw new InvalidOperationException("No GitHub resolver found for SuperHackers");
+
+    private readonly IContentDeliverer _deliverer = deliverers.FirstOrDefault(d =>
+            d.SourceName?.Equals(ContentSourceNames.GitHubDeliverer, StringComparison.OrdinalIgnoreCase) == true)
+        ?? throw new InvalidOperationException("No GitHub deliverer found for SuperHackers");
+
+    /// <inheritdoc/>
+    public override string SourceName => PublisherTypeConstants.TheSuperHackers;
+
+    /// <inheritdoc/>
+    public override string Description => SuperHackersConstants.ProviderDescription;
+
+    /// <inheritdoc/>
+    public override bool IsEnabled => true;
+
+    /// <inheritdoc/>
+    public override ContentSourceCapabilities Capabilities =>
+        ContentSourceCapabilities.RequiresDiscovery |
+        ContentSourceCapabilities.SupportsPackageAcquisition;
+
+    /// <inheritdoc/>
+    protected override IContentDiscoverer Discoverer => _discoverer;
+
+    /// <inheritdoc/>
+    protected override IContentResolver Resolver => _resolver;
+
+    /// <inheritdoc/>
+    protected override IContentDeliverer Deliverer => _deliverer;
+
+    /// <inheritdoc/>
+    public override async Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
+        string contentId,
+        CancellationToken cancellationToken = default)
+    {
+        Logger.LogInformation("Getting SuperHackers manifest for: {ContentId}", contentId);
+
+        // Create a search result for resolution
+        var searchResult = new ContentSearchResult
+        {
+            Id = contentId,
+            Name = SuperHackersConstants.PublisherName,
+            Version = contentId,
+            ProviderName = SourceName,
+            RequiresResolution = true,
+            ResolverId = SuperHackersConstants.ResolverId,
+        };
+
+        var manifestResult = await Resolver.ResolveAsync(searchResult, cancellationToken);
+        if (!manifestResult.Success || manifestResult.Data == null)
+        {
+            return OperationResult<ContentManifest>.CreateFailure(
+                $"Failed to resolve manifest: {manifestResult.FirstError}");
+        }
+
+        var validationResult = await ContentValidator.ValidateManifestAsync(
+            manifestResult.Data,
+            cancellationToken);
+
+        if (!validationResult.IsValid)
+        {
+            var errors = validationResult.Issues.Select(i => $"Validation failed: {i.Message}");
+            return OperationResult<ContentManifest>.CreateFailure(errors);
+        }
+
+        return manifestResult;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        Logger.LogInformation("Preparing SuperHackers content: {Version}", manifest.Version);
+
+        try
+        {
+            if (!Deliverer.CanDeliver(manifest))
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Cannot deliver content for manifest {manifest.Id}");
+            }
+
+            var deliveryResult = await Deliverer.DeliverContentAsync(
+                manifest,
+                workingDirectory,
+                progress,
+                cancellationToken);
+
+            if (!deliveryResult.Success)
+            {
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Content delivery failed: {deliveryResult.FirstError}");
+            }
+
+            var resultManifest = deliveryResult.Data ?? manifest;
+            Logger.LogInformation("Successfully prepared SuperHackers content {ManifestId}", manifest.Id);
+            return OperationResult<ContentManifest>.CreateSuccess(resultManifest);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to prepare SuperHackers content");
+            return OperationResult<ContentManifest>.CreateFailure(
+                $"Content preparation failed: {ex.Message}");
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersUpdateService.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersUpdateService.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.GitHub;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Results.Content;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Content.Services.Publishers;
+
+/// <summary>
+/// Background service for monitoring TheSuperHackers GitHub releases.
+/// Checks for new releases from the GeneralsGameCode repository.
+/// </summary>
+public class SuperHackersUpdateService(
+    ILogger<SuperHackersUpdateService> logger,
+    IGitHubApiClient gitHubClient,
+    IContentManifestPool manifestPool)
+    : ContentUpdateServiceBase(logger)
+{
+    // TheSuperHackers repository information
+    private const string RepositoryOwner = SuperHackersConstants.GeneralsGameCodeOwner;
+    private const string RepositoryName = SuperHackersConstants.GeneralsGameCodeRepo;
+
+    /// <inheritdoc />
+    protected override string ServiceName => SuperHackersConstants.ServiceName;
+
+    /// <inheritdoc />
+    protected override TimeSpan UpdateCheckInterval => TimeSpan.FromHours(SuperHackersConstants.UpdateCheckIntervalHours);
+
+    /// <inheritdoc />
+    public override async Task<ContentUpdateCheckResult> CheckForUpdatesAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Checking for TheSuperHackers GitHub releases");
+
+        try
+        {
+            // Get latest release from GitHub
+            var latestRelease = await gitHubClient.GetLatestReleaseAsync(
+                RepositoryOwner,
+                RepositoryName,
+                cancellationToken);
+
+            if (latestRelease == null)
+            {
+                logger.LogWarning("No releases found for {Owner}/{Repo}", RepositoryOwner, RepositoryName);
+                return ContentUpdateCheckResult.CreateNoUpdateAvailable();
+            }
+
+            var latestVersion = ExtractVersionFromTag(latestRelease.TagName);
+            logger.LogDebug(
+                "Latest GitHub release: {TagName} (extracted version: {Version})",
+                latestRelease.TagName,
+                latestVersion);
+
+            // Check installed versions for both Generals and Zero Hour
+            var currentVersionGenerals = await GetInstalledVersionAsync(SuperHackersConstants.GeneralsSuffix, cancellationToken);
+            var currentVersionZeroHour = await GetInstalledVersionAsync(SuperHackersConstants.ZeroHourSuffix, cancellationToken);
+
+            // Use the higher of the two installed versions
+            var currentVersion = string.IsNullOrEmpty(currentVersionGenerals)
+                ? currentVersionZeroHour
+                : (string.IsNullOrEmpty(currentVersionZeroHour)
+                    ? currentVersionGenerals
+                    : string.Compare(currentVersionGenerals, currentVersionZeroHour, StringComparison.Ordinal) > 0
+                        ? currentVersionGenerals
+                        : currentVersionZeroHour);
+
+            logger.LogDebug(
+                "Installed versions - Generals: {GeneralsVersion}, ZeroHour: {ZeroHourVersion}, Using: {CurrentVersion}",
+                currentVersionGenerals ?? "none",
+                currentVersionZeroHour ?? "none",
+                currentVersion ?? "none");
+
+            // Compare versions
+            bool updateAvailable = CompareVersions(latestVersion, currentVersion);
+
+            if (updateAvailable)
+            {
+                return ContentUpdateCheckResult.CreateUpdateAvailable(
+                    latestVersion,
+                    currentVersion,
+                    latestRelease.PublishedAt?.DateTime,
+                    latestRelease.HtmlUrl,
+                    latestRelease.Body);
+            }
+
+            return ContentUpdateCheckResult.CreateNoUpdateAvailable(currentVersion, latestVersion);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to check for TheSuperHackers updates");
+            return ContentUpdateCheckResult.CreateFailure(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Extracts version number from GitHub release tag.
+    /// Handles formats like "v1.2.3", "1.2.3", "release-1.2.3", etc.
+    /// </summary>
+    /// <param name="tagName">The GitHub release tag.</param>
+    /// <returns>The extracted version string.</returns>
+    private static string ExtractVersionFromTag(string tagName)
+    {
+        if (string.IsNullOrWhiteSpace(tagName))
+            return "0";
+
+        // Remove common prefixes
+        var version = tagName
+            .Replace("v", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace("release-", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace("release_", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Trim();
+
+        return version;
+    }
+
+    /// <summary>
+    /// Compares two version strings to determine if an update is available.
+    /// </summary>
+    /// <param name="latestVersion">The latest available version.</param>
+    /// <param name="currentVersion">The currently installed version.</param>
+    /// <returns>True if the latest version is newer than the current version.</returns>
+    private static bool CompareVersions(string? latestVersion, string? currentVersion)
+    {
+        if (string.IsNullOrEmpty(latestVersion))
+            return false;
+
+        if (string.IsNullOrEmpty(currentVersion))
+            return true;
+
+        // Simple string comparison for now
+        // Could be enhanced with semantic version parsing if needed
+        return string.Compare(latestVersion, currentVersion, StringComparison.Ordinal) > 0;
+    }
+
+    /// <summary>
+    /// Gets the installed version for a specific game variant.
+    /// </summary>
+    /// <param name="gameVariant">The game variant (generals or zerohour).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The installed version or null if not found.</returns>
+    private async Task<string?> GetInstalledVersionAsync(string gameVariant, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Query manifest pool for TheSuperHackers game client manifests
+            var manifestsResult = await manifestPool.GetAllManifestsAsync(cancellationToken);
+
+            if (!manifestsResult.Success || manifestsResult.Data == null)
+            {
+                return null;
+            }
+
+            // Find manifest for the specific game variant
+            var manifest = manifestsResult.Data.FirstOrDefault(m =>
+                m.Publisher?.PublisherType?.Equals(PublisherTypeConstants.TheSuperHackers, StringComparison.OrdinalIgnoreCase) == true &&
+                m.ContentType == ContentType.GameClient &&
+                m.Id.Value.Contains(gameVariant, StringComparison.OrdinalIgnoreCase));
+
+            return manifest?.Version;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to get installed version for {GameVariant}", gameVariant);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Adds support for TheSuperHackers publisher, enabling discovery, resolution, and delivery of weekly game code releases from their GitHub repository. This integrates with GenHub's three-tier content pipeline architecture, allowing users to install and manage Generals and Zero Hour game clients directly from the community-maintained repository.

### Changes

**Core Constants & Configuration**
- `PublisherTypeConstants.cs`: Added `TheSuperHackers` publisher type identifier
- `SuperHackersConstants.cs`: Centralized constants for repository info, service configuration, and manifest generation
- `ContentSourceNames.cs`: Added `GitHubDeliverer` source name constant
- `GitHubConstants.cs`: Extended GitHub-related constants for API interactions, UI, and parsing

**Content Provider Implementation**
- `SuperHackersProvider.cs`: New content provider inheriting from `BaseContentProvider`, orchestrates GitHub-based content pipeline for TSH releases
- `SuperHackersManifestFactory.cs`: IPublisherManifestFactory implementation that creates separate manifests for Generals and Zero Hour from extracted releases

#### Manifest Generation
The `SuperHackersManifestFactory` handles TSH's unique multi-game structure:
- Releases contain separate executables for Generals (`generalsv.exe`) and Zero Hour (`generalszh.exe`)
- Factory detects executables and creates separate manifests per game type
- Each manifest includes game-specific files while excluding the other game's binaries

#### Integration with Game Profiles
- Acquired TSH manifests become available in `IContentManifestPool`
- Users can enable TSH game clients in `GameProfile.EnabledContentIds`
- Workspace preparation includes TSH executables and dependencies
- Launch orchestration handles TSH-specific executables