### PR TITLE
feat: implement GeneralsOnline profile reconciliation service and update detection

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/Content/IGeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IGeneralsOnlineProfileReconciler.cs
@@ -1,0 +1,26 @@
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Service for reconciling profiles when GeneralsOnline updates are detected.
+/// When an update is found, this service updates all profiles using GeneralsOnline,
+/// removes old manifests and CAS content, and prepares profiles for the new version.
+/// </summary>
+public interface IGeneralsOnlineProfileReconciler
+{
+    /// <summary>
+    /// Checks for GeneralsOnline updates and reconciles all affected profiles if an update is found.
+    /// This method should be called before launching a GeneralsOnline profile.
+    /// </summary>
+    /// <param name="triggeringProfileId">The ID of the profile that triggered the check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// - Success with Data=true: Update was found and applied successfully.
+    /// - Success with Data=false: No update was needed.
+    /// - Failure: Update check or reconciliation failed.
+    /// </returns>
+    Task<OperationResult<bool>> CheckAndReconcileIfNeededAsync(
+        string triggeringProfileId,
+        CancellationToken cancellationToken = default);
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceReconcilerConflictTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceReconcilerConflictTests.cs
@@ -55,7 +55,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
         };
 
         // Act
-        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config, CancellationToken.None);
+        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config);
 
         // Assert
         Assert.NotEmpty(result);
@@ -86,7 +86,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
         };
 
         // Act
-        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config, CancellationToken.None);
+        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config);
 
         // Assert
         Assert.NotEmpty(result);
@@ -117,7 +117,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
         };
 
         // Act
-        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config, CancellationToken.None);
+        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config);
 
         // Assert
         Assert.NotEmpty(result);
@@ -149,7 +149,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
         };
 
         // Act
-        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config, CancellationToken.None);
+        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config);
 
         // Assert
         Assert.NotEmpty(result);
@@ -180,7 +180,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
         };
 
         // Act
-        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config, CancellationToken.None);
+        var result = await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config);
 
         // Assert
         Assert.NotEmpty(result);
@@ -208,7 +208,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
         };
 
         // Act
-        await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config, CancellationToken.None);
+        await _reconciler.AnalyzeWorkspaceDeltaAsync(null, config);
 
         // Assert
         _mockLogger.Verify(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
@@ -44,6 +44,7 @@ public class GameProfileModuleTests
         services.AddScoped(provider => new Mock<IWorkspaceManager>().Object);
         services.AddScoped(provider => new Mock<ILaunchRegistry>().Object);
         services.AddScoped(provider => new Mock<INotificationService>().Object);
+        services.AddScoped(provider => new Mock<IGeneralsOnlineProfileReconciler>().Object);
 
         // Act
         services.AddGameProfileServices();
@@ -121,6 +122,7 @@ public class GameProfileModuleTests
         services.AddScoped(provider => new Mock<IWorkspaceManager>().Object);
         services.AddScoped(provider => new Mock<ILaunchRegistry>().Object);
         services.AddScoped(provider => new Mock<INotificationService>().Object);
+        services.AddScoped(provider => new Mock<IGeneralsOnlineProfileReconciler>().Object);
 
         // Act
         services.AddGameProfileServices();
@@ -180,6 +182,7 @@ public class GameProfileModuleTests
         services.AddScoped(provider => new Mock<IWorkspaceManager>().Object);
         services.AddScoped(provider => new Mock<ILaunchRegistry>().Object);
         services.AddScoped(provider => new Mock<INotificationService>().Object);
+        services.AddScoped(provider => new Mock<IGeneralsOnlineProfileReconciler>().Object);
 
         // Act
         services.AddGameProfileServices();
@@ -270,6 +273,7 @@ public class GameProfileModuleTests
         services.AddSingleton<ICasService>(new Mock<ICasService>().Object);
         services.AddSingleton<INotificationService>(new Mock<INotificationService>().Object);
         services.AddSingleton<GenHub.Core.Interfaces.Shortcuts.IShortcutService>(new Mock<GenHub.Core.Interfaces.Shortcuts.IShortcutService>().Object);
+        services.AddScoped(provider => new Mock<IGeneralsOnlineProfileReconciler>().Object);
 
         // Act
         services.AddGameProfileServices();
@@ -306,6 +310,7 @@ public class GameProfileModuleTests
         services.AddScoped(provider => new Mock<IWorkspaceManager>().Object);
         services.AddScoped(provider => new Mock<ILaunchRegistry>().Object);
         services.AddScoped(provider => new Mock<INotificationService>().Object);
+        services.AddScoped(provider => new Mock<IGeneralsOnlineProfileReconciler>().Object);
 
         // Act
         services.AddGameProfileServices();

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -415,10 +415,9 @@ public class GeneralsOnlineManifestFactory(
                     var fileName = Path.GetFileName(relativePath);
                     var isExecutable = false;
 
-                    // Handle map files - include them with UserMapsDirectory install target
+                    // Skip map files in GameClient manifests - they belong in the MapPack manifest
                     if (isMap)
                     {
-                        manifestFiles.Add(CreateMapManifestFile(relativePath, fileInfo, hash));
                         continue;
                     }
 
@@ -444,7 +443,7 @@ public class GeneralsOnlineManifestFactory(
                     });
                 }
 
