### PR TITLE
 feat: Add Replay Manager tool with cloud sharing and drag-and-drop

### DIFF
--- a/GenHub/Directory.Packages.props
+++ b/GenHub/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Avalonia.Desktop" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.7" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.7" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.7" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="2.4.1" />
@@ -26,6 +27,7 @@
     <PackageVersion Include="ReactiveUI" Version="19.6.1" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageVersion Include="Slugify.Core" Version="5.1.1" />
+    <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <!-- Test packages -->

--- a/GenHub/GenHub.Core/Constants/ApiConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ApiConstants.cs
@@ -59,6 +59,42 @@ public static class ApiConstants
     /// </summary>
     public const string GitHubApiRunArtifactsFormat = "https://api.github.com/repos/{0}/{1}/actions/runs/{2}/artifacts";
 
+    // UploadThing
+
+    /// <summary>
+    /// UploadThing API version.
+    /// </summary>
+    public const string UploadThingApiVersion = "7.7.4";
+
+    /// <summary>
+    /// UploadThing prepare upload URL.
+    /// </summary>
+    public const string UploadThingPrepareUrl = "https://api.uploadthing.com/v7/prepareUpload";
+
+    /// <summary>
+    /// UploadThing public file URL format.
+    /// </summary>
+    public const string UploadThingPublicUrlFormat = "https://utfs.io/f/{0}";
+
+    /// <summary>
+    /// UploadThing URL fragment for identification.
+    /// </summary>
+    public const string UploadThingUrlFragment = "utfs.io/f/";
+
+    // GenTool
+
+    /// <summary>
+    /// GenTool data URL fragment for identification.
+    /// </summary>
+    public const string GenToolUrlFragment = "gentool.net/data/";
+
+    // Generals Online
+
+    /// <summary>
+    /// Generals Online view match URL fragment.
+    /// </summary>
+    public const string GeneralsOnlineViewMatchFragment = "playgenerals.online/viewmatch";
+
     // User agents
 
     /// <summary>

--- a/GenHub/GenHub.Core/Constants/ErrorMessages.cs
+++ b/GenHub/GenHub.Core/Constants/ErrorMessages.cs
@@ -1,0 +1,62 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Error message constants.
+/// </summary>
+public static class ErrorMessages
+{
+    /// <summary>
+    /// Error message for missing UploadThing token.
+    /// </summary>
+    public const string UploadThingTokenMissing = "UploadThing V7 Token is missing. Ensure UPLOADTHING_TOKEN is in your .env file.";
+
+    /// <summary>
+    /// Error message for ZIP validation failure.
+    /// </summary>
+    public const string ZipValidationFailed = "ZIP validation failed for upload: {Error}";
+
+    /// <summary>
+    /// Error message for file exceeding size limit.
+    /// </summary>
+    public const string FileExceedsSizeLimit = "File exceeds size limit: {Path}";
+
+    /// <summary>
+    /// Error message for failed prepare upload.
+    /// </summary>
+    public const string V7PrepareUploadFailed = "V7 PrepareUpload failed: {StatusCode} - {Error}";
+
+    /// <summary>
+    /// Error message for missing required fields in UploadThing response.
+    /// </summary>
+    public const string UploadThingMissingFields = "UploadThing V7 returned 200 OK but missing required fields. Response: {Response}";
+
+    /// <summary>
+    /// Error message for failed binary upload.
+    /// </summary>
+    public const string V7BinaryUploadFailed = "V7 PUT Binary Upload failed: {StatusCode} - {Error}";
+
+    /// <summary>
+    /// Error message for exception in UploadThing flow.
+    /// </summary>
+    public const string ExceptionInUploadThingFlow = "Exception in UploadThing V7 flow";
+
+    /// <summary>
+    /// Error message for could not extract download URL.
+    /// </summary>
+    public const string CouldNotExtractDownloadUrl = "Could not extract download URL from the provided source.";
+
+    /// <summary>
+    /// Error message for download failed.
+    /// </summary>
+    public const string DownloadFailed = "Download failed.";
+
+    /// <summary>
+    /// Error message for replay exceeding size.
+    /// </summary>
+    public const string ReplayExceedsMaxSize = "Replay file exceeds maximum size of 1 MB ({0:F1} KB).";
+
+    /// <summary>
+    /// Error message for failed to process ZIP.
+    /// </summary>
+    public const string FailedToProcessZip = "Failed to process ZIP: {0}";
+}

--- a/GenHub/GenHub.Core/Constants/FileTypes.cs
+++ b/GenHub/GenHub.Core/Constants/FileTypes.cs
@@ -34,4 +34,24 @@ public static class FileTypes
     /// Default settings file name.
     /// </summary>
     public const string SettingsFileName = "settings.json";
+
+    /// <summary>
+    /// File extension for replay files.
+    /// </summary>
+    public const string ReplayFileExtension = ".rep";
+
+    /// <summary>
+    /// File extension for ZIP files.
+    /// </summary>
+    public const string ZipFileExtension = ".zip";
+
+    /// <summary>
+    /// File extension pattern for replay files.
+    /// </summary>
+    public const string ReplayFilePattern = "*.rep";
+
+    /// <summary>
+    /// File extension pattern for ZIP files.
+    /// </summary>
+    public const string ZipFilePattern = "*.zip";
 }

--- a/GenHub/GenHub.Core/Constants/LogMessages.cs
+++ b/GenHub/GenHub.Core/Constants/LogMessages.cs
@@ -1,0 +1,72 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Log message constants.
+/// </summary>
+public static class LogMessages
+{
+    /// <summary>
+    /// Log message for identifying URL source.
+    /// </summary>
+    public const string IdentifyingUrlSource = "Identifying source for URL: {Url}, Source: {Source}";
+
+    /// <summary>
+    /// Log message for failed URL extraction.
+    /// </summary>
+    public const string FailedToExtractDownloadUrl = "Failed to extract download URL from: {Url}";
+
+    /// <summary>
+    /// Log message for missing replay link on Generals Online.
+    /// </summary>
+    public const string CouldNotFindReplayLinkGeneralsOnline = "Could not find replay link on Generals Online page: {Url}";
+
+    /// <summary>
+    /// Log message for missing replay link on GenTool.
+    /// </summary>
+    public const string CouldNotFindReplayLinkGenTool = "Could not find replay link on GenTool page: {Url}";
+
+    /// <summary>
+    /// Log message for creating replay directory.
+    /// </summary>
+    public const string CreatingReplayDirectory = "Creating replay directory: {Path}";
+
+    /// <summary>
+    /// Log message for deleted replay.
+    /// </summary>
+    public const string DeletedReplay = "Deleted replay: {Path}";
+
+    /// <summary>
+    /// Log message for failed replay deletion.
+    /// </summary>
+    public const string FailedToDeleteReplay = "Failed to delete replay: {Path}";
+
+    /// <summary>
+    /// Log message for uploading to UploadThing.
+    /// </summary>
+    public const string UploadingToUploadThing = "Uploading to UploadThing V7: {Path}";
+
+    /// <summary>
+    /// Log message for successful UploadThing upload.
+    /// </summary>
+    public const string UploadThingSuccessful = "UploadThing V7 successful. Public URL: {Url}";
+
+    /// <summary>
+    /// Log message for failed ZIP creation.
+    /// </summary>
+    public const string FailedToCreateZip = "Failed to create ZIP: {Path}";
+
+    /// <summary>
+    /// Log message for detected ZIP file.
+    /// </summary>
+    public const string DetectedZipFile = "Detected ZIP file, extracting contents";
+
+    /// <summary>
+    /// Log message for failed import from ZIP.
+    /// </summary>
+    public const string FailedToImportFromZip = "Failed to import from ZIP: {Path}";
+
+    /// <summary>
+    /// Log message for failed stream import.
+    /// </summary>
+    public const string FailedToImportStream = "Failed to import stream for file: {FileName}";
+}

--- a/GenHub/GenHub.Core/Constants/PlatformConstants.cs
+++ b/GenHub/GenHub.Core/Constants/PlatformConstants.cs
@@ -1,0 +1,17 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Platform-specific constants.
+/// </summary>
+public static class PlatformConstants
+{
+    /// <summary>
+    /// Windows Explorer executable name.
+    /// </summary>
+    public const string WindowsExplorerExecutable = "explorer.exe";
+
+    /// <summary>
+    /// Windows Explorer select argument.
+    /// </summary>
+    public const string WindowsExplorerSelectArgument = "/select,\"{0}\"";
+}

