### PR TITLE
fix: add ManualInstallationStorage for when no GameInstallations are detected 

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
@@ -17,6 +17,7 @@ public class GameInstallationServiceTests
 {
     private readonly Mock<IGameInstallationDetectionOrchestrator> _orchestratorMock;
     private readonly Mock<IGameClientDetectionOrchestrator> _clientOrchestratorMock;
+    private readonly Mock<ILogger<GameInstallationService>> _loggerMock;
     private readonly GameInstallationService _service;
 
     /// <summary>
@@ -26,6 +27,7 @@ public class GameInstallationServiceTests
     {
         _orchestratorMock = new Mock<IGameInstallationDetectionOrchestrator>();
         _clientOrchestratorMock = new Mock<IGameClientDetectionOrchestrator>();
+        _loggerMock = new Mock<ILogger<GameInstallationService>>();
 
         // Setup client orchestrator to return empty clients by default
         var clientResult = DetectionResult<GameClient>.CreateSuccess(Enumerable.Empty<GameClient>(), TimeSpan.Zero);
@@ -37,7 +39,7 @@ public class GameInstallationServiceTests
                 return Task.FromResult(clientResult);
             });
 
-        _service = new GameInstallationService(_orchestratorMock.Object, _clientOrchestratorMock.Object);
+        _service = new GameInstallationService(_orchestratorMock.Object, _clientOrchestratorMock.Object, _loggerMock.Object);
     }
 
     /// <summary>
