### PR TITLE
feat: enhance game profile settings UI, local content, and dependency resolution

### DIFF
--- a/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
+++ b/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
@@ -80,6 +80,21 @@ public class LocalContentService(
 
             var manifest = builder.Build();
 
+            // Auto-add GameInstallation dependency for GameClient content types
+            // This ensures auto-resolution logic works correctly for locally added clients
+            if (contentType == ContentType.GameClient)
+            {
+                manifest.Dependencies.Add(new ContentDependency
+                {
+                    Id = ManifestId.Create(ManifestConstants.DefaultContentDependencyId),
+                    DependencyType = ContentType.GameInstallation,
+                    CompatibleGameTypes = [targetGame],
+                    IsOptional = false,
+                });
+
+                logger.LogInformation("Auto-added GameInstallation dependency for local GameClient");
+            }
+
             // Override publisher info to mark as local content
             manifest.Publisher = new PublisherInfo
             {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -315,7 +315,6 @@ public class GameProfileSettingsViewModelDependencyTests
         Assert.DoesNotMatch("Error: Missing required dependencies", _viewModel.StatusMessage);
     }
 
-
     /// <summary>
     /// Verifies that enabling content requiring a different Game Installation automatically switches the selected installation.
     /// </summary>
@@ -323,7 +322,6 @@ public class GameProfileSettingsViewModelDependencyTests
     [Fact]
     public async Task EnableContent_AutoSwitches_GameInstallation_When_Dependency_Requires_Different_Type()
     {
-
         // Arrange
         var modManifestId = new ManifestId("1.0.0.mod.generalsonline");
         var zeroHourInstallId = new ManifestId("1.0.0.gameinstallation.zerohour");
@@ -340,7 +338,7 @@ public class GameProfileSettingsViewModelDependencyTests
                 {
                     Id = zeroHourInstallId, // Specifically requires Zero Hour
                     DependencyType = ContentType.GameInstallation,
-                    CompatibleGameTypes = [GameType.ZeroHour]
+                    CompatibleGameTypes = [GameType.ZeroHour],
                 },
             ],
         };
@@ -357,7 +355,7 @@ public class GameProfileSettingsViewModelDependencyTests
             ContentType = ContentType.GameInstallation,
             GameType = GameType.Generals,
             InstallationType = GameInstallationType.Steam, // Added required property
-            IsEnabled = true // Initially selected/enabled
+            IsEnabled = true, // Initially selected/enabled
         };
 
         var zeroHourInstall = new ViewModelContentDisplayItem
@@ -367,7 +365,7 @@ public class GameProfileSettingsViewModelDependencyTests
             ContentType = ContentType.GameInstallation,
             GameType = GameType.ZeroHour,
             InstallationType = GameInstallationType.Steam, // Added required property
-            IsEnabled = false
+            IsEnabled = false,
         };
 
         _viewModel.AvailableGameInstallations = [generalsInstall, zeroHourInstall];
@@ -381,7 +379,7 @@ public class GameProfileSettingsViewModelDependencyTests
             ContentType = ContentType.GameClient,
             GameType = GameType.ZeroHour, // Added required property (assuming match)
             InstallationType = GameInstallationType.Unknown, // Added required property
-            IsEnabled = false
+            IsEnabled = false,
         };
         _viewModel.AvailableContent.Add(modDisplayItem);
 
@@ -425,7 +423,7 @@ public class GameProfileSettingsViewModelDependencyTests
             ContentType = ContentType.GameInstallation,
             GameType = GameType.Generals,
             InstallationType = GameInstallationType.EaApp,
-            IsEnabled = true
+            IsEnabled = true,
         };
 
         var zeroHourInstall = new ViewModelContentDisplayItem
@@ -435,7 +433,7 @@ public class GameProfileSettingsViewModelDependencyTests
             ContentType = ContentType.GameInstallation,
             GameType = GameType.ZeroHour,
             InstallationType = GameInstallationType.EaApp,
-            IsEnabled = false
+            IsEnabled = false,
         };
 
         _viewModel.AvailableGameInstallations = [generalsInstall, zeroHourInstall];
@@ -450,9 +448,10 @@ public class GameProfileSettingsViewModelDependencyTests
             ContentType = ContentType.GameClient,
             GameType = GameType.ZeroHour,
             InstallationType = GameInstallationType.EaApp,
+
             // CRITICAL: SourceId must point to the installation
             SourceId = zeroHourInstallId.Value,
-            IsEnabled = false
+            IsEnabled = false,
         };
         _viewModel.AvailableContent.Add(clientDisplayItem);
 
@@ -492,7 +491,7 @@ public class GameProfileSettingsViewModelDependencyTests
                     Id = mapPackId,
                     DependencyType = ContentType.MapPack,
                     IsOptional = false,
-                    Name = "QuickMatch MapPack"
+                    Name = "QuickMatch MapPack",
                 },
             ],
         };
@@ -525,7 +524,7 @@ public class GameProfileSettingsViewModelDependencyTests
             ContentType = ContentType.GameClient,
             GameType = GameType.ZeroHour, // Added required property
             InstallationType = GameInstallationType.Unknown, // Added required property
