### PR TITLE
feat(gamelod): fix texture quality reset to low by mapping Very High to High (0) in Options.ini

### DIFF
--- a/GenHub/GenHub.Core/Constants/GameSettingsConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsConstants.cs
@@ -23,6 +23,21 @@ public static class GameSettingsConstants
         /// Low (0) maps to TextureReduction 2.
         /// </summary>
         public const int ReductionOffset = 2;
+
+        /// <summary>
+        /// Texture reduction value for low quality.
+        /// </summary>
+        public const int TextureReductionLow = 2;
+
+        /// <summary>
+        /// Texture reduction value for medium quality.
+        /// </summary>
+        public const int TextureReductionMedium = 1;
+
+        /// <summary>
+        /// Texture reduction value for high quality.
+        /// </summary>
+        public const int TextureReductionHigh = 0;
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -1,0 +1,66 @@
+using System;
+using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameProfile;
+using GenHub.Core.Models.GameSettings;
+using Xunit;
+
+namespace GenHub.Tests.Core.Helpers;
+
+/// <summary>
+/// Tests for the <see cref="GameSettingsMapper"/> class.
+/// </summary>
+public class GameSettingsMapperTests
+{
+    /// <summary>
+    /// Verifies that all texture quality levels map to the correct engine values.
+    /// </summary>
+    /// <param name="quality">The texture quality level.</param>
+    /// <param name="expectedReduction">The expected texture reduction value in Options.ini.</param>
+    [Theory]
+    [InlineData(TextureQuality.Low, GameSettingsConstants.TextureQuality.TextureReductionLow)]
+    [InlineData(TextureQuality.Medium, GameSettingsConstants.TextureQuality.TextureReductionMedium)]
+    [InlineData(TextureQuality.High, GameSettingsConstants.TextureQuality.TextureReductionHigh)]
+    [InlineData(TextureQuality.VeryHigh, GameSettingsConstants.TextureQuality.TextureReductionHigh)]
+    public void ApplyToOptions_AllTextureQualities_SetsCorrectReduction(TextureQuality quality, int expectedReduction)
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            VideoTextureQuality = quality,
+        };
+        var options = new IniOptions();
+
+        // Act
+        GameSettingsMapper.ApplyToOptions(profile, options);
+
+        // Assert
+        Assert.Equal(expectedReduction, options.Video.TextureReduction);
+    }
+
+    /// <summary>
+    /// Verifies that mapping from engine values correctly results in the expected texture quality.
+    /// </summary>
+    /// <param name="reduction">The texture reduction value from Options.ini.</param>
+    /// <param name="expectedQuality">The expected texture quality level.</param>
+    [Theory]
+    [InlineData(GameSettingsConstants.TextureQuality.TextureReductionLow, TextureQuality.Low)]
+    [InlineData(GameSettingsConstants.TextureQuality.TextureReductionMedium, TextureQuality.Medium)]
+    [InlineData(GameSettingsConstants.TextureQuality.TextureReductionHigh, TextureQuality.High)]
+    public void ApplyFromOptions_AllReductions_MapsToCorrectQuality(int reduction, TextureQuality expectedQuality)
+    {
+        // Arrange
+        var options = new IniOptions();
+        options.Video.TextureReduction = reduction;
+        var profile = new GameProfile();
+
+        // Act
+        GameSettingsMapper.ApplyFromOptions(options, profile);
+
+        // Assert
+        Assert.Equal(expectedQuality, profile.VideoTextureQuality);
+    }
+}
+
+


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Replaced formula-based texture quality mapping (`2 - TextureQuality`) with explicit switch expressions using newly defined constants (`TextureReductionLow = 2`, `TextureReductionMedium = 1`, `TextureReductionHigh = 0`). This change prevents `TextureQuality.VeryHigh` from being mapped to an invalid value of -1 in `Options.ini` by clamping it to 0 (High quality) instead, which resolves the texture quality reset issue.

Key improvements:
- Added three new constants to `GameSettingsConstants.TextureQuality` for explicit texture reduction values
- Updated `ApplyToOptions` to use switch expression mapping `VeryHigh` to `TextureReductionHigh` (0)
- Updated `ApplyFromOptions` to use switch expression with explicit constant matching
- Added comprehensive unit tests covering all mappings including the `VeryHigh` edge case

The implementation properly follows the constants style guide and addresses feedback from previous review threads.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risk
- The changes are well-implemented with proper constants usage, comprehensive test coverage, and clear documentation. The fix correctly addresses the root cause of texture quality resetting by preventing invalid -1 values. All mappings are bidirectional and properly tested.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Constants/GameSettingsConstants.cs | Added texture reduction constants (Low=2, Medium=1, High=0) for clearer code |
| GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs | Replaced formula-based mapping with explicit switch expressions using new constants, maps VeryHigh to High (0) |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs | Added comprehensive tests verifying bidirectional texture quality mappings |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Profile as GameProfile
    participant Mapper as GameSettingsMapper
    participant Options as IniOptions
    participant Constants as GameSettingsConstants

    Note over Profile,Options: ApplyToOptions (Profile → Options.ini)
    Profile->>Mapper: VideoTextureQuality = VeryHigh/High/Medium/Low
    Mapper->>Constants: Get TextureReduction constant
    Constants-->>Mapper: Returns 0, 1, or 2
    Mapper->>Options: Set TextureReduction value
    Note over Options: VeryHigh & High → 0<br/>Medium → 1<br/>Low → 2

    Note over Profile,Options: ApplyFromOptions (Options.ini → Profile)
    Options->>Mapper: TextureReduction = 0, 1, or 2
    Mapper->>Constants: Match against constants
    Constants-->>Mapper: Returns matching constant
    Mapper->>Profile: Set VideoTextureQuality
    Note over Profile: 0 → High<br/>1 → Medium<br/>2 → Low
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - Use dedicated constants classes instead of hardcoding constants string, integers or variables in ser... ([source](https://app.greptile.com/review/custom-context?memory=53453b3b-b708-4856-b1b0-0cbc8bfe5330))

<!-- /greptile_comment -->