### PR TITLE
feat: add build infrastructure for Velopack CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
   WINDOWS_PROJECT: 'GenHub/GenHub.Windows/GenHub.Windows.csproj'
   LINUX_PROJECT: 'GenHub/GenHub.Linux/GenHub.Linux.csproj'
   TEST_PROJECTS: 'GenHub/GenHub.Tests/**/*.csproj'
-  
+
 jobs:
   detect-changes:
     name: Detect File Changes
@@ -75,16 +75,16 @@ jobs:
     needs: detect-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.any == 'true' || needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.windows == 'true' }}
     runs-on: windows-latest
-    
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-          
+
       - name: Cache NuGet Packages
         uses: actions/cache@v3
         with:
@@ -92,30 +92,95 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
-      
+
+      - name: Extract Build Info
+        id: buildinfo
+        shell: pwsh
+        run: |
+          $shortHash = "${{ github.sha }}".Substring(0, 7)
+          $prNumber = "${{ github.event.pull_request.number }}"
+          $runNumber = "${{ github.run_number }}"
+
+          # Velopack requires SemVer2 3-part version (MAJOR.MINOR.PATCH)
+          # Using 0.0.X format to indicate alpha/pre-release status
+          if ($prNumber) {
+            $version = "0.0.$runNumber-pr$prNumber"
+            $channel = "PR"
+          } else {
+            $version = "0.0.$runNumber"
+            $channel = "CI"
+          }
+
+          Write-Host "Build Info:"
+          Write-Host "  Short Hash: $shortHash"
+          Write-Host "  PR Number: $prNumber"
+          Write-Host "  Run Number: $runNumber"
+          Write-Host "  Version: $version (SemVer2 for Velopack)"
+          Write-Host "  Channel: $channel"
+
+          echo "SHORT_HASH=$shortHash" >> $env:GITHUB_OUTPUT
+          echo "PR_NUMBER=$prNumber" >> $env:GITHUB_OUTPUT
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          echo "CHANNEL=$channel" >> $env:GITHUB_OUTPUT
+
       - name: Build Projects
         shell: pwsh
         run: |
-          # Build projects in the correct order (core dependencies first)
-          Write-Host "Building Core project"
-          dotnet build "${{ env.CORE_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }}
-          
-          Write-Host "Building UI project"  
-          dotnet build "${{ env.UI_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }}
-          
+          $buildProps = @(
+            "-p:Version=${{ steps.buildinfo.outputs.VERSION }}"
+            "-p:GitShortHash=${{ steps.buildinfo.outputs.SHORT_HASH }}"
+            "-p:PullRequestNumber=${{ steps.buildinfo.outputs.PR_NUMBER }}"
+            "-p:BuildChannel=${{ steps.buildinfo.outputs.CHANNEL }}"
+          )
+
+          Write-Host "Building Core project with build info"
+          dotnet build "${{ env.CORE_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} @buildProps
+
+          Write-Host "Building UI project"
+          dotnet build "${{ env.UI_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} @buildProps
+
           Write-Host "Building Windows project"
-          dotnet build "${{ env.WINDOWS_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }}
-      
+          dotnet build "${{ env.WINDOWS_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} @buildProps
+
       - name: Publish Windows App
         shell: pwsh
         run: |
+          $buildProps = @(
+            "-p:Version=${{ steps.buildinfo.outputs.VERSION }}"
+            "-p:GitShortHash=${{ steps.buildinfo.outputs.SHORT_HASH }}"
+            "-p:PullRequestNumber=${{ steps.buildinfo.outputs.PR_NUMBER }}"
+            "-p:BuildChannel=${{ steps.buildinfo.outputs.CHANNEL }}"
+          )
+
           Write-Host "Publishing Windows application"
+          Write-Host "Version: ${{ steps.buildinfo.outputs.VERSION }}"
           dotnet publish "${{ env.WINDOWS_PROJECT }}" `
             -c ${{ env.BUILD_CONFIGURATION }} `
             -r win-x64 `
             --self-contained true `
