### PR TITLE
refactor: filter non-workspace files from workspace strategies

### DIFF
--- a/GenHub/GenHub.Core/Extensions/WorkspaceConfigurationExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/WorkspaceConfigurationExtensions.cs
@@ -24,4 +24,21 @@ public static class WorkspaceConfigurationExtensions
             .Select(g => g.OrderByDescending(x => ContentTypePriority.GetPriority(x.Manifest.ContentType))
                           .First().File);
     }
+
+    /// <summary>
+    /// Gets all unique files intended for the workspace from all manifests, deduplicated by relative path.
+    /// Only includes files where <see cref="ManifestFile.InstallTarget"/> is <see cref="GenHub.Core.Models.Enums.ContentInstallTarget.Workspace"/>.
+    /// </summary>
+    /// <param name="configuration">The workspace configuration to get files from.</param>
+    /// <returns>An enumerable of unique workspace-specific manifest files.</returns>
+    public static IEnumerable<ManifestFile> GetWorkspaceUniqueFiles(
+        this WorkspaceConfiguration configuration)
+    {
+        return configuration.Manifests
+            .SelectMany(m => (m.Files ?? []).Select(f => new { File = f, Manifest = m }))
+            .Where(x => x.File.InstallTarget == GenHub.Core.Models.Enums.ContentInstallTarget.Workspace)
+            .GroupBy(x => x.File.RelativePath, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.OrderByDescending(x => ContentTypePriority.GetPriority(x.Manifest.ContentType))
+                          .First().File);
+    }
 }

--- a/GenHub/GenHub/Features/Workspace/Strategies/SymlinkOnlyStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/SymlinkOnlyStrategy.cs
@@ -108,7 +108,8 @@ public sealed class SymlinkOnlyStrategy(
             // Deduplicate files by RelativePath - multiple manifests may contain the same file
             // (e.g., GameClient and GameInstallation both contain the executable)
             // Group by path and take the first occurrence to avoid parallel creation conflicts
-            var manifestFiles = configuration.GetAllUniqueFiles()
+            // include files where InstallTarget is Workspace.
+            var manifestFiles = configuration.GetWorkspaceUniqueFiles()
                 .Select(f => new { Manifest = configuration.Manifests.First(m => m.Files.Contains(f)), File = f })
                 .ToList();
 
@@ -233,12 +234,7 @@ public sealed class SymlinkOnlyStrategy(
     {
         // For game installation files, treat them the same as local files
         // We need to find the manifest that contains this file
-        var manifest = configuration.Manifests.FirstOrDefault(m => m.Files.Contains(file));
-        if (manifest is null)
-        {
-            throw new InvalidOperationException($"Could not find manifest containing file {file.RelativePath}");
-        }
-
+        var manifest = configuration.Manifests.FirstOrDefault(m => m.Files.Contains(file)) ?? throw new InvalidOperationException($"Could not find manifest containing file {file.RelativePath}");
         await ProcessLocalFileAsync(file, manifest, targetPath, configuration, cancellationToken);
     }
 }

--- a/GenHub/GenHub/Features/Workspace/WorkspaceReconciler.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceReconciler.cs
@@ -42,7 +42,7 @@ public class WorkspaceReconciler(ILogger<WorkspaceReconciler> logger)
 
         foreach (var manifest in configuration.Manifests)
         {
-            foreach (var file in manifest.Files ?? Enumerable.Empty<ManifestFile>())
+            foreach (var file in (manifest.Files ?? Enumerable.Empty<ManifestFile>()).Where(f => f.InstallTarget == ContentInstallTarget.Workspace))
             {
                 var relativePath = file.RelativePath.Replace('/', Path.DirectorySeparatorChar);
 


### PR DESCRIPTION
This PR ensures that files not intended for the game workspace (such as maps and user data) are excluded from workspace linking and reconciliation. It introduces filtering through a `GetWorkspaceUniqueFiles` extension and refactors all strategies to focus only on workspace content.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a filtering mechanism to ensure workspace strategies and reconciliation only process files intended for the game workspace, excluding user data files like maps, replays, and screenshots. The implementation adds a new `GetWorkspaceUniqueFiles()` extension method that filters files by `InstallTarget.Workspace`, and updates all four workspace strategies (FullCopy, HardLink, HybridCopySymlink, SymlinkOnly) plus the WorkspaceReconciler to use this filtered set.

**Key Changes:**
- New extension method `GetWorkspaceUniqueFiles()` filters files by `ContentInstallTarget.Workspace` before deduplication
- All strategies now use the filtered method instead of `GetAllUniqueFiles()` to prevent non-workspace files from being processed
- WorkspaceReconciler applies the same filtering to ensure only workspace files are tracked in delta analysis
- `ResolveTargetPath()` refactored to remove unused manifest parameter and handle non-workspace targets gracefully with warnings
- Comprehensive test added verifying non-workspace files are excluded from all file operations
- Minor improvements: structured logging parameters, throw expressions for null checks, `GC.SuppressFinalize` in test cleanup

The changes are well-architected and maintain backward compatibility while fixing a logical issue where workspace operations were incorrectly handling files meant for other install targets.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The refactoring is focused and well-tested with a new comprehensive test covering all strategies. The implementation is consistent across all affected files, uses proper filtering at the source (extension method), and includes defensive fallback handling. Code quality improvements align with style guide, and the changes fix a real logical issue without breaking existing functionality.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Extensions/WorkspaceConfigurationExtensions.cs | Added new `GetWorkspaceUniqueFiles` extension method that filters files by `InstallTarget.Workspace`, complementing existing `GetAllUniqueFiles` method |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs | Added comprehensive test verifying all strategies exclude non-workspace files from file operations, plus proper `GC.SuppressFinalize` call in Dispose |
| GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs | Refactored `ResolveTargetPath` to remove manifest parameter and handle non-workspace targets gracefully with warning logging instead of throwing exceptions |
| GenHub/GenHub/Features/Workspace/WorkspaceReconciler.cs | Applied workspace file filtering in delta analysis to ensure only workspace-targeted files are tracked for reconciliation |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Strategy as WorkspaceStrategy
    participant Extensions as WorkspaceConfigurationExtensions
    participant Config as WorkspaceConfiguration
    participant Reconciler as WorkspaceReconciler
    
    Note over Strategy,Reconciler: Workspace Preparation Flow
    
    Strategy->>Extensions: GetWorkspaceUniqueFiles(config)
    Extensions->>Config: Get Manifests
    Config-->>Extensions: List of Manifests
    Extensions->>Extensions: SelectMany(Files) + Filter by InstallTarget.Workspace
    Extensions->>Extensions: GroupBy(RelativePath) + Deduplicate
    Extensions-->>Strategy: Workspace-only files
    
    Strategy->>Strategy: Process each workspace file
    Strategy->>Strategy: Copy/Link/Symlink operations
    
    Note over Reconciler: Workspace Reconciliation Flow
    
    Reconciler->>Config: Get Manifests
    Config-->>Reconciler: List of Manifests
    Reconciler->>Reconciler: Filter files by InstallTarget.Workspace
    Reconciler->>Reconciler: Build expected files dictionary
    Reconciler->>Reconciler: Compare with existing workspace
    Reconciler-->>Strategy: Delta operations (Add/Update/Remove/Skip)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->