### PR TITLE
feat: implement interactive numeric inputs for game settings

### DIFF
--- a/GenHub/GenHub/Features/GameProfiles/Views/GameSettingsView.axaml
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameSettingsView.axaml
@@ -13,6 +13,7 @@
         <conv:ThemeBackgroundConverter x:Key="ThemeBackgroundConverter" />
         <conv:ThemeBorderConverter x:Key="ThemeBorderConverter" />
         <conv:ColorToBrushConverter x:Key="ColorToBrushConverter" />
+        <conv:NullableDecimalToIntConverter x:Key="NullableDecimalToIntConverter" />
     </UserControl.Resources>
 
     <UserControl.Styles>
@@ -82,6 +83,35 @@
             <Setter Property="CornerRadius" Value="6" />
             <Setter Property="Padding" Value="12" />
             <Setter Property="Margin" Value="0,0,0,12" />
+        </Style>
+
+        <!-- Phantom NumericUpDown style -->
+        <Style Selector="NumericUpDown.phantom">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="ShowButtonSpinner" Value="False" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Height" Value="20" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="MaxWidth" Value="45" />
+            <Setter Property="Width" Value="45" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="TextAlignment" Value="Center" />
+            <Setter Property="Watermark" Value="0" />
+        </Style>
+        <Style Selector="NumericUpDown.phantom:pointerover /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="#10FFFFFF" />
+            <Setter Property="CornerRadius" Value="4" />
+        </Style>
+        <Style Selector="NumericUpDown.phantom:focus /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="#20FFFFFF" />
+            <Setter Property="CornerRadius" Value="4" />
+        </Style>
+        <Style Selector="NumericUpDown.phantom /template/ TextBox#PART_TextBox">
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="Padding" Value="0" />
         </Style>
     </UserControl.Styles>
 
@@ -157,12 +187,12 @@
                             </Grid>
                             
                             <!-- Gamma Slider -->
-                            <Grid ColumnDefinitions="110,*,40" Margin="0,12,0,0">
+                            <Grid ColumnDefinitions="110,*,60" Margin="0,12,0,0">
                                 <TextBlock Grid.Column="0" Text="Gamma" VerticalAlignment="Center" />
                                 <Slider Grid.Column="1" Value="{Binding Gamma}" Minimum="0" Maximum="100" 
                                         TickFrequency="10" IsSnapToTickEnabled="True" VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="2" Text="{Binding Gamma}" FontWeight="Bold" 
-                                           VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                <NumericUpDown Grid.Column="2" Classes="phantom" Value="{Binding Gamma, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="100" 
+                                               Increment="10" ClipValueToMinMax="True" FormatString="0" />
                             </Grid>
                         </StackPanel>
                     </Border>
@@ -185,41 +215,41 @@
                             <CheckBox Content="Audio Enabled" IsChecked="{Binding AudioEnabled}" FontWeight="Medium" Margin="0,0,0,12" />
                             
                             <!-- Volume sliders grid -->
-                            <Grid ColumnDefinitions="100,*,40" RowDefinitions="Auto,Auto,Auto,Auto,Auto" IsEnabled="{Binding AudioEnabled}">
+                            <Grid ColumnDefinitions="100,*,60" RowDefinitions="Auto,Auto,Auto,Auto,Auto" IsEnabled="{Binding AudioEnabled}">
                                 <!-- Sound Volume -->
                                 <TextBlock Grid.Column="0" Grid.Row="0" Text="Sound" VerticalAlignment="Center" Margin="0,0,0,10" />
                                 <Slider Grid.Column="1" Grid.Row="0" Value="{Binding SoundVolume}" Minimum="0" Maximum="100" 
                                         TickFrequency="5" IsSnapToTickEnabled="True" VerticalAlignment="Center" Margin="0,0,0,10" />