-            -o "win-publish"
-      
+            -o "win-publish" `
+            @buildProps
+
+      - name: Install Velopack CLI
+        run: dotnet tool install -g vpk
+
+      - name: Create Velopack Package
+        shell: pwsh
+        run: |
+          Write-Host "Creating Velopack package..."
+          vpk pack `
+            --packId GenHub `
+            --packVersion ${{ steps.buildinfo.outputs.VERSION }} `
+            --packDir win-publish `
+            --mainExe GenHub.Windows.exe `
+            --packTitle "GenHub" `
+            --packAuthors "Community Outpost" `
+            --icon GenHub/GenHub/Assets/Icons/generalshub.ico `
+            --outputDir velopack-release
+
+          Write-Host "Velopack artifacts created:"
+          Get-ChildItem -Path "velopack-release" -Recurse | Select-Object Name, Length
+
       - name: Run Tests
         id: tests
         shell: pwsh
@@ -133,33 +198,51 @@ jobs:
           } else {
             Write-Host "No test projects found."
           }
-      - name: Upload Windows Artifact
+
+      - name: Upload Velopack Update Package (.nupkg)
         uses: actions/upload-artifact@v4
         with:
-          name: genhub-windows
-          path: win-publish
+          name: genhub-velopack-windows-${{ steps.buildinfo.outputs.VERSION }}
+          path: velopack-release/*.nupkg
           if-no-files-found: error
-          
+          retention-days: 30
+
+      - name: Upload Velopack Setup Installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: genhub-setup-windows-${{ steps.buildinfo.outputs.VERSION }}
+          path: velopack-release/*-Setup.exe
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload Velopack Metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: genhub-metadata-windows-${{ steps.buildinfo.outputs.VERSION }}
+          path: velopack-release/RELEASES
+          if-no-files-found: error
+          retention-days: 30
+
   build-linux:
     name: Build Linux
     needs: detect-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.any == 'true' || needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.linux == 'true' }}
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-          
+
       - name: Install Linux Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libx11-dev
-          
+
       - name: Cache NuGet Packages
         uses: actions/cache@v3
         with:
@@ -167,28 +250,79 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
-      
+
+      - name: Extract Build Info
+        id: buildinfo
+        run: |
+          SHORT_HASH=$(echo "${{ github.sha }}" | cut -c1-7)
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          RUN_NUMBER="${{ github.run_number }}"
+
+          # Velopack requires SemVer2 3-part version (MAJOR.MINOR.PATCH)
+          # Using 0.0.X format to indicate alpha/pre-release status
+          if [ -n "$PR_NUMBER" ]; then
+            VERSION="0.0.${RUN_NUMBER}-pr${PR_NUMBER}"
+            CHANNEL="PR"
+          else
+            VERSION="0.0.${RUN_NUMBER}"
+            CHANNEL="CI"
+          fi
+
+          echo "Build Info:"
+          echo "  Short Hash: $SHORT_HASH"
+          echo "  PR Number: $PR_NUMBER"
+          echo "  Run Number: $RUN_NUMBER"
+          echo "  Version: $VERSION (SemVer2 for Velopack)"
+          echo "  Channel: $CHANNEL"
+
+          echo "SHORT_HASH=$SHORT_HASH" >> $GITHUB_OUTPUT
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Build Projects
         run: |
-          # Build projects, which will also restore dependencies
-          echo "Building Core project"
-          dotnet build "${{ env.CORE_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }}
-          
+          BUILD_PROPS="-p:Version=${{ steps.buildinfo.outputs.VERSION }} -p:GitShortHash=${{ steps.buildinfo.outputs.SHORT_HASH }} -p:PullRequestNumber=${{ steps.buildinfo.outputs.PR_NUMBER }} -p:BuildChannel=${{ steps.buildinfo.outputs.CHANNEL }}"
+
+          echo "Building Core project with build info"
+          dotnet build "${{ env.CORE_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} $BUILD_PROPS
+
           echo "Building UI project"
-          dotnet build "${{ env.UI_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }}
-          
-          echo "Building Linux project"  
-          dotnet build "${{ env.LINUX_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }}
-      
+          dotnet build "${{ env.UI_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} $BUILD_PROPS
+
+          echo "Building Linux project"
+          dotnet build "${{ env.LINUX_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} $BUILD_PROPS
+
       - name: Publish Linux App
         run: |
+          BUILD_PROPS="-p:Version=${{ steps.buildinfo.outputs.VERSION }} -p:GitShortHash=${{ steps.buildinfo.outputs.SHORT_HASH }} -p:PullRequestNumber=${{ steps.buildinfo.outputs.PR_NUMBER }} -p:BuildChannel=${{ steps.buildinfo.outputs.CHANNEL }}"
+
           echo "Publishing Linux application"
           dotnet publish "${{ env.LINUX_PROJECT }}" \
             -c ${{ env.BUILD_CONFIGURATION }} \
             -r linux-x64 \
             --self-contained true \
-            -o "linux-publish"
-      
+            -o "linux-publish" \
+            $BUILD_PROPS
+
+      - name: Install Velopack CLI
+        run: dotnet tool install -g vpk
+
+      - name: Create Velopack Package
+        run: |
+          echo "Creating Velopack package..."
+          vpk pack \
+            --packId GenHub \
+            --packVersion ${{ steps.buildinfo.outputs.VERSION }} \
+            --packDir linux-publish \
+            --mainExe GenHub.Linux \
+            --packTitle "GenHub" \
+            --packAuthors "Community Outpost" \
+            --icon GenHub/GenHub/Assets/Icons/generalshub-icon.png \
+            --outputDir velopack-release
+
+          echo "Velopack artifacts created:"
+          ls -lh velopack-release/
+
       - name: Run Tests
         run: |
           shopt -s globstar nullglob
@@ -197,17 +331,67 @@ jobs:
             echo "Testing $test_project"
             dotnet test "$test_project" -c ${{ env.BUILD_CONFIGURATION }} --verbosity normal
           done
-        
-      - name: Upload Linux Artifact
+
+      - name: Upload Velopack Update Package (.nupkg)
         uses: actions/upload-artifact@v4
         with:
-          name: genhub-linux
-          path: linux-publish
+          name: genhub-velopack-linux-${{ steps.buildinfo.outputs.VERSION }}
+          path: velopack-release/*.nupkg
           if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload Velopack Metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: genhub-metadata-linux-${{ steps.buildinfo.outputs.VERSION }}
+          path: velopack-release/releases.*.json
+          if-no-files-found: error
+          retention-days: 30
+
+  release:
+    name: Create Release
+    needs: [build-windows, build-linux]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: genhub-velopack-windows-*
+          merge-multiple: true
+          path: release-assets/windows
+
+      - name: Download Linux Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: genhub-velopack-linux-*
+          merge-multiple: true
+          path: release-assets/linux
+
+      - name: Prepare Release Assets
+        run: |
+          mkdir final-assets
+          cp release-assets/windows/*.nupkg final-assets/
+          cp release-assets/linux/*.nupkg final-assets/ || true
+          # Prioritize Windows RELEASES file for now
+          cp release-assets/windows/RELEASES final-assets/RELEASES || true
+          # Include Setup.exe for easy first-time installation (Velopack names it GenHub-win-Setup.exe)
+          cp release-assets/windows/*-Setup.exe final-assets/ || true
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v0.0.${{ github.run_number }}
+          name: GenHub Alpha ${{ github.run_number }}
+          prerelease: true
+          draft: false
+          files: final-assets/*
 
   summary:
     name: Build Summary
-    needs: [build-windows, build-linux]
+    needs: [build-windows, build-linux, release]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -221,3 +405,4 @@ jobs:
           echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
           echo "| Windows | ${{ needs.build-windows.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Linux | ${{ needs.build-linux.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Release | ${{ needs.release.result == 'success' && '✅ Created' || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY

--- a/GenHub/Directory.Build.props
+++ b/GenHub/Directory.Build.props
@@ -1,14 +1,44 @@
 <Project>
   <PropertyGroup>
-    <!-- 
-      Change this to update version everywhere
-      Format: Major.Minor.Patch[-prerelease] (e.g., 1.0.0-alpha.1)
+    <!--
+      Alpha versioning: 0.0.X format
+      CI will override with: 0.0.{runNumber} or 0.0.{runNumber}-pr{prNumber}
     -->
-    <Version>1.0.0-alpha.1</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-    
+    <Version>0.0.1</Version>
+    <AssemblyVersion>0.0.1.0</AssemblyVersion>
+    <FileVersion>0.0.1.0</FileVersion>
+
     <!-- Make version available to source generators / build-time code -->
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+
+    <!--
+      Build info for CI - these are overridden by CI workflow via MSBuild properties:
+      dotnet build -p:GitShortHash=abc1234 -p:PullRequestNumber=42 -p:BuildChannel=PR
+    -->
+    <GitShortHash></GitShortHash>
+    <PullRequestNumber></PullRequestNumber>
+    <BuildChannel>Dev</BuildChannel>
+
+    <!--
+      Include git hash in InformationalVersion for display
+      Results in: "0.0.150+abc1234" for CI builds
+    -->
+    <InformationalVersion Condition="'$(GitShortHash)' != ''">$(Version)+$(GitShortHash)</InformationalVersion>
   </PropertyGroup>
+
+  <!-- Embed build metadata in assembly for runtime access -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>GitShortHash</_Parameter1>
+      <_Parameter2>$(GitShortHash)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>PullRequestNumber</_Parameter1>
+      <_Parameter2>$(PullRequestNumber)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BuildChannel</_Parameter1>
+      <_Parameter2>$(BuildChannel)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/GenHub/GenHub.Core/Constants/AppConstants.cs
+++ b/GenHub/GenHub.Core/Constants/AppConstants.cs
@@ -1,5 +1,5 @@
-using GenHub.Core.Models.Enums;
 using System.Reflection;
+using GenHub.Core.Models.Enums;
 
 namespace GenHub.Core.Constants;
 
@@ -13,7 +13,7 @@ public static class AppConstants
     /// </summary>
     public const string AppName = "GenHub";
 
-    private static readonly Lazy<string> _appVersion = new Lazy<string>(() =>
+    private static readonly Lazy<string> _appVersion = new(() =>
     {
         var assembly = Assembly.GetExecutingAssembly();
         return assembly
@@ -23,11 +23,20 @@ public static class AppConstants
         ?? "0.0.0-dev";
     });
 
+    private static readonly Lazy<string> _gitShortHash = new(() =>
+        GetAssemblyMetadata("GitShortHash") ?? string.Empty);
+
+    private static readonly Lazy<string> _pullRequestNumber = new(() =>
+        GetAssemblyMetadata("PullRequestNumber") ?? string.Empty);
+
+    private static readonly Lazy<string> _buildChannel = new(() =>
+        GetAssemblyMetadata("BuildChannel") ?? "Dev");
+
     /// <summary>
     /// Gets the full semantic version of the application.
     /// This value is automatically extracted from assembly metadata at runtime.
     /// To change version: Update &lt;Version&gt; in GenHub/Directory.Build.props.
-    /// Format: Major.Minor.Patch[-prerelease] (e.g., "1.0.0-alpha.1").
+    /// Format: 0.0.X[-prY] (e.g., "0.0.150" or "0.0.150-pr42").
     /// </summary>
     public static string AppVersion => _appVersion.Value;
 
@@ -37,9 +46,51 @@ public static class AppConstants
     public static string DisplayVersion => $"v{AppVersion}";
 
     /// <summary>
+    /// Gets the short git commit hash (7 chars) for this build, or empty for local builds.
+    /// </summary>
+    public static string GitShortHash => _gitShortHash.Value;
+
+    /// <summary>
+    /// Gets the PR number if this is a PR build, or empty for other builds.
+    /// </summary>
+    public static string PullRequestNumber => _pullRequestNumber.Value;
+
+    /// <summary>
+    /// Gets the build channel (Dev, PR, CI, Release).
+    /// </summary>
+    public static string BuildChannel => _buildChannel.Value;
+
+    /// <summary>
+    /// Gets a value indicating whether this is a CI/CD build (has git hash embedded).
+    /// </summary>
+    public static bool IsCiBuild => !string.IsNullOrEmpty(GitShortHash);
+
+    /// <summary>
+    /// Gets the full display version including hash for dev builds.
+    /// Format examples:
+    /// Local: "v0.0.1".
+    /// CI: "v0.0.150 (abc1234)".
+    /// PR: "v0.0.150-pr3 (abc1234)".
+    /// </summary>
+    public static string FullDisplayVersion
+    {
+        get
+        {
+            var version = DisplayVersion;
+
+            if (string.IsNullOrEmpty(GitShortHash))
+            {
+                return version;
+            }
+
+            return $"{version} ({GitShortHash})";
+        }
+    }
+
+    /// <summary>
     /// The GitHub repository URL for the application.
     /// </summary>
-    public const string GitHubRepositoryUrl = "https://github.com/community-outpost/genhub";
+    public const string GitHubRepositoryUrl = "https://github.com/" + GitHubRepositoryOwner + "/" + GitHubRepositoryName;
 
     /// <summary>
     /// The GitHub repository owner.
@@ -65,4 +116,16 @@ public static class AppConstants
     /// The default GitHub token file name.
     /// </summary>
     public const string TokenFileName = ".ghtoken";
+
+    /// <summary>
+    /// Gets assembly metadata by key.
+    /// </summary>
+    private static string? GetAssemblyMetadata(string key)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        return assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == key)
+            ?.Value;
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Constants/AppConstantsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Constants/AppConstantsTests.cs
@@ -21,10 +21,14 @@ public class AppConstantsTests
             // Application name and version
             Assert.Equal("GenHub", AppConstants.AppName);
 
-            // Version is dynamically loaded from assembly, just verify it's not empty and starts with expected prefix
+            // AppVersion should be a valid semantic version starting with 0.0 (alpha format)
             Assert.NotNull(AppConstants.AppVersion);
             Assert.NotEmpty(AppConstants.AppVersion);
-            Assert.StartsWith("1.", AppConstants.AppVersion);
+            Assert.StartsWith("0.0", AppConstants.AppVersion);
+
+            // DisplayVersion should have 'v' prefix
+            Assert.NotNull(AppConstants.DisplayVersion);
+            Assert.StartsWith("v0.0", AppConstants.DisplayVersion);
 
             // Theme constants
             Assert.Equal(Theme.Dark, AppConstants.DefaultTheme);

--- a/docs/velopack-integration.md
+++ b/docs/velopack-integration.md
@@ -5,16 +5,19 @@ GenHub uses [Velopack](https://velopack.io/) for application installation and au
 ## Overview
 
 Velopack provides:
+
 - **Zero-config installers** - Generate installers automatically from your build output
 - **Automatic updates** - Delta updates that only download changed files
 - **Cross-platform** - Single solution for Windows and Linux
 - **GitHub Releases integration** - Seamless updates from GitHub
+- **CI Artifact Updates** - Subscribe to PR builds for testing
 
 ## How It Works
 
 ### 1. Application Startup
 
 When GenHub starts, `VelopackApp.Build().Run()` is called first in `Program.cs`. This handles:
+
 - First-run initialization
 - Update installation on startup
 - Install/uninstall hooks
@@ -22,7 +25,11 @@ When GenHub starts, `VelopackApp.Build().Run()` is called first in `Program.cs`.
 
 ### 2. Update Checking
 
-The `VelopackUpdateManager` service checks for updates from GitHub Releases:
+GenHub supports two update sources:
+
+#### GitHub Releases (Stable Channel)
+
+The `VelopackUpdateManager` service checks for stable releases:
 
 ```csharp
 var updateInfo = await _velopackUpdateManager.CheckForUpdatesAsync();
