### PR TITLE
feat: add header collapse functionality in Game Profiles and add background image

### DIFF
--- a/GenHub/Directory.Packages.props
+++ b/GenHub/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.7" />
+
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="2.4.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.7" />

--- a/GenHub/GenHub.Core/Constants/TimeIntervals.cs
+++ b/GenHub/GenHub.Core/Constants/TimeIntervals.cs
@@ -6,6 +6,11 @@ namespace GenHub.Core.Constants;
 public static class TimeIntervals
 {
     /// <summary>
+    /// Delay before the Game Profiles header automatically collapses.
+    /// </summary>
+    public const int HeaderCollapseDelayMs = 500;
+
+    /// <summary>
     /// Default timeout for updater operations.
     /// </summary>
     public static readonly TimeSpan UpdaterTimeout = TimeSpan.FromMinutes(10);

--- a/GenHub/GenHub.Core/Constants/UiConstants.cs
+++ b/GenHub/GenHub.Core/Constants/UiConstants.cs
@@ -37,6 +37,16 @@ public static class UiConstants
     /// </summary>
     public const string StatusErrorColor = "#F44336";
 
+    /// <summary>
+    /// Default theme color for Generals content.
+    /// </summary>
+    public const string GeneralsThemeColor = "#BD5A0F";
+
+    /// <summary>
+    /// Default theme color for Zero Hour content.
+    /// </summary>
+    public const string ZeroHourThemeColor = "#1B6575";
+
     // Content type display names
 
     /// <summary>

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -320,8 +320,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Notify SettingsViewModel when it becomes visible/invisible
         SettingsViewModel.IsViewVisible = value == NavigationTab.Settings;
 
-        // Refresh Downloads tab when it becomes visible
-        if (value == NavigationTab.Downloads)
+        // Refresh Tabs when they become visible
+        if (value == NavigationTab.GameProfiles)
+        {
+            GameProfilesViewModel.OnTabActivated();
+        }
+        else if (value == NavigationTab.Downloads)
         {
             _ = DownloadsViewModel.OnTabActivatedAsync();
         }

--- a/GenHub/GenHub/Common/Views/MainView.axaml
+++ b/GenHub/GenHub/Common/Views/MainView.axaml
@@ -94,8 +94,8 @@
             <Setter Property="Background">
                 <Setter.Value>
                     <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
-                        <GradientStop Color="#2D2D2D" Offset="0" />
-                        <GradientStop Color="#202020" Offset="1" />
+                        <GradientStop Color="#992D2D2D" Offset="0" />
+                        <GradientStop Color="#99202020" Offset="1" />
                     </LinearGradientBrush>
                 </Setter.Value>
             </Setter>
@@ -128,8 +128,18 @@
             <settingsViews:SettingsView />
         </DataTemplate>
     </UserControl.DataTemplates>
-
+ 
     <Grid>
+        <!-- Global background image for all tabs -->
+        <Image Source="avares://GenHub/Assets/background.jpg" 
+               Stretch="UniformToFill" 
+               HorizontalAlignment="Stretch" 
+               VerticalAlignment="Stretch"
+               Grid.RowSpan="2"/>
+
+        <!-- Semi-transparent overlay to improve text readability -->
+        <Border Background="#F2141414" Grid.RowSpan="2" />
+
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -179,12 +189,12 @@
         </Border>
 
         <!-- Main content area -->
-        <Grid Grid.Row="1" Background="#1A1A1A">
+        <Grid Grid.Row="1">
             <ContentControl Content="{Binding CurrentTabViewModel}" />
             <!-- Version label in bottom right corner -->
             <TextBlock Text="{x:Static constants:AppConstants.DisplayVersion}"
                        FontSize="9"
-                       Foreground="#404040"
+                       Foreground="#808080"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Bottom"
                        Margin="0,0,10,5" />

--- a/GenHub/GenHub/Features/Downloads/Views/DownloadsView.axaml
+++ b/GenHub/GenHub/Features/Downloads/Views/DownloadsView.axaml
@@ -6,8 +6,7 @@
              xmlns:views="clr-namespace:GenHub.Features.Downloads.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="GenHub.Features.Downloads.Views.DownloadsView"
-             x:DataType="vm:DownloadsViewModel"
-             Background="#1A1A1A">
+             x:DataType="vm:DownloadsViewModel">
 
     <UserControl.Styles>
         <Style Selector="Button.github-button">

--- a/GenHub/GenHub/Features/GameProfiles/Views/GameProfileLauncherView.axaml
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameProfileLauncherView.axaml
@@ -9,13 +9,25 @@
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="550"
     x:Class="GenHub.Features.GameProfiles.Views.GameProfileLauncherView"
     x:Name="ProfileLauncher"
-    x:DataType="vm:GameProfileLauncherViewModel"
-    Background="#1A1A1A">
+    x:DataType="vm:GameProfileLauncherViewModel">
 
     <UserControl.Resources>
         <conv:ContrastTextColorConverter x:Key="ContrastTextColorConverter" />
         <conv:ProfileCoverConverter x:Key="ProfileCoverConverter" />
         <conv:StringToImageConverter x:Key="StringToImageConverter" />
+        
+        <x:Double x:Key="ExpandedHeight">100.0</x:Double>
+        <x:Double x:Key="CollapsedHeight">0.0</x:Double>
+        <x:Double x:Key="FullOpacity">1.0</x:Double>
+        <x:Double x:Key="ZeroOpacity">0.0</x:Double>
+
+        <conv:BoolToValueConverter x:Key="HeaderMaxHeightConverter" 
+                                   TrueValue="{StaticResource ExpandedHeight}" 
+                                   FalseValue="{StaticResource CollapsedHeight}" />
+        <conv:BoolToValueConverter x:Key="HeaderOpacityConverter" 
+                                   TrueValue="{StaticResource FullOpacity}" 
+                                   FalseValue="{StaticResource ZeroOpacity}" />
+        
         <conv:BoolToValueConverter x:Key="BoolToVisibilityConverter"
             TrueValue="Visible"
             FalseValue="Collapsed" />
@@ -183,62 +195,83 @@
         </Style>
     </UserControl.Styles>
 
-    <Grid RowDefinitions="Auto,*">
-        <!-- Header with Title and Actions -->
-        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="16 16 16 8">
-            <StackPanel Grid.Column="0" Orientation="Vertical" VerticalAlignment="Center">
-                <TextBlock Text="Game Profiles" FontSize="20" FontWeight="SemiBold"
-                    Foreground="White" Margin="0 0 0 4" />
-                <TextBlock Text="Select a profile to launch or create a new one"
-                    Foreground="#AAAAAA" FontSize="13" />
-            </StackPanel>
+    <Grid RowDefinitions="Auto, *">
+        <!-- Row 0: Collapsible Header Container -->
+        <Grid Grid.Row="0" 
+              Background="Transparent"
+              PointerEntered="HeaderZone_PointerEntered"
+              PointerExited="HeaderZone_PointerExited">
+            <!-- Persistent hit-test area that ensures the Grid is Tall enough even when collapsed -->
+            <Panel Height="60" 
+                   VerticalAlignment="Top" 
+                   IsHitTestVisible="False" />
 
-            <!-- Action buttons section in header -->
-            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
-                <!-- Edit Mode Toggle button -->
-               <Button Name="EditModeToggle"
-                    Command="{Binding ToggleEditModeCommand, Mode=OneWay}"
-                    Background="{Binding IsEditMode, Converter={StaticResource EditModeToggleBackgroundConverter}, Mode=OneWay}"
-                    ToolTip.Tip="Toggle Edit Mode"
-                    Width="42" Height="42"
-                    CornerRadius="21"
-                    Padding="0">
-                    <Grid>
-                        <!-- Use a different icon based on edit mode state -->
-                        <PathIcon
-                            Data="M20.71,4.04C21.1,3.65 21.1,3 20.71,2.63L18.37,0.29C18,-.1 17.35,-.1 16.96,0.29L15.12,2.12L18.87,5.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
-                            Width="18" Height="18"
-                            Foreground="White"
-                            IsVisible="{Binding !IsEditMode, Mode=OneWay}" />
-                        <PathIcon
-                            Data="M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3M19,19H5V5H19V19M17,11V13H7V11H17M13,15V17H7V15H13Z"
-                            Width="18" Height="18"
-                            Foreground="White"
-                            IsVisible="{Binding IsEditMode, Mode=OneWay}" />
+            <!-- Animated Header Content -->
+            <Border Classes="header-container" ClipToBounds="True">
+                <Border.Styles>
+                    <Style Selector="Border.header-container">
+                        <Setter Property="Transitions">
+                            <Transitions>
+                                <DoubleTransition Property="MaxHeight" Duration="0:0:0.4" Easing="CubicEaseOut" />
+                                <DoubleTransition Property="Opacity" Duration="0:0:0.4" Easing="CubicEaseOut" />
+                            </Transitions>
+                        </Setter>
+                    </Style>
+                </Border.Styles>
+                
+                <!-- Use HeaderMaxHeightConverter and HeaderOpacityConverter -->
+                <Border.MaxHeight>
+                    <Binding Path="IsHeaderExpanded" Converter="{StaticResource HeaderMaxHeightConverter}" />
+                </Border.MaxHeight>
+
+                <Border.Opacity>
+                    <Binding Path="IsHeaderExpanded" Converter="{StaticResource HeaderOpacityConverter}" />
+                </Border.Opacity>
+
+                <StackPanel Margin="0,0,0,10">
+                    <!-- Title and Info -->
+                    <Grid ColumnDefinitions="*,Auto" Margin="20,16,20,8">
+                        <StackPanel Grid.Column="0" Orientation="Vertical" VerticalAlignment="Center">
+                            <TextBlock Text="Game Profiles" FontSize="20" FontWeight="SemiBold"
+                                Foreground="White" Margin="0 0 0 4" />
+                            <TextBlock Text="Select a profile to launch or create a new one"
+                                Foreground="#AAAAAA" FontSize="13" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
+                           <Button Name="EditModeToggle"
+                                Command="{Binding ToggleEditModeCommand, Mode=OneWay}"
+                                Background="{Binding IsEditMode, Converter={StaticResource EditModeToggleBackgroundConverter}, Mode=OneWay}"
+                                ToolTip.Tip="Toggle Edit Mode"
+                                Width="42" Height="42"
+                                CornerRadius="21"
+                                Padding="0">
+                                <Grid>
+                                    <PathIcon
+                                        Data="M20.71,4.04C21.1,3.65 21.1,3 20.71,2.63L18.37,0.29C18,-.1 17.35,-.1 16.96,0.29L15.12,2.12L18.87,5.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+                                        Width="18" Height="18"
+                                        Foreground="White"
+                                        IsVisible="{Binding !IsEditMode, Mode=OneWay}" />
+                                    <PathIcon
+                                        Data="M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3M19,19H5V5H19V19M17,11V13H7V11H17M13,15V17H7V15H13Z"
+                                        Width="18" Height="18"
+                                        Foreground="White"
+                                        IsVisible="{Binding IsEditMode, Mode=OneWay}" />
+                                </Grid>
+                            </Button>
+                            
+                        <Button Grid.Column="2"
+                                Command="{Binding ScanForGamesCommand}"
+                                Content="SCAN"
+                                Classes="outline" />
+                        </StackPanel>
                     </Grid>
-                </Button>
-
-                <!-- Scan button -->
-                <Button Command="{Binding ScanForGamesCommand}"
-                    Background="#333333"
-                    Padding="16 8"
-                    CornerRadius="4" 
-                    IsEnabled="{Binding !IsScanning}">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="Scan" IsVisible="{Binding !IsScanning}" />
-                        <TextBlock Text="Scanning..." IsVisible="{Binding IsScanning}" />
-                        <ProgressBar IsVisible="{Binding IsScanning}" 
-                                     IsIndeterminate="True" 
-                                     Width="60" 
-                                     Height="4" 
-                                     VerticalAlignment="Center" />
-                    </StackPanel>
-                </Button>
-            </StackPanel>
+                </StackPanel>
+            </Border>
         </Grid>
 
-        <!-- Profiles Grid -->
-        <ScrollViewer Grid.Row="1" Padding="10">
+        <!-- Row 1: Main Content (Game Profiles List) -->
+        <ScrollViewer Grid.Row="1" Margin="10">
             <StackPanel>
                 <ItemsControl ItemsSource="{Binding Profiles}">
                     <ItemsControl.ItemsPanel>

--- a/GenHub/GenHub/Features/GameProfiles/Views/GameProfileLauncherView.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameProfileLauncherView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using GenHub.Features.GameProfiles.ViewModels;
 
 namespace GenHub.Features.GameProfiles.Views;
 
@@ -18,5 +19,21 @@ public partial class GameProfileLauncherView : UserControl
     private void InitializeComponent()
     {
         Avalonia.Markup.Xaml.AvaloniaXamlLoader.Load(this);
+    }
+
+    private void HeaderZone_PointerEntered(object? sender, Avalonia.Input.PointerEventArgs e)
+    {
+        if (DataContext is GameProfileLauncherViewModel vm)
+        {
+            vm.ExpandHeaderCommand.Execute(null);
+        }
+    }
+
+    private void HeaderZone_PointerExited(object? sender, Avalonia.Input.PointerEventArgs e)
+    {
+        if (DataContext is GameProfileLauncherViewModel vm)
+        {
+            vm.StartHeaderTimerCommand.Execute(null);
+        }
     }
 }