@@ -214,7 +216,7 @@ public class GameInstallationServiceTests
     public void Dispose_ShouldDisposeResources()
     {
         // Arrange
-        var service = new GameInstallationService(_orchestratorMock.Object, _clientOrchestratorMock.Object);
+        var service = new GameInstallationService(_orchestratorMock.Object, _clientOrchestratorMock.Object, _loggerMock.Object);
 
         // Act
         service.Dispose();

--- a/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
+++ b/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
@@ -1,10 +1,9 @@
-using System;
-using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GitHub;
 using GenHub.Core.Interfaces.Shortcuts;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Interfaces.Workspace;
+using GenHub.Features.GameInstallations;
 using GenHub.Features.Workspace;
 using GenHub.Windows.Features.GitHub.Services;
 using GenHub.Windows.Features.Shortcuts;
@@ -12,7 +11,7 @@ using GenHub.Windows.Features.Workspace;
 using GenHub.Windows.GameInstallations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Runtime.Versioning;
+using System;
 
 namespace GenHub.Windows.Infrastructure.DependencyInjection;
 
@@ -32,6 +31,7 @@ public static class WindowsServicesModule
         services.AddSingleton<IGameInstallationDetector, WindowsInstallationDetector>();
         services.AddSingleton<IGitHubTokenStorage, WindowsGitHubTokenStorage>();
         services.AddSingleton<IShortcutService, WindowsShortcutService>();
+        services.AddSingleton<IManualInstallationStorage, ManualInstallationStorage>();
 
         // Register WindowsFileOperationsService with factory to avoid circular dependency
         services.AddScoped<IFileOperationsService>(serviceProvider =>

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateService.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateService.cs
@@ -115,10 +115,16 @@ public class GeneralsOnlineUpdateService(
                 return null;
             }
 
-            var latestVersionUrl = provider.Endpoints.GetEndpoint("latestVersionUrl");
+            var latestVersionUrl = provider.Endpoints.GetEndpoint("custom.latestVersionUrl");
             if (string.IsNullOrEmpty(latestVersionUrl))
             {
-                logger.LogError("latestVersionUrl not configured in provider definition");
+                // Fallback to standard endpoint name lookup
+                latestVersionUrl = provider.Endpoints.GetEndpoint("latestVersionUrl");
+            }
+
+            if (string.IsNullOrEmpty(latestVersionUrl))
+            {
+                logger.LogError("latestVersionUrl not configured in provider definition (checked both 'custom.latestVersionUrl' and 'latestVersionUrl')");
                 return null;
             }
 

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -12,7 +12,6 @@ using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameClients;
 using GenHub.Core.Models.GameInstallations;
-using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -27,17 +26,13 @@ namespace GenHub.Features.GameInstallations;
 /// content manifests for detected installations and populate their AvailableClients.
 /// </remarks>
 public class GameInstallationService(
-    IGameInstallationDetectionOrchestrator detectionOrchestrator,
-    IGameClientDetectionOrchestrator clientOrchestrator,
-    IManifestGenerationService? manifestGenerationService = null,
-    IContentManifestPool? contentManifestPool = null,
-    ILogger<GameInstallationService>? logger = null) : IGameInstallationService, IDisposable
+IGameInstallationDetectionOrchestrator detectionOrchestrator,
+IGameClientDetectionOrchestrator clientOrchestrator,
+ILogger<GameInstallationService> logger,
+IManifestGenerationService? manifestGenerationService = null,
+IContentManifestPool? contentManifestPool = null,
+IManualInstallationStorage? manualInstallationStorage = null) : IGameInstallationService, IDisposable
 {
-    private readonly IGameInstallationDetectionOrchestrator _detectionOrchestrator = detectionOrchestrator ?? throw new ArgumentNullException(nameof(detectionOrchestrator));
-    private readonly IGameClientDetectionOrchestrator _clientOrchestrator = clientOrchestrator ?? throw new ArgumentNullException(nameof(clientOrchestrator));
-    private readonly IManifestGenerationService? _manifestGenerationService = manifestGenerationService;
-    private readonly IContentManifestPool? _contentManifestPool = contentManifestPool;
-    private readonly ILogger<GameInstallationService> _logger = logger ?? NullLogger<GameInstallationService>.Instance;
     private readonly SemaphoreSlim _cacheLock = new(1, 1);
     private ReadOnlyCollection<GameInstallation>? _cachedInstallations;
     private bool _disposed = false;
@@ -88,19 +83,10 @@ public class GameInstallationService(
             var initResult = await TryInitializeCacheAsync(cancellationToken);
             if (!initResult.Success)
             {
-                // Even if detection failing (e.g. no auto-detect), we might have manual installs.
-                // But TryInitializeCacheAsync returns Failure if detect fails?
-                // Looking at TryInitializeCacheAsync, it returns Failure if detection error.
-                // But we should probably allow failure if we have a cache?
-                // For now, let's stick to existing logic but maybe we need to be careful.
-                // If init failed, we might still want to proceed if we manually injected?
-                // But let's assume detection usually succeeds (returns empty list if none found?).
-                // "Failed to detect" usually means exception.
-
-                // If cache is null, we can't do much.
+                // If TryInitializeCacheAsync failed and cache is null, return failure
                 if (_cachedInstallations == null)
                 {
-                     return OperationResult<IReadOnlyList<GameInstallation>>.CreateFailure(initResult.Errors[0]);
+                    return OperationResult<IReadOnlyList<GameInstallation>>.CreateFailure(initResult.Errors[0]);
                 }
             }
 
@@ -122,51 +108,98 @@ public class GameInstallationService(
     {
         ArgumentNullException.ThrowIfNull(installation);
 
+        logger!.LogInformation(
+            "[DIAGNOSTIC] RegisterManualInstallationAsync called for installation ID: {InstallationId}, Path: {Path}, Type: {Type}",
+            installation.Id,
+            installation.InstallationPath,
+            installation.InstallationType);
+
         await _cacheLock.WaitAsync(cancellationToken);
         try
         {
             // Ensure cache is initialized (or at least exists)
             if (_cachedInstallations == null)
             {
+                logger.LogWarning(
+                    "[DIAGNOSTIC] Cache is null during RegisterManualInstallationAsync, initializing with auto-detection only");
+
                 // Try to initialize standard way first
                 try
                 {
                     // logic from TryInitializeCacheAsync but without the lock since we hold it
-                    var detectionResult = await _detectionOrchestrator.DetectAllInstallationsAsync(cancellationToken);
+                    var detectionResult = await detectionOrchestrator.DetectAllInstallationsAsync(cancellationToken);
                     if (detectionResult.Success)
                     {
                         var installations = detectionResult.Items.ToList();
                         await PopulateGameClientsAndManifestsAsync(installations, cancellationToken);
                         _cachedInstallations = installations.AsReadOnly();
+                        logger.LogInformation(
+                            "[DIAGNOSTIC] Cache initialized with {Count} auto-detected installations",
+                            _cachedInstallations.Count);
                     }
                     else
                     {
                         // Fallback to empty list
                         _cachedInstallations = new List<GameInstallation>().AsReadOnly();
+                        logger.LogWarning(
+                            "[DIAGNOSTIC] Auto-detection failed, cache initialized as empty list");
                     }
                 }
                 catch
                 {
                      _cachedInstallations = new List<GameInstallation>().AsReadOnly();
+                     logger.LogWarning(
+                        "[DIAGNOSTIC] Exception during cache initialization, cache initialized as empty list");
                 }
             }
 
             var currentList = _cachedInstallations.ToList();
+            var previousCount = currentList.Count;
 
             // Update existing or add new
             var existingIndex = currentList.FindIndex(i => i.Id == installation.Id);
             if (existingIndex >= 0)
             {
                 currentList[existingIndex] = installation;
+                logger.LogInformation(
+                    "[DIAGNOSTIC] Updated existing manual installation: {Id} ({Path})",
+                    installation.Id,
+                    installation.InstallationPath);
             }
             else
             {
                 currentList.Add(installation);
+                logger.LogInformation(
+                    "[DIAGNOSTIC] Added new manual installation: {Id} ({Path})",
+                    installation.Id,
+                    installation.InstallationPath);
             }
 
             _cachedInstallations = currentList.AsReadOnly();
 
-            _logger.LogInformation("Registered manual installation: {Id} ({Path})", installation.Id, installation.InstallationPath);
+            logger.LogInformation(
+                "[DIAGNOSTIC] Cache now contains {Count} installations (was {PreviousCount})",
+                _cachedInstallations.Count,
+                previousCount);
+
+            // Persist manual installation to storage
+            if (manualInstallationStorage != null)
+            {
+                try
+                {
+                    await manualInstallationStorage.SaveManualInstallationAsync(installation, cancellationToken);
+                    logger.LogInformation(
+                        "[DIAGNOSTIC] Persisted manual installation {Id} to storage",
+                        installation.Id);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "[DIAGNOSTIC] Failed to persist manual installation {Id} to storage",
+                        installation.Id);
+                }
+            }
 
             return OperationResult<bool>.CreateSuccess(true);
         }
@@ -182,8 +215,28 @@ public class GameInstallationService(
         _cacheLock.Wait();
         try
         {
+            var previousCount = _cachedInstallations?.Count ?? 0;
             _cachedInstallations = null;
-            _logger.LogInformation("Installation cache invalidated");
+            logger!.LogInformation(
+                "[DIAGNOSTIC] Installation cache invalidated (had {PreviousCount} installations, now null)",
+                previousCount);
+
+            // Clear manual installations from storage when cache is invalidated
+            if (manualInstallationStorage != null)
+            {
+                try
+                {
+                    manualInstallationStorage.ClearAllAsync(default).GetAwaiter().GetResult();
+                    logger.LogInformation(
+                        "[DIAGNOSTIC] Cleared manual installations from storage");
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "[DIAGNOSTIC] Failed to clear manual installations from storage");
+                }
+            }
         }
         finally
         {
@@ -222,8 +275,14 @@ public class GameInstallationService(
     {
         if (_cachedInstallations != null)
         {
+            logger!.LogInformation(
+                "[DIAGNOSTIC] TryInitializeCacheAsync: Cache already initialized with {Count} installations",
+                _cachedInstallations.Count);
             return OperationResult<bool>.CreateSuccess(true);
         }
+
+        logger!.LogInformation(
+            "[DIAGNOSTIC] TryInitializeCacheAsync: Cache is null, initializing via auto-detection and manual installations");
 
         await _cacheLock.WaitAsync(cancellationToken);
         try
@@ -233,27 +292,91 @@ public class GameInstallationService(
                 return OperationResult<bool>.CreateSuccess(true);
             }
 
-            var detectionResult = await _detectionOrchestrator.DetectAllInstallationsAsync(cancellationToken);
+            var detectionResult = await detectionOrchestrator.DetectAllInstallationsAsync(cancellationToken);
+
+            // Start with auto-detected installations if successful, otherwise empty list
+            List<GameInstallation> mergedInstallations;
+            int autoCount = 0;
+            bool detectionHadError = !detectionResult.Success;
             if (detectionResult.Success)
             {
-                var installations = detectionResult.Items.ToList();
-
-                // Generate manifests and populate AvailableVersions for each installation
-                await PopulateGameClientsAndManifestsAsync(installations, cancellationToken);
-
-                _cachedInstallations = installations.AsReadOnly();
-
-                _logger.LogInformation(
-                    "Initialized installation cache with {Count} installations",
-                    _cachedInstallations.Count);
-
-                return OperationResult<bool>.CreateSuccess(true);
+                mergedInstallations = detectionResult.Items.ToList();
+                autoCount = mergedInstallations.Count;
+                logger.LogInformation(
+                    "[DIAGNOSTIC] Auto-detection found {Count} installations",
+                    autoCount);
             }
             else
+            {
+                logger.LogWarning(
+                    "[DIAGNOSTIC] Auto-detection failed: {Errors}. Starting with empty list.",
+                    string.Join(", ", detectionResult.Errors));
+                mergedInstallations = new List<GameInstallation>();
+            }
+
+            // Load persisted manual installations and merge with auto-detected ones
+            if (manualInstallationStorage != null)
+            {
+                try
+                {
+                    var manualInstallations = await manualInstallationStorage.LoadManualInstallationsAsync(cancellationToken);
+                    var loadedManualCount = manualInstallations.Count;
+
+                    // Merge manual installations, avoiding duplicates by path
+                    foreach (var manualInstall in manualInstallations)
+                    {
+                        var existingByPath = mergedInstallations.FirstOrDefault(i =>
+                            i.InstallationPath.Equals(manualInstall.InstallationPath, StringComparison.OrdinalIgnoreCase));
+
+                        if (existingByPath != null)
+                        {
+                            logger.LogInformation(
+                                    "[DIAGNOSTIC] Skipping manual installation {Id} - path conflicts with auto-detected installation",
+                                    manualInstall.Id);
+                        }
+                        else
+                        {
+                            mergedInstallations.Add(manualInstall);
+                            logger.LogInformation(
+                                    "[DIAGNOSTIC] Merged manual installation {Id} into cache",
+                                    manualInstall.Id);
+                        }
+                    }
+
+                    logger.LogInformation(
+                            "[DIAGNOSTIC] Loaded {ManualCount} manual installations from storage",
+                            loadedManualCount);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(
+                            ex,
+                            "[DIAGNOSTIC] Failed to load manual installations from storage");
+                }
+            }
+
+            // Generate manifests and populate AvailableVersions for each installation
+            await PopulateGameClientsAndManifestsAsync(mergedInstallations, cancellationToken);
+
+            _cachedInstallations = mergedInstallations.AsReadOnly();
+
+            var totalCount = _cachedInstallations.Count;
+            var manualCount = totalCount - autoCount;
+
+            logger.LogInformation(
+                    "[DIAGNOSTIC] Cache initialized with {Count} total installations ({AutoCount} auto-detected, {ManualCount} manual)",
+                    totalCount,
+                    autoCount,
+                    manualCount);
+
+            // Return failure if detection had an error and we have no installations
+            if (detectionHadError && mergedInstallations.Count == 0)
             {
                 return OperationResult<bool>.CreateFailure(
                     $"Failed to detect game installations: {string.Join(", ", detectionResult.Errors)}");
             }
+
+            return OperationResult<bool>.CreateSuccess(true);
         }
         finally
         {
@@ -274,10 +397,10 @@ public class GameInstallationService(
             installation.Fetch();
         }
 
-        var clientResult = await _clientOrchestrator.DetectGameClientsFromInstallationsAsync(installations, cancellationToken);
+        var clientResult = await clientOrchestrator.DetectGameClientsFromInstallationsAsync(installations, cancellationToken);
         if (!clientResult.Success)
         {
-            _logger.LogWarning("Client detection failed: {Errors}", string.Join(", ", clientResult.Errors));
+            logger!.LogWarning("Client detection failed: {Errors}", string.Join(", ", clientResult.Errors));
             return;
         }
 
@@ -286,11 +409,11 @@ public class GameInstallationService(
         {
             var installationClients = clientsByInstallation.FirstOrDefault(g => g.Key == installation.Id)?.ToList() ?? Enumerable.Empty<GameClient>();
             installation.PopulateGameClients(installationClients);
-            _logger.LogDebug("Populated {ClientCount} clients for installation {Id}", installationClients.Count(), installation.Id);
+            logger!.LogDebug("Populated {ClientCount} clients for installation {Id}", installationClients.Count(), installation.Id);
         }
 
         // Create and register GameInstallation manifests to the pool
-        if (_manifestGenerationService != null && _contentManifestPool != null)
+        if (manifestGenerationService != null && contentManifestPool != null)
         {
             foreach (var installation in installations)
             {
@@ -299,7 +422,7 @@ public class GameInstallationService(
         }
         else
         {
-            _logger.LogWarning("ManifestGenerationService or ContentManifestPool not available, skipping GameInstallation manifest registration");
+            logger!.LogWarning("ManifestGenerationService or ContentManifestPool not available, skipping GameInstallation manifest registration");
         }
     }
 
@@ -354,7 +477,7 @@ public class GameInstallationService(
 
             if (baseGameClient == null)
             {
-                _logger.LogWarning(
+                logger!.LogWarning(
                     "No base game client found for {GameType} in installation {InstallationId}, skipping GameInstallation manifest creation",
                     gameType,
                     installation.Id);
@@ -374,7 +497,7 @@ public class GameInstallationService(
             }
 
             // Create the GameInstallation manifest
-            var manifestBuilder = await _manifestGenerationService!.CreateGameInstallationManifestAsync(
+            var manifestBuilder = await manifestGenerationService!.CreateGameInstallationManifestAsync(
                 installationPath,
                 gameType,
                 installation.InstallationType,
@@ -383,11 +506,11 @@ public class GameInstallationService(
             var manifest = manifestBuilder.Build();
 
             // Register the manifest to the pool
-            var addResult = await _contentManifestPool!.AddManifestAsync(manifest, installationPath, null, cancellationToken);
+            var addResult = await contentManifestPool!.AddManifestAsync(manifest, installationPath, null, cancellationToken);
 
             if (addResult.Success)
             {
-                _logger.LogInformation(
+                logger!.LogInformation(
                     "Registered GameInstallation manifest {ManifestId} for {GameType} in installation {InstallationId}",
                     manifest.Id,
                     gameType,
@@ -395,7 +518,7 @@ public class GameInstallationService(
             }
             else
             {
-                _logger.LogWarning(
+                logger!.LogWarning(
                     "Failed to register GameInstallation manifest for {GameType} in installation {InstallationId}: {Errors}",
                     gameType,
                     installation.Id,
@@ -404,7 +527,7 @@ public class GameInstallationService(
         }
         catch (Exception ex)
         {
-            _logger.LogError(
+            logger!.LogError(
                 ex,
                 "Error creating GameInstallation manifest for {GameType} in installation {InstallationId}",
                 gameType,

--- a/GenHub/GenHub/Features/GameInstallations/IManualInstallationStorage.cs
+++ b/GenHub/GenHub/Features/GameInstallations/IManualInstallationStorage.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Models.GameInstallations;
+
+namespace GenHub.Features.GameInstallations;
+
+/// <summary>
+/// Interface for persisting manually registered game installations.
+/// </summary>
+public interface IManualInstallationStorage
+{
+    /// <summary>
+    /// Gets all persisted manual installations.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A list of manual installations.</returns>
+    Task<List<GameInstallation>> LoadManualInstallationsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves a manual installation to persistent storage.
+    /// </summary>
+    /// <param name="installation">The installation to save.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SaveManualInstallationAsync(GameInstallation installation, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a manual installation from persistent storage.
+    /// </summary>
+    /// <param name="installationId">The installation ID to remove.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task RemoveManualInstallationAsync(string installationId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears all manual installations from persistent storage.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task ClearAllAsync(CancellationToken cancellationToken = default);
+}

--- a/GenHub/GenHub/Features/GameInstallations/ManualInstallationStorage.cs
+++ b/GenHub/GenHub/Features/GameInstallations/ManualInstallationStorage.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.GameInstallations;
+
+/// <summary>
+/// Provides persistence for manually registered game installations.
+/// </summary>
+public sealed class ManualInstallationStorage : IManualInstallationStorage
+{
+    private const string ManualInstallationsFileName = "manual_installations.json";
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IAppConfiguration _appConfig;
+    private readonly ILogger<ManualInstallationStorage> _logger;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly string _storagePath;
+    private List<ManualInstallationDto>? _cachedInstallations;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManualInstallationStorage"/> class.
+    /// </summary>
+    /// <param name="appConfig">The application configuration.</param>
+    /// <param name="logger">The logger.</param>
+    public ManualInstallationStorage(
+        IAppConfiguration appConfig,
+        ILogger<ManualInstallationStorage> logger)
+    {
+        _appConfig = appConfig ?? throw new ArgumentNullException(nameof(appConfig));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _storagePath = Path.Combine(
+            _appConfig.GetConfiguredDataPath(),
+            ManualInstallationsFileName);
+    }
+
+    /// <summary>
+    /// Gets all persisted manual installations.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A list of manual installations.</returns>
+    public async Task<List<GameInstallation>> LoadManualInstallationsAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_cachedInstallations != null)
+            {
+                return _cachedInstallations.Select(dto => dto.ToGameInstallation()).ToList();
+            }
+
+            if (!File.Exists(_storagePath))
+            {
+                _logger.LogInformation(
+                    "[ManualInstallationStorage] No manual installations file found at {Path}",
+                    _storagePath);
+                _cachedInstallations = new List<ManualInstallationDto>();
+                return new List<GameInstallation>();
+            }
+
+            try
+            {
+                var json = await File.ReadAllTextAsync(_storagePath, cancellationToken);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    _logger.LogWarning(
+                        "[ManualInstallationStorage] Manual installations file is empty at {Path}",
+                        _storagePath);
+                    _cachedInstallations = new List<ManualInstallationDto>();
+                    return new List<GameInstallation>();
+                }
+
+                var dtos = JsonSerializer.Deserialize<List<ManualInstallationDto>>(json, JsonOptions)
+                    ?? new List<ManualInstallationDto>();
+
+                _cachedInstallations = dtos;
+                var installations = dtos.Select(dto => dto.ToGameInstallation()).ToList();
+
+                _logger.LogInformation(
+                    "[ManualInstallationStorage] Loaded {Count} manual installations from {Path}",
+                    installations.Count,
+                    _storagePath);
+
+                return installations;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "[ManualInstallationStorage] Failed to load manual installations from {Path}",
+                    _storagePath);
+                _cachedInstallations = new List<ManualInstallationDto>();
+                return new List<GameInstallation>();
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Saves a manual installation to persistent storage.
+    /// </summary>
+    /// <param name="installation">The installation to save.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task SaveManualInstallationAsync(GameInstallation installation, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(installation);
+
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            // Load existing installations
+            var dtos = _cachedInstallations ?? new List<ManualInstallationDto>();
+
+            // Update existing or add new
+            var existingIndex = dtos.FindIndex(dto => dto.Id == installation.Id);
+            if (existingIndex >= 0)
+            {
+                dtos[existingIndex] = ManualInstallationDto.FromGameInstallation(installation);
+                _logger.LogInformation(
+                    "[ManualInstallationStorage] Updated manual installation {Id} in storage",
+                    installation.Id);
+            }
+            else
+            {
+                dtos.Add(ManualInstallationDto.FromGameInstallation(installation));
+                _logger.LogInformation(
+                    "[ManualInstallationStorage] Added manual installation {Id} to storage",
+                    installation.Id);
+            }
+
+            _cachedInstallations = dtos;
+
+            // Save to file
+            await SaveToFileAsync(dtos, cancellationToken);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Removes a manual installation from persistent storage.
+    /// </summary>
+    /// <param name="installationId">The installation ID to remove.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task RemoveManualInstallationAsync(string installationId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(installationId))
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_cachedInstallations == null)
+            {
+                return;
+            }
+
+            var removed = _cachedInstallations.RemoveAll(dto => dto.Id == installationId);
+            if (removed > 0)
+            {
+                _logger.LogInformation(
+                    "[ManualInstallationStorage] Removed manual installation {Id} from storage",
+                    installationId);
+                await SaveToFileAsync(_cachedInstallations, cancellationToken);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Clears all manual installations from persistent storage.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task ClearAllAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            _cachedInstallations = new List<ManualInstallationDto>();
+
+            if (File.Exists(_storagePath))
+            {
+                File.Delete(_storagePath);
+                _logger.LogInformation(
+                    "[ManualInstallationStorage] Cleared all manual installations from {Path}",
+                    _storagePath);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task SaveToFileAsync(List<ManualInstallationDto> dtos, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_storagePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var json = JsonSerializer.Serialize(dtos, JsonOptions);
+            await File.WriteAllTextAsync(_storagePath, json, cancellationToken);
+
+            _logger.LogDebug(
+                "[ManualInstallationStorage] Saved {Count} manual installations to {Path}",
+                dtos.Count,
+                _storagePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "[ManualInstallationStorage] Failed to save manual installations to {Path}",
+                _storagePath);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Data transfer object for serializing manual installations.
+    /// </summary>
+    private sealed class ManualInstallationDto
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string InstallationPath { get; set; } = string.Empty;
+
+        public string InstallationType { get; set; } = string.Empty;
+
+        public bool HasGenerals { get; set; }
+
+        public string GeneralsPath { get; set; } = string.Empty;
+
+        public bool HasZeroHour { get; set; }
+
+        public string ZeroHourPath { get; set; } = string.Empty;
+
+        public DateTime DetectedAt { get; set; }
+
+        public static ManualInstallationDto FromGameInstallation(GameInstallation installation)
+        {
+            return new ManualInstallationDto
+            {
+                Id = installation.Id,
+                InstallationPath = installation.InstallationPath,
+                InstallationType = installation.InstallationType.ToString(),
+                HasGenerals = installation.HasGenerals,
+                GeneralsPath = installation.GeneralsPath,
+                HasZeroHour = installation.HasZeroHour,
+                ZeroHourPath = installation.ZeroHourPath,
+                DetectedAt = installation.DetectedAt,
+            };
+        }
+
+        public GameInstallation ToGameInstallation()
+        {
+            return new GameInstallation(InstallationPath, ParseInstallationType())
+            {
+                Id = Id,
+                HasGenerals = HasGenerals,
+                GeneralsPath = GeneralsPath,
+                HasZeroHour = HasZeroHour,
+                ZeroHourPath = ZeroHourPath,
+                DetectedAt = DetectedAt,
+            };
+        }
+
+        private GameInstallationType ParseInstallationType()
+        {
+            if (Enum.TryParse<GameInstallationType>(InstallationType, out var type))
+            {
+                return type;
+            }
+
+            return GameInstallationType.Retail;
+        }
+    }
+}

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -1,0 +1,41 @@
+# Multi-Instance Debugging Support
+
+GenHub supports running multiple instances simultaneously for debugging purposes. This is useful when testing multiple workspaces or debugging concurrent operations.
+
+## Enabling Multi-Instance Mode
+
+### Command Line Argument
+Pass `--multi-instance` or `-m` when launching the application:
+
+```bash
+GenHub.exe --multi-instance
+# or
+GenHub.exe -m
+```
+
+### Environment Variable
+Set the `GENHUB_MULTI_INSTANCE` environment variable to `1`:
+
+```powershell
+$env:GENHUB_MULTI_INSTANCE = "1"
+GenHub.exe
+```
+
+## Behavior
+
+When multi-instance mode is enabled:
+
+- The single-instance lock is bypassed
+- Multiple instances can run simultaneously
+- Each instance operates independently with its own workspace
+
+## Use Cases
+
+- Testing workspace switching between multiple instances
+- Debugging concurrent operations
+- Testing profile management across separate sessions
+
+## Limitations
+
+- Ensure different workspaces are used to avoid conflicts
+- Some operations may conflict if run simultaneously on the same data

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -143,9 +143,13 @@ public class MyService(ILogger<MyService> logger)
 
 GeneralsHub includes comprehensive unit and integration tests:
 
-- **xUnit**: Testing framework  
-- **FluentAssertions**: Readable assertions  
-- **Moq**: Mocking dependencies  
+- **xUnit**: Testing framework
+- **FluentAssertions**: Readable assertions
+- **Moq**: Mocking dependencies
+
+### Debugging
+
+GenHub supports [multi-instance debugging](./debugging.md) for testing multiple workspaces or debugging concurrent operations.
 
 ---
 


### PR DESCRIPTION
This PR introduces persistent storage for manual game installations and adds multi-instance debugging support. It also improves the reliability of the application update process through HTTP retries, GitHub API caching, and enhanced error handling.

**Changes**
*   **Game Installations:** Added `IManualInstallationStorage` to persist manually added games across sessions.
*   **Debugging:** Added `--multi-instance` flag and environment variable support to bypass single-instance locks.
*   **Updates:** Refactored `VelopackUpdateManager` with retry logic, centralized constants, and GitHub PAT support.
*   **Maintenance:** Improved workspace cleanup to remove orphaned directories and added API response caching in `OctokitGitHubApiClient`.