@@ -34,12 +41,107 @@ if (updateInfo != null)
 }
 ```
 
+#### PR Artifacts (Testing Channel)
+
+Users can subscribe to specific Pull Request builds for testing:
+
+```csharp
+// Subscribe to PR #3
+_userSettingsService.Update(s => s.SubscribedPrNumber = 3);
+
+// Check for PR updates
+var prInfo = await _velopackUpdateManager.GetSubscribedPrInfoAsync();
+if (prInfo?.LatestArtifact != null)
+{
+    // Install PR build
+    await _velopackUpdateManager.InstallPrArtifactAsync(prInfo, progress);
+}
+```
+
 ### 3. Update Flow
 
-1. **Check** - Application queries GitHub Releases for new versions
-2. **Download** - Delta packages are downloaded (only changes)
-3. **Apply** - Update is staged and applied on next restart
+1. **Check** - Application queries GitHub Releases or PR artifacts for new versions
+2. **Download** - Packages are downloaded (delta updates when possible)
+3. **Apply** - Update is staged and applied
 4. **Restart** - Application restarts with new version
+
+## Versioning Scheme
+
+GenHub uses a custom versioning scheme optimized for continuous integration:
+
+### Version Format
+
+```
+0.0.{RUN_NUMBER}[-pr{PR_NUMBER}][+{BUILD_METADATA}]
+```
+
+**Components:**
+
+- `0.0.X` - Base version (0.0 indicates pre-1.0 development)
+- `RUN_NUMBER` - GitHub Actions run number (auto-incrementing)
+- `-pr{N}` - Optional PR number for pull request builds
+- `+{HASH}` - Build metadata (git commit hash, stripped for comparison)
+
+### Examples
+
+```bash
+# Main branch build (run #157)
+0.0.157
+
+# PR #3 build (run #160)
+0.0.160-pr3
+
+# Full version with build metadata
+0.0.160-pr3+051baf8.051baf832a894f542e60d3e4c2471c7d4dd753da
+```
+
+### Version Comparison
+
+GenHub strips build metadata (everything after `+`) when comparing versions:
+
+```csharp
+// These are considered the same version:
+"0.0.160-pr3+051baf8..."
+"0.0.160-pr3+18d0017..."
+// Both compare as: "0.0.160-pr3"
+```
+
+This allows users to reinstall the same PR build with different commits without version conflicts.
+
+## Update Channels
+
+GenHub provides two update channels that users can switch between:
+
+### Stable Channel
+
+- **Source**: GitHub Releases
+- **Versions**: `0.0.X` (no PR suffix)
+- **Updates**: Only stable builds from main branch
+- **Recommended for**: Production use
+
+### Artifacts Channel (PR Subscription)
+
+- **Source**: GitHub Actions CI artifacts
+- **Versions**: `0.0.X-prY` format
+- **Updates**: Specific PR builds
+- **Recommended for**: Testing features, bug fixes
+- **Requires**: GitHub Personal Access Token (PAT) with `repo` scope
+
+#### Subscribing to PR Builds
+
+1. Navigate to Settings → Updates
+2. Click "Manage Updates & PRs"
+3. Enter GitHub PAT (if not already configured)
+4. Select a PR from the list
+5. Click "Subscribe"
+
+The app will now check for updates from that PR instead of stable releases.
+
+#### Unsubscribing
+
+1. Open "Manage Updates & PRs"
+2. Click "Unsubscribe" on the currently subscribed PR
+3. App returns to stable channel
 
 ## Building Releases
 
@@ -48,90 +150,129 @@ if (updateInfo != null)
 - .NET 8 SDK
 - Velopack CLI tool: `dotnet tool install -g vpk`
 
+### Version Number Generation
+
+GenHub uses GitHub Actions run numbers for versioning:
+
+```yaml
+# CI builds (PRs and main branch)
+VERSION: 0.0.${{ github.run_number }}[-pr${{ github.event.pull_request.number }}]
+
+# Example outputs:
+# Main branch: 0.0.157
+# PR #3: 0.0.160-pr3
+```
+
 ### Manual Build Process
 
 #### Windows
 
 ```powershell