--- a/GenHub/GenHub/Features/Settings/Views/SettingsView.axaml
+++ b/GenHub/GenHub/Features/Settings/Views/SettingsView.axaml
@@ -271,7 +271,7 @@
     </Style>
   </UserControl.Styles>
 
-  <ScrollViewer Background="#1A1A1A" Focusable="True">
+  <ScrollViewer Focusable="True">
     <StackPanel Margin="30" Spacing="25" MaxWidth="800">
       
       <!-- Header -->

--- a/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml
+++ b/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml
@@ -5,8 +5,7 @@
              xmlns:vm="clr-namespace:GenHub.Features.Tools.ViewModels"
              mc:Ignorable="d" d:DesignWidth="1100" d:DesignHeight="700"
              x:Class="GenHub.Features.Tools.Views.ToolsView"
-             x:DataType="vm:ToolsViewModel"
-             Background="#1A1A1A">
+             x:DataType="vm:ToolsViewModel">
 
   <UserControl.Styles>
     <Style Selector="Border.tool-list-card">

--- a/GenHub/GenHub/GenHub.csproj
+++ b/GenHub/GenHub/GenHub.csproj
@@ -17,6 +17,7 @@
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
+
         <PackageReference Include="CommunityToolkit.Mvvm" />
         <PackageReference Include="Material.Icons.Avalonia" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />


### PR DESCRIPTION
#### Overview 
This PR adds a background image to the entire application with an opaque/transparent black cover. It also makes the header inside the `GameProfileLauncherView` collapsible.

#### Video
https://github.com/user-attachments/assets/dd065e88-0a23-4a25-a3c6-80d49bb3ca58