--- a/GenHub/GenHub.Core/Constants/RegexConstants.cs
+++ b/GenHub/GenHub.Core/Constants/RegexConstants.cs
@@ -1,0 +1,17 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Regex pattern constants.
+/// </summary>
+public static class RegexConstants
+{
+    /// <summary>
+    /// Regex pattern for Generals Online replay URLs.
+    /// </summary>
+    public const string GeneralsOnlineReplayPattern = @"https://matchdata\.playgenerals\.online/[^""]+_replay\.rep";
+
+    /// <summary>
+    /// Regex pattern for GenTool replay links.
+    /// </summary>
+    public const string GenToolReplayPattern = @"href=""([^\""]+\.rep)""";
+}

--- a/GenHub/GenHub.Core/Constants/ReplayManagerConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ReplayManagerConstants.cs
@@ -1,0 +1,32 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Constants for the Replay Manager feature.
+/// </summary>
+public static class ReplayManagerConstants
+{
+    /// <summary>
+    /// Maximum size for a single replay file in bytes (1 MB).
+    /// </summary>
+    public const long MaxReplaySizeBytes = 1024 * 1024;
+
+    /// <summary>
+    /// Maximum weekly upload bytes (10 MB).
+    /// </summary>
+    public const long MaxWeeklyUploadBytes = 10 * 1024 * 1024;
+
+    /// <summary>
+    /// Prefix for temporary import files.
+    /// </summary>
+    public const string TempImportFilePrefix = "genhub_import_";
+
+    /// <summary>
+    /// Prefix for temporary share files.
+    /// </summary>
+    public const string TempShareFilePrefix = "genhub_share_";
+
+    /// <summary>
+    /// Default file name for imported replays.
+    /// </summary>
+    public const string DefaultImportedReplayFileName = "imported_replay.rep";
+}

--- a/GenHub/GenHub.Core/Constants/ToolConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ToolConstants.cs
@@ -1,0 +1,53 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Constants for tool plugin metadata and configuration.
+/// </summary>
+public static class ToolConstants
+{
+    /// <summary>
+    /// Constants for the Replay Manager tool plugin.
+    /// </summary>
+    public static class ReplayManager
+    {
+        /// <summary>
+        /// The unique identifier for the Replay Manager tool.
+        /// </summary>
+        public const string Id = "genhub.tools.replaymanager";
+
+        /// <summary>
+        /// The display name for the Replay Manager tool.
+        /// </summary>
+        public const string Name = "Replay Manager";
+
+        /// <summary>
+        /// The version of the Replay Manager tool.
+        /// </summary>
+        public const string Version = "1.0.0";
+
+        /// <summary>
+        /// The author of the Replay Manager tool.
+        /// </summary>
+        public const string Author = "GenHub Team";
+
+        /// <summary>
+        /// The description of the Replay Manager tool.
+        /// </summary>
+        public const string Description = "Manage, import, and share replay files for Command & Conquer: Generals and Zero Hour.";
+
+        /// <summary>
+        /// The icon path for the Replay Manager tool.
+        /// </summary>
+        public const string IconPath = "Assets/Icons/replay.png"; // Placeholder
+
+        /// <summary>
+        /// Whether the Replay Manager tool is bundled with the application.
+        /// </summary>
+        public const bool IsBundled = true;
+
+        /// <summary>
+        /// The tags associated with the Replay Manager tool.
+        /// </summary>
+        public static readonly string[] Tags = ["replays", "file-management", "sharing"];
+    }
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/IToolRegistry.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/IToolRegistry.cs
@@ -19,11 +19,17 @@ public interface IToolRegistry
     IToolPlugin? GetToolById(string toolId);
 
     /// <summary>
-    /// Registers a new tool plugin.
+    /// Registers a new tool plugin with an assembly path (external tool).
     /// </summary>
     /// <param name="plugin">The tool plugin to register.</param>
     /// <param name="assemblyPath">The path to the tool assembly.</param>
     void RegisterTool(IToolPlugin plugin, string assemblyPath);
+
+    /// <summary>
+    /// Registers a new built-in tool plugin.
+    /// </summary>
+    /// <param name="plugin">The tool plugin to register.</param>
+    void RegisterTool(IToolPlugin plugin);
 
     /// <summary>
     /// Unregisters a tool plugin by its ID.

--- a/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IReplayDirectoryService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IReplayDirectoryService.cs
@@ -1,0 +1,54 @@
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Tools.ReplayManager;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Core.Interfaces.Tools.ReplayManager;
+
+/// <summary>
+/// Manages replay directory operations.
+/// </summary>
+public interface IReplayDirectoryService
+{
+    /// <summary>
+    /// Gets the replay directory path for the specified game version.
+    /// </summary>
+    /// <param name="version">The game version.</param>
+    /// <returns>The path to the replay directory.</returns>
+    string GetReplayDirectory(GameType version);
+
+    /// <summary>
+    /// Ensures the replay directory exists, creating it if necessary.
+    /// </summary>
+    /// <param name="version">The game version.</param>
+    void EnsureDirectoryExists(GameType version);
+
+    /// <summary>
+    /// Gets all replay files for the specified game version.
+    /// </summary>
+    /// <param name="version">The game version.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A list of replay files.</returns>
+    Task<IReadOnlyList<ReplayFile>> GetReplaysAsync(GameType version, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes the specified replay files (moves to Recycle Bin).
+    /// </summary>
+    /// <param name="replays">The replays to delete.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if deletion was successful.</returns>
+    Task<bool> DeleteReplaysAsync(IEnumerable<ReplayFile> replays, CancellationToken ct = default);
+
+    /// <summary>
+    /// Opens the replay directory in Windows Explorer.
+    /// </summary>
+    /// <param name="version">The game version.</param>
+    void OpenInExplorer(GameType version);
+
+    /// <summary>
+    /// Reveals a specific file in Windows Explorer.
+    /// </summary>
+    /// <param name="replay">The replay file to reveal.</param>
+    void RevealInExplorer(ReplayFile replay);
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IReplayExportService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IReplayExportService.cs
@@ -1,0 +1,39 @@
+using GenHub.Core.Models.Tools.ReplayManager;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Core.Interfaces.Tools.ReplayManager;
+
+/// <summary>
+/// Handles exporting and sharing replays.
+/// </summary>
+public interface IReplayExportService
+{
+    /// <summary>
+    /// Uploads replays to UploadThing and returns the share URL.
+    /// </summary>
+    /// <param name="replays">The replays to upload.</param>
+    /// <param name="progress">Progress reporter for upload updates.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The share URL if successful, otherwise null.</returns>
+    Task<string?> UploadToUploadThingAsync(
+        IEnumerable<ReplayFile> replays,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates a ZIP archive of the specified replays.
+    /// </summary>
+    /// <param name="replays">The replays to export.</param>
+    /// <param name="destinationPath">The destination ZIP file path.</param>
+    /// <param name="progress">Progress reporter for compression updates.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The path to the created ZIP file if successful, otherwise null.</returns>
+    Task<string?> ExportToZipAsync(
+        IEnumerable<ReplayFile> replays,
+        string destinationPath,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default);
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IReplayImportService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IReplayImportService.cs
@@ -1,0 +1,82 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Tools.ReplayManager;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Core.Interfaces.Tools.ReplayManager;
+
+/// <summary>
+/// Handles importing replays from various sources.
+/// </summary>
+public interface IReplayImportService
+{
+    /// <summary>
+    /// Maximum size for a single replay file in bytes (1 MB).
+    /// </summary>
+    public const long MaxReplaySizeBytes = ReplayManagerConstants.MaxReplaySizeBytes;
+
+    /// <summary>
+    /// Imports a replay from a URL.
+    /// </summary>
+    /// <param name="url">The URL to import from.</param>
+    /// <param name="targetVersion">The target game version.</param>
+    /// <param name="progress">Progress reporter for download updates.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The result of the import operation.</returns>
+    Task<ImportResult> ImportFromUrlAsync(
+        string url,
+        GameType targetVersion,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Imports replay files from local paths.
+    /// </summary>
+    /// <param name="filePaths">The paths to the local files.</param>
+    /// <param name="targetVersion">The target game version.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The result of the import operation.</returns>
+    Task<ImportResult> ImportFromFilesAsync(
+        IEnumerable<string> filePaths,
+        GameType targetVersion,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Imports replays from a ZIP archive.
+    /// </summary>
+    /// <param name="zipPath">The path to the ZIP archive.</param>
+    /// <param name="targetVersion">The target game version.</param>
+    /// <param name="progress">Progress reporter for extraction updates.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The result of the import operation.</returns>
+    Task<ImportResult> ImportFromZipAsync(
+        string zipPath,
+        GameType targetVersion,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Validates a ZIP archive to ensure it contains only a single layer of replay files.
+    /// </summary>
+    /// <param name="zipPath">The path to the ZIP archive.</param>
+    /// <returns>A result indicating whether the ZIP is valid and any error message.</returns>
+    (bool IsValid, string? ErrorMessage) ValidateZip(string zipPath);
+
+    /// <summary>
+    /// Imports replays from a stream (e.g., for drag-and-drop).
+    /// </summary>
+    /// <param name="stream">The stream to read from.</param>
+    /// <param name="fileName">The name of the file being imported.</param>
+    /// <param name="targetVersion">The target game version.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The result of the import operation.</returns>
+    Task<ImportResult> ImportFromStreamAsync(
+        Stream stream,
+        string fileName,
+        GameType targetVersion,
+        CancellationToken ct = default);
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IUploadRateLimitService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IUploadRateLimitService.cs
@@ -1,0 +1,55 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Models.Tools.ReplayManager;
+
+namespace GenHub.Core.Interfaces.Tools.ReplayManager;
+
+/// <summary>
+/// Manages upload rate limiting to prevent spam.
+/// </summary>
+public interface IUploadRateLimitService
+{
+    /// <summary>
+    /// Maximum upload size per week in bytes (10 MB).
+    /// </summary>
+    public const long MaxWeeklyUploadBytes = ReplayManagerConstants.MaxWeeklyUploadBytes;
+
+    /// <summary>
+    /// Checks if an upload of the specified size is allowed.
+    /// </summary>
+    /// <param name="fileSizeBytes">The size of the file to upload in bytes.</param>
+    /// <returns>True if the upload is allowed, false if it would exceed the weekly limit.</returns>
+    Task<bool> CanUploadAsync(long fileSizeBytes);
+
+    /// <summary>
+    /// Records a successful upload.
+    /// </summary>
+    /// <param name="fileSizeBytes">The size of the uploaded file in bytes.</param>
+    /// <param name="url">The public URL of the uploaded file.</param>
+    /// <param name="fileName">The name of the uploaded file.</param>
+    void RecordUpload(long fileSizeBytes, string url, string fileName);
+
+    /// <summary>
+    /// Gets the current usage information.
+    /// </summary>
+    /// <returns>A <see cref="UsageInfo"/> containing the current usage information.</returns>
+    Task<UsageInfo> GetUsageInfoAsync();
+
+    /// <summary>
+    /// Gets the history of uploads.
+    /// </summary>
+    /// <returns>A list of upload history items.</returns>
+    Task<IEnumerable<UploadHistoryItem>> GetUploadHistoryAsync();
+
+    /// <summary>
+    /// Removes a specific upload history item by URL.
+    /// </summary>
+    /// <param name="url">The URL of the upload to remove.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task RemoveHistoryItemAsync(string url);
+
+    /// <summary>
+    /// Clears all upload history.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task ClearHistoryAsync();
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IUrlParserService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IUrlParserService.cs
@@ -1,0 +1,33 @@
+using GenHub.Core.Models.Tools.ReplayManager;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GenHub.Core.Interfaces.Tools.ReplayManager;
+
+/// <summary>
+/// Parses and identifies replay source URLs.
+/// </summary>
+public interface IUrlParserService
+{
+    /// <summary>
+    /// Identifies the source of a replay URL.
+    /// </summary>
+    /// <param name="url">The URL to identify.</param>
+    /// <returns>The identified source.</returns>
+    ReplaySource IdentifySource(string url);
+
+    /// <summary>
+    /// Validates if the URL is a supported replay source.
+    /// </summary>
+    /// <param name="url">The URL to validate.</param>
+    /// <returns>True if the URL is supported.</returns>
+    bool IsValidReplayUrl(string url);
+
+    /// <summary>
+    /// Extracts the direct download URL from a source-specific URL.
+    /// </summary>
+    /// <param name="url">The source URL.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The direct download URL if successful, otherwise null.</returns>
+    Task<string?> GetDirectDownloadUrlAsync(string url, CancellationToken ct = default);
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IZipValidationService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/IZipValidationService.cs
@@ -1,0 +1,16 @@
+using System.IO;
+
+namespace GenHub.Core.Interfaces.Tools.ReplayManager;
+
+/// <summary>
+/// Service for validating ZIP files.
+/// </summary>
+public interface IZipValidationService
+{
+    /// <summary>
+    /// Validates if the given file path points to a valid ZIP archive.
+    /// </summary>
+    /// <param name="zipPath">The path to the ZIP file.</param>
+    /// <returns>A tuple with validation result and error message if invalid.</returns>
+    (bool IsValid, string? ErrorMessage) ValidateZip(string zipPath);
+}

--- a/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/UsageInfo.cs
+++ b/GenHub/GenHub.Core/Interfaces/Tools/ReplayManager/UsageInfo.cs
@@ -1,0 +1,12 @@
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Tools.ReplayManager;
+
+namespace GenHub.Core.Interfaces.Tools.ReplayManager;
+
+/// <summary>
+/// Represents usage information for upload limits.
+/// </summary>
+/// <param name="UsedBytes">The number of bytes used in the current week.</param>
+/// <param name="LimitBytes">The maximum allowed bytes per week.</param>
+/// <param name="ResetDate">The date and time when the usage resets.</param>
+public readonly record struct UsageInfo(long UsedBytes, long LimitBytes, DateTime ResetDate);

--- a/GenHub/GenHub.Core/Models/Tools/ReplayManager/ImportResult.cs
+++ b/GenHub/GenHub.Core/Models/Tools/ReplayManager/ImportResult.cs
@@ -1,0 +1,32 @@
+namespace GenHub.Core.Models.Tools.ReplayManager;
+
+/// <summary>
+/// Result of an import operation.
+/// </summary>
+public sealed class ImportResult
+{
+    /// <summary>
+    /// Gets a value indicating whether the import was successful.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the number of files successfully imported.
+    /// </summary>
+    public required int FilesImported { get; init; }
+
+    /// <summary>
+    /// Gets the number of files skipped.
+    /// </summary>
+    public required int FilesSkipped { get; init; }
+
+    /// <summary>
+    /// Gets the list of error messages.
+    /// </summary>
+    public IReadOnlyList<string> Errors { get; init; } = [];
+
+    /// <summary>
+    /// Gets the list of imported file paths.
+    /// </summary>
+    public IReadOnlyList<string> ImportedFiles { get; init; } = [];
+}

--- a/GenHub/GenHub.Core/Models/Tools/ReplayManager/ReplayFile.cs
+++ b/GenHub/GenHub.Core/Models/Tools/ReplayManager/ReplayFile.cs
@@ -1,0 +1,51 @@
+using GenHub.Core.Models.Enums;
+
+namespace GenHub.Core.Models.Tools.ReplayManager;
+
+/// <summary>
+/// Represents a replay file on disk.
+/// </summary>
+public sealed class ReplayFile
+{
+    /// <summary>
+    /// Gets or sets the full path to the replay file.
+    /// </summary>
+    public required string FullPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the file name.
+    /// </summary>
+    public required string FileName { get; set; }
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public required long SizeInBytes { get; init; }
+
+    /// <summary>
+    /// Gets the last modified date/time.
+    /// </summary>
+    public required DateTime LastModified { get; init; }
+
+    /// <summary>
+    /// Gets the game version this replay belongs to.
+    /// </summary>
+    public required GameType GameVersion { get; init; }
+
+    /// <summary>
+    /// Gets or sets the replay metadata.
+    /// </summary>
+    public ReplayMetadata? Metadata { get; set; }
+
+    /// <summary>
+    /// Gets the formatted file size string.
+    /// </summary>
+    public string FormattedSize => FormatFileSize(SizeInBytes);
+
+    private static string FormatFileSize(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        _ => $"{bytes / (1024.0 * 1024.0):F1} MB",
+    };
+}

--- a/GenHub/GenHub.Core/Models/Tools/ReplayManager/ReplayMetadata.cs
+++ b/GenHub/GenHub.Core/Models/Tools/ReplayManager/ReplayMetadata.cs
@@ -1,0 +1,27 @@
+namespace GenHub.Core.Models.Tools.ReplayManager;
+
+/// <summary>
+/// Placeholder for future replay parsing feature.
+/// </summary>
+public sealed class ReplayMetadata
+{
+    /// <summary>
+    /// Gets the map name.
+    /// </summary>
+    public string? MapName { get; init; }
+
+    /// <summary>
+    /// Gets the list of players.
+    /// </summary>
+    public IReadOnlyList<string>? Players { get; init; }
+
+    /// <summary>
+    /// Gets the game duration.
+    /// </summary>
+    public TimeSpan? Duration { get; init; }
+
+    /// <summary>
+    /// Gets the date the game was played.
+    /// </summary>
+    public DateTime? GameDate { get; init; }
+}

--- a/GenHub/GenHub.Core/Models/Tools/ReplayManager/ReplaySource.cs
+++ b/GenHub/GenHub.Core/Models/Tools/ReplayManager/ReplaySource.cs
@@ -1,0 +1,32 @@
+namespace GenHub.Core.Models.Tools.ReplayManager;
+
+/// <summary>
+/// Identifies the source of a replay URL.
+/// </summary>
+public enum ReplaySource
+{
+    /// <summary>
+    /// Unknown source.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// UploadThing file hosting.
+    /// </summary>
+    UploadThing,
+
+    /// <summary>
+    /// Generals Online community platform.
+    /// </summary>
+    GeneralsOnline,
+
+    /// <summary>
+    /// GenTool community tool/website.
+    /// </summary>
+    GenTool,
+
+    /// <summary>
+    /// Direct link to a .rep or .zip file.
+    /// </summary>
+    DirectLink,
+}

--- a/GenHub/GenHub.Core/Models/Tools/ReplayManager/UploadHistoryItem.cs
+++ b/GenHub/GenHub.Core/Models/Tools/ReplayManager/UploadHistoryItem.cs
@@ -1,0 +1,14 @@
+namespace GenHub.Core.Models.Tools.ReplayManager;
+
+/// <summary>
+/// Represents a single item in the upload history.
+/// </summary>
+/// <param name="Timestamp">The UTC timestamp of the upload.</param>
+/// <param name="SizeBytes">The size of the uploaded file in bytes.</param>
+/// <param name="Url">The public URL of the upload.</param>
+/// <param name="FileName">The name of the uploaded file.</param>
+public record UploadHistoryItem(
+    System.DateTime Timestamp,
+    long SizeBytes,
+    string Url,
+    string FileName);

--- a/GenHub/GenHub.Core/Models/Tools/ToolMetadata.cs
+++ b/GenHub/GenHub.Core/Models/Tools/ToolMetadata.cs
@@ -36,7 +36,12 @@ public class ToolMetadata
     public string? IconPath { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the tool is bundled with the application and cannot be removed.
+    /// </summary>
+    public bool IsBundled { get; set; }
+
+    /// <summary>
     /// Gets or sets the tags/categories for the tool.
     /// </summary>
-    public List<string> Tags { get; set; } = new();
+    public List<string> Tags { get; set; } = [];
 }

--- a/GenHub/GenHub.Core/Services/Tools/ToolRegistry.cs
+++ b/GenHub/GenHub.Core/Services/Tools/ToolRegistry.cs
@@ -14,7 +14,7 @@ public class ToolRegistry : IToolRegistry
     /// <inheritdoc/>
     public IReadOnlyList<IToolPlugin> GetAllTools()
     {
-        return _tools.Values.ToList();
+        return [.. _tools.Values];
     }
 
     /// <inheritdoc/>
@@ -39,13 +39,19 @@ public class ToolRegistry : IToolRegistry
     }
 
     /// <inheritdoc/>
+    public void RegisterTool(IToolPlugin plugin)
+    {
+        _tools[plugin.Metadata.Id] = plugin;
+    }
+
+    /// <inheritdoc/>
     public bool UnregisterTool(string toolId)
     {
         var removed = _tools.TryRemove(toolId, out var plugin);
         if (removed && plugin != null)
         {
             plugin.Dispose();
-            _toolAssemblyPaths.TryRemove(toolId, out var path);
+            _ = _toolAssemblyPaths.TryRemove(toolId, out _);
         }
 
         return removed;

--- a/GenHub/GenHub.Core/Utilities/ZipValidation.cs
+++ b/GenHub/GenHub.Core/Utilities/ZipValidation.cs
@@ -1,0 +1,40 @@
+using System.IO;
+
+namespace GenHub.Core.Utilities;
+
+/// <summary>
+/// Utility methods for ZIP file validation.
+/// </summary>
+public static class ZipValidation
+{
+    /// <summary>
+    /// Validates if the given file path points to a valid ZIP archive by checking magic bytes.
+    /// </summary>
+    /// <param name="filePath">The path to the file to validate.</param>
+    /// <returns>True if the file appears to be a valid ZIP archive.</returns>
+    public static bool IsValidZipFile(string filePath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            if (stream.Length < 4)
+            {
+                return false;
+            }
+
+            var buffer = new byte[4];
+            if (stream.Read(buffer, 0, 4) < 4)
+            {
+                return false;
+            }
+
+            // Check for ZIP magic bytes: 50 4B 03 04 (local file header) or 50 4B 05 06 (end of central directory)
+            return (buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x03 && buffer[3] == 0x04) ||
+                   (buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x05 && buffer[3] == 0x06);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/ToolSystemIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/ToolSystemIntegrationTests.cs
@@ -18,8 +18,8 @@ public class ToolSystemIntegrationTests
     private readonly Mock<IUserSettingsService> _mockSettingsService;
     private readonly UserSettings _testSettings;
     private readonly IToolPluginLoader _pluginLoader;
-    private readonly IToolRegistry _registry;
-    private readonly IToolManager _toolService;
+    private readonly ToolRegistry _registry;
+    private readonly ToolService _toolService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolSystemIntegrationTests"/> class.
@@ -32,7 +32,7 @@ public class ToolSystemIntegrationTests
 
         _testSettings = new UserSettings
         {
-            InstalledToolAssemblyPaths = new List<string>(),
+            InstalledToolAssemblyPaths = [],
         };
 
         _mockSettingsService.Setup(x => x.Get()).Returns(_testSettings);
@@ -44,6 +44,7 @@ public class ToolSystemIntegrationTests
             _pluginLoader,
             _registry,
             _mockSettingsService.Object,
+            [],
             _mockServiceLogger.Object);
     }
 
@@ -67,6 +68,7 @@ public class ToolSystemIntegrationTests
             mockLoader.Object,
             _registry,
             _mockSettingsService.Object,
+            [],
             _mockServiceLogger.Object);
 
         Action<UserSettings>? capturedUpdateAction = null;
@@ -126,7 +128,7 @@ public class ToolSystemIntegrationTests
         var plugin2 = new MockToolPlugin("test.tool2", "Test Tool 2", "1.0.0", "Author 2");
         var plugin3 = new MockToolPlugin("test.tool3", "Test Tool 3", "1.0.0", "Author 3");
 
-        _testSettings.InstalledToolAssemblyPaths = new List<string> { path1, path2, path3 };
+        _testSettings.InstalledToolAssemblyPaths = [path1, path2, path3];
 
         var mockLoader = new Mock<IToolPluginLoader>();
         mockLoader.Setup(x => x.LoadPluginFromAssembly(path1)).Returns(plugin1);
@@ -137,6 +139,7 @@ public class ToolSystemIntegrationTests
             mockLoader.Object,
             _registry,
             _mockSettingsService.Object,
+            [],
             _mockServiceLogger.Object);
 
         // Act
@@ -179,6 +182,7 @@ public class ToolSystemIntegrationTests
             mockLoader.Object,
             _registry,
             _mockSettingsService.Object,
+            [],
             _mockServiceLogger.Object);
 
         // Act
@@ -220,6 +224,7 @@ public class ToolSystemIntegrationTests
             mockLoader.Object,
             _registry,
             _mockSettingsService.Object,
+            [],
             _mockServiceLogger.Object);
 
         // Act - Add first version

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceStrategyBaseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceStrategyBaseTests.cs
@@ -128,8 +128,8 @@ public class WorkspaceStrategyBaseTests : IDisposable
 
         var config = new WorkspaceConfiguration
         {
-            Manifests = new List<ContentManifest>
-            {
+            Manifests =
+            [
                 new()
                 {
                     Files =
@@ -138,7 +138,7 @@ public class WorkspaceStrategyBaseTests : IDisposable
                         new() { RelativePath = "config.ini", Size = 500 },
                     ],
                 },
-            },
+            ],
             GameClient = new GameClient { ExecutablePath = "generals.exe" },
         };
 
@@ -195,6 +195,8 @@ public class WorkspaceStrategyBaseTests : IDisposable
         {
             Directory.Delete(_tempDir, true);
         }
+
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -74,7 +74,7 @@ public class WorkspaceValidatorTests : IDisposable
             Id = string.Empty,
             BaseInstallationPath = string.Empty,
             WorkspaceRootPath = string.Empty,
-            Manifests = new List<ContentManifest> { new() { Files = new List<ManifestFile>(), }, },
+            Manifests = [new() { Files = [], }],
         };
 
         // Act
@@ -111,7 +111,7 @@ public class WorkspaceValidatorTests : IDisposable
     {
         // Arrange
         var config = CreateValidConfiguration();
-        config.Manifests = new List<ContentManifest> { new() { Files = new List<ManifestFile>(), }, };
+        config.Manifests = [new() { Files = [], }];
 
         // Act
         var result = await _validator.ValidateConfigurationAsync(config);
@@ -145,7 +145,7 @@ public class WorkspaceValidatorTests : IDisposable
             Id = Path.GetFileName(_workspaceDir),
             BaseInstallationPath = _sourceDir,
             WorkspaceRootPath = Path.GetDirectoryName(_workspaceDir) ?? _workspaceDir,
-            Manifests = new List<ContentManifest>(), // Empty for this test
+            Manifests = [], // Empty for this test
             GameClient = new GameClient { Id = "test" },
             Strategy = WorkspaceStrategy.FullCopy,
         };
@@ -183,7 +183,7 @@ public class WorkspaceValidatorTests : IDisposable
             Id = Path.GetFileName(destPath),
             BaseInstallationPath = sourcePath,
             WorkspaceRootPath = Path.GetDirectoryName(destPath) ?? destPath,
-            Manifests = new List<ContentManifest>(), // Empty for this test
+            Manifests = [], // Empty for this test
             GameClient = new GameClient { Id = "test" },
             Strategy = WorkspaceStrategy.HardLink,
         };
@@ -218,16 +218,16 @@ public class WorkspaceValidatorTests : IDisposable
         // Create a configuration with large files to trigger disk space warning
         var largeFileManifest = new ContentManifest
         {
-            Files = new List<ManifestFile>
-            {
+            Files =
+            [
                 new() { RelativePath = "huge.bin", Size = long.MaxValue / 2 },
-            },
+            ],
         };
 
         var config = new WorkspaceConfiguration
         {
             Id = "test-workspace",
-            Manifests = new List<ContentManifest> { largeFileManifest },
+            Manifests = [largeFileManifest],
             Strategy = WorkspaceStrategy.FullCopy,
             BaseInstallationPath = _sourceDir,
             WorkspaceRootPath = Path.GetDirectoryName(_workspaceDir) ?? _workspaceDir,
@@ -260,6 +260,8 @@ public class WorkspaceValidatorTests : IDisposable
         {
             Directory.Delete(_tempDir, true);
         }
+
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>
@@ -271,17 +273,17 @@ public class WorkspaceValidatorTests : IDisposable
         return new WorkspaceConfiguration
         {
             Id = "test-workspace",
-            Manifests = new List<ContentManifest>
-            {
+            Manifests =
+            [
                 new()
                 {
-                    Files = new List<ManifestFile>
-                    {
+                    Files =
+                    [
                         new() { RelativePath = "generals.exe", Size = 1000000, IsExecutable = true },
                         new() { RelativePath = "config.ini", Size = 500 },
-                    },
+                    ],
                 },
-            },
+            ],
             BaseInstallationPath = _sourceDir,
             WorkspaceRootPath = _workspaceDir,
             GameClient = new GameClient { Id = "test-version" },

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
@@ -150,8 +150,8 @@ public class SharedViewModelModuleTests
         mock.Setup(x => x.GetLastSelectedTab()).Returns(NavigationTab.Home);
         mock.Setup(x => x.GetApplicationDataPath()).Returns(Path.Combine(Path.GetTempPath(), "GenHubTest", "Content"));
         mock.Setup(x => x.GetWorkspacePath()).Returns(Path.Combine(Path.GetTempPath(), "GenHubTest", "Workspace"));
-        mock.Setup(x => x.GetContentDirectories()).Returns(new List<string> { Path.GetTempPath() });
-        mock.Setup(x => x.GetGitHubDiscoveryRepositories()).Returns(new List<string> { "test/repo" });
+        mock.Setup(x => x.GetContentDirectories()).Returns([Path.GetTempPath()]);
+        mock.Setup(x => x.GetGitHubDiscoveryRepositories()).Returns(["test/repo"]);
         mock.Setup(x => x.GetCasConfiguration()).Returns(new GenHub.Core.Models.Storage.CasConfiguration());
         mock.Setup(x => x.GetDownloadUserAgent()).Returns("TestAgent/1.0");
         mock.Setup(x => x.GetDownloadTimeoutSeconds()).Returns(120);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Results/DetectionResultTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Results/DetectionResultTests.cs
@@ -13,7 +13,7 @@ public class DetectionResultTests
     [Fact]
     public void Succeeded_SetsPropertiesCorrectly()
     {
-        var items = new List<string> { "a", "b" };
+        List<string> items = ["a", "b"];
         var elapsed = TimeSpan.FromSeconds(1);
         var result = DetectionResult<string>.CreateSuccess(items, elapsed);
         Assert.True(result.Success);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/WorkspaceCasIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/WorkspaceCasIntegrationTests.cs
@@ -139,6 +139,8 @@ public class WorkspaceCasIntegrationTests : IDisposable
         {
             // Ignore cleanup errors
         }
+
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>
@@ -172,8 +174,8 @@ public class WorkspaceCasIntegrationTests : IDisposable
         var manifest = new ContentManifest
         {
             Id = "1.0.genhub.mod.testmod",
-            Files = new List<ManifestFile>
-            {
+            Files =
+            [
                 new ManifestFile
                 {
                     RelativePath = "data/mymod.big",
@@ -181,13 +183,13 @@ public class WorkspaceCasIntegrationTests : IDisposable
                     SourceType = ContentSourceType.ContentAddressable,
                     Size = 16,
                 },
-            },
+            ],
         };
 
         var config = new WorkspaceConfiguration
         {
             Id = "test-workspace",
-            Manifests = new List<ContentManifest> { manifest },
+            Manifests = [manifest],
             Strategy = WorkspaceStrategy.SymlinkOnly,
             WorkspaceRootPath = _testWorkspacePath,
             BaseInstallationPath = _testWorkspacePath,

--- a/GenHub/GenHub.Windows/GameInstallations/WindowsInstallationDetector.cs
+++ b/GenHub/GenHub.Windows/GameInstallations/WindowsInstallationDetector.cs
@@ -31,6 +31,8 @@ public class WindowsInstallationDetector(ILogger<WindowsInstallationDetector> lo
     /// </summary>
     public bool CanDetectOnCurrentPlatform => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+    private static readonly GameInstallationType[] PriorityOrder = [GameInstallationType.Steam, GameInstallationType.EaApp, GameInstallationType.CDISO, GameInstallationType.Retail, GameInstallationType.TheFirstDecade];
+
     /// <summary>
     /// Scan for Windows platform installations and return them.
     /// </summary>
@@ -192,8 +194,7 @@ public class WindowsInstallationDetector(ILogger<WindowsInstallationDetector> lo
         var deduplicated = new List<GameInstallation>();
 
         // Define priority order: Steam > EA App > CDISO > Retail
-        var priorityOrder = new[] { GameInstallationType.Steam, GameInstallationType.EaApp, GameInstallationType.CDISO, GameInstallationType.Retail, GameInstallationType.TheFirstDecade };
-        var orderedInstallations = installations.OrderBy(i => Array.IndexOf(priorityOrder, i.InstallationType)).ToList();
+        var orderedInstallations = installations.OrderBy(i => Array.IndexOf(PriorityOrder, i.InstallationType)).ToList();
 
         foreach (var installation in orderedInstallations)
         {

--- a/GenHub/GenHub.Windows/GenHub.Windows.csproj
+++ b/GenHub/GenHub.Windows/GenHub.Windows.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop" />
+        <PackageReference Include="DotNetEnv" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia.Diagnostics">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/GenHub/GenHub.Windows/Program.cs
+++ b/GenHub/GenHub.Windows/Program.cs
@@ -1,12 +1,13 @@
-using System;
-using System.Linq;
 using Avalonia;
+using DotNetEnv;
 using GenHub.Core.Constants;
 using GenHub.Core.Helpers;
 using GenHub.Infrastructure.DependencyInjection;
 using GenHub.Windows.Infrastructure.DependencyInjection;
 using GenHub.Windows.Infrastructure.SingleInstance;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Velopack;
 
@@ -32,6 +33,16 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // Load environment variables (locally)
+        try
+        {
+            Env.TraversePath().Load();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to load environment variables: {ex}");
+        }
+
         // Initialize Velopack - must be first to handle install/update hooks
         VelopackApp.Build().Run();
 

--- a/GenHub/GenHub/App.axaml
+++ b/GenHub/GenHub/App.axaml
@@ -4,6 +4,7 @@
              x:Class="GenHub.App">
     <Application.Styles>
         <FluentTheme />
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
         <StyleInclude Source="avares://GenHub/Assets/Styles/ComboBoxStyles.axaml" />
     </Application.Styles>
     <Application.Resources>
@@ -16,5 +17,7 @@
         <local:ColorToBrushConverter x:Key="ColorToBrushConverter" />
         <local:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <local:IntToBoolConverter x:Key="IntToBoolConverter" />
+        <local:EnumToBoolConverter x:Key="EnumToBoolConverter" />
+        <local:EqualsToConverter x:Key="EqualsToConverter" />
     </Application.Resources>
 </Application>

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -93,10 +93,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
         try
         {
             _selectedTab = _configurationProvider.GetLastSelectedTab();
-            if (_selectedTab == NavigationTab.Tools)
-            {
-                _selectedTab = NavigationTab.GameProfiles;
-            }
 
             _logger?.LogDebug("Initial settings loaded, selected tab: {Tab}", _selectedTab);
         }
@@ -146,6 +142,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [
         NavigationTab.GameProfiles,
         NavigationTab.Downloads,
+        NavigationTab.Tools,
         NavigationTab.Settings,
     ];
 

--- a/GenHub/GenHub/Common/Views/MainView.axaml
+++ b/GenHub/GenHub/Common/Views/MainView.axaml
@@ -157,7 +157,6 @@
                         Command="{Binding SelectTabCommand}"
                         CommandParameter="{x:Static enums:NavigationTab.Tools}"
                         Content="Tools"
-                        IsVisible="False"
                         Name="Tab2Button" />
                     <Button Classes="modern-tab"
                         Classes.active="{Binding SelectedTab, Converter={x:Static conv:NavigationTabConverter.Instance}, ConverterParameter={x:Static enums:NavigationTab.Settings}}"

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostResolver.cs
@@ -150,12 +150,12 @@ public class CommunityOutpostResolver(
             if (mirrorUrls.Count > 1)
             {
                 // Store as custom tag since Metadata doesn't have arbitrary storage
-                builtManifest.Metadata.Tags ??= new List<string>();
+                builtManifest.Metadata.Tags ??= [];
                 builtManifest.Metadata.Tags.Add($"mirrors:{mirrorUrls.Count}");
             }
 
             // Store the content code for the factory to use
-            builtManifest.Metadata.Tags ??= new List<string>();
+            builtManifest.Metadata.Tags ??= [];
             builtManifest.Metadata.Tags.Add($"contentCode:{contentCode}");
             builtManifest.Metadata.Tags.Add($"installTarget:{contentMetadata.InstallTarget}");
 
@@ -215,7 +215,7 @@ public class CommunityOutpostResolver(
         if (metadata.Category == GenPatcherContentCategory.OfficialPatch && !string.IsNullOrEmpty(metadata.LanguageCode))
         {
             var languageName = GetLanguageDisplayName(metadata.LanguageCode);
-            var codePrefix = contentCode.Length >= 3 ? contentCode.Substring(0, 3) : contentCode;
+            var codePrefix = contentCode.Length >= 3 ? contentCode[..3] : contentCode;
             return $"patch{codePrefix}{languageName}".ToLowerInvariant();
         }
 
@@ -361,12 +361,12 @@ public class CommunityOutpostResolver(
 
         try
         {
-            return JsonSerializer.Deserialize<List<string>>(mirrorUrlsJson) ?? new List<string>();
+            return JsonSerializer.Deserialize<List<string>>(mirrorUrlsJson) ?? [];
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to deserialize mirror URLs");
-            return new List<string>();
+            return [];
         }
     }
 }

--- a/GenHub/GenHub/Features/Tools/ReplayManager/ReplayManagerToolPlugin.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/ReplayManagerToolPlugin.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Tools;
+using GenHub.Core.Models.Tools;
+using GenHub.Features.Tools.ReplayManager.ViewModels;
+using GenHub.Features.Tools.ReplayManager.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GenHub.Features.Tools.ReplayManager;
+
+/// <summary>
+/// Tool plugin implementation for the Replay Manager.
+/// </summary>
+public sealed class ReplayManagerToolPlugin : IToolPlugin
+{
+    private ReplayManagerView? _view;
+    private IServiceProvider? _serviceProvider;
+
+    /// <inheritdoc />
+    public ToolMetadata Metadata => new()
+    {
+        Id = ToolConstants.ReplayManager.Id,
+        Name = ToolConstants.ReplayManager.Name,
+        Version = ToolConstants.ReplayManager.Version,
+        Author = ToolConstants.ReplayManager.Author,
+        Description = ToolConstants.ReplayManager.Description,
+        Tags = [.. ToolConstants.ReplayManager.Tags],
+        IconPath = ToolConstants.ReplayManager.IconPath,
+        IsBundled = ToolConstants.ReplayManager.IsBundled,
+    };
+
+    /// <inheritdoc />
+    public Control CreateControl()
+    {
+        if (_view == null && _serviceProvider != null)
+        {
+            var viewModel = _serviceProvider.GetRequiredService<ReplayManagerViewModel>();
+            _view = new ReplayManagerView { DataContext = viewModel };
+
+            // Initialize the ViewModel to load replays
+            _ = viewModel.InitializeAsync();
+        }
+
+        return _view ?? (Control)new TextBlock { Text = "Error loading Replay Manager" };
+    }
+
+    /// <inheritdoc />
+    public void OnActivated(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc />
+    public void OnDeactivated()
+    {
+        // View and ViewModel state is preserved for now.
+        // Could call a reset or save method on ViewModel if needed.
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _view = null;
+        _serviceProvider = null;
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayDirectoryService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayDirectoryService.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Tools.ReplayManager;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Tools.ReplayManager.Services;
+
+/// <summary>
+/// Implementation of <see cref="IReplayDirectoryService"/> for managing replay files on disk.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ReplayDirectoryService"/> class.
+/// </remarks>
+/// <param name="logger">The logger instance.</param>
+public sealed class ReplayDirectoryService(ILogger<ReplayDirectoryService> logger) : IReplayDirectoryService
+{
+    /// <inheritdoc />
+    public string GetReplayDirectory(GameType version)
+    {
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        var gameDataFolder = version switch
+        {
+            GameType.Generals => GameSettingsConstants.FolderNames.Generals,
+            GameType.ZeroHour => GameSettingsConstants.FolderNames.ZeroHour,
+            _ => throw new ArgumentException("Unsupported game version", nameof(version)),
+        };
+
+        return Path.Combine(documents, gameDataFolder, GameSettingsConstants.FolderNames.Replays);
+    }
+
+    /// <inheritdoc />
+    public void EnsureDirectoryExists(GameType version)
+    {
+        var path = GetReplayDirectory(version);
+        if (!Directory.Exists(path))
+        {
+            logger.LogInformation(LogMessages.CreatingReplayDirectory, path);
+            Directory.CreateDirectory(path);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ReplayFile>> GetReplaysAsync(GameType version, CancellationToken ct = default)
+    {
+        var directory = GetReplayDirectory(version);
+        if (!Directory.Exists(directory))
+        {
+            return [];
+        }
+
+        return await Task.Run(
+            () =>
+            {
+                var files = Directory.GetFiles(directory, "*.*")
+                    .Where(f => f.EndsWith(".rep", StringComparison.OrdinalIgnoreCase) ||
+                               f.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+                return files.Select(f =>
+                {
+                    var info = new FileInfo(f);
+                    return new ReplayFile
+                    {
+                        FullPath = f,
+                        FileName = Path.GetFileName(f),
+                        SizeInBytes = info.Length,
+                        LastModified = info.LastWriteTime,
+                        GameVersion = version,
+                    };
+                }).OrderByDescending(r => r.LastModified).ToList();
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteReplaysAsync(IEnumerable<ReplayFile> replays, CancellationToken ct = default)
+    {
+        return await Task.Run(
+            () =>
+            {
+                var success = true;
+                foreach (var replay in replays)
+                {
+                    try
+                    {
+                        if (File.Exists(replay.FullPath))
+                        {
+                            // In a real production app, we would use a library or platform-specific call
+                            // to move to Recycle Bin. For now, we perform a standard delete.
+                            // TODO: Implement Recycle Bin support for Windows
+                            File.Delete(replay.FullPath);
+                            logger.LogInformation(LogMessages.DeletedReplay, replay.FullPath);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, LogMessages.FailedToDeleteReplay, replay.FullPath);
+                        success = false;
+                    }
+                }
+
+                return success;
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public void OpenInExplorer(GameType version)
+    {
+        var path = GetReplayDirectory(version);
+        if (Directory.Exists(path))
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = PlatformConstants.WindowsExplorerExecutable,
+                Arguments = path,
+                UseShellExecute = true,
+            });
+        }
+    }
+
+    /// <inheritdoc />
+    public void RevealInExplorer(ReplayFile replay)
+    {
+        if (File.Exists(replay.FullPath))
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = PlatformConstants.WindowsExplorerExecutable,
+                Arguments = string.Format(PlatformConstants.WindowsExplorerSelectArgument, replay.FullPath),
+                UseShellExecute = true,
+            });
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayExportService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayExportService.cs
@@ -1,0 +1,249 @@
+using GenHub.Core.Constants;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using GenHub.Core.Models.Tools.ReplayManager;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Tools.ReplayManager.Services;
+
+/// <summary>
+/// Implementation of <see cref="IReplayExportService"/> for exporting and sharing replays using UploadThing v7.
+/// </summary>
+public sealed class ReplayExportService(
+    HttpClient httpClient,
+    IZipValidationService zipValidationService,
+    ILogger<ReplayExportService> logger) : IReplayExportService
+{
+    private const string UploadThingApiVersion = ApiConstants.UploadThingApiVersion;
+
+    /// <inheritdoc />
+    public async Task<string?> UploadToUploadThingAsync(
+        IEnumerable<ReplayFile> replays,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default)
+    {
+        var token = Environment.GetEnvironmentVariable("UPLOADTHING_TOKEN") ??
+                    Environment.GetEnvironmentVariable("GENHUB_UPLOADTHING_TOKEN");
+
+        if (string.IsNullOrEmpty(token))
+        {
+            logger.LogError(ErrorMessages.UploadThingTokenMissing);
+            return null;
+        }
+
+        string? zipToUpload = null;
+        bool isTemporaryZip = false;
+
+        try
+        {
+            var replayList = replays.ToList();
+            if (replayList.Count == 0) return null;
+
+            if (replayList.Count == 1 && replayList[0].FileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                var (isValid, errorMessage) = zipValidationService.ValidateZip(replayList[0].FullPath);
+                if (!isValid)
+                {
+                    logger.LogError(ErrorMessages.ZipValidationFailed, errorMessage);
+                    throw new ArgumentException(errorMessage ?? "Invalid ZIP archive for upload.");
+                }
+
+                zipToUpload = replayList[0].FullPath;
+            }
+            else
+            {
+                var tempZip = Path.Combine(Path.GetTempPath(), $"{ReplayManagerConstants.TempShareFilePrefix}{Guid.NewGuid()}.zip");
+                var createdZip = await this.ExportToZipAsync(replayList, tempZip, progress, ct);
+                if (createdZip == null) return null;
+
+                zipToUpload = createdZip;
+                isTemporaryZip = true;
+            }
+
+            if (new FileInfo(zipToUpload).Length > ReplayManagerConstants.MaxReplaySizeBytes)
+            {
+                logger.LogError(ErrorMessages.FileExceedsSizeLimit, zipToUpload);
+                return null;
+            }
+
+            return await this.PerformV7UploadAsync(zipToUpload, token, progress, ct);
+        }
+        catch (ArgumentException)
+        {
+            throw; // Bubble up validation errors
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to upload to UploadThing V7");
+            return null;
+        }
+        finally
+        {
+            if (isTemporaryZip && !string.IsNullOrEmpty(zipToUpload) && File.Exists(zipToUpload))
+            {
+                File.Delete(zipToUpload);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> ExportToZipAsync(IEnumerable<ReplayFile> replays, string destinationPath, IProgress<double>? progress = null, CancellationToken ct = default)
+    {
+        try
+        {
+            return await Task.Run(
+                () =>
+                {
+                    var replayList = replays.ToList();
+                    if (replayList.Count == 0) return null;
+
+                    using var zipFile = File.Create(destinationPath);
+                    using var archive = new ZipArchive(zipFile, ZipArchiveMode.Create);
+
+                    int total = replayList.Count;
+                    int count = 0;
+
+                    foreach (var replay in replayList)
+                {
+                    count++;
+                    progress?.Report((double)count / total * 0.4);
+
+                    if (!File.Exists(replay.FullPath)) continue;
+                    archive.CreateEntryFromFile(replay.FullPath, replay.FileName);
+                }
+
+                    return destinationPath;
+            },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, LogMessages.FailedToCreateZip, destinationPath);
+            return null;
+        }
+    }
+
+    private async Task<string?> PerformV7UploadAsync(
+        string filePath,
+        string token,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default)
+    {
+        logger.LogInformation(LogMessages.UploadingToUploadThing, filePath);
+
+        try
+        {
+            var fileInfo = new FileInfo(filePath);
+            var fileName = Path.GetFileName(filePath);
+
+            // Step 1: Prepare the upload
+            const string PrepareUrl = ApiConstants.UploadThingPrepareUrl;
+
+            var requestPayload = new V7FileRequestDetail
+            {
+                FileName = fileName,
+                FileSize = fileInfo.Length,
+                ContentTypes = [
+                    "application/zip",
+                ],
+            };
+
+            var prepareRequest = new HttpRequestMessage(HttpMethod.Post, PrepareUrl);
+            prepareRequest.Headers.Add("x-uploadthing-api-key", token);
+            prepareRequest.Headers.Add("x-uploadthing-version", UploadThingApiVersion);
+            prepareRequest.Content = JsonContent.Create(requestPayload);
+
+            var prepareResponse = await httpClient.SendAsync(prepareRequest, ct);
+            if (!prepareResponse.IsSuccessStatusCode)
+            {
+                var error = await prepareResponse.Content.ReadAsStringAsync(ct);
+                logger.LogError(ErrorMessages.V7PrepareUploadFailed, prepareResponse.StatusCode, error);
+                return null;
+            }
+
+            var instruction = await prepareResponse.Content.ReadFromJsonAsync<V7FileInstruction>(cancellationToken: ct);
+
+            if (instruction?.PresignedUrl == null || instruction?.Key == null)
+            {
+                var rawResponse = await prepareResponse.Content.ReadAsStringAsync(ct);
+                logger.LogError(ErrorMessages.UploadThingMissingFields, rawResponse);
+                return null;
+            }
+
+            // Step 2: Upload binary via PUT
+            // CRITICAL FIX: The UploadThing docs specify using FormData (multipart/form-data)
+            // for the PUT request, not raw binary.
+            using var fileStream = File.OpenRead(filePath); // FIXED: Removed invalid buffer size argument
+
+            // Create the multipart content
+            var multipartContent = new MultipartFormDataContent();
+
+            // Add the file to the form data with the name "file"
+            var fileContent = new StreamContent(fileStream);
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
+            multipartContent.Add(fileContent, "file", fileName);
+
+            var uploadRequest = new HttpRequestMessage(HttpMethod.Put, instruction.PresignedUrl)
+            {
+                Content = multipartContent,
+            };
+
+            // MultipartFormDataContent will automatically set the Content-Type with a boundary
+            uploadRequest.Headers.UserAgent.ParseAdd("GenHub/1.0");
+
+            progress?.Report(0.6);
+
+            var uploadResponse = await httpClient.SendAsync(uploadRequest, ct);
+            if (!uploadResponse.IsSuccessStatusCode)
+            {
+                var uploadError = await uploadResponse.Content.ReadAsStringAsync(ct);
+                logger.LogError(ErrorMessages.V7BinaryUploadFailed, uploadResponse.StatusCode, uploadError);
+                return null;
+            }
+
+            var publicFileUrl = string.Format(ApiConstants.UploadThingPublicUrlFormat, instruction.Key);
+
+            logger.LogInformation(LogMessages.UploadThingSuccessful, publicFileUrl);
+            progress?.Report(1.0);
+
+            return publicFileUrl;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, ErrorMessages.ExceptionInUploadThingFlow);
+            return null;
+        }
+    }
+
+    // --- V7 Request DTOs ---
+    private sealed class V7FileRequestDetail
+    {
+        [JsonPropertyName("fileName")]
+        public string FileName { get; set; } = string.Empty;
+
+        [JsonPropertyName("fileSize")]
+        public long FileSize { get; set; }
+
+        [JsonPropertyName("contentTypes")]
+        public List<string> ContentTypes { get; set; } = [];
+    }
+
+    // --- V7 Response DTO ---
+    private sealed class V7FileInstruction
+    {
+        [JsonPropertyName("url")]
+        public string? PresignedUrl { get; set; }
+
+        [JsonPropertyName("key")]
+        public string? Key { get; set; }
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
@@ -1,0 +1,340 @@
+using GenHub.Core.Constants;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Tools.ReplayManager;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Tools.ReplayManager.Services;
+
+/// <summary>
+/// Implementation of <see cref="IReplayImportService"/> for importing replay files.
+/// </summary>
+public sealed class ReplayImportService(
+    IDownloadService downloadService,
+    IReplayDirectoryService directoryService,
+    IUrlParserService urlParserService,
+    IZipValidationService zipValidationService,
+    ILogger<ReplayImportService> logger) : IReplayImportService
+{
+    /// <inheritdoc />
+    public async Task<ImportResult> ImportFromUrlAsync(
+        string url,
+        GameType targetVersion,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default)
+    {
+        logger.LogInformation("Importing replay from URL: {Url}", url);
+
+        try
+        {
+            var directUrl = await urlParserService.GetDirectDownloadUrlAsync(url, ct);
+            if (string.IsNullOrEmpty(directUrl))
+            {
+                return new ImportResult
+                {
+                    Success = false,
+                    FilesImported = 0,
+                    FilesSkipped = 0,
+                    Errors = [ErrorMessages.CouldNotExtractDownloadUrl],
+                };
+            }
+
+            var tempPath = Path.Combine(Path.GetTempPath(), $"{ReplayManagerConstants.TempImportFilePrefix}{Guid.NewGuid()}.rep");
+            try
+            {
+                var downloadProgress = progress != null ? new Progress<DownloadProgress>(p => progress.Report(p.Percentage / 100.0)) : null;
+                var result = await downloadService.DownloadFileAsync(new Uri(directUrl), tempPath, progress: downloadProgress, cancellationToken: ct);
+
+                if (!result.Success)
+                {
+                    return new ImportResult
+                    {
+                        Success = false,
+                        FilesImported = 0,
+                        FilesSkipped = 0,
+                        Errors = [ErrorMessages.DownloadFailed],
+                    };
+                }
+
+                var info = new FileInfo(tempPath);
+                if (info.Length > ReplayManagerConstants.MaxReplaySizeBytes)
+                {
+                    if (File.Exists(tempPath))
+                    {
+                        File.Delete(tempPath);
+                    }
+
+                    return new ImportResult
+                    {
+                        Success = false,
+                        FilesImported = 0,
+                        FilesSkipped = 0,
+                        Errors = [string.Format(ErrorMessages.ReplayExceedsMaxSize, info.Length / 1024.0)],
+                    };
+                }
+
+                // Detect if the downloaded file is a ZIP by checking magic bytes
+                if (IsZipFile(tempPath))
+                {
+                    logger.LogInformation(LogMessages.DetectedZipFile);
+                    return await ImportFromZipAsync(tempPath, targetVersion, progress, ct);
+                }
+
+                var importedFileName = GetFileNameFromUrl(directUrl);
+                using var stream = File.OpenRead(tempPath);
+                return await ImportFromStreamAsync(stream, importedFileName, targetVersion, ct);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to import from URL: {Url}", url);
+            return new ImportResult { Success = false, FilesImported = 0, FilesSkipped = 0, Errors = [ex.Message] };
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ImportResult> ImportFromFilesAsync(
+        IEnumerable<string> filePaths,
+        GameType targetVersion,
+        CancellationToken ct = default)
+    {
+        var imported = new List<string>();
+        var errors = new List<string>();
+        int skipped = 0;
+
+        foreach (var path in filePaths)
+        {
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                var isZip = path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+                var info = new FileInfo(path);
+
+                // Only enforce 1MB limit for individual .rep files, not for ZIP archives
+                if (!isZip && info.Length > ReplayManagerConstants.MaxReplaySizeBytes)
+                {
+                    errors.Add($"File {Path.GetFileName(path)} skipped: exceeds 1 MB.");
+                    skipped++;
+                    continue;
+                }
+
+                if (isZip)
+                {
+                    var zipResult = await ImportFromZipAsync(path, targetVersion, null, ct);
+                    imported.AddRange(zipResult.ImportedFiles);
+                    errors.AddRange(zipResult.Errors);
+                    skipped += zipResult.FilesSkipped;
+                    continue;
+                }
+
+                using var stream = File.OpenRead(path);
+                var result = await ImportFromStreamAsync(stream, Path.GetFileName(path), targetVersion, ct);
+                if (result.Success)
+                {
+                    imported.AddRange(result.ImportedFiles);
+                }
+                else
+                {
+                    errors.AddRange(result.Errors);
+                    skipped++;
+                }
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Failed to import {Path.GetFileName(path)}: {ex.Message}");
+                skipped++;
+            }
+        }
+
+        return new ImportResult
+        {
+            Success = imported.Count > 0,
+            FilesImported = imported.Count,
+            FilesSkipped = skipped,
+            ImportedFiles = imported,
+            Errors = errors,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<ImportResult> ImportFromZipAsync(
+        string zipPath,
+        GameType targetVersion,
+        IProgress<double>? progress = null,
+        CancellationToken ct = default)
+    {
+        var (isValid, errorMessage) = ValidateZip(zipPath);
+        if (!isValid)
+        {
+            logger.LogWarning("Import from ZIP failed validation: {Error}", errorMessage);
+            return new ImportResult
+            {
+                Success = false,
+                FilesImported = 0,
+                FilesSkipped = 0,
+                Errors = [errorMessage ?? "Invalid ZIP archive."],
+            };
+        }
+
+        var imported = new List<string>();
+        var errors = new List<string>();
+        int skipped = 0;
+
+        try
+        {
+            using var archive = ZipFile.OpenRead(zipPath);
+            var entries = archive.Entries.Where(e => !string.IsNullOrEmpty(e.Name)).ToList();
+            int total = entries.Count;
+            int count = 0;
+
+            foreach (var entry in entries)
+            {
+                count++;
+                progress?.Report((double)count / total);
+
+                using var stream = entry.Open();
+                var result = await ImportFromStreamAsync(stream, entry.Name, targetVersion, ct);
+                if (result.Success)
+                {
+                    imported.AddRange(result.ImportedFiles);
+                }
+                else
+                {
+                    errors.AddRange(result.Errors);
+                    skipped++;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, LogMessages.FailedToImportFromZip, zipPath);
+            errors.Add(string.Format(ErrorMessages.FailedToProcessZip, ex.Message));
+        }
+
+        return new ImportResult
+        {
+            Success = imported.Count > 0,
+            FilesImported = imported.Count,
+            FilesSkipped = skipped,
+            ImportedFiles = imported,
+            Errors = errors,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<ImportResult> ImportFromStreamAsync(
+        Stream stream,
+        string fileName,
+        GameType targetVersion,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            directoryService.EnsureDirectoryExists(targetVersion);
+            var targetDir = directoryService.GetReplayDirectory(targetVersion);
+
+            // Handle filename conflict
+            var targetPath = GetUniquePath(Path.Combine(targetDir, fileName));
+
+            using var fileStream = File.Create(targetPath);
+            await stream.CopyToAsync(fileStream, ct);
+
+            return new ImportResult
+            {
+                Success = true,
+                FilesImported = 1,
+                FilesSkipped = 0,
+                ImportedFiles = [targetPath],
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, LogMessages.FailedToImportStream, fileName);
+            return new ImportResult { Success = false, FilesImported = 0, FilesSkipped = 1, Errors = [ex.Message] };
+        }
+    }
+
+    /// <inheritdoc />
+    public (bool IsValid, string? ErrorMessage) ValidateZip(string zipPath)
+    {
+        return zipValidationService.ValidateZip(zipPath);
+    }
+
+    private static bool IsZipFile(string filePath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            if (stream.Length < 4)
+            {
+                return false;
+            }
+
+            var buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+
+            // Check for ZIP magic bytes: 50 4B 03 04 (local file header) or 50 4B 05 06 (end of central directory)
+            return (buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x03 && buffer[3] == 0x04) ||
+                   (buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x05 && buffer[3] == 0x06);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string GetUniquePath(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return path;
+        }
+
+        var directory = Path.GetDirectoryName(path) ?? string.Empty;
+        var name = Path.GetFileNameWithoutExtension(path);
+        var extension = Path.GetExtension(path);
+        int count = 1;
+
+        while (File.Exists(path))
+        {
+            path = Path.Combine(directory, $"{name} ({count}){extension}");
+            count++;
+        }
+
+        return path;
+    }
+
+    private static string GetFileNameFromUrl(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            var fileName = Path.GetFileName(uri.LocalPath);
+            return string.IsNullOrEmpty(fileName) ? ReplayManagerConstants.DefaultImportedReplayFileName : fileName;
+        }
+        catch
+        {
+            return "imported_replay.rep";
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/UploadRateLimitService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/UploadRateLimitService.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using GenHub.Core.Models.Tools.ReplayManager;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Tools.ReplayManager.Services;
+
+/// <summary>
+/// Implementation of <see cref="IUploadRateLimitService"/> for tracking upload quotas.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="UploadRateLimitService"/> class.
+/// </remarks>
+/// <param name="logger">Logger instance.</param>
+/// <param name="appConfig">Application configuration service.</param>
+public sealed class UploadRateLimitService(ILogger<UploadRateLimitService> logger, IAppConfiguration appConfig) : IUploadRateLimitService
+{
+    /// <summary>
+    /// Record of an upload for rate limiting purposes.
+    /// </summary>
+    internal sealed class UploadRecord
+    {
+        /// <summary>
+        /// Gets or sets the timestamp of the upload.
+        /// </summary>
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the upload in bytes.
+        /// </summary>
+        public long SizeBytes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the public URL of the upload.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the uploaded file.
+        /// </summary>
+        public string? FileName { get; set; }
+    }
+
+    private static readonly object _fileLock = new();
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly ILogger<UploadRateLimitService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly string _historyFilePath = Path.Combine(appConfig.GetConfiguredDataPath(), "upload_history.json");
+    private List<UploadRecord>? _cache;
+
+    /// <inheritdoc />
+    public async Task<bool> CanUploadAsync(long fileSizeBytes)
+    {
+        var usage = await GetUsageInfoAsync();
+        return usage.UsedBytes + fileSizeBytes <= usage.LimitBytes;
+    }
+
+    /// <inheritdoc />
+    public void RecordUpload(long fileSizeBytes, string url, string fileName)
+    {
+        lock (_fileLock)
+        {
+            try
+            {
+                var history = LoadHistoryInternal();
+                history.Add(new UploadRecord
+                {
+                    Timestamp = DateTime.UtcNow,
+                    SizeBytes = fileSizeBytes,
+                    Url = url,
+                    FileName = fileName,
+                });
+
+                SaveHistoryInternal(history);
+                _cache = history; // Update cache
+                _logger.LogInformation("Recorded upload of {Size} bytes. Total history: {Count} items.", fileSizeBytes, history.Count);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to record upload");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<UsageInfo> GetUsageInfoAsync()
+    {
+        var history = LoadHistoryInternal();
+        var weekAgo = DateTime.UtcNow.AddDays(-7);
+
+        // Calculate usage from the last 7 days
+        var recentUploads = history.Where(r => r.Timestamp >= weekAgo).ToList();
+        var usedBytes = recentUploads.Sum(r => r.SizeBytes);
+
+        // Reset date is 7 days from the oldest upload in the current rolling week
+        var oldestInWindow = recentUploads.OrderBy(r => r.Timestamp).FirstOrDefault();
+        var resetDate = oldestInWindow != null
+            ? oldestInWindow.Timestamp.AddDays(7)
+            : DateTime.UtcNow;
+
+        return Task.FromResult(new UsageInfo(usedBytes, IUploadRateLimitService.MaxWeeklyUploadBytes, resetDate));
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<UploadHistoryItem>> GetUploadHistoryAsync()
+    {
+        var history = LoadHistoryInternal();
+
+        // Return all history (up to 30 days as filtered in loading)
+        var items = history.Select(r => new UploadHistoryItem(
+            r.Timestamp,
+            r.SizeBytes,
+            r.Url ?? string.Empty,
+            r.FileName ?? "Unknown File"));
+
+        return Task.FromResult(items);
+    }
+
+    /// <inheritdoc />
+    public Task RemoveHistoryItemAsync(string url)
+    {
+        return Task.Run(() =>
+        {
+            lock (_fileLock)
+            {
+                try
+                {
+                    var history = LoadHistoryInternal();
+                    var removed = history.RemoveAll(r => r.Url == url);
+
+                    if (removed > 0)
+                    {
+                        SaveHistoryInternal(history);
+                        _cache = history; // Update cache
+                        _logger.LogInformation("Removed {Count} upload history item(s) with URL: {Url}", removed, url);
+                    }
+                    else
+                    {
+                        _logger.LogWarning("No upload history item found with URL: {Url}", url);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to remove upload history item with URL: {Url}", url);
+                }
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    public Task ClearHistoryAsync()
+    {
+        return Task.Run(() =>
+        {
+            lock (_fileLock)
+            {
+                try
+                {
+                    _cache = [];
+
+                    if (File.Exists(_historyFilePath))
+                    {
+                        File.Delete(_historyFilePath);
+                        _logger.LogInformation("Cleared all upload history");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to clear upload history");
+                }
+            }
+        });
+    }
+
+    private List<UploadRecord> LoadHistoryInternal()
+    {
+        lock (_fileLock)
+        {
+            if (_cache != null)
+            {
+                return [.. _cache];
+            }
+
+            try
+            {
+                if (!File.Exists(_historyFilePath))
+                {
+                    _logger.LogDebug("Upload history file not found at {Path}, starting fresh.", _historyFilePath);
+                    _cache = [];
+                    return [];
+                }
+
+                var json = File.ReadAllText(_historyFilePath);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    _cache = [];
+                    return [];
+                }
+
+                var history = JsonSerializer.Deserialize<List<UploadRecord>>(json, _jsonOptions) ?? [];
+
+                // Clean up old entries (older than 30 days) to keep file size small
+                var thirtyDaysAgo = DateTime.UtcNow.AddDays(-30);
+                _cache = [.. history.Where(r => r.Timestamp >= thirtyDaysAgo).OrderByDescending(r => r.Timestamp)];
+
+                _logger.LogDebug("Loaded {Count} upload records from history.", _cache.Count);
+                return [.. _cache];
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load upload history from {Path}. The file may be corrupt or inaccessible.", _historyFilePath);
+
+                // Return empty but don't set cache to empty if we want to retry next time?
+                // Actually, if it's corrupt, returning empty might cause us to overwrite it with new data.
+                // We'll return a new list so the app continues working.
+                return [];
+            }
+        }
+    }
+
+    private void SaveHistoryInternal(List<UploadRecord> history)
+    {
+        lock (_fileLock)
+        {
+            try
+            {
+                var directory = Path.GetDirectoryName(_historyFilePath);
+                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                var json = JsonSerializer.Serialize(history, _jsonOptions);
+                File.WriteAllText(_historyFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save upload history to {Path}", _historyFilePath);
+            }
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/UrlParserService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/UrlParserService.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using GenHub.Core.Models.Tools.ReplayManager;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Tools.ReplayManager.Services;
+
+/// <summary>
+/// Service for parsing replay URLs and extracting direct download links.
+/// </summary>
+public sealed partial class UrlParserService(HttpClient httpClient, ILogger<UrlParserService> logger) : IUrlParserService
+{
+    /// <inheritdoc />
+    public ReplaySource IdentifySource(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return ReplaySource.Unknown;
+        }
+
+        if (url.Contains(ApiConstants.UploadThingUrlFragment))
+        {
+            return ReplaySource.UploadThing;
+        }
+
+        if (url.Contains(ApiConstants.GeneralsOnlineViewMatchFragment))
+        {
+            return ReplaySource.GeneralsOnline;
+        }
+
+        if (url.Contains(ApiConstants.GenToolUrlFragment))
+        {
+            return ReplaySource.GenTool;
+        }
+
+        if (url.EndsWith(FileTypes.ReplayFileExtension, StringComparison.OrdinalIgnoreCase) ||
+            url.EndsWith(FileTypes.ZipFileExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            return ReplaySource.DirectLink;
+        }
+
+        return ReplaySource.Unknown;
+    }
+
+    /// <inheritdoc />
+    public bool IsValidReplayUrl(string url)
+    {
+        return IdentifySource(url) != ReplaySource.Unknown;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetDirectDownloadUrlAsync(string url, CancellationToken ct = default)
+    {
+        var source = IdentifySource(url);
+        logger.LogInformation(LogMessages.IdentifyingUrlSource, url, source);
+
+        try
+        {
+            return source switch
+            {
+                ReplaySource.UploadThing => url, // UploadThing links are usually direct (utfs.io/f/...)
+                ReplaySource.DirectLink => url,
+                ReplaySource.GeneralsOnline => await ExtractGeneralsOnlineUrlAsync(url, ct),
+                ReplaySource.GenTool => await ExtractGenToolUrlAsync(url, ct),
+                _ => null,
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, LogMessages.FailedToExtractDownloadUrl, url);
+            return null;
+        }
+    }
+
+    [GeneratedRegex(RegexConstants.GeneralsOnlineReplayPattern)]
+    private static partial Regex GeneralsOnlineRegex();
+
+    [GeneratedRegex(RegexConstants.GenToolReplayPattern, RegexOptions.IgnoreCase)]
+    private static partial Regex GenToolRegex();
+
+    private async Task<string?> ExtractGeneralsOnlineUrlAsync(string url, CancellationToken ct)
+    {
+        // Example: https://www.playgenerals.online/viewmatch?match=354994
+        // Search for a link matching *_replay.rep
+        var html = await httpClient.GetStringAsync(url, ct);
+
+        // Regex to find matchdata link: https://matchdata.playgenerals.online/..._replay.rep
+        var match = GeneralsOnlineRegex().Match(html);
+        if (match.Success)
+        {
+            return match.Value;
+        }
+
+        logger.LogWarning(LogMessages.CouldNotFindReplayLinkGeneralsOnline, url);
+        return null;
+    }
+
+    private async Task<string?> ExtractGenToolUrlAsync(string url, CancellationToken ct)
+    {
+        var html = await httpClient.GetStringAsync(url, ct);
+        var match = GenToolRegex().Match(html);
+        if (match.Success)
+        {
+            var relativeUrl = match.Groups[1].Value;
+            if (Uri.IsWellFormedUriString(relativeUrl, UriKind.Absolute))
+            {
+                return relativeUrl;
+            }
+
+            var baseUri = new Uri(url);
+            var absoluteUri = new Uri(baseUri, relativeUrl);
+            return absoluteUri.ToString();
+        }
+
+        logger.LogWarning(LogMessages.CouldNotFindReplayLinkGenTool, url);
+        return null;
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ZipValidationService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ZipValidationService.cs
@@ -1,0 +1,73 @@
+using GenHub.Core.Constants;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Tools.ReplayManager.Services;
+
+/// <summary>
+/// Implementation of <see cref="IZipValidationService"/> for validating ZIP archives.
+/// </summary>
+public sealed class ZipValidationService(ILogger<ZipValidationService> logger) : IZipValidationService
+{
+    /// <inheritdoc />
+    public (bool IsValid, string? ErrorMessage) ValidateZip(string zipPath)
+    {
+        try
+        {
+            if (!File.Exists(zipPath))
+            {
+                return (false, "ZIP file does not exist.");
+            }
+
+            using var archive = ZipFile.OpenRead(zipPath);
+            if (archive.Entries.Count == 0)
+            {
+                return (false, "ZIP archive is empty.");
+            }
+
+            foreach (var entry in archive.Entries)
+            {
+                // Check for directories (Name is empty for directory entries)
+                if (string.IsNullOrEmpty(entry.Name))
+                {
+                    return (false, "ZIP contains directories. Only a single layer of files is allowed.");
+                }
+
+                // Check for nested files (FullName should equal Name for root files)
+                // Normalize slashes just in case
+                var normalizedFullName = entry.FullName.Replace('\\', '/');
+                if (normalizedFullName != entry.Name)
+                {
+                    return (false, $"ZIP contains nested files ({entry.FullName}). Only a single layer of files is allowed.");
+                }
+
+                // Check extension
+                if (!entry.Name.EndsWith(".rep", StringComparison.OrdinalIgnoreCase))
+                {
+                    return (false, $"ZIP contains non-replay file: {entry.Name}. Only .rep files are allowed.");
+                }
+
+                // Check size
+                if (entry.Length > ReplayManagerConstants.MaxReplaySizeBytes)
+                {
+                    return (false, $"File {entry.Name} in ZIP exceeds 1 MB limit.");
+                }
+            }
+
+            return (true, null);
+        }
+        catch (InvalidDataException)
+        {
+            return (false, "The file is not a valid ZIP archive.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error validating ZIP: {Path}", zipPath);
+            return (false, $"Validation error: {ex.Message}");
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/ViewModels/UploadHistoryItemViewModel.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/ViewModels/UploadHistoryItemViewModel.cs
@@ -1,0 +1,106 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using GenHub.Core.Models.Tools.ReplayManager;
+
+namespace GenHub.Features.Tools.ReplayManager.ViewModels;
+
+/// <summary>
+/// ViewModel for a single upload history item.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="UploadHistoryItemViewModel"/> class.
+/// </remarks>
+/// <param name="item">The upload history item.</param>
+public partial class UploadHistoryItemViewModel(UploadHistoryItem item) : ObservableObject
+{
+    private readonly UploadHistoryItem _item = item;
+
+    /// <summary>
+    /// Gets the filename.
+    /// </summary>
+    public string FileName => _item.FileName;
+
+    /// <summary>
+    /// Gets the URL.
+    /// </summary>
+    public string Url => _item.Url;
+
+    /// <summary>
+    /// Gets the formatted timestamp display.
+    /// </summary>
+    public string TimestampDisplay => GetTimeAgo(_item.Timestamp);
+
+    /// <summary>
+    /// Gets the formatted size display.
+    /// </summary>
+    public string SizeDisplay => FormatSize(_item.SizeBytes);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the file existence has been verified.
+    /// </summary>
+    [ObservableProperty]
+    private bool isVerified;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the file exists in storage.
+    /// </summary>
+    [ObservableProperty]
+    private bool fileExists;
+
+    /// <summary>
+    /// Gets a value indicating whether the upload is still active (file exists in storage).
+    /// </summary>
+    public bool IsActive => IsVerified ? FileExists : (DateTime.UtcNow - _item.Timestamp).TotalDays < 14;
+
+    /// <summary>
+    /// Gets the status color based on activity.
+    /// </summary>
+    public string StatusColor => IsActive ? "#4CAF50" : "#888888";
+
+    private static string GetTimeAgo(DateTime timestamp)
+    {
+        var span = DateTime.UtcNow - timestamp;
+        if (span.TotalDays > 1)
+        {
+            return $"{(int)span.TotalDays}d ago";
+        }
+
+        if (span.TotalHours > 1)
+        {
+            return $"{(int)span.TotalHours}h ago";
+        }
+
+        if (span.TotalMinutes > 1)
+        {
+            return $"{(int)span.TotalMinutes}m ago";
+        }
+
+        return "Just now";
+    }
+
+    private static string FormatSize(long bytes)
+    {
+        string[] sizes = ["B", "KB", "MB", "GB", "TB"];
+        double len = bytes;
+        int order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len /= 1024;
+        }
+
+        return $"{len:0.##} {sizes[order]}";
+    }
+
+    partial void OnFileExistsChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsActive));
+        OnPropertyChanged(nameof(StatusColor));
+    }
+
+    partial void OnIsVerifiedChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsActive));
+        OnPropertyChanged(nameof(StatusColor));
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Views/ReplayManagerView.axaml
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Views/ReplayManagerView.axaml
@@ -1,0 +1,286 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:GenHub.Features.Tools.ReplayManager.ViewModels"
+             xmlns:models="using:GenHub.Core.Models.Tools.ReplayManager"
+             xmlns:enums="using:GenHub.Core.Models.Enums"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             x:Class="GenHub.Features.Tools.ReplayManager.Views.ReplayManagerView"
+             x:DataType="vm:ReplayManagerViewModel"
+             DragDrop.AllowDrop="True">
+
+  <Design.DataContext>
+    <!-- Placeholder for design time -->
+  </Design.DataContext>
+
+  <Grid RowDefinitions="Auto,Auto,*,Auto,Auto" MinWidth="600"
+        VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+    <!-- Header/Tabs -->
+    <Border Grid.Row="0" Background="{DynamicResource CardBackground}" CornerRadius="12" Margin="0,0,0,16" Padding="6" BoxShadow="0 4 12 0 #20000000">
+      <Grid ColumnDefinitions="*,Auto">
+        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
+          <RadioButton Content="Generals" 
+                       IsChecked="{Binding SelectedTab, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static enums:GameType.Generals}}"
+                       GroupName="GameTabs" 
+                       Classes="TabButton"/>
+          <RadioButton Content="Zero Hour" 
+                       IsChecked="{Binding SelectedTab, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static enums:GameType.ZeroHour}}"
+                       GroupName="GameTabs" 
+                       Classes="TabButton"/>
+        </StackPanel>
+        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+          <Button Content="↻" Command="{Binding LoadReplaysCommand}" Classes="Secondary" IsEnabled="{Binding !IsBusy}" ToolTip.Tip="Refresh List"/>
+          <Button Content="📁" Command="{Binding OpenFolderCommand}" Classes="Secondary" IsEnabled="{Binding !IsBusy}" ToolTip.Tip="Open Folder in Explorer"/>
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <!-- Import Bar -->
+    <Border Grid.Row="1" Background="{DynamicResource CardBackground}" CornerRadius="12" Margin="0,0,0,16" Padding="12" BoxShadow="0 4 12 0 #20000000">
+      <Grid ColumnDefinitions="*,Auto,Auto" MinWidth="400">
+        <TextBox Grid.Column="0" Watermark="Paste Replay URL (UploadThing, Generals Online, GenTool...)" 
+                 Text="{Binding ImportUrl}" Margin="0,0,12,0" VerticalContentAlignment="Center"
+                 MaxWidth="600" HorizontalAlignment="Stretch"/>
+        <Button Grid.Column="1" Command="{Binding ImportFromUrlCommand}" 
+                Classes="Primary" Margin="0,0,8,0" IsEnabled="{Binding !IsBusy}"
+                ToolTip.Tip="Import replay from the pasted URL">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="📥"/>
+            <TextBlock Text="Import"/>
+          </StackPanel>
+        </Button>
+        <Button Grid.Column="2" Command="{Binding BrowseAndImportCommand}" 
+                Classes="Secondary" IsEnabled="{Binding !IsBusy}"
+                ToolTip.Tip="Select replays or ZIPs from your computer">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="📎"/>
+            <TextBlock Text="Browse"/>
+          </StackPanel>
+        </Button>
+      </Grid>
+    </Border>
+
+    <!-- Replay List -->
+    <Panel Grid.Row="2">
+      <Border Background="{DynamicResource CardBackground}" CornerRadius="12" ClipToBounds="True" BoxShadow="0 4 12 0 #20000000">
+        <DataGrid Name="ReplaysGrid"
+                  ItemsSource="{Binding CurrentReplays}" 
+                  SelectionMode="Extended"
+                  CellEditEnded="OnCellEditEnded"
+                  HeadersVisibility="Column"
+                  CanUserResizeColumns="True"
+                  GridLinesVisibility="Horizontal"
+                  BorderThickness="0"
+                  RowHeight="40">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Filename" Binding="{Binding FileName}" Width="*" MinWidth="100" />
+            <DataGridTextColumn Header="Size" Binding="{Binding FormattedSize}" Width="Auto" MinWidth="80" IsReadOnly="True" />
+            <DataGridTextColumn Header="Modified" Binding="{Binding LastModified, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="Auto" MinWidth="130" IsReadOnly="True" />
+            <DataGridTemplateColumn Width="140" Header="Actions">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                  <Button IsEnabled="False"
+                          Classes="Link" Padding="4" HorizontalAlignment="Center"
+                          ToolTip.Tip="Parse replay details (Coming Soon)">
+                    <!-- TODO: Attach Parse Replay Command -->
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                      <TextBlock Text="⚙️" FontSize="12"/>
+                      <TextBlock Text="PARSE" FontSize="10"/>
+                    </StackPanel>
+                  </Button>
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+          </DataGrid.Columns>
+        </DataGrid>
+      </Border>
+      
+      <!-- Drag & Drop Overlay -->
+      <Border Name="DragDropOverlay" 
+              Background="#CC000000" 
+              IsVisible="False"
+              IsHitTestVisible="False"
+              CornerRadius="12"
+              Opacity="0">
+        <Border.Transitions>
+          <Transitions>
+            <DoubleTransition Property="Opacity" Duration="0:0:0.25" />
+          </Transitions>
+        </Border.Transitions>
+        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="16">
+          <TextBlock Text="📥" FontSize="64" HorizontalAlignment="Center" Opacity="0.8"/>
+          <TextBlock Text="Drop replays or ZIPs to import" Classes="H2" HorizontalAlignment="Center"/>
+          <TextBlock Text="Single .rep files or ZIP archives only (max 1MB)" FontSize="12" Opacity="0.6" HorizontalAlignment="Center"/>
+        </StackPanel>
+      </Border>
+      
+      <!-- Loading Overlay -->
+      <Border Background="#66000000" IsVisible="{Binding IsBusy}" CornerRadius="12">
+        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="16">
+          <ProgressBar Value="{Binding Progress, Mode=OneWay}" Minimum="0" Maximum="1" Width="240" Height="4"
+                       IsIndeterminate="{Binding Progress, Converter={StaticResource EqualsToConverter}, ConverterParameter=0.0}"/>
+          <TextBlock Text="{Binding StatusMessage}" HorizontalAlignment="Center" FontWeight="SemiBold"/>
+        </StackPanel>
+      </Border>
+    </Panel>
+
+    <!-- Action Bar -->
+    <Border Grid.Row="3" Background="{DynamicResource CardBackground}" CornerRadius="12" Margin="0,16,0,0" Padding="12" BoxShadow="0 4 12 0 #20000000">
+      <Grid ColumnDefinitions="Auto,*,Auto" MinWidth="400">
+        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="12">
+          <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+            <TextBlock Text="Selected:" Opacity="0.7"/>
+            <TextBlock Text="{Binding SelectedReplays.Count}" FontWeight="Bold" Foreground="{DynamicResource AccentColor}"/>
+          </StackPanel>
+          <Button Command="{Binding DeleteSelectedCommand}" 
+                  Classes="Danger" IsEnabled="{Binding SelectedReplays.Count}">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock Text="🗑️"/>
+              <TextBlock Text="Delete"/>
+            </StackPanel>
+          </Button>
+        </StackPanel>
+
+        <TextBlock Grid.Column="1" Text="{Binding StatusMessage}" 
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Opacity="0.7" FontStyle="Italic" Margin="12,0"/>
+
+        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
+          <Button Command="{Binding UncompressSelectedCommand}" 
+                  Classes="Secondary" IsEnabled="{Binding HasSelectedZips}"
+                  ToolTip.Tip="Extract replays from selected ZIP archives">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock Text="📦🔓"/>
+              <TextBlock Text="Uncompress"/>
+            </StackPanel>
+          </Button>
+          <TextBox MinWidth="100" MaxWidth="150" Watermark="ZIP Name" Text="{Binding ZipName}" VerticalAlignment="Center" ToolTip.Tip="Filename for the new ZIP archive"/>
+          <Button Command="{Binding ExportToZipCommand}" 
+                  Classes="Secondary" IsEnabled="{Binding SelectedReplays.Count}"
+                  ToolTip.Tip="Create a ZIP archive from selected replays">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock Text="📦"/>
+              <TextBlock Text="Zip"/>
+            </StackPanel>
+          </Button>
+          <StackPanel Orientation="Horizontal" Spacing="1">
+            <Button Command="{Binding UploadAndShareCommand}" 
+                    Classes="Primary" IsEnabled="{Binding SelectedReplays.Count}"
+                    CornerRadius="4,0,0,4"
+                    ToolTip.Tip="Upload selected replays to the cloud and copy link to clipboard">
+              <StackPanel Orientation="Horizontal" Spacing="6">
+                <TextBlock Text="☁️"/>
+                <TextBlock Text="Upload"/>
+              </StackPanel>
+            </Button>
+            <Button Command="{Binding ToggleHistoryCommand}"
+                    Classes="Primary"
+                    CornerRadius="0,4,4,0"
+                    Padding="8,0"
+                    ToolTip.Tip="View upload history">
+              <TextBlock Text="▼" FontSize="10" VerticalAlignment="Center"/>
+            </Button>
+            
+            <Popup IsOpen="{Binding IsHistoryOpen}" 
+                   Placement="Bottom" PlacementTarget="{Binding $parent[StackPanel]}"
+                   IsLightDismissEnabled="True">
+              <Border Background="#252525" BorderBrush="#333333" BorderThickness="1" CornerRadius="8" 
+                      Padding="12" MinWidth="300" MaxHeight="400" BoxShadow="0 4 12 0 #40000000">
+                <Grid RowDefinitions="Auto,*">
+                  <Grid Grid.Row="1">
+                    <ScrollViewer IsVisible="{Binding UploadHistory.Count}">
+                      <ItemsControl ItemsSource="{Binding UploadHistory}">
+                        <ItemsControl.ItemTemplate>
+                          <DataTemplate>
+                            <Border BorderBrush="#333333" BorderThickness="0,0,0,1" Padding="0,8">
+                              <Grid ColumnDefinitions="*,Auto,Auto,Auto">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                  <TextBlock Text="{Binding FileName}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                  <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock Text="{Binding TimestampDisplay}" FontSize="11" Opacity="0.6"/>
+                                    <TextBlock Text="{Binding SizeDisplay}" FontSize="11" Opacity="0.6"/>
+                                    <Border Background="Transparent" BorderBrush="{Binding StatusColor}" BorderThickness="1" CornerRadius="4" Padding="4,0" Margin="4,0,0,0">
+                                      <Panel>
+                                        <TextBlock Text="Active" FontSize="10" Foreground="{Binding StatusColor}" 
+                                                   IsVisible="{Binding IsActive}"/>
+                                        <TextBlock Text="Expired" FontSize="10" Foreground="{Binding StatusColor}" 
+                                                   IsVisible="{Binding !IsActive}"/>
+                                      </Panel>
+                                    </Border>
+                                  </StackPanel>
+                                </StackPanel>
+                                
+                                <Button Grid.Column="1" Classes="Secondary" 
+                                        Command="{Binding $parent[UserControl].((vm:ReplayManagerViewModel)DataContext).CopyUrlCommand}" 
+                                        CommandParameter="{Binding Url}"
+                                        Padding="6,4" Margin="8,0,0,0" VerticalAlignment="Center"
+                                        ToolTip.Tip="Copy Link">
+                                  <TextBlock Text="📋"/>
+                                </Button>
+                                
+                                <Button Grid.Column="2" Classes="Danger" 
+                                        Command="{Binding $parent[UserControl].((vm:ReplayManagerViewModel)DataContext).RemoveHistoryItemCommand}" 
+                                        CommandParameter="{Binding}"
+                                        Padding="6,4" Margin="4,0,0,0" VerticalAlignment="Center"
+                                        ToolTip.Tip="Remove from history">
+                                  <TextBlock Text="🗑️"/>
+                                </Button>
+                              </Grid>
+                            </Border>
+                          </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                      </ItemsControl>
+                    </ScrollViewer>
+                    
+                    <TextBlock Text="No history yet" IsVisible="{Binding !UploadHistory.Count}" 
+                               HorizontalAlignment="Center" Opacity="0.5" Margin="0,20"/>
+                  </Grid>
+                
+                <!-- Clear All Button -->
+                <Button Command="{Binding ClearHistoryCommand}"
+                        Classes="Danger"
+                        HorizontalAlignment="Stretch"
+                        Margin="0,8,0,0"
+                        IsVisible="{Binding UploadHistory.Count}"
+                        ToolTip.Tip="Clear all upload history">
+                  <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
+                    <TextBlock Text="🗑️"/>
+                    <TextBlock Text="Clear All History"/>
+                  </StackPanel>
+                </Button>
+                </Grid>
+              </Border>
+            </Popup>
+          </StackPanel>
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <!-- Footer Storage Notice -->
+    <TextBlock Grid.Row="4" Text="Files are maintained for up to 14 days or until storage is full. Maximum 1MB per file." 
+               FontSize="11" Opacity="0.4" HorizontalAlignment="Right" Margin="0,8,0,0" TextWrapping="Wrap" MaxWidth="600"/>
+  </Grid>
+
+  <UserControl.Styles>
+    <Style Selector="RadioButton.TabButton">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Border Name="Root" CornerRadius="8" Padding="16,8" Background="Transparent">
+            <TextBlock Text="{TemplateBinding Content}" FontWeight="SemiBold" 
+                       Foreground="{TemplateBinding Foreground}"/>
+          </Border>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="RadioButton.TabButton:pointerover /template/ Border#Root">
+      <Setter Property="Background" Value="#10FFFFFF" />
+    </Style>
+    <Style Selector="RadioButton.TabButton:checked /template/ Border#Root">
+      <Setter Property="Background" Value="{DynamicResource AccentColor}" />
+    </Style>
+    <Style Selector="RadioButton.TabButton:checked">
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+  </UserControl.Styles>
+</UserControl>

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Views/ReplayManagerView.axaml.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Views/ReplayManagerView.axaml.cs
@@ -1,0 +1,163 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using GenHub.Core.Models.Tools.ReplayManager;
+using GenHub.Features.Tools.ReplayManager.ViewModels;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace GenHub.Features.Tools.ReplayManager.Views;
+
+/// <summary>
+/// Interaction logic for <see cref="ReplayManagerView"/>.
+/// </summary>
+public partial class ReplayManagerView : UserControl
+{
+    private Border? _dragDropOverlay;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayManagerView"/> class.
+    /// </summary>
+    public ReplayManagerView()
+    {
+        InitializeComponent();
+        AddHandler(DragDrop.DragOverEvent, DragOver);
+        AddHandler(DragDrop.DragLeaveEvent, DragLeave);
+        AddHandler(DragDrop.DropEvent, Drop);
+
+        var dataGrid = this.Find<DataGrid>("ReplaysGrid");
+        if (dataGrid != null)
+        {
+            dataGrid.SelectionChanged += OnSelectionChanged;
+
+            // CellEditEnded is handled via XAML, but can also be attached here if needed.
+        }
+    }
+
+    /// <summary>
+    /// Handles the cell edit ended event for the data grid.
+    /// </summary>
+    /// <param name="sender">The sender of the event.</param>
+    /// <param name="e">The event arguments.</param>
+    public void OnCellEditEnded(object? sender, DataGridCellEditEndedEventArgs e)
+    {
+        if (e.EditAction == DataGridEditAction.Commit && e.Row.DataContext is ReplayFile replay)
+        {
+            // The FileName property is updated by the binding before this event fires.
+            // replay.FullPath contains the original path.
+            var oldPath = replay.FullPath;
+            var directory = Path.GetDirectoryName(oldPath);
+            if (directory == null) return;
+
+            var newFileName = replay.FileName;
+
+            // Ensure .rep extension if missing?
+            if (!newFileName.EndsWith(".rep", StringComparison.OrdinalIgnoreCase))
+            {
+                newFileName += ".rep";
+            }
+
+            var newPath = Path.Combine(directory, newFileName);
+
+            if (string.Equals(oldPath, newPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            try
+            {
+                File.Move(oldPath, newPath);
+                replay.FullPath = newPath;
+                replay.FileName = newFileName; // Ensure case or extension is normalized
+            }
+            catch (IOException)
+            {
+                // File exists or other IO error
+                replay.FileName = Path.GetFileName(oldPath);
+            }
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+        _dragDropOverlay = this.Find<Border>("DragDropOverlay");
+    }
+
+    private void DragOver(object? sender, DragEventArgs e)
+    {
+        if (e.Data.Contains(DataFormats.Files))
+        {
+            var files = e.Data.GetFiles();
+            bool hasValidFiles = files != null && files.Any(f =>
+            {
+                var path = f.Path.LocalPath;
+                return path.EndsWith(".rep", StringComparison.OrdinalIgnoreCase) ||
+                       path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+            });
+
+            if (hasValidFiles)
+            {
+                e.DragEffects = DragDropEffects.Copy;
+                if (_dragDropOverlay != null)
+                {
+                    _dragDropOverlay.IsVisible = true;
+                    _dragDropOverlay.Opacity = 1.0;
+                }
+            }
+            else
+            {
+                e.DragEffects = DragDropEffects.None;
+            }
+        }
+        else
+        {
+            e.DragEffects = DragDropEffects.None;
+        }
+    }
+
+    private void DragLeave(object? sender, RoutedEventArgs e)
+    {
+        if (_dragDropOverlay != null)
+        {
+            _dragDropOverlay.Opacity = 0.0;
+
+            // We use a small delay or just wait for transition? IsVisible=false breaks transition if immediate.
+            // But IsVisible=false is needed when fully hidden to not block input.
+            // Actually hit test is off, so it should be fine.
+            // Better to hide IsVisible after transition or just leave it visible but Opacity 0?
+            // Let's just set Opacity 0 for now.
+        }
+    }
+
+    private async void Drop(object? sender, DragEventArgs e)
+    {
+        if (_dragDropOverlay != null)
+        {
+            _dragDropOverlay.Opacity = 0.0;
+            _dragDropOverlay.IsVisible = false;
+        }
+
+        if (e.Data.Contains(DataFormats.Files))
+        {
+            var files = e.Data.GetFiles();
+            if (files != null && DataContext is ReplayManagerViewModel vm)
+            {
+                var filePaths = files.Select(f => f.Path.LocalPath).ToList();
+                await vm.ImportFilesAsync(filePaths);
+            }
+        }
+    }
+
+    private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (sender is DataGrid dg && DataContext is ReplayManagerViewModel vm)
+        {
+            var selected = dg.SelectedItems.OfType<ReplayFile>().ToList();
+            vm.UpdateSelectedReplays(selected);
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Tools/ViewModels/ToolsViewModel.cs
+++ b/GenHub/GenHub/Features/Tools/ViewModels/ToolsViewModel.cs
@@ -76,7 +76,7 @@ public partial class ToolsViewModel(IToolManager toolService, ILogger<ToolsViewM
     /// <summary>
     /// Gets the collection of installed tools.
     /// </summary>
-    public ObservableCollection<IToolPlugin> InstalledTools { get; } = new();
+    public ObservableCollection<IToolPlugin> InstalledTools { get; } = [];
 
     /// <summary>
     /// Initializes the ViewModel by loading saved tools.
@@ -153,13 +153,13 @@ public partial class ToolsViewModel(IToolManager toolService, ILogger<ToolsViewM
             {
                 Title = "Select Tool Plugin Assembly",
                 AllowMultiple = false,
-                FileTypeFilter = new[]
-                {
+                FileTypeFilter =
+                [
                     new FilePickerFileType("Tool Plugin Assembly")
                     {
-                        Patterns = new[] { "*.dll" },
+                        Patterns = ["*.dll"],
                     },
-                },
+                ],
             });
 
             if (files.Count > 0)
@@ -205,6 +205,11 @@ public partial class ToolsViewModel(IToolManager toolService, ILogger<ToolsViewM
     {
         var toolToRemove = tool ?? SelectedTool;
         if (toolToRemove == null) return;
+        if (toolToRemove.Metadata.IsBundled)
+        {
+            ShowStatusMessage($"✗ Tool '{toolToRemove.Metadata.Name}' is a bundled tool and cannot be removed.", error: true);
+            return;
+        }
 
         try
         {

--- a/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml
+++ b/GenHub/GenHub/Features/Tools/Views/ToolsView.axaml
@@ -10,34 +10,45 @@
 
   <UserControl.Styles>
     <Style Selector="Border.tool-list-card">
-      <Setter Property="Background" Value="#2D2D30" />
+      <Setter Property="Background" Value="#1E1E1E" />
       <Setter Property="CornerRadius" Value="8" />
-      <Setter Property="BorderBrush" Value="#3F3F46" />
+      <Setter Property="BorderBrush" Value="#333333" />
       <Setter Property="BorderThickness" Value="1" />
     </Style>
 
     <Style Selector="Border.tool-content-card">
-      <Setter Property="Background" Value="#2D2D30" />
+      <Setter Property="Background" Value="#1A1A1A" />
       <Setter Property="CornerRadius" Value="8" />
-      <Setter Property="BorderBrush" Value="#3F3F46" />
+      <Setter Property="BorderBrush" Value="#333333" />
       <Setter Property="BorderThickness" Value="1" />
     </Style>
 
     <Style Selector="ListBoxItem">
       <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Foreground" Value="#E0E0E0" />
-      <Setter Property="Padding" Value="12,10" />
-      <Setter Property="Margin" Value="4,2" />
+      <Setter Property="Foreground" Value="#CCCCCC" />
+      <Setter Property="Padding" Value="12,12" />
+      <Setter Property="Margin" Value="0,2" />
       <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="ClipToBounds" Value="False" />
+      <Setter Property="Transitions">
+        <Transitions>
+          <BrushTransition Property="Background" Duration="0:0:0.2" />
+        </Transitions>
+      </Setter>
     </Style>
 
     <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter">
-      <Setter Property="Background" Value="#404040" />
+      <Setter Property="Background" Value="#333333" />
+      <Setter Property="Foreground" Value="White" />
     </Style>
 
     <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
-      <Setter Property="Background" Value="#0078D4" />
+      <Setter Property="Background" Value="#3D3D42" />
       <Setter Property="TextBlock.Foreground" Value="White" />
+    </Style>
+
+    <Style Selector="ListBoxItem:selected">
+      <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
     <Style Selector="Button.primary-button">
@@ -200,19 +211,59 @@
     </Border>
 
     <!-- Main Content -->
-    <Grid Grid.Row="2" ColumnDefinitions="300,*">
+    <Grid Grid.Row="2" ColumnDefinitions="Auto,*">
       <!-- Left Panel: Tool List -->
-      <Border Grid.Column="0" Classes="tool-list-card" Margin="0,0,15,0">
+      <Border Grid.Column="0" 
+              Classes="tool-list-card" 
+              Margin="0,0,15,0"
+              Width="{Binding SidebarWidth}">
         <Grid RowDefinitions="Auto,*,Auto" Margin="15">
           <!-- Tool List Header -->
-          <StackPanel Grid.Row="0" Spacing="10" Margin="0,0,0,15">
-            <TextBlock Text="Installed Tools" Classes="section-title" />
-            <Button Content="➕ Add Tool"
-                    Command="{Binding AddToolCommand}"
-                    Classes="primary-button"
-                    HorizontalAlignment="Stretch"
-                    IsEnabled="{Binding !IsLoading}" />
-          </StackPanel>
+          <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,15">
+            <TextBlock Grid.Column="0" 
+                       Text="Installed Tools" 
+                       Classes="section-title"
+                       VerticalAlignment="Center"
+                       IsVisible="{Binding !IsSidebarCollapsed}" />
+            
+            <Button Grid.Column="1"
+                    Command="{Binding ToggleSidebarCommand}"
+                    Classes="icon-button"
+                    ToolTip.Tip="{Binding SidebarToggleTooltip}"
+                    Width="32" Height="32"
+                    Padding="0"
+                    Background="Transparent"
+                    BorderThickness="0">
+                <Path Fill="#AAAAAA"
+                      Stretch="Uniform"
+                      Width="12" Height="12">
+                    <Path.Styles>
+                        <Style Selector="Path">
+                            <Setter Property="Data" Value="M 8 0 L 0 5 L 8 10 Z" />
+                        </Style>
+                        <Style Selector="Path[Tag=True]">
+                            <Setter Property="Data" Value="M 0 0 L 8 5 L 0 10 Z" />
+                        </Style>
+                    </Path.Styles>
+                    <Path.Tag>
+                        <Binding Path="IsSidebarCollapsed" />
+                    </Path.Tag>
+                </Path>
+            </Button>
+          </Grid>
+
+          <!-- Add Tool Button (Full or Icon) -->
+          <Button Grid.Row="0"
+                  Margin="0,35,0,0"
+                  Command="{Binding AddToolCommand}"
+                  Classes="primary-button"
+                  HorizontalAlignment="Stretch"
+                  IsEnabled="{Binding !IsLoading}">
+              <Panel>
+                  <TextBlock Text="➕ Add Tool" IsVisible="{Binding !IsSidebarCollapsed}" />
+                  <TextBlock Text="➕" IsVisible="{Binding IsSidebarCollapsed}" />
+              </Panel>
+          </Button>
 
           <!-- Tool List -->
           <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
@@ -245,23 +296,27 @@
                        SelectedItem="{Binding SelectedTool}"
                        Background="Transparent"
                        BorderThickness="0"
+                       Padding="0"
                        IsVisible="{Binding HasTools}">
                 <ListBox.ItemTemplate>
                   <DataTemplate>
-                    <Grid ColumnDefinitions="*,Auto,Auto">
-                      <StackPanel Grid.Column="0" Spacing="4">
+                    <Grid ColumnDefinitions="*,Auto">
+                      <StackPanel Grid.Column="0" Spacing="4" VerticalAlignment="Center">
                         <TextBlock Text="{Binding Metadata.Name}" Classes="tool-name" />
                         <TextBlock Text="{Binding Metadata.Version, StringFormat='v{0}'}"
-                                   Classes="tool-version" />
+                                   Classes="tool-version"
+                                   IsVisible="{Binding !$parent[UserControl].((vm:ToolsViewModel)DataContext).IsSidebarCollapsed}" />
                       </StackPanel>
                       
                       <!-- Menu Button with Flyout -->
                       <Button Grid.Column="1"
                               Classes="icon-button"
-                              Width="32"
-                              Height="32"
-                              Padding="4"
-                              Margin="4,0,0,0">
+                              Width="24"
+                              Height="24"
+                              Padding="0"
+                              Background="Transparent"
+                              BorderThickness="0"
+                              IsVisible="{Binding !$parent[UserControl].((vm:ToolsViewModel)DataContext).IsSidebarCollapsed}">
                         <Button.Flyout>
                           <MenuFlyout Placement="BottomEdgeAlignedRight">
                             <MenuItem Header="View Details"
@@ -273,14 +328,15 @@
                             </MenuItem>
                             <MenuItem Header="Remove Tool"
                                       Command="{Binding $parent[UserControl].((vm:ToolsViewModel)DataContext).RemoveToolCommand}"
-                                      CommandParameter="{Binding}">
+                                      CommandParameter="{Binding}"
+                                      IsVisible="{Binding !Metadata.IsBundled}">
                               <MenuItem.Icon>
                                 <TextBlock Text="🗑️" FontSize="14" />
                               </MenuItem.Icon>
                             </MenuItem>
                           </MenuFlyout>
                         </Button.Flyout>
-                        <TextBlock Text="…" FontSize="16" FontWeight="Bold" HorizontalAlignment="Center"/>
+                        <TextBlock Text="⋮" FontSize="16" Foreground="#888888" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                       </Button>
                     </Grid>
                   </DataTemplate>
@@ -291,11 +347,15 @@
 
           <!-- Tool Actions -->
           <StackPanel Grid.Row="2" Spacing="8" Margin="0,15,0,0">
-            <Button Content="🔄 Refresh"
-                    Command="{Binding RefreshToolsCommand}"
+            <Button Command="{Binding RefreshToolsCommand}"
                     Classes="secondary-button"
                     HorizontalAlignment="Stretch"
-                    IsEnabled="{Binding !IsLoading}" />
+                    IsEnabled="{Binding !IsLoading}">
+                <Panel>
+                    <TextBlock Text="🔄 Refresh" IsVisible="{Binding !IsSidebarCollapsed}" />
+                    <TextBlock Text="🔄" IsVisible="{Binding IsSidebarCollapsed}" />
+                </Panel>
+            </Button>
           </StackPanel>
         </Grid>
       </Border>
@@ -309,7 +369,7 @@
                 Margin="0,0,0,20"
                 IsVisible="{Binding SelectedTool, Converter={x:Static ObjectConverters.IsNotNull}}">
             <TextBlock Grid.Column="0" 
-                       Text="{Binding SelectedTool.Metadata.Name}" 
+                       Text="{Binding SelectedTool.Metadata.Name, FallbackValue=''}" 
                        Classes="section-title" 
                        FontSize="20" 
                        VerticalAlignment="Center" />
@@ -319,11 +379,11 @@
                         VerticalAlignment="Center">
               <StackPanel Orientation="Horizontal" Spacing="5">
                 <TextBlock Text="version" Foreground="#AAAAAA" FontSize="14" />
-                <TextBlock Text="{Binding SelectedTool.Metadata.Version}" Foreground="#E0E0E0" FontSize="14" />
+                <TextBlock Text="{Binding SelectedTool.Metadata.Version, FallbackValue=''}" Foreground="#E0E0E0" FontSize="14" />
               </StackPanel>
               <StackPanel Orientation="Horizontal" Spacing="5">
                 <TextBlock Text="by" Foreground="#AAAAAA" FontSize="14" />
-                <TextBlock Text="{Binding SelectedTool.Metadata.Author}" Foreground="#E0E0E0" FontSize="14" />
+                <TextBlock Text="{Binding SelectedTool.Metadata.Author, FallbackValue=''}" Foreground="#E0E0E0" FontSize="14" />
               </StackPanel>
             </StackPanel>
           </Grid>
@@ -342,10 +402,8 @@
             </StackPanel>
 
             <!-- Tool Control Container -->
-            <ScrollViewer VerticalScrollBarVisibility="Auto"
-                          IsVisible="{Binding CurrentToolControl, Converter={x:Static ObjectConverters.IsNotNull}}">
-              <ContentControl Content="{Binding CurrentToolControl}" />
-            </ScrollViewer>
+            <ContentControl Content="{Binding CurrentToolControl}" 
+                            IsVisible="{Binding CurrentToolControl, Converter={x:Static ObjectConverters.IsNotNull}}" />
           </Panel>
         </Grid>
       </Border>
@@ -378,7 +436,7 @@
             <!-- Tool Name -->
             <StackPanel Spacing="5">
               <TextBlock Text="Name" FontSize="12" FontWeight="SemiBold" Foreground="#AAAAAA" />
-              <TextBlock Text="{Binding ToolForDetails.Metadata.Name}" 
+              <TextBlock Text="{Binding ToolForDetails.Metadata.Name, FallbackValue=''}" 
                          FontSize="16" 
                          FontWeight="SemiBold" 
                          Foreground="#FFFFFF" />
@@ -387,7 +445,7 @@
             <!-- Version -->
             <StackPanel Spacing="5">
               <TextBlock Text="Version" FontSize="12" FontWeight="SemiBold" Foreground="#AAAAAA" />
-              <TextBlock Text="{Binding ToolForDetails.Metadata.Version}" 
+              <TextBlock Text="{Binding ToolForDetails.Metadata.Version, FallbackValue=''}" 
                          FontSize="14" 
                          Foreground="#E0E0E0" />
             </StackPanel>
@@ -395,7 +453,7 @@
             <!-- Author -->
             <StackPanel Spacing="5">
               <TextBlock Text="Author" FontSize="12" FontWeight="SemiBold" Foreground="#AAAAAA" />
-              <TextBlock Text="{Binding ToolForDetails.Metadata.Author}" 
+              <TextBlock Text="{Binding ToolForDetails.Metadata.Author, FallbackValue=''}" 
                          FontSize="14" 
                          Foreground="#E0E0E0" />
             </StackPanel>
@@ -404,7 +462,7 @@
             <StackPanel Spacing="5" 
                         IsVisible="{Binding ToolForDetails.Metadata.Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
               <TextBlock Text="Description" FontSize="12" FontWeight="SemiBold" Foreground="#AAAAAA" />
-              <TextBlock Text="{Binding ToolForDetails.Metadata.Description}" 
+              <TextBlock Text="{Binding ToolForDetails.Metadata.Description, FallbackValue=''}" 
                          FontSize="14" 
                          Foreground="#E0E0E0"
                          TextWrapping="Wrap" />
@@ -413,7 +471,7 @@
             <!-- Tool ID -->
             <StackPanel Spacing="5">
               <TextBlock Text="Tool ID" FontSize="12" FontWeight="SemiBold" Foreground="#AAAAAA" />
-              <TextBlock Text="{Binding ToolForDetails.Metadata.Id}" 
+              <TextBlock Text="{Binding ToolForDetails.Metadata.Id, FallbackValue=''}" 
                          FontSize="14" 
                          Foreground="#E0E0E0"
                          TextWrapping="Wrap" />

--- a/GenHub/GenHub/GenHub.csproj
+++ b/GenHub/GenHub/GenHub.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Avalonia.Desktop" />
         <PackageReference Include="Avalonia.Themes.Fluent" />
         <PackageReference Include="Avalonia.Fonts.Inter" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia.Diagnostics">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/GenHub/GenHub/Infrastructure/Converters/EnumToBoolConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/EnumToBoolConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace GenHub.Infrastructure.Converters;
+
+/// <summary>
+/// Converts an enum value to a boolean based on whether it matches the parameter.
+/// </summary>
+public sealed class EnumToBoolConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+        {
+            return false;
+        }
+
+        return value.ToString() == parameter.ToString();
+    }
+
+    /// <inheritdoc />
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b && b && parameter != null)
+        {
+            return Enum.Parse(targetType, parameter.ToString()!);
+        }
+
+        return AvaloniaProperty.UnsetValue;
+    }
+}

--- a/GenHub/GenHub/Infrastructure/Converters/EqualsToConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/EqualsToConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace GenHub.Infrastructure.Converters;
+
+/// <summary>
+/// Converts a value to a boolean based on whether it equals the parameter.
+/// </summary>
+public sealed class EqualsToConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null)
+        {
+            return parameter == null;
+        }
+
+        return value.Equals(parameter);
+    }
+
+    /// <inheritdoc />
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value != null && value.Equals(true) ? parameter : AvaloniaProperty.UnsetValue;
+    }
+}

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/AppServices.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/AppServices.cs
@@ -1,5 +1,6 @@
-using System;
+using GenHub.Features.Tools.ReplayManager;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace GenHub.Infrastructure.DependencyInjection;
 
@@ -42,6 +43,7 @@ public static class AppServices
 
         // Register Tools services
         services.AddToolsServices();
+        services.AddReplayManagerServices();
 
         // Register Notification services
         services.AddNotificationModule();

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ReplayManagerModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ReplayManagerModule.cs
@@ -1,0 +1,38 @@
+using GenHub.Core.Interfaces.Tools;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using GenHub.Features.Tools.ReplayManager;
+using GenHub.Features.Tools.ReplayManager.Services;
+using GenHub.Features.Tools.ReplayManager.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GenHub.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// Dependency injection module for the Replay Manager tool.
+/// </summary>
+public static class ReplayManagerModule
+{
+    /// <summary>
+    /// Adds Replay Manager services to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddReplayManagerServices(this IServiceCollection services)
+    {
+        // Services
+        services.AddSingleton<IReplayDirectoryService, ReplayDirectoryService>();
+        services.AddSingleton<IUrlParserService, UrlParserService>();
+        services.AddSingleton<IReplayImportService, ReplayImportService>();
+        services.AddSingleton<IReplayExportService, ReplayExportService>();
+        services.AddSingleton<IUploadRateLimitService, UploadRateLimitService>();
+        services.AddSingleton<IZipValidationService, ZipValidationService>();
+
+        // ViewModel (Singleton to persist state across tool activations)
+        services.AddSingleton<ReplayManagerViewModel>();
+
+        // Tool Plugin (Registered as a singleton IToolPlugin)
+        services.AddSingleton<IToolPlugin, ReplayManagerToolPlugin>();
+
+        return services;
+    }
+}

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -7,7 +7,7 @@ export default withMermaid(
         description: 'C&C Launcher Documentation',
         base:
             process.env.NODE_ENV === 'production' ||
-            process.env.GITHUB_ACTIONS === 'true'
+                process.env.GITHUB_ACTIONS === 'true'
                 ? '/wiki/'
                 : '/',
 
@@ -90,6 +90,12 @@ export default withMermaid(
                         { text: 'Workspace Assembly', link: '/FlowCharts/Assembly-Flow' },
                         { text: 'Manifest Creation', link: '/FlowCharts/Manifest-Creation-Flow' },
                         { text: 'Complete User Flow', link: '/FlowCharts/Complete-User-Flow' }
+                    ]
+                },
+                {
+                    text: 'Tools',
+                    items: [
+                        { text: 'Replay Manager', link: '/tools/replay-manager' }
                     ]
                 }
             ],

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -1256,6 +1256,46 @@ Predefined resolution options available in the game settings.
 
 ---
 
+## ToolConstants Class
+
+Constants for tool plugin metadata and configuration.
+
+### ReplayManager Subclass
+
+Constants specific to the Replay Manager tool plugin.
+
+| Constant     | Value                                      | Description                                      |
+| ------------ | ------------------------------------------ | ------------------------------------------------ |
+| `Id`         | `"genhub.tools.replaymanager"`             | Unique identifier for the Replay Manager tool    |
+| `Name`       | `"Replay Manager"`                         | Display name for the Replay Manager tool         |
+| `Version`    | `"1.0.0"`                                  | Version of the Replay Manager tool               |
+| `Author`     | `"GenHub Team"`                            | Author of the Replay Manager tool                |
+| `Description`| `"Manage, import, and share replay files for Command & Conquer: Generals and Zero Hour."` | Description of the Replay Manager tool |
+| `Tags`       | `["replays", "file-management", "sharing"]`| Tags associated with the Replay Manager tool     |
+| `IconPath`   | `"Assets/Icons/replay.png"`                | Icon path for the Replay Manager tool (placeholder) |
+| `IsBundled`  | `true`                                     | Whether the tool is bundled with the application |
+
+### Usage Example
+
+```csharp
+using GenHub.Core.Constants;
+
+// Create tool metadata using constants
+var metadata = new ToolMetadata
+{
+    Id = ToolConstants.ReplayManager.Id,
+    Name = ToolConstants.ReplayManager.Name,
+    Version = ToolConstants.ReplayManager.Version,
+    Author = ToolConstants.ReplayManager.Author,
+    Description = ToolConstants.ReplayManager.Description,
+    Tags = ToolConstants.ReplayManager.Tags,
+    IconPath = ToolConstants.ReplayManager.IconPath,
+    IsBundled = ToolConstants.ReplayManager.IsBundled,
+};
+```
+
+---
+
 ## Related Documentation
 
 - [Manifest ID System](manifest-id-system.md)  

--- a/docs/tools/replay-manager.md
+++ b/docs/tools/replay-manager.md
@@ -1,0 +1,62 @@
+# Replay Manager
+
+The Replay Manager is a built-in tool in GenHub that allows you to manage, import, and share your Command & Conquer: Generals and Zero Hour replay files with ease.
+
+## Features
+
+- **Unified View**: See all your replays for both Generals and Zero Hour in one place.
+- **Easy Import**: Import replays directly from URLs or by dragging and dropping files.
+- **Cloud Sharing**: Share your best matches instantly via UploadThing.
+- **Local Export**: Bundle multiple replays into a ZIP archive for local storage or manual sharing.
+- **Conflict Resolution**: Automatically handles duplicate filenames during import.
+
+## Getting Started
+
+To access the Replay Manager:
+1. Open GenHub.
+2. Navigate to the **TOOLS** tab.
+3. Select **Replay Manager** from the sidebar.
+
+## Importing Replays
+
+### From URL
+You can import replays from various sources by pasting the link into the import bar:
+- **UploadThing**: Direct links from other GenHub users.
+- **Generals Online**: Match view URLs.
+- **GenTool**: Directory URLs from the GenTool data repository.
+- **Direct Links**: Any URL ending in `.rep` or `.zip`.
+
+### Drag and Drop
+Simply drag one or more `.rep` or `.zip` files from your computer and drop them anywhere on the Replay Manager window to import them.
+
+## Sharing Replays
+
+1. Select the replays you want to share from the list.
+2. Click **Upload & Share**.
+3. Once the upload is complete, the download link will be copied to your clipboard automatically.
+
+> [!IMPORTANT]
+> **Size Limit**: Each individual replay or ZIP file must be under **1 MB**.
+> **Privacy**: Shared replays are maintained for up to 14 days or until storage is full.
+
+## Storage Policy
+
+Replays imported or shared via GenHub are subject to the following policies:
+- Files are maintained in our cloud storage for **14 days**.
+- Older files may be removed automatically to make room for new ones.
+- Only `.rep` files are allowed within shared archives.
+
+## Architecture
+
+The Replay Manager is built on a modular service architecture:
+
+- **`IReplayDirectoryService`**: Manages replay directory operations and file system access.
+- **`IReplayImportService`**: Handles importing replays from URLs, local files, and ZIP archives.
+- **`IReplayExportService`**: Manages exporting and cloud sharing via UploadThing.
+- **`IUploadRateLimitService`**: Enforces weekly upload quotas and tracks upload history.
+- **`IUrlParserService`**: Identifies and validates replay source URLs *(coming soon)*.
+
+## Upcoming Features
+
+- **Enhanced URL Parser**: Improved support for additional replay sources and better URL validation.
+- **Replay Metadata Viewer**: View detailed match information directly in GenHub.


### PR DESCRIPTION
This PR introduces a Replay Manager tool to GenHub, enabling users to manage, import, and share Command & Conquer: Generals and Zero Hour replay files directly from the application.

## Summary

The Replay Manager is now available as a bundled tool in the Tools tab. It provides a unified interface to handle replay files, supporting drag-and-drop imports, cloud sharing via UploadThing, and local ZIP archiving.

### Key Features

-   **Unified Replay Management**
    -   View, sort, and manage replays for both Generals and Zero Hour in a single interface.
    -   Support for inline renaming of files directly in the DataGrid.
    -   Delete selected replays or reveal them in Windows Explorer.

-   **Flexible Importing**
    -   **Drag & Drop:** Drop `.rep` or `.zip` files directly onto the view to import them.
    -   **URL Import:** Paste URLs from various sources:
        -   Direct links (`.rep`/`.zip`).
        -   Generals Online match pages.
        -   GenTool data pages.
        -   UploadThing shared links.
    -   **File Picker:** Browse local file system to select replays.

-   **Export & Cloud Sharing**
    -   **Local ZIP:** Bundle selected replays into a ZIP archive stored in the replay folder.
    -   **UploadThing Integration:** Upload replays to the cloud (UploadThing v7) to generate shareable links.
    -   **History Tracking:** View upload history, verify link validity, and remove old entries.

-   **Rate Limiting**
    -   Enforces a 10MB weekly upload limit to prevent abuse.
    -   Tracks usage and calculates reset dates automatically.

-   **Validation**
    -   ZIP archives are validated to ensure they contain only a single layer of `.rep` files.
    -   File size checks (1MB limit per file).

### Technical Changes

**Core & Infrastructure**
-   Added `IReplayDirectoryService`, `IReplayImportService`, `IReplayExportService`, `IUploadRateLimitService`, `IUrlParserService`, and `IZipValidationService`.
-   Implemented new service classes for handling file I/O, HTTP requests, and ZIP operations.
-   Added `DotNetEnv` package to support loading environment variables (e.g., `UPLOADTHING_TOKEN`) from a `.env` file.
-   Added `Avalonia.Controls.DataGrid` package for the file list view.
-   Registered all new services and the `ReplayManagerToolPlugin` in the Dependency Injection module.
-   Updated `ToolService` to distinguish between "bundled" (built-in) and external plugins, preventing the removal of bundled tools.

**UI/UX**
-   Created `ReplayManagerView` with a responsive layout, progress bars, and overlay notifications.
-   Implemented `ReplayManagerViewModel` using the MVVM pattern with CommunityToolkit.Mvvm.
-   Added `EnumToBoolConverter` and `EqualsToConverter` for improved data binding.
-   **Tools Hub Enhancements:** Added a collapsible sidebar feature and updated the "Remove" logic to disable removal for bundled tools. Re-enabled the "Tools" navigation tab.

**Documentation**
-   Added documentation for the new Tool constants and Replay Manager usage in `docs/`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Introduces a comprehensive Replay Manager tool as a bundled feature in GenHub's Tools tab with drag-and-drop importing, cloud sharing via UploadThing, and local ZIP archiving for Command & Conquer replay files.
- Implements a new tool plugin architecture distinguishing between built-in bundled tools and external plugins, preventing removal of core functionality like the Replay Manager.
- Modernizes codebase syntax throughout using C#12collection expressions and proper disposal patterns while adding necessary UI converters and constants for the new functionality.

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `GenHub/GenHub/Features/Tools/ReplayManager/ViewModels/ReplayManagerViewModel.cs` | New comprehensive ViewModel with complex async operations, fire-and-forget HTTP tasks that need proper error handling, and potential infinite loop in file naming logic |
| `GenHub/GenHub/Features/Tools/ReplayManager/Views/ReplayManagerView.axaml.cs` | New code-behind with drag-and-drop functionality but silent error handling and potential null reference issues in drag validation |
| `GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayExportService.cs` | New UploadThing cloud integration service with environment variable authentication and proper cleanup, but potential authentication failures if token missing |
| `GenHub/GenHub.Core/Services/Tools/ToolService.cs` | Updated to support bundled tools architecture with proper DI integration but potential issues if built-in plugins collection is null |

<h3>Confidence score: 3/5</h3>


- This PR introduces significant new functionality with complex async operations and external service integrations that could fail in production
- Score lowered due to potential runtime issues in ViewModels (fire-and-forget tasks, file naming conflicts), silent error handling in UI code, and dependency on external environment variables for authentication
- Pay close attention to `ReplayManagerViewModel.cs` for async operation handling and `ReplayExportService.cs` for authentication token management

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ReplayManagerViewModel
    participant UploadRateLimitService
    participant ReplayExportService
    participant ZipValidationService
    participant HttpClient
    participant UploadThing
    participant Clipboard

    User->>ReplayManagerViewModel: "Click Upload & Share"
    ReplayManagerViewModel->>UploadRateLimitService: "CanUploadAsync(totalSize)"
    UploadRateLimitService-->>ReplayManagerViewModel: "true/false"
    
    alt Upload allowed
        ReplayManagerViewModel->>ReplayExportService: "UploadToUploadThingAsync(replays)"
        
        alt Multiple files or single .rep
            ReplayExportService->>ReplayExportService: "CreateTemporaryZip(replays)"
            ReplayExportService->>ZipValidationService: "ValidateZip(zipPath)"
            ZipValidationService-->>ReplayExportService: "validation result"
        else Single ZIP file
            ReplayExportService->>ZipValidationService: "ValidateZip(existingZip)"
            ZipValidationService-->>ReplayExportService: "validation result"
        end
        
        ReplayExportService->>HttpClient: "POST /prepareUpload"
        HttpClient->>UploadThing: "Request presigned URL"
        UploadThing-->>HttpClient: "Presigned URL + key"
        HttpClient-->>ReplayExportService: "Upload instructions"
        
        ReplayExportService->>HttpClient: "PUT binary data to presigned URL"
        HttpClient->>UploadThing: "Upload file"
        UploadThing-->>HttpClient: "Upload success"
        HttpClient-->>ReplayExportService: "Upload complete"
        
        ReplayExportService-->>ReplayManagerViewModel: "Public URL"
        ReplayManagerViewModel->>Clipboard: "SetTextAsync(url)"
        ReplayManagerViewModel->>UploadRateLimitService: "RecordUpload(size, url, filename)"
        ReplayManagerViewModel->>User: "Show success notification"
    else Upload denied
        ReplayManagerViewModel->>User: "Show rate limit error"
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - What: Enforce Conventional Commits format with allowed types (feat, fix, docs, style, refactor, perf... ([source](https://app.greptile.com/review/custom-context?memory=1b73a4ea-9e3a-4ae6-8c70-82c24d9898f8))
- Context from `dashboard` - Coding style used in the application which PullRequests and coding style has to be applied to. ([source](https://app.greptile.com/review/custom-context?memory=c1973f9e-036e-4c3f-890f-12fb9a5d7c5c))

<!-- /greptile_comment -->