+# Set version
+$VERSION = "0.0.157"  # Or "0.0.160-pr3" for PR builds
+
 # Publish the application
 dotnet publish GenHub/GenHub.Windows/GenHub.Windows.csproj `
   -c Release `
   --self-contained `
   -r win-x64 `
-  -o ./publish/windows
+  -o ./publish/windows `
+  -p:Version=$VERSION
 
 # Package with Velopack
 vpk pack `
   --packId GenHub `
-  --packVersion 1.0.0 `
+  --packVersion $VERSION `
   --packDir ./publish/windows `
   --mainExe GenHub.Windows.exe `
   --packTitle "GenHub" `
   --packAuthors "Community Outpost" `
   --icon GenHub/GenHub/Assets/Icons/generalshub.ico `
   --outputDir ./releases
-
-# For alpha/beta releases, use semantic versioning prerelease identifiers:
-# vpk pack ... --packVersion 1.0.0-alpha.1
-# vpk pack ... --packVersion 1.0.0-beta.2
-# vpk pack ... --packVersion 1.0.0-rc.1
 ```
 
 #### Linux
 
 ```bash
+# Set version
+VERSION="0.0.157"  # Or "0.0.160-pr3" for PR builds
+
 # Publish the application
 dotnet publish GenHub/GenHub.Linux/GenHub.Linux.csproj \
   -c Release \
   --self-contained \
   -r linux-x64 \