-            IsEnabled = false
+            IsEnabled = false,
         };
         _viewModel.AvailableContent.Add(clientDisplayItem);
 

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -289,6 +289,25 @@ public class GameClientDetector(
             var manifest = builder.Build();
             manifest.ContentType = ContentType.GameClient;
 
+            // Add game installation dependency if installation is provided (Fix for 1.04/1.08 auto-selection)
+            if (installation != null)
+            {
+                var dependencyName = gameType == GameType.ZeroHour
+                    ? GameClientConstants.ZeroHourInstallationDependencyName
+                    : GameClientConstants.GeneralsInstallationDependencyName;
+
+                var installDependency = new ContentDependency
+                {
+                    Id = ManifestId.Create(ManifestConstants.DefaultContentDependencyId),
+                    Name = dependencyName,
+                    DependencyType = ContentType.GameInstallation,
+                    InstallBehavior = DependencyInstallBehavior.RequireExisting,
+                    CompatibleGameTypes = [gameType],
+                    IsOptional = false,
+                };
+                manifest.Dependencies.Add(installDependency);
+            }
+
             // Use ManifestIdGenerator for deterministic client ID generation
             if (installation != null)
             {

--- a/GenHub/GenHub/Features/GameProfiles/Views/GameProfileSettingsWindow.axaml
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameProfileSettingsWindow.axaml
@@ -862,6 +862,24 @@
                                    FontSize="10" Opacity="0.6" FontStyle="Italic" />
                     </StackPanel>
                     
+                    <!-- Game Type Selection - Only for Game Client -->
+                    <StackPanel Spacing="6"
+                                IsVisible="{Binding SelectedLocalContentType, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static models:ContentType.GameClient}}">
+                        <TextBlock Text="Target Game" FontSize="12" Opacity="0.8" />
+                        <ComboBox ItemsSource="{x:Static vm:GameProfileSettingsViewModel.AvailableLocalGameTypes}"
+                                  SelectedItem="{Binding SelectedLocalGameType}"
+                                  HorizontalAlignment="Stretch"
+                                  MinHeight="36">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={x:Static conv:GameTypeDisplayConverter.Instance}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <TextBlock Text="Specify which game version this executable belongs to"
+                                   FontSize="10" Opacity="0.6" FontStyle="Italic" />
+                    </StackPanel>
+                    
                     <!-- Action Buttons -->
                     <Grid ColumnDefinitions="*,Auto,Auto" Margin="0,8,0,0">
                         <Button Grid.Column="1" Content="Cancel"

--- a/GenHub/GenHub/Features/GameProfiles/Views/GameProfileSettingsWindow.axaml
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameProfileSettingsWindow.axaml
@@ -368,7 +368,7 @@
                                     IsVisible="{Binding EnabledContent.Count, Converter={x:Static ObjectConverters.Equal}, ConverterParameter=0}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <TextBlock Text="⚠️" FontSize="14" />
-                                    <TextBlock Text="No content enabled. Add at least one Game Installation to launch this profile."
+                                    <TextBlock Text="No content enabled. Add at least one Game Client (Executable) to launch this profile."
                                                FontSize="12" Opacity="0.9" TextWrapping="Wrap" VerticalAlignment="Center" />
                                 </StackPanel>
                             </Border>
@@ -420,15 +420,7 @@
                             
                             <!-- Content type filter pills -->
                             <WrapPanel Margin="0,0,0,12" HorizontalAlignment="Center">
-                                <Button Classes="filter-pill" Margin="0,0,8,8"
-                                        Classes.selected="{Binding SelectedContentType, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static models:ContentType.GameInstallation}}"
-                                        Command="{Binding SelectContentTypeFilterCommand}"
-                                        CommandParameter="{x:Static models:ContentType.GameInstallation}">
-                                    <StackPanel Orientation="Horizontal" Spacing="6">
-                                        <PathIcon Data="M19,20H4C2.89,20 2,19.1 2,18V6C2,4.89 2.89,4 4,4H10L12,6H19A2,2 0 0,1 21,8H21L4,8V18L6.14,10H23.21L20.93,18.5C20.7,19.37 19.92,20 19,20Z" Width="16" Height="16" />
-                                        <TextBlock Text="Installation" FontSize="12" />
-                                    </StackPanel>
-                                </Button>
+
                                 
                                 <Button Classes="filter-pill" Margin="0,0,8,8"
                                         Classes.selected="{Binding SelectedContentType, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static models:ContentType.GameClient}}"

--- a/GenHub/GenHub/Infrastructure/Converters/NullableDecimalToIntConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/NullableDecimalToIntConverter.cs
@@ -55,7 +55,9 @@ public class NullableDecimalToIntConverter : IValueConverter
                 {
                     return System.Convert.ChangeType(parameter, targetType, culture);
                 }
-                catch { }
+                catch
+                {
+                }
             }
 
             try


### PR DESCRIPTION
## Overview
This series of changes streamlines the game profile configuration process by automating dependency resolution and simplifying the UI. The core focus is moving "Game Installation" management into the background—automatically switching base installations based on the selected Game Client or Mod—and improving the workflow for adding local content.

## Technical Changelog
- **1f1c3f39**: Implemented `ResolveDependenciesAsync` in the profile view model. This automatically switches the active `GameInstallation` (e.g., Generals vs. Zero Hour) when a specific client is enabled. Added comprehensive unit tests for dependency auto-resolution and MapPack auto-enablement.
- **154b34e8**: Enhanced local content support. Added a `GameType` selector in the UI for adding local executables, allowing users to specify the target game version. Updated the local content service to automatically inject installation dependencies into synthetic manifests.
- **a6a71999**: Simplified the UI by removing `GameInstallation` from the visible content filters, making `GameClient` the default view. Refactored `EnableContent` into an asynchronous internal logic flow (`EnableContentInternal`) to safely handle recursive dependency resolution and loading guards.

## Impact
- **UX Improvement**: Users no longer need to manually toggle between game installations; selecting a mod or client now automatically configures the correct base game.
- **Robustness**: Local executables now benefit from the same validation and dependency logic as manifest-based content.
- **Code Quality**: Improved async safety in the ViewModel and decoupled the UI filters from the underlying dependency requirements.

https://github.com/user-attachments/assets/3bee7fbe-8915-4ad1-b1dd-5239ffe98983