-                logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files (including maps)", manifest.Name, manifestFiles.Count);
+                logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
             }
 
             updatedManifests.Add(new ContentManifest

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -1,0 +1,507 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.GameProfiles;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Interfaces.Workspace;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameProfile;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Service for reconciling profiles when GeneralsOnline updates are detected.
+/// When an update is found, this service updates all profiles using GeneralsOnline,
+/// removes old manifests and CAS content, and prepares profiles for the new version.
+/// </summary>
+public class GeneralsOnlineProfileReconciler(
+    ILogger<GeneralsOnlineProfileReconciler> logger,
+    GeneralsOnlineUpdateService updateService,
+    IGameProfileManager profileManager,
+    IContentManifestPool manifestPool,
+    IContentOrchestrator contentOrchestrator,
+    IWorkspaceManager workspaceManager,
+    INotificationService notificationService)
+    : IGeneralsOnlineProfileReconciler
+    {
+    /// <inheritdoc/>
+    public async Task<OperationResult<bool>> CheckAndReconcileIfNeededAsync(
+        string triggeringProfileId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogInformation(
+                "[GO Reconciler] Checking for GeneralsOnline updates (triggered by profile: {ProfileId})",
+                triggeringProfileId);
+
+            // Step 1: Check for updates
+            var updateResult = await updateService.CheckForUpdatesAsync(cancellationToken);
+
+            if (!updateResult.Success)
+            {
+                logger.LogWarning(
+                    "[GO Reconciler] Update check failed: {Error}",
+                    updateResult.FirstError);
+                return OperationResult<bool>.CreateFailure(
+                    $"Failed to check for GeneralsOnline updates: {updateResult.FirstError}");
+            }
+
+            if (!updateResult.IsUpdateAvailable)
+            {
+                logger.LogInformation(
+                    "[GO Reconciler] No update available. Current version: {Version}",
+                    updateResult.CurrentVersion);
+                return OperationResult<bool>.CreateSuccess(false);
+            }
+
+            logger.LogInformation(
+                "[GO Reconciler] Update available! Current: {CurrentVersion}, Latest: {LatestVersion}",
+                updateResult.CurrentVersion,
+                updateResult.LatestVersion);
+
+            // Step 2: Notify user that update is being installed
+            notificationService.ShowInfo(
+                "GeneralsOnline Update Found",
+                $"Installing GeneralsOnline {updateResult.LatestVersion}. Please wait...",
+                NotificationDurations.VeryLong);
+
+            // Step 3: Find all GeneralsOnline manifests currently installed
+            var oldManifests = await FindGeneralsOnlineManifestsAsync(cancellationToken);
+            if (oldManifests.Count == 0)
+            {
+                logger.LogWarning("[GO Reconciler] No existing GeneralsOnline manifests found in pool");
+            }
+
+            logger.LogInformation(
+                "[GO Reconciler] Found {Count} existing GeneralsOnline manifests to replace",
+                oldManifests.Count);
+
+            // Step 4: Download and acquire new content
+            // Step 4: Download and acquire new content
+            var acquireResult = await AcquireLatestVersionAsync(oldManifests, cancellationToken);
+            if (!acquireResult.Success)
+            {
+                notificationService.ShowError(
+                    "GeneralsOnline Update Failed",
+                    $"Failed to download update: {acquireResult.FirstError}",
+                    NotificationDurations.Critical);
+
+                return OperationResult<bool>.CreateFailure(
+                    $"Failed to acquire new GeneralsOnline version: {acquireResult.FirstError}");
+            }
+
+            var newManifests = acquireResult.Data!;
+            logger.LogInformation(
+                "[GO Reconciler] Successfully acquired {Count} new manifests",
+                newManifests.Count);
+
+            // Step 5: Update all affected profiles
+            var updateProfilesResult = await UpdateAllAffectedProfilesAsync(
+                oldManifests,
+                newManifests,
+                cancellationToken);
+
+            if (!updateProfilesResult.Success)
+            {
+                notificationService.ShowWarning(
+                    "GeneralsOnline Update Partial",
+                    $"Some profiles could not be updated: {updateProfilesResult.FirstError}",
+                    NotificationDurations.VeryLong);
+            }
+
+            // Step 6: Remove old manifests from pool (excluding any that match the new ones)
+            await RemoveOldManifestsAsync(oldManifests, newManifests, cancellationToken);
+
+            // Step 7: Show success notification
+            notificationService.ShowSuccess(
+                "GeneralsOnline Updated",
+                $"Successfully updated to version {updateResult.LatestVersion}. {updateProfilesResult.Data} profiles updated.",
+                NotificationDurations.Long);
+
+            logger.LogInformation(
+                "[GO Reconciler] Reconciliation complete. Updated {ProfileCount} profiles",
+                updateProfilesResult.Data);
+
+            return OperationResult<bool>.CreateSuccess(true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[GO Reconciler] Reconciliation failed unexpectedly");
+            notificationService.ShowError(
+                "GeneralsOnline Update Error",
+                $"An error occurred during update: {ex.Message}",
+                NotificationDurations.Critical);
+            return OperationResult<bool>.CreateFailure($"Reconciliation failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Builds a mapping from old manifest IDs to new manifest IDs.
+    /// </summary>
+    private static Dictionary<string, string> BuildManifestMapping(
+        List<ContentManifest> oldManifests,
+        List<ContentManifest> newManifests)
+    {
+        var mapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var oldManifest in oldManifests)
+        {
+            // Find corresponding new manifest by matching content type and name pattern
+            var newManifest = newManifests.FirstOrDefault(n =>
+                n.ContentType == oldManifest.ContentType &&
+                MatchesByVariant(oldManifest.Id.Value, n.Id.Value));
+
+            if (newManifest != null)
+            {
+                mapping[oldManifest.Id.Value] = newManifest.Id.Value;
+            }
+        }
+
+        return mapping;
+    }
+
+    /// <summary>
+    /// Checks if two manifest IDs refer to the same variant (30hz, 60hz, or quickmatch-maps).
+    /// </summary>
+    private static bool MatchesByVariant(string oldId, string newId)
+    {
+        // Extract variant suffix from manifest ID
+        // Format: 1.{version}.generalsonline.{contenttype}.{variant}
+        var oldVariant = ExtractVariant(oldId);
+        var newVariant = ExtractVariant(newId);
+
+        return string.Equals(oldVariant, newVariant, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Extracts the variant suffix from a manifest ID.
+    /// </summary>
+    private static string? ExtractVariant(string manifestId)
+    {
+        // Manifest ID formats:
+        // Real: 1.1220251.generalsonline.gameclient.30hz
+        // Spoofed: 1.101201.generalsonline.gameclient.30hz
+        // File: ...manifest.json (should not be here but just in case)
+        var parts = manifestId.Split('.');
+        if (parts.Length == 0) return null;
+
+        var lastPart = parts[^1];
+
+        // Handle common variants directly
+        if (lastPart.Equals("30hz", StringComparison.OrdinalIgnoreCase) ||
+            lastPart.Equals("60hz", StringComparison.OrdinalIgnoreCase) ||
+            lastPart.Equals("quickmatchmaps", StringComparison.OrdinalIgnoreCase))
+        {
+            return lastPart;
+        }
+
+        // If something like .manifest.json appended (though ID shouldn't have it)
+        if (parts.Length > 1)
+        {
+             return parts[^1];
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if a profile uses any GeneralsOnline content.
+    /// </summary>
+    private static bool ProfileUsesGeneralsOnline(
+        GameProfile profile,
+        List<ContentManifest> goManifests)
+    {
+        if (profile.EnabledContentIds == null || profile.EnabledContentIds.Count == 0)
+        {
+            return false;
+        }
+
+        var goManifestIds = goManifests.Select(m => m.Id.Value).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return profile.EnabledContentIds.Any(id => goManifestIds.Contains(id));
+    }
+
+    /// <summary>
+    /// Updates content IDs by replacing old GeneralsOnline IDs with new ones.
+    /// </summary>
+    private static List<string> UpdateContentIds(
+        List<string>? currentIds,
+        Dictionary<string, string> mapping)
+    {
+        if (currentIds == null || currentIds.Count == 0)
+        {
+            return [];
+        }
+
+        var newIds = new List<string>();
+
+        foreach (var id in currentIds)
+        {
+            if (mapping.TryGetValue(id, out var newId))
+            {
+                newIds.Add(newId);
+            }
+            else
+            {
+                // Keep non-GO content IDs as-is
+                newIds.Add(id);
+            }
+        }
+
+        return newIds;
+    }
+
+    /// <summary>
+    /// Finds all GeneralsOnline manifests currently in the manifest pool.
+    /// </summary>
+    private async Task<List<ContentManifest>> FindGeneralsOnlineManifestsAsync(
+        CancellationToken cancellationToken)
+    {
+        var manifestsResult = await manifestPool.GetAllManifestsAsync(cancellationToken);
+        if (!manifestsResult.Success || manifestsResult.Data == null)
+        {
+            return [];
+        }
+
+        return [.. manifestsResult.Data
+            .Where(m =>
+                m.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true ||
+
+                // Check ID pattern
+                m.Id.Value.Contains(".generalsonline.", StringComparison.OrdinalIgnoreCase) ||
+
+                // Check Name fallback
+                m.Name.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase))];
+    }
+
+    /// <summary>
+    /// Acquires the latest GeneralsOnline version by searching and downloading.
+    /// Returns all new manifests found in the pool that weren't there before.
+    /// </summary>
+    private async Task<OperationResult<List<ContentManifest>>> AcquireLatestVersionAsync(
+        List<ContentManifest> oldManifests,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Search for GeneralsOnline content
+            var searchQuery = new ContentSearchQuery
+            {
+                ProviderName = GeneralsOnlineConstants.PublisherType,
+                ContentType = ContentType.GameClient,
+                TargetGame = GameType.ZeroHour,
+            };
+
+            var searchResult = await contentOrchestrator.SearchAsync(searchQuery, cancellationToken);
+            if (!searchResult.Success || searchResult.Data == null || !searchResult.Data.Any())
+            {
+                return OperationResult<List<ContentManifest>>.CreateFailure(
+                    "No GeneralsOnline content found from provider");
+            }
+
+            // Acquire each search result (triggers provider to install 30Hz, 60Hz, MapPack)
+            foreach (var result in searchResult.Data)
+            {
+                logger.LogInformation(
+                    "[GO Reconciler] Acquiring content: {Name} ({ContentType})",
+                    result.Name,
+                    result.ContentType);
+
+                var acquireResult = await contentOrchestrator.AcquireContentAsync(
+                    result,
+                    progress: null,
+                    cancellationToken);
+
+                if (!acquireResult.Success)
+                {
+                    logger.LogWarning(
+                        "[GO Reconciler] Failed to acquire {Name}: {Error}",
+                        result.Name,
+                        acquireResult.FirstError);
+                }
+            }
+
+            // Rationale: The provider might create multiple manifests (variants/dependencies)
+            // We scan the pool to find EVERYTHING that is GeneralsOnline and NOT in our old list.
+            var allGoManifests = await FindGeneralsOnlineManifestsAsync(cancellationToken);
+            var oldIds = oldManifests.Select(m => m.Id.Value).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var newManifests = allGoManifests
+                .Where(m => !oldIds.Contains(m.Id.Value))
+                .ToList();
+
+            if (newManifests.Count == 0)
+            {
+                return OperationResult<List<ContentManifest>>.CreateFailure(
+                    "Acquisition completed but no new GeneralsOnline manifests were found in the pool");
+            }
+
+            logger.LogInformation(
+                "[GO Reconciler] Identified {Count} new manifests in pool: {Manifests}",
+                newManifests.Count,
+                string.Join(", ", newManifests.Select(m => m.Id.Value)));
+
+            return OperationResult<List<ContentManifest>>.CreateSuccess(newManifests);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[GO Reconciler] Failed to acquire latest version");
+            return OperationResult<List<ContentManifest>>.CreateFailure(
+                $"Failed to acquire latest version: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Updates all profiles that use GeneralsOnline content.
+    /// </summary>
+    private async Task<OperationResult<int>> UpdateAllAffectedProfilesAsync(
+        List<ContentManifest> oldManifests,
+        List<ContentManifest> newManifests,
+        CancellationToken cancellationToken)
+    {
+        var profilesResult = await profileManager.GetAllProfilesAsync(cancellationToken);
+        if (!profilesResult.Success || profilesResult.Data == null)
+        {
+            return OperationResult<int>.CreateFailure(
+                $"Failed to get profiles: {profilesResult.FirstError}");
+        }
+
+        // Build mapping from old manifest IDs to new manifest IDs
+        var manifestMapping = BuildManifestMapping(oldManifests, newManifests);
+
+        var updatedCount = 0;
+        var errors = new List<string>();
+
+        foreach (var profile in profilesResult.Data)
+        {
+            // Check if profile uses any GeneralsOnline content
+            if (!ProfileUsesGeneralsOnline(profile, oldManifests))
+            {
+                continue;
+            }
+
+            logger.LogInformation(
+                "[GO Reconciler] Updating profile: {ProfileName} ({ProfileId})",
+                profile.Name,
+                profile.Id);
+
+            try
+            {
+                // Update enabled content IDs
+                var newContentIds = UpdateContentIds(profile.EnabledContentIds, manifestMapping);
+
+                // Cleanup workspace if it exists
+                if (!string.IsNullOrEmpty(profile.ActiveWorkspaceId))
+                {
+                    logger.LogDebug(
+                        "[GO Reconciler] Cleaning up workspace for profile {ProfileId}",
+                        profile.Id);
+
+                    var cleanupResult = await workspaceManager.CleanupWorkspaceAsync(
+                        profile.ActiveWorkspaceId,
+                        cancellationToken);
+
+                    if (!cleanupResult.Success)
+                    {
+                        logger.LogWarning(
+                            "[GO Reconciler] Failed to cleanup workspace for profile {ProfileId}: {Error}",
+                            profile.Id,
+                            cleanupResult.FirstError);
+                    }
+                }
+
+                // Update the profile
+                var updateRequest = new UpdateProfileRequest
+                {
+                    EnabledContentIds = newContentIds,
+
+                    // Clear active workspace so it will be recreated on next launch
+                    ActiveWorkspaceId = string.Empty,
+                };
+
+                var updateResult = await profileManager.UpdateProfileAsync(
+                    profile.Id,
+                    updateRequest,
+                    cancellationToken);
+
+                if (updateResult.Success)
+                {
+                    updatedCount++;
+                    logger.LogInformation(
+                        "[GO Reconciler] Successfully updated profile: {ProfileName}",
+                        profile.Name);
+                }
+                else
+                {
+                    errors.Add($"Failed to update profile '{profile.Name}': {updateResult.FirstError}");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "[GO Reconciler] Error updating profile {ProfileId}", profile.Id);
+                errors.Add($"Error updating profile '{profile.Name}': {ex.Message}");
+            }
+        }
+
+        if (errors.Count > 0 && updatedCount == 0)
+        {
+            return OperationResult<int>.CreateFailure(string.Join("; ", errors));
+        }
+
+        if (errors.Count > 0)
+        {
+            logger.LogWarning(
+                "[GO Reconciler] Updated {Count} profiles with {ErrorCount} errors",
+                updatedCount,
+                errors.Count);
+        }
+
+        return OperationResult<int>.CreateSuccess(updatedCount);
+    }
+
+    /// <summary>
+    /// Removes old GeneralsOnline manifests from the manifest pool, unless they are part of the new update.
+    /// </summary>
+    private async Task RemoveOldManifestsAsync(
+        List<ContentManifest> oldManifests,
+        List<ContentManifest> newManifests,
+        CancellationToken cancellationToken)
+    {
+        // Create lookup for new IDs to avoid accidental deletion of fresh content
+        var newManifestIds = newManifests.Select(m => m.Id.Value).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var manifest in oldManifests)
+        {
+            if (newManifestIds.Contains(manifest.Id.Value))
+            {
+                logger.LogInformation(
+                    "[GO Reconciler] Skipping removal of manifest {ManifestId} as it matches new content",
+                    manifest.Id.Value);
+                continue;
+            }
+
+            logger.LogInformation(
+                "[GO Reconciler] Removing old manifest: {ManifestId} ({Name})",
+                manifest.Id.Value,
+                manifest.Name);
+
+            var removeResult = await manifestPool.RemoveManifestAsync(manifest.Id, cancellationToken);
+            if (!removeResult.Success)
+            {
+                logger.LogWarning(
+                    "[GO Reconciler] Failed to remove old manifest {ManifestId}: {Error}",
+                    manifest.Id.Value,
+                    removeResult.FirstError);
+            }
+        }
+    }
+}

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -618,8 +618,19 @@ public class GameClientDetector(
                         PublisherType = identification.PublisherId, // Store publisher type
                     };
 
-                    await GeneratePublisherClientManifestAsync(gameClient, installationPath, gameType, identification);
-                    detectedClients.Add(gameClient);
+                    // Check if this is one of the excluded game clients that should not generate manifests
+                    var exeName = Path.GetFileName(executablePath).ToLowerInvariant();
+                    if (exeName == "generalsv.exe" || exeName == "generalszh.exe" || exeName == "generalsonlinezh_30.exe" || exeName == "generalsonlinezh_60.exe")
+                    {
+                        // For these clients, only detect and prompt user, do not generate manifest or store in CAS
+                        gameClient.Id = Guid.NewGuid().ToString();
+                        detectedClients.Add(gameClient);
+                    }
+                    else
+                    {
+                        await GeneratePublisherClientManifestAsync(gameClient, installationPath, gameType, identification);
+                        detectedClients.Add(gameClient);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/GenHub/GenHub/Features/GameClients/GameClientHashRegistry.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientHashRegistry.cs
@@ -17,6 +17,8 @@ public class GameClientHashRegistry : IGameClientHashRegistry
 {
     // Core Hash Constants - These are the foundational hashes for official EA/Steam releases
     private const string Generals108Hash = "1c96366ff6a99f40863f6bbcfa8bf7622e8df1f80a474201e0e95e37c6416255";
+    private const string SteamZeroHour104Hash = "7B075B9F0BAA9DF81651C0C9DD7D8C445454AE1B2452B928F4A1D9332E9CCECE";
+
     private const string ZeroHour104Hash = "f37a4929f8d697104e99c2bcf46f8d833122c943afcd87fd077df641d344495b";
     private const string ZeroHour105Hash = "420fba1dbdc4c14e2418c2b0d3010b9fac6f314eafa1f3a101805b8d98883ea1";
 
@@ -150,6 +152,7 @@ public class GameClientHashRegistry : IGameClientHashRegistry
     private void InitializeCoreHashes()
     {
         _knownHashes.TryAdd(Generals108Hash, new GameClientInfo(GameType.Generals, "1.08", "EA/Steam", "Official Generals 1.08 executable", true));
+        _knownHashes.TryAdd(SteamZeroHour104Hash, new GameClientInfo(GameType.ZeroHour, "1.04", "Steam", "Official Steam Zero Hour 1.04 executable", true));
         _knownHashes.TryAdd(ZeroHour104Hash, new GameClientInfo(GameType.ZeroHour, "1.04", "EA/Steam", "Official Zero Hour 1.04 executable", true));
         _knownHashes.TryAdd(ZeroHour105Hash, new GameClientInfo(GameType.ZeroHour, "1.05", "EA/Steam", "Official Zero Hour 1.05 executable", true));
     }

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -163,7 +163,7 @@ public class GameInstallationService(
             {
                 currentList.Add(installation);
             }
-            
+
             _cachedInstallations = currentList.AsReadOnly();
 
             _logger.LogInformation("Registered manual installation: {Id} ({Path})", installation.Id, installation.InstallationPath);

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -11,6 +11,7 @@ using GenHub.Core.Constants;
 using GenHub.Core.Extensions;
 using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Interfaces.GameSettings;
@@ -47,13 +48,9 @@ public class ProfileLauncherFacade(
     IGameSettingsService gameSettingsService,
     IStorageLocationService storageLocationService,
     INotificationService notificationService,
+    IGeneralsOnlineProfileReconciler generalsOnlineReconciler,
     ILogger<ProfileLauncherFacade> logger) : IProfileLauncherFacade
 {
-    /// <summary>
-    /// Timeout for game settings application to prevent blocking the launch process.
-    /// </summary>
-    private static readonly TimeSpan GameSettingsApplicationTimeout = TimeSpan.FromSeconds(5);
-
     /// <inheritdoc/>
     public async Task<ProfileOperationResult<GameLaunchInfo>> LaunchProfileAsync(string profileId, bool skipUserDataCleanup = false, CancellationToken cancellationToken = default)
     {
@@ -109,6 +106,47 @@ public class ProfileLauncherFacade(
                 {
                     profile.GameInstallationId = resolvedInstallation.Id;
                     logger.LogInformation("Rebound profile {ProfileId} to installation {InstallationId}", profileId, resolvedInstallation.Id);
+                }
+            }
+
+            // Step 2.5: Check for GeneralsOnline updates if this is a GO profile
+            logger.LogInformation(
+                "Profile Publisher Debug: Client={Client}, Publisher={PublisherType}, IsGO={IsGO}",
+                profile.GameClient?.Name ?? "null",
+                profile.GameClient?.PublisherType ?? "null",
+                IsGeneralsOnlineProfile(profile));
+
+            if (IsGeneralsOnlineProfile(profile))
+            {
+                logger.LogDebug("[Launch] Step 2.5: Checking for GeneralsOnline updates");
+                var reconcileResult = await generalsOnlineReconciler.CheckAndReconcileIfNeededAsync(
+                    profileId,
+                    cancellationToken);
+
+                if (!reconcileResult.Success)
+                {
+                    logger.LogError(
+                        "[Launch] GeneralsOnline reconciliation failed: {Error}",
+                        reconcileResult.FirstError);
+                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                        $"GeneralsOnline update failed: {reconcileResult.FirstError}");
+                }
+
+                if (reconcileResult.Data)
+                {
+                    // Profile was updated, reload it
+                    logger.LogInformation("[Launch] Profile was updated by GeneralsOnline reconciliation, reloading");
+                    profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
+                    if (profileResult.Failed)
+                    {
+                        return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                            string.Join(", ", profileResult.Errors));
+                    }
+
+                    profile = profileResult.Data!;
+                    logger.LogDebug(
+                        "[Launch] Profile reloaded after GeneralsOnline update - EnabledContent: {ContentCount} items",
+                        profile.EnabledContentIds?.Count ?? 0);
                 }
             }
 
@@ -754,6 +792,37 @@ public class ProfileLauncherFacade(
         }
 
         return parts.Count > 0 ? $"({string.Join(" and ", parts)})" : string.Empty;
+    }
+
+    /// <summary>
+    /// Checks if a profile uses a GeneralsOnline game client.
+    /// </summary>
+    /// <param name="profile">The profile to check.</param>
+    /// <returns>True if the profile uses GeneralsOnline, false otherwise.</returns>
+    private static bool IsGeneralsOnlineProfile(GameProfile profile)
+    {
+        // Check PublisherType first
+        if (profile.GameClient?.PublisherType?.Equals(
+            PublisherTypeConstants.GeneralsOnline,
+            StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return true;
+        }
+
+        // Check if Name contains "GeneralsOnline" (for legacy or incomplete profiles)
+        if (profile.GameClient?.Name?.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return true;
+        }
+
+        // Final fallback: Check enabled content for GeneralsOnline manifests
+        if (profile.EnabledContentIds != null &&
+            profile.EnabledContentIds.Any(id => id.Contains("generalsonline", StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -965,6 +965,7 @@ public partial class GameProfileSettingsViewModel : ViewModelBase
                             if (compatibleInstallation != null)
                             {
                                 logger?.LogDebug(
+                                    "Found compatible installation {InstallationName} for content {ContentSourceId} ({ContentName})",
                                     compatibleInstallation.DisplayName,
                                     contentItem.SourceId,
                                     contentItem.DisplayName);
@@ -1691,6 +1692,7 @@ public partial class GameProfileSettingsViewModel : ViewModelBase
                     CommandLineArguments = CommandLineArguments,
                     IconPath = IconPath,
                     CoverPath = CoverPath,
+                    ThemeColor = ColorValue,
                 };
 
                 // Populate settings into create request

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -359,7 +359,7 @@ public class WorkspaceManager(
             }
 
             // Analyze deltas using the reconciler
-            var deltas = await reconciler.AnalyzeWorkspaceDeltaAsync(currentWorkspace, newConfiguration, cancellationToken);
+            var deltas = await reconciler.AnalyzeWorkspaceDeltaAsync(currentWorkspace, newConfiguration);
 
             // Filter to only removal operations
             var removalDeltas = deltas.Where(d => d.Operation == WorkspaceDeltaOperation.Remove).ToList();

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -168,6 +168,9 @@ public static class ContentPipelineModule
 
         // Register Generals Online update service
         services.AddSingleton<GeneralsOnlineUpdateService>();
+
+        // Register Generals Online profile reconciler
+        services.AddSingleton<IGeneralsOnlineProfileReconciler, GeneralsOnlineProfileReconciler>();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR introduces a update management system for GeneralsOnline profiles. It implements a new reconciliation service that automatically detects, downloads, and applies GeneralsOnline updates when a profile is launched. Additionally, it includes improvements to the update service's version detection logic, fixes regarding map manifest handling, and support for specific Steam game executables.

## Key Changes

### 🆕 New Features
*   **GeneralsOnline Profile Reconciler**
    *   Introduced `IGeneralsOnlineProfileReconciler` and `GeneralsOnlineProfileReconciler`.
    *   Automatically checks for GeneralsOnline updates before launching a profile.
    *   If an update is found:
        *   Downloads the latest content manifests (30Hz, 60Hz, MapPack).
        *   Maps old manifest IDs to new ones based on variant types.
        *   Updates all affected profiles to reference the new content IDs.
        *   Cleans up active workspaces to force a refresh with the new content.
        *   Removes obsolete manifests from the content pool.
        *   Provides user notifications throughout the process.

*   **Launch Integration**
    *   Integrated `IGeneralsOnlineProfileReconciler` into `ProfileLauncherFacade`.
    *   Added logic to detect GeneralsOnline profiles (via PublisherType, Name, or ContentIds).
    *   If a GO profile is detected, reconciliation runs automatically before game launch.
    *   Profile data is reloaded after a successful update to ensure the launch uses the latest content.

### 🔧 Improvements & Fixes
*   **Update Service Robustness**
    *   Enhanced `GeneralsOnlineUpdateService.GetLatestVersionAsync` with a fallback mechanism. If `latest.txt` is unavailable, it now attempts to parse the version from `manifest.json`.
    *   Updated `GeneralsOnlineUpdateService` to use primary constructor syntax and added `GC.SuppressFinalize`.

*   **Manifest Generation**
    *   Fixed `GeneralsOnlineManifestFactory` to explicitly skip map files when generating GameClient manifests. This prevents duplication and ensures maps are correctly handled via the MapPack manifest.

*   **Game Detection**
    *   Updated `GameClientDetector` to skip manifest generation and CAS storage for specific base executables (e.g., `generalsv.exe`, `generalszh.exe`, `generalsonlinezh_30.exe`). This prevents these raw executables from being treated as separate mod content.

*   **Hash Registry**
    *   Added support for the Steam version of Zero Hour 1.04 (`SteamZeroHour104Hash`).

### 🛠️ Refactoring
*   **Workspace Reconciler**
    *   Removed `CancellationToken` parameters from `AnalyzeWorkspaceDeltaAsync` and `FileNeedsUpdateAsync` as they were unnecessary for the internal implementation.
    *   Optimized dictionary lookups using `TryGetValue`.
*   **Tests**
    *   Updated `WorkspaceReconcilerConflictTests` to reflect the signature changes in `WorkspaceReconciler`.
    *   Registered `Mock<IGeneralsOnlineProfileReconciler>` in `GameProfileModuleTests` to satisfy new dependencies.