-  -o ./publish/linux
+  -o ./publish/linux \
+  -p:Version=$VERSION
 
 # Package with Velopack
 vpk pack \
   --packId GenHub \
-  --packVersion 1.0.0 \
+  --packVersion $VERSION \
   --packDir ./publish/linux \
   --mainExe GenHub.Linux \
   --packTitle "GenHub" \
   --packAuthors "Community Outpost" \
   --icon GenHub/GenHub/Assets/Icons/generalshub.ico \
   --outputDir ./releases
-
-# For alpha/beta releases:
-# vpk pack ... --packVersion 1.0.0-alpha.1
-# vpk pack ... --packVersion 1.0.0-beta.2
 ```
 
 ### Automated CI/CD
 
-GenHub includes a GitHub Actions workflow (`.github/workflows/release.yml`) that automatically:
+GenHub includes GitHub Actions workflows:
+
+#### `.github/workflows/ci.yml` - Continuous Integration
+
+Runs on every push and PR:
+
+1. Builds for Windows and Linux
+2. Packages with Velopack using `0.0.{RUN_NUMBER}[-pr{PR_NUMBER}]` versioning
+3. Uploads artifacts to GitHub Actions
+4. Generates `releases.win.json` and `releases.linux.json` metadata
+
+**Artifacts uploaded:**
+
+- `genhub-velopack-windows-{VERSION}` - Windows installer and packages
+- `genhub-velopack-linux-{VERSION}` - Linux packages
+- `genhub-metadata-windows-{VERSION}` - Update metadata (`releases.win.json`)
+- `genhub-metadata-linux-{VERSION}` - Update metadata (`releases.linux.json`)
+
+#### `.github/workflows/release.yml` - Stable Releases
+
+Triggered by version tags (`v*`):
 
 1. Builds releases for Windows and Linux
-2. Packages them with Velopack
-3. Creates a GitHub Release with installers
+2. Creates GitHub Release
+3. Uploads installers and packages
 4. Publishes update feed for automatic updates
 
-**To trigger a release:**
+**To trigger a stable release:**
 
 ```bash
-git tag v1.0.0
-git push origin v1.0.0
+git tag v0.0.157
+git push origin v0.0.157
 ```
-
-Or manually through GitHub Actions workflow dispatch.
 
 ## Release Artifacts
 
 After packaging, Velopack generates:
 
-- **GenHub-win-Setup.exe** (Windows) - Full installer that installs to `%LOCALAPPDATA%\GenHub`
+### Windows
+
+- **GenHub-{Version}-Setup.exe** - Full installer (installs to `%LOCALAPPDATA%\GenHub`)
 - **GenHub-{Version}-full.nupkg** - Full release package
 - **GenHub-{Version}-delta.nupkg** - Delta update package (if previous version exists)
-- **GenHub-win-Portable.zip** - Portable version (no installation required)
-- **RELEASES** - Update feed manifest
+- **GenHub-{Version}-Portable.zip** - Portable version (no installation required)
+- **releases.win.json** - Update feed manifest (JSON format)
 
-Upload all artifacts to GitHub Releases. Velopack will automatically serve updates.
+### Linux
+
+- **GenHub-{Version}-linux-x64.AppImage** - AppImage installer
+- **GenHub-{Version}-full.nupkg** - Full release package
+- **GenHub-{Version}-delta.nupkg** - Delta update package
+- **releases.linux.json** - Update feed manifest (JSON format)
+
+**Note**: Velopack v0.0.942+ uses JSON format (`releases.*.json`) instead of the legacy `RELEASES` file.
 
 ## Installation Locations
 
@@ -139,7 +280,7 @@ Upload all artifacts to GitHub Releases. Velopack will automatically serve updat
 
 - **Installation Directory**: `%LOCALAPPDATA%\GenHub\` (e.g., `C:\Users\YourName\AppData\Local\GenHub\`)
 - **User Data**: `%APPDATA%\GenHub\`
-- **Update Cache**: `%LOCALAPPDATA%\GenHub\`
+- **Update Cache**: `%LOCALAPPDATA%\GenHub\packages\`
 
 **Note**: Velopack uses a "one-click" installer that always installs to LocalAppData. This location:
 
@@ -150,111 +291,62 @@ Upload all artifacts to GitHub Releases. Velopack will automatically serve updat
 
 ### Linux Installation
 
-- **Installation Directory**: `/usr/local/bin/GenHub/` or `~/.local/share/GenHub/`
+- **Installation Directory**: `~/.local/share/GenHub/`
 - **User Data**: `~/.config/GenHub/`
 - **Update Cache**: `~/.cache/GenHub/`
 
 The app ID `GenHub` ensures clean, predictable installation paths without vendor prefixes.
 
-## Release Channels and Prerelease Versions
+## Update Features
 
-Velopack supports **semantic versioning prerelease identifiers** for alpha, beta, and release candidate builds. You can use semver formats without needing separate channels:
+### Dismiss Updates
 
-### Semantic Versioning Examples
+Users can dismiss update notifications:
 
-**Version Format:** `MAJOR.MINOR.PATCH[-PRERELEASE]`
-
-```bash
-# Stable release
-vpk pack ... --packVersion 1.0.0
-
-# Alpha releases (early testing) - increment the number after alpha
-vpk pack ... --packVersion 1.0.0-alpha.1
-vpk pack ... --packVersion 1.0.0-alpha.2
-vpk pack ... --packVersion 1.0.0-alpha.3
-
-# Beta releases (feature complete, testing)
-vpk pack ... --packVersion 1.0.0-beta.1
-vpk pack ... --packVersion 1.0.0-beta.2
-
-# Release candidates
-vpk pack ... --packVersion 1.0.0-rc.1
-vpk pack ... --packVersion 1.0.0-rc.2
-
-# Final stable release
-vpk pack ... --packVersion 1.0.0
-
-# Next feature version - start over with alpha
-vpk pack ... --packVersion 1.1.0-alpha.1
-vpk pack ... --packVersion 1.1.0-alpha.2
-vpk pack ... --packVersion 1.1.0-beta.1
-vpk pack ... --packVersion 1.1.0
-
-# Patch release
-vpk pack ... --packVersion 1.1.1
-
-# Major version bump
-vpk pack ... --packVersion 2.0.0-alpha.1
+```csharp
+// In UpdateNotificationViewModel
+private void DismissUpdate()
+{
+    // Persist dismissed version to prevent showing again
+    _userSettingsService.Update(s => s.DismissedUpdateVersion = LatestVersion);
+    IsUpdateAvailable = false;
+}
 ```
 
-**Versioning Flow:**
+Dismissed updates won't reappear until a **different version** is available.
 
-```text
-1.0.0-alpha.1 → 1.0.0-alpha.2 → ... → 1.0.0-beta.1 → 1.0.0-beta.2 → 1.0.0
-                                                                        ↓
-1.1.0-alpha.1 → 1.1.0-alpha.2 → ... → 1.1.0-beta.1 → 1.1.0 ←─────────┘
+### PR Update Priority
+
+When subscribed to a PR:
+
+1. PR updates take priority over stable releases
+2. Version comparison ignores build metadata
+3. Users can "switch" to any PR build regardless of version number
+4. Unsubscribing returns to stable channel
+
+### Build Metadata Handling
+
+Build metadata (commit hashes) is:
+
+- **Included** in the version string for tracking
+- **Displayed** in the UI for transparency
+- **Stripped** during version comparison to avoid false updates
+- **Logged** for debugging purposes
+
+Example:
+
 ```
-
-### How Velopack Handles Prereleases
-
-- **Stable users** (installed from a stable version like `1.0.0`) will ONLY receive stable updates
-- **Prerelease users** (installed from `1.0.0-beta.1`) will receive ALL updates including prereleases
-- Versioning follows [SemVer 2.0](https://semver.org/) rules
-- Users on prereleases automatically upgrade to stable when available
-
-### Using Channels for Different Features
-
-If you need separate feature branches (e.g., stable vs experimental features), use the `--channel` parameter:
-
-```bash
-# Stable channel (default: "win" for Windows, "linux" for Linux)
-vpk pack ... --packVersion 1.0.0
-
-# Beta feature channel
-vpk pack ... --packVersion 1.0.0 --channel win-beta
-
-# Experimental channel
-vpk pack ... --packVersion 1.0.0 --channel win-experimental
+Display: v0.0.160-pr3 (051baf8)
+Full version: 0.0.160-pr3+051baf8.051baf832a894f542e60d3e4c2471c7d4dd753da
+Comparison: 0.0.160-pr3
 ```
-
-**Note**: Once a user installs from a specific channel, they only receive updates from that channel unless they explicitly switch.
-
-### Recommended Strategy
-
-For most use cases, use **prerelease identifiers** instead of channels:
-
-- ✅ Simpler: No channel management needed
-- ✅ Automatic graduation: Beta users get stable updates automatically
-- ✅ Clear versioning: Everyone sees the same version numbers
-
-Use channels only if you need persistent feature branches (like stable/nightly builds).
-
-## Update Channel Management
-
-By default, GenHub uses the default update channel. You can create multiple channels (stable, beta, etc.):
-
-```bash
-vpk pack ... --channel beta
-```
-
-Users will automatically receive updates from their installed channel.
 
 ## Testing Updates Locally
 
 ### 1. Create Test Release
 
 ```powershell
-vpk pack --packId GenHub --packVersion 1.0.0 --packDir ./publish --mainExe GenHub.Windows.exe -o ./test-releases
+vpk pack --packId GenHub --packVersion 0.0.100 --packDir ./publish --mainExe GenHub.Windows.exe -o ./test-releases
 ```
 
 ### 2. Create Second Version
@@ -262,7 +354,7 @@ vpk pack --packId GenHub --packVersion 1.0.0 --packDir ./publish --mainExe GenHu
 Update your code, then:
 
 ```powershell
-vpk pack --packId GenHub --packVersion 1.0.1 --packDir ./publish --mainExe GenHub.Windows.exe -o ./test-releases --delta ./test-releases/RELEASES
+vpk pack --packId GenHub --packVersion 0.0.101 --packDir ./publish --mainExe GenHub.Windows.exe -o ./test-releases --delta ./test-releases/releases.win.json
 ```
 
 ### 3. Test Update
@@ -270,7 +362,8 @@ vpk pack --packId GenHub --packVersion 1.0.1 --packDir ./publish --mainExe GenHu
 Point UpdateManager to local directory:
 
 ```csharp
-var manager = new UpdateManager("file:///C:/path/to/test-releases");
+var source = new SimpleWebSource("file:///C:/path/to/test-releases");
+var manager = new UpdateManager(source);
 ```
 
 ## Architecture
@@ -280,7 +373,9 @@ var manager = new UpdateManager("file:///C:/path/to/test-releases");
 - **VelopackApp** - Handles application lifecycle hooks
 - **VelopackUpdateManager** - Service for checking/downloading/applying updates
 - **IVelopackUpdateManager** - Interface for update operations
-- **UpdateInfo** - Model containing update metadata
+- **UpdateInfo** - Model containing update metadata from Velopack
+- **ArtifactUpdateInfo** - Model for PR artifact metadata
+- **PullRequestInfo** - Model for PR information and artifacts
 - **UpdateProgress** - Progress reporting model
 
 ### Integration Points
@@ -288,6 +383,28 @@ var manager = new UpdateManager("file:///C:/path/to/test-releases");
 - `Program.cs` - VelopackApp.Build().Run() initialization
 - `AppUpdateModule.cs` - DI registration
 - `VelopackUpdateManager.cs` - Update service implementation
+- `UpdateNotificationViewModel.cs` - UI logic for update notifications
+- `MainViewModel.cs` - Main window update badge logic
+
+### Key Services
+
+```csharp
+public interface IVelopackUpdateManager
+{
+    // Stable channel updates
+    Task<UpdateInfo?> CheckForUpdatesAsync(CancellationToken cancellationToken = default);
+    Task DownloadUpdatesAsync(UpdateInfo updateInfo, IProgress<UpdateProgress>? progress = null);
+    void ApplyUpdatesAndRestart(UpdateInfo updateInfo);
+
+    // PR artifact updates
+    Task<PullRequestInfo?> GetSubscribedPrInfoAsync(CancellationToken cancellationToken = default);
+    Task InstallPrArtifactAsync(PullRequestInfo prInfo, IProgress<UpdateProgress>? progress = null, CancellationToken cancellationToken = default);
+
+    // Properties
+    bool HasUpdateAvailableFromGitHub { get; }
+    string? LatestVersionFromGitHub { get; }
+}
+```
 
 ## Troubleshooting
 
@@ -295,18 +412,72 @@ var manager = new UpdateManager("file:///C:/path/to/test-releases");
 
 Velopack only works when the app is installed. When running from Visual Studio or `dotnet run`, updates are disabled. This is expected behavior.
 
+To test updates:
+
+1. Build a Velopack package
+2. Install it using the Setup.exe
+3. Run the installed app
+
 ### Update Check Fails
 
-- Ensure GitHub repository is public or provide authentication
-- Verify GitHub Releases contain Velopack packages
+- **GitHub Releases**: Ensure repository is public or provide authentication
+- **PR Artifacts**: Requires GitHub PAT with `repo` scope
+- Verify GitHub Releases/Actions contain Velopack packages
 - Check network connectivity
+- Review logs for specific error messages
 
 ### Version Comparison Issues
 
-Velopack uses semantic versioning (SemVer). Ensure version numbers follow `Major.Minor.Patch` format.
+GenHub strips build metadata before comparison. If updates aren't detected:
+
+1. Check version format: `0.0.X` or `0.0.X-prY`
+2. Verify build metadata is after `+` symbol
+3. Review logs for version comparison details
+
+### PR Artifact Installation Fails
+
+Common issues:
+
+1. **"No update found from PR artifact"**
+   - Current version >= target version
+   - Velopack won't "downgrade" by default
+   - Solution: Uninstall and run Setup.exe from PR artifact
+
+2. **"Already installed"**
+   - Same base version with different build metadata
+   - This is expected - versions are identical
+
+3. **Authentication errors**
+   - GitHub PAT missing or invalid
+   - PAT needs `repo` scope for private repos
+
+### App Doesn't Restart After Update
+
+- Ensure using `ApplyUpdatesAndRestart()` not `ApplyUpdatesAndExit()`
+- Check logs for update application errors
+- Verify update package integrity
+
+## Security Considerations
+
+### GitHub Personal Access Tokens
+
+- **Storage**: Tokens are stored in Windows Credential Manager (Windows) or Keyring (Linux)
+- **Scope**: Only `repo` scope is required
+- **Usage**: Only for downloading PR artifacts
+- **Rotation**: Users can update/remove tokens at any time
+
+### Update Verification
+
+Velopack verifies package integrity using:
+
+- SHA256 checksums in metadata files
+- Package signatures (if configured)
+- HTTPS for all downloads
 
 ## Additional Resources
 
 - [Velopack Documentation](https://docs.velopack.io/)
 - [Velopack GitHub](https://github.com/velopack/velopack)
 - [GitHub Releases Guide](https://docs.github.com/en/repositories/releasing-projects-on-github)
+- [GitHub Actions Artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts)
+- [Semantic Versioning](https://semver.org/)


### PR DESCRIPTION
## Summary

This PR adds automated Velopack packaging to the CI/CD pipeline, enabling automatic installer generation and update package creation for both Windows and Linux builds.

## Changes

### CI Workflow
- Extract build metadata (git hash, PR number, run number) for versioning
- Install Velopack CLI and create packages during CI builds
- Upload versioned artifacts: setup installers, update packages (.nupkg), and metadata
- Add release job that creates GitHub Releases for main branch builds
- Update build summary to include release status

### Versioning
- Switch to `0.0.X` alpha versioning scheme (SemVer2 compatible with Velopack)
- CI builds use format: `0.0.{RUN_NUMBER}` or `0.0.{RUN_NUMBER}-pr{PR_NUMBER}`
- Embed git hash in `InformationalVersion` for traceability
- Add assembly metadata attributes for runtime access to build info

### Runtime Build Info
- Expose `GitShortHash`, `PullRequestNumber`, `BuildChannel` via `AppConstants`
- Add `IsCiBuild` and `FullDisplayVersion` properties
- Display version format: `v0.0.150 (abc1234)` or `v0.0.150-pr42 PR#42 (abc1234)`

### Documentation
- Comprehensive update to `velopack-integration.md`
- Document versioning scheme, update channels, and PR artifact support
- Add troubleshooting section for common issues

## Artifacts Produced

| Platform | Artifact | Description |
|----------|----------|-------------|
| Windows | `genhub-velopack-windows-{VERSION}` | Update package (.nupkg) |
| Windows | `genhub-setup-windows-{VERSION}` | Setup installer (.exe) |
| Windows | `genhub-metadata-windows-{VERSION}` | RELEASES file |
| Linux | `genhub-velopack-linux-{VERSION}` | Update package (.nupkg) |
| Linux | `genhub-metadata-linux-{VERSION}` | releases.linux.json |

## Breaking Changes

- Version format changed from `1.0.0-alpha.1` to `0.0.X`
- Test assertions updated to expect `0.0` prefix