### PR TITLE
feat: add a tracker for total installs and updates on github

### DIFF
--- a/Landing-page/index.html
+++ b/Landing-page/index.html
@@ -347,8 +347,10 @@
             owner: 'community-outpost',
             repo: 'GenHub',
             cacheKey: 'genhub_stats_v1',
-            apiUrl: 'https://api.github.com/repos/community-outpost/GenHub/releases?per_page=100'
+            perPage: 100
           };
+
+          const apiUrl = `https://api.github.com/repos/${CONFIG.owner}/${CONFIG.repo}/releases?per_page=${CONFIG.perPage}`;
 
           // Initialize
           document.addEventListener('DOMContentLoaded', initStats);
@@ -357,8 +359,13 @@
             // Check cache first (session-only to ensure fresh data per visit)
             const cached = sessionStorage.getItem(CONFIG.cacheKey);
             if (cached) {
-              renderStats(JSON.parse(cached));
-              return;
+              try {
+                renderStats(JSON.parse(cached));
+                return;
+              } catch (parseError) {
+                // Cache is corrupted, clear it and proceed to fetch
+                sessionStorage.removeItem(CONFIG.cacheKey);
+              }
             }
 
             try {
@@ -372,8 +379,13 @@
           }
 
           async function fetchGitHubStats() {
-            const response = await fetch(CONFIG.apiUrl);
-            
+            // Add timeout to prevent indefinite hanging
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+
+            const response = await fetch(apiUrl, { signal: controller.signal });
+            clearTimeout(timeoutId);
+
             if (response.status === 403) {
               throw new Error('Rate limit exceeded. Try again later.');
             }
@@ -395,7 +407,7 @@
                 const name = asset.name.toLowerCase();
                 
                 // Setup.exe = Fresh installs
-                if (name.endsWith('-setup.exe') || name.endsWith('.exe') && !name.includes('full') && !name.includes('delta')) {
+                if (name.endsWith('-setup.exe') || (name.endsWith('.exe') && !name.includes('full') && !name.includes('delta'))) {
                   releaseInstalls += asset.download_count;
                 }
                 // .nupkg = Updates (both full and delta count as update mechanisms)


### PR DESCRIPTION
This PR adds a simple tracker showing how many installs and updates are there for GenHub

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Added a GitHub stats tracking widget to the landing page that displays total installs and updates for GenHub releases. The widget fetches data from the GitHub Releases API, categorizes downloads by file type (setup executables vs update packages), and caches results in sessionStorage for the browser session.

**Key implementation details:**
- Tracks installs via `-setup.exe` files and `.exe` files without 'full'/'delta' keywords
- Tracks updates via `.nupkg` files (Velopack update packages)
- Includes 10-second timeout protection for API calls
- Handles API rate limiting (403 errors) gracefully
- Uses animated number counting for visual polish
- Hover tooltip shows per-release breakdown
- XSS protection via `escapeHtml()` utility

**Code quality:**
- Clean implementation with proper error handling
- Session-only caching prevents stale data
- Follows conventional commits format
- All event handlers properly scoped in IIFE
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with low risk - it adds a self-contained stats widget with proper error handling
- Score reflects well-structured implementation with timeout protection, error handling, and XSS prevention. Deducted one point because inline styles/scripts in HTML aren't ideal for maintainability, though acceptable for a simple landing page
- No files require special attention - the single changed file has been thoroughly reviewed
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Landing-page/index.html | Added GitHub stats widget showing install/update counts with hover breakdown, uses sessionStorage caching and proper error handling |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant SessionStorage
    participant GitHubAPI
    participant StatsWidget

    User->>Browser: Load landing page
    Browser->>StatsWidget: DOMContentLoaded event
    StatsWidget->>SessionStorage: Check for cached stats (genhub_stats_v1)
    
    alt Cache exists
        SessionStorage-->>StatsWidget: Return cached data
        StatsWidget->>StatsWidget: Parse JSON
        alt Parse successful
            StatsWidget->>Browser: renderStats(cached data)
            Browser->>User: Display animated stats
        else Parse fails
            StatsWidget->>SessionStorage: Remove corrupted cache
            StatsWidget->>GitHubAPI: Fetch releases (timeout: 10s)
        end
    else No cache
        StatsWidget->>GitHubAPI: Fetch releases (timeout: 10s)
    end
    
    alt API success
        GitHubAPI-->>StatsWidget: Return releases JSON
        StatsWidget->>StatsWidget: Process assets (categorize by file type)
        StatsWidget->>StatsWidget: Calculate totals (installs vs updates)
        StatsWidget->>SessionStorage: Cache processed data
        StatsWidget->>Browser: renderStats(data)
        Browser->>User: Display animated stats
    else API fails (403/timeout/error)
        GitHubAPI-->>StatsWidget: Error
        StatsWidget->>Browser: Display error message
        Browser->>User: Show "-" for stats
    end
    
    User->>Browser: Hover over stats card
    Browser->>User: Show release breakdown tooltip
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->