-                                <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding SoundVolume}" FontWeight="Bold" 
-                                           VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,0,10" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="0" Classes="phantom" Value="{Binding SoundVolume, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="100" 
+                                               Increment="5" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,10" />
 
                                 <!-- 3D Sound Volume -->
                                 <TextBlock Grid.Column="0" Grid.Row="1" Text="3D Sound" VerticalAlignment="Center" Margin="0,0,0,10" />
                                 <Slider Grid.Column="1" Grid.Row="1" Value="{Binding ThreeDSoundVolume}" Minimum="0" Maximum="100" 
                                         TickFrequency="5" IsSnapToTickEnabled="True" VerticalAlignment="Center" Margin="0,0,0,10" />
-                                <TextBlock Grid.Column="2" Grid.Row="1" Text="{Binding ThreeDSoundVolume}" FontWeight="Bold" 
-                                           VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,0,10" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="1" Classes="phantom" Value="{Binding ThreeDSoundVolume, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="100" 
+                                               Increment="5" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,10" />
 
                                 <!-- Speech Volume -->
                                 <TextBlock Grid.Column="0" Grid.Row="2" Text="Speech" VerticalAlignment="Center" Margin="0,0,0,10" />
                                 <Slider Grid.Column="1" Grid.Row="2" Value="{Binding SpeechVolume}" Minimum="0" Maximum="100" 
                                         TickFrequency="5" IsSnapToTickEnabled="True" VerticalAlignment="Center" Margin="0,0,0,10" />
-                                <TextBlock Grid.Column="2" Grid.Row="2" Text="{Binding SpeechVolume}" FontWeight="Bold" 
-                                           VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,0,10" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="2" Classes="phantom" Value="{Binding SpeechVolume, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="100" 
+                                               Increment="5" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,10" />
 
                                 <!-- Music Volume -->
                                 <TextBlock Grid.Column="0" Grid.Row="3" Text="Music" VerticalAlignment="Center" Margin="0,0,0,10" />
                                 <Slider Grid.Column="1" Grid.Row="3" Value="{Binding MusicVolume}" Minimum="0" Maximum="100" 
                                         TickFrequency="5" IsSnapToTickEnabled="True" VerticalAlignment="Center" Margin="0,0,0,10" />
-                                <TextBlock Grid.Column="2" Grid.Row="3" Text="{Binding MusicVolume}" FontWeight="Bold" 
-                                           VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,0,10" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="3" Classes="phantom" Value="{Binding MusicVolume, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="100" 
+                                               Increment="5" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,10" />
 
                                 <!-- Number of Sounds -->
                                 <TextBlock Grid.Column="0" Grid.Row="4" Text="Channels" VerticalAlignment="Center" />
                                 <Slider Grid.Column="1" Grid.Row="4" Value="{Binding NumSounds}" Minimum="2" Maximum="32" 
                                         TickFrequency="2" IsSnapToTickEnabled="True" VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="2" Grid.Row="4" Text="{Binding NumSounds}" FontWeight="Bold" 
-                                           VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="4" Classes="phantom" Value="{Binding NumSounds, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=2, UpdateSourceTrigger=LostFocus}" Minimum="2" Maximum="32" 
+                                               Increment="2" ClipValueToMinMax="True" FormatString="0" />
                             </Grid>
                         </StackPanel>
                     </Border>
@@ -295,22 +325,22 @@
                             
                             <!-- Font Sizes -->
                             <TextBlock Classes="subsection-header" Text="Font Sizes" />
-                            <Grid ColumnDefinitions="110,*,40" RowDefinitions="Auto,Auto,Auto,Auto">
+                            <Grid ColumnDefinitions="110,*,60" RowDefinitions="Auto,Auto,Auto,Auto">
                                 <TextBlock Grid.Column="0" Grid.Row="0" Text="System Time" VerticalAlignment="Center" Margin="0,0,0,8" />
                                 <Slider Grid.Column="1" Grid.Row="0" Value="{Binding TshSystemTimeFontSize}" Minimum="0" Maximum="24" TickFrequency="1" IsSnapToTickEnabled="True" Margin="0,0,0,8" />
-                                <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding TshSystemTimeFontSize}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,0,8" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="0" Classes="phantom" Value="{Binding TshSystemTimeFontSize, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="24" Increment="1" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,8" />
                                 
                                 <TextBlock Grid.Column="0" Grid.Row="1" Text="Latency" VerticalAlignment="Center" Margin="0,0,0,8" />
                                 <Slider Grid.Column="1" Grid.Row="1" Value="{Binding TshNetworkLatencyFontSize}" Minimum="0" Maximum="24" TickFrequency="1" IsSnapToTickEnabled="True" Margin="0,0,0,8" />
-                                <TextBlock Grid.Column="2" Grid.Row="1" Text="{Binding TshNetworkLatencyFontSize}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,0,8" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="1" Classes="phantom" Value="{Binding TshNetworkLatencyFontSize, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="24" Increment="1" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,8" />
                                 
                                 <TextBlock Grid.Column="0" Grid.Row="2" Text="FPS" VerticalAlignment="Center" Margin="0,0,0,8" />
                                 <Slider Grid.Column="1" Grid.Row="2" Value="{Binding TshRenderFpsFontSize}" Minimum="0" Maximum="24" TickFrequency="1" IsSnapToTickEnabled="True" Margin="0,0,0,8" />
-                                <TextBlock Grid.Column="2" Grid.Row="2" Text="{Binding TshRenderFpsFontSize}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,0,8" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="2" Classes="phantom" Value="{Binding TshRenderFpsFontSize, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="24" Increment="1" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,8" />
                                 
                                 <TextBlock Grid.Column="0" Grid.Row="3" Text="Adjustment" VerticalAlignment="Center" />
                                 <Slider Grid.Column="1" Grid.Row="3" Value="{Binding TshResolutionFontAdjustment}" Minimum="-100" Maximum="100" TickFrequency="10" IsSnapToTickEnabled="True" />
-                                <TextBlock Grid.Column="2" Grid.Row="3" Text="{Binding TshResolutionFontAdjustment}" FontWeight="Bold" VerticalAlignment="Center" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="3" Classes="phantom" Value="{Binding TshResolutionFontAdjustment, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=-100, UpdateSourceTrigger=LostFocus}" Minimum="-100" Maximum="100" Increment="10" ClipValueToMinMax="True" FormatString="0" />
                             </Grid>
                             
                             <!-- Cursor Capture -->
@@ -330,10 +360,10 @@
                             </StackPanel>
                             
                             <!-- Money Alert Volume -->
-                            <Grid ColumnDefinitions="110,*,40" Margin="0,12,0,0">
+                            <Grid ColumnDefinitions="110,*,60" Margin="0,12,0,0">
                                 <TextBlock Grid.Column="0" Text="Money Alert" VerticalAlignment="Center" />
                                 <Slider Grid.Column="1" Value="{Binding TshMoneyTransactionVolume}" Minimum="0" Maximum="100" TickFrequency="5" IsSnapToTickEnabled="True" />
-                                <TextBlock Grid.Column="2" Text="{Binding TshMoneyTransactionVolume}" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                <NumericUpDown Grid.Column="2" Classes="phantom" Value="{Binding TshMoneyTransactionVolume, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0, UpdateSourceTrigger=LostFocus}" Minimum="0" Maximum="100" Increment="5" ClipValueToMinMax="True" FormatString="0" />
                             </Grid>
                         </StackPanel>
                     </Border>
@@ -372,27 +402,27 @@
                             <!-- Render Settings -->
                             <TextBlock Classes="subsection-header" Text="Render" Margin="0,8,0,8" />
                             <CheckBox Content="Limit Framerate" IsChecked="{Binding GoRenderLimitFramerate}" Margin="0,0,0,4" />
-                            <Grid ColumnDefinitions="110,*,40" Margin="0,0,0,8">
+                            <Grid ColumnDefinitions="110,*,60" Margin="0,0,0,8">
                                 <TextBlock Grid.Column="0" Text="FPS Limit" VerticalAlignment="Center" />
                                 <Slider Grid.Column="1" Value="{Binding GoRenderFpsLimit}" Minimum="30" Maximum="240" TickFrequency="10" IsSnapToTickEnabled="True" 
                                         IsEnabled="{Binding GoRenderLimitFramerate}" />
-                                <TextBlock Grid.Column="2" Text="{Binding GoRenderFpsLimit}" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                <NumericUpDown Grid.Column="2" Classes="phantom" Value="{Binding GoRenderFpsLimit, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=30, UpdateSourceTrigger=LostFocus}" Minimum="30" Maximum="240" Increment="10" ClipValueToMinMax="True" FormatString="0" IsEnabled="{Binding GoRenderLimitFramerate}" />
                             </Grid>
                             
                             <!-- Camera Settings -->
                             <TextBlock Classes="subsection-header" Text="Camera" Margin="0,0,0,8" />
-                            <Grid ColumnDefinitions="110,*,50" RowDefinitions="Auto,Auto,Auto">
+                            <Grid ColumnDefinitions="110,*,60" RowDefinitions="Auto,Auto,Auto">
                                 <TextBlock Grid.Column="0" Grid.Row="0" Text="Max Height" VerticalAlignment="Center" Margin="0,0,0,8" />
                                 <Slider Grid.Column="1" Grid.Row="0" Value="{Binding GoCameraMaxHeightOnlyWhenLobbyHost}" Minimum="100" Maximum="500" TickFrequency="10" IsSnapToTickEnabled="True" Margin="0,0,0,8" />
-                                <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding GoCameraMaxHeightOnlyWhenLobbyHost, StringFormat={}{0:F0}}" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,0,8" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="0" Classes="phantom" Value="{Binding GoCameraMaxHeightOnlyWhenLobbyHost, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=100, UpdateSourceTrigger=LostFocus}" Minimum="100" Maximum="500" Increment="10" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,8" />
                                 
                                 <TextBlock Grid.Column="0" Grid.Row="1" Text="Min Height" VerticalAlignment="Center" Margin="0,0,0,8" />
                                 <Slider Grid.Column="1" Grid.Row="1" Value="{Binding GoCameraMinHeight}" Minimum="100" Maximum="500" TickFrequency="10" IsSnapToTickEnabled="True" Margin="0,0,0,8" />
-                                <TextBlock Grid.Column="2" Grid.Row="1" Text="{Binding GoCameraMinHeight, StringFormat={}{0:F0}}" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,0,8" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="1" Classes="phantom" Value="{Binding GoCameraMinHeight, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=100, UpdateSourceTrigger=LostFocus}" Minimum="100" Maximum="500" Increment="10" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,8" />
                                 
                                 <TextBlock Grid.Column="0" Grid.Row="2" Text="Move Speed" VerticalAlignment="Center" />
                                 <Slider Grid.Column="1" Grid.Row="2" Value="{Binding GoCameraMoveSpeedRatio}" Minimum="0.5" Maximum="3.0" TickFrequency="0.1" IsSnapToTickEnabled="True" />
-                                <TextBlock Grid.Column="2" Grid.Row="2" Text="{Binding GoCameraMoveSpeedRatio, StringFormat={}{0:F1}}" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="2" Classes="phantom" Value="{Binding GoCameraMoveSpeedRatio, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=0.5, UpdateSourceTrigger=LostFocus}" Minimum="0.5" Maximum="3.0" Increment="0.1" ClipValueToMinMax="True" FormatString="F1" />
                             </Grid>
                             
                             <!-- Account Options -->
@@ -404,14 +434,14 @@
                             
                             <!-- Chat Settings -->
                             <TextBlock Classes="subsection-header" Text="Chat" Margin="0,8,0,8" />
-                            <Grid ColumnDefinitions="110,*,40" RowDefinitions="Auto,Auto">
+                            <Grid ColumnDefinitions="110,*,60" RowDefinitions="Auto,Auto">
                                 <TextBlock Grid.Column="0" Grid.Row="0" Text="Font Size" VerticalAlignment="Center" Margin="0,0,0,8" />
                                 <Slider Grid.Column="1" Grid.Row="0" Value="{Binding GoChatFontSize}" Minimum="8" Maximum="24" TickFrequency="1" IsSnapToTickEnabled="True" Margin="0,0,0,8" />
-                                <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding GoChatFontSize}" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,0,8" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="0" Classes="phantom" Value="{Binding GoChatFontSize, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=8, UpdateSourceTrigger=LostFocus}" Minimum="8" Maximum="24" Increment="1" ClipValueToMinMax="True" FormatString="0" Margin="0,0,0,8" />
                                 
                                 <TextBlock Grid.Column="0" Grid.Row="1" Text="Fade Out (s)" VerticalAlignment="Center" />
                                 <Slider Grid.Column="1" Grid.Row="1" Value="{Binding GoChatDurationSecondsUntilFadeOut}" Minimum="5" Maximum="120" TickFrequency="5" IsSnapToTickEnabled="True" />
-                                <TextBlock Grid.Column="2" Grid.Row="1" Text="{Binding GoChatDurationSecondsUntilFadeOut}" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                <NumericUpDown Grid.Column="2" Grid.Row="1" Classes="phantom" Value="{Binding GoChatDurationSecondsUntilFadeOut, Converter={StaticResource NullableDecimalToIntConverter}, ConverterParameter=5, UpdateSourceTrigger=LostFocus}" Minimum="5" Maximum="120" Increment="5" ClipValueToMinMax="True" FormatString="0" />
                             </Grid>
                             
                             <!-- Notifications -->

--- a/GenHub/GenHub/Infrastructure/Converters/NullableDecimalToIntConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/NullableDecimalToIntConverter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace GenHub.Infrastructure.Converters;
+
+/// <summary>
+/// Converts between nullable decimal (from NumericUpDown) and int (ViewModel property).
+/// Handles null/empty input by returning a default value (ConverterParameter or 0).
+/// </summary>
+public class NullableDecimalToIntConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        // Direction: ViewModel (int/float) -> View (decimal?)
+        if (value == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return System.Convert.ToDecimal(value, culture);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+
+    /// <inheritdoc />
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        // Direction: View (decimal?) -> ViewModel (int/float)
+        if (value is decimal decimalVal)
+        {
+            try
+            {
+                return System.Convert.ChangeType(decimalVal, targetType, culture);
+            }
+            catch
+            {
+                return Avalonia.Data.BindingOperations.DoNothing;
+            }
+        }
+
+        // Handle null/empty input
+        if (value is null)
+        {
+            // Try to use the parameter as the fallback value
+            if (parameter != null)
+            {
+                try
+                {
+                    return System.Convert.ChangeType(parameter, targetType, culture);
+                }
+                catch { }
+            }
+
+            try
+            {
+                return System.Convert.ChangeType(0, targetType, culture);
+            }
+            catch
+            {
+                return Avalonia.Data.BindingOperations.DoNothing;
+            }
+        }
+
+        return Avalonia.Data.BindingOperations.DoNothing;
+    }
+}


### PR DESCRIPTION
#### Summary
This PR replaces the read-only `TextBlock` elements located next to sliders in the `GameSettingsView` with a custom-styled `NumericUpDown` control. This allows users to either use the slider for coarse adjustments or type precise values manually.

#### Changes
*   **New Infrastructure:** Added `NullableDecimalToIntConverter` to bridge the gap between the `decimal?` type used by Avalonia's `NumericUpDown` and the `int`/`float` types used in our ViewModels.
*   **UI Styling:** Created a new `phantom` style for `NumericUpDown`. This style removes the default borders and spinner buttons, making the control look like a standard label until it is hovered or focused, preserving the clean UI aesthetic.
*   **Layout Adjustments:**
    *   Increased the value column width in the settings grids from `40`/`50` to `60` to accommodate three-digit inputs.
    *   Applied the new input logic to:
        *   **Video:** Gamma settings.
        *   **Audio:** Master, 3D, Speech, Music, and Channel counts.
        *   **Tsh Settings:** Font sizes, Resolution adjustment, and Money Alert volume.
        *   **Game Options:** FPS limits, Camera heights/speed, and Chat settings.
*   **Behavior:** Set `UpdateSourceTrigger=LostFocus` on all numeric inputs to prevent partial data from being processed while the user is still typing.


https://github.com/user-attachments/assets/749aaa9e-6f01-445c-8b99-6d6ab4531ba9


