### PR TITLE
feat(website): add a tracker for total installs and updates on github for the website (#270)

### DIFF
--- a/Landing-page/index.html
+++ b/Landing-page/index.html
@@ -347,8 +347,10 @@
             owner: 'community-outpost',
             repo: 'GenHub',
             cacheKey: 'genhub_stats_v1',
-            apiUrl: 'https://api.github.com/repos/community-outpost/GenHub/releases?per_page=100'
+            perPage: 100
           };
+
+          const apiUrl = `https://api.github.com/repos/${CONFIG.owner}/${CONFIG.repo}/releases?per_page=${CONFIG.perPage}`;
 
           // Initialize
           document.addEventListener('DOMContentLoaded', initStats);
@@ -357,8 +359,13 @@
             // Check cache first (session-only to ensure fresh data per visit)
             const cached = sessionStorage.getItem(CONFIG.cacheKey);
             if (cached) {
-              renderStats(JSON.parse(cached));
-              return;
+              try {
+                renderStats(JSON.parse(cached));
+                return;
+              } catch (parseError) {
+                // Cache is corrupted, clear it and proceed to fetch
+                sessionStorage.removeItem(CONFIG.cacheKey);
+              }
             }
 
             try {
@@ -372,8 +379,13 @@
           }
 
           async function fetchGitHubStats() {
-            const response = await fetch(CONFIG.apiUrl);
-            
+            // Add timeout to prevent indefinite hanging
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+
+            const response = await fetch(apiUrl, { signal: controller.signal });
+            clearTimeout(timeoutId);
+
             if (response.status === 403) {
               throw new Error('Rate limit exceeded. Try again later.');
             }
@@ -395,7 +407,7 @@
                 const name = asset.name.toLowerCase();
                 
                 // Setup.exe = Fresh installs
-                if (name.endsWith('-setup.exe') || name.endsWith('.exe') && !name.includes('full') && !name.includes('delta')) {
+                if (name.endsWith('-setup.exe') || (name.endsWith('.exe') && !name.includes('full') && !name.includes('delta'))) {
                   releaseInstalls += asset.download_count;
                 }
                 // .nupkg = Updates (both full and delta count as update mechanisms)


### PR DESCRIPTION
See (#270) for the PR

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an interactive stats widget to the landing page that tracks total installs and updates from GitHub releases. The widget fetches release data from the GitHub API, categorizes downloads based on Velopack naming conventions (`-setup.exe` for installs, `.nupkg` for updates), and displays aggregated statistics with a hover-to-reveal breakdown by version.

**Key Changes:**
- Added CSS styling for stats card with hover effects and tooltip animations
- Implemented JavaScript module with session-based caching to reduce API calls
- Includes proper error handling for rate limits, timeouts (10s), and network failures
- Uses XSS protection via `escapeHtml()` for user-visible data
- Provides smooth number animations using `requestAnimationFrame`

**Implementation Quality:**
- Well-structured code with clear separation of concerns
- Graceful degradation when API is unavailable
- Responsive design consistent with existing landing page styles
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor considerations for responsive design testing
- The implementation demonstrates good engineering practices with proper error handling, security considerations (XSS prevention, timeouts), and performance optimizations (caching). Code is well-documented and follows consistent patterns. Score is 4/5 rather than 5/5 because the widget uses fixed width (280px) which may need responsive design verification on mobile devices, and the API rate limiting could affect users on shared IPs during high traffic.
- No files require special attention - the implementation is clean and well-structured
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Landing-page/index.html | Added GitHub stats widget with install/update tracking, proper error handling, caching, and XSS protection |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant SessionStorage
    participant GitHubAPI
    participant StatsWidget

    User->>Browser: Load Landing Page
    Browser->>StatsWidget: DOMContentLoaded Event
    StatsWidget->>SessionStorage: Check for cached stats (genhub_stats_v1)
    
    alt Cache exists
        SessionStorage-->>StatsWidget: Return cached data
        StatsWidget->>StatsWidget: Parse JSON
        StatsWidget->>Browser: renderStats(data)
        Browser->>User: Display stats with animation
    else Cache missing or corrupted
        StatsWidget->>GitHubAPI: GET /repos/community-outpost/GenHub/releases
        Note over StatsWidget,GitHubAPI: 10 second timeout via AbortController
        
        alt Success (200 OK)
            GitHubAPI-->>StatsWidget: Return releases array
            StatsWidget->>StatsWidget: Process releases & categorize assets
            Note over StatsWidget: -setup.exe → installs<br/>.nupkg → updates
            StatsWidget->>StatsWidget: Calculate totals & history
            StatsWidget->>SessionStorage: Cache processed data
            StatsWidget->>Browser: renderStats(data)
            Browser->>User: Display stats with animation
        else Rate Limited (403)
            GitHubAPI-->>StatsWidget: 403 Forbidden
            StatsWidget->>Browser: handleError("Rate limit exceeded")
            Browser->>User: Display error message
        else Timeout or Error
            GitHubAPI-->>StatsWidget: Error/Timeout
            StatsWidget->>Browser: handleError(error)
            Browser->>User: Display error message
        end
    end
    
    User->>Browser: Hover over stats card
    Browser->>User: Show tooltip with release breakdown
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->