### PR TITLE
fix: reorganize settings UI, fix content priority resolution, and eliminate CAS warnings

### DIFF
--- a/GenHub/Directory.Build.props
+++ b/GenHub/Directory.Build.props
@@ -14,6 +14,7 @@
     <_NumericVersion Condition="!$(Version.Contains('-'))">$(Version)</_NumericVersion>
     <AssemblyVersion>$(_NumericVersion)</AssemblyVersion>
     <FileVersion>$(_NumericVersion)</FileVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!-- Make version available to source generators / build-time code -->
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/GenHub/GenHub.Core/Constants/FileTypes.cs
+++ b/GenHub/GenHub.Core/Constants/FileTypes.cs
@@ -84,4 +84,9 @@ public static class FileTypes
     /// File extension for user data manifest files.
     /// </summary>
     public const string UserDataManifestExtension = ".userdata.json";
+
+    /// <summary>
+    /// File name for source path mapping files.
+    /// </summary>
+    public const string SourcePathFileName = "source.path";
 }

--- a/GenHub/GenHub.Core/Constants/FileTypes.cs
+++ b/GenHub/GenHub.Core/Constants/FileTypes.cs
@@ -86,7 +86,9 @@ public static class FileTypes
     public const string UserDataManifestExtension = ".userdata.json";
 
     /// <summary>
-    /// File name for source path mapping files.
+    /// Filename used to store the source directory path mapping for a manifest's content.
+    /// This file is written inside the manifest's data directory and contains the path
+    /// to the original source directory (e.g., local installation folder).
     /// </summary>
     public const string SourcePathFileName = "source.path";
 }

--- a/GenHub/GenHub.Core/Constants/FileTypes.cs
+++ b/GenHub/GenHub.Core/Constants/FileTypes.cs
@@ -91,4 +91,10 @@ public static class FileTypes
     /// to the original source directory (e.g., local installation folder).
     /// </summary>
     public const string SourcePathFileName = "source.path";
+
+    /// <summary>
+    /// Sentinel value written to <see cref="SourcePathFileName"/> when content is stored
+    /// via CAS and has no source directory.
+    /// </summary>
+    public const string CasOnlySourceMarker = "CAS-ONLY";
 }

--- a/GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs
+++ b/GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs
@@ -161,38 +161,6 @@ public static class GenPatcherContentRegistry
             Variants = ResolutionVariants,
         },
 
-        // Camera Modifications
-        ["crgn"] = new GenPatcherContentMetadata
-        {
-            ContentCode = "crgn",
-            DisplayName = "Camera Mod - Generals",
-            Description = "Camera modification for Generals",
-            ContentType = ContentType.Addon,
-            TargetGame = GameType.Generals,
-            Category = GenPatcherContentCategory.Camera,
-            InstallTarget = ContentInstallTarget.Workspace,
-        },
-        ["crzh"] = new GenPatcherContentMetadata
-        {
-            ContentCode = "crzh",
-            DisplayName = "Camera Mod - Zero Hour",
-            Description = "Camera modification for Zero Hour",
-            ContentType = ContentType.Addon,
-            TargetGame = GameType.ZeroHour,
-            Category = GenPatcherContentCategory.Camera,
-            InstallTarget = ContentInstallTarget.Workspace,
-        },
-        ["dczh"] = new GenPatcherContentMetadata
-        {
-            ContentCode = "dczh",
-            DisplayName = "D-Control - Zero Hour",
-            Description = "D-Control camera for Zero Hour",
-            ContentType = ContentType.Addon,
-            TargetGame = GameType.ZeroHour,
-            Category = GenPatcherContentCategory.Camera,
-            InstallTarget = ContentInstallTarget.Workspace,
-        },
-
         // Hotkeys
         ["ewba"] = new GenPatcherContentMetadata
         {

--- a/GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs
+++ b/GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs
@@ -161,6 +161,38 @@ public static class GenPatcherContentRegistry
             Variants = ResolutionVariants,
         },
 
+        // Camera Modifications
+        ["crgn"] = new GenPatcherContentMetadata
+        {
+            ContentCode = "crgn",
+            DisplayName = "Camera Mod - Generals",
+            Description = "Camera modification for Generals",
+            ContentType = ContentType.Addon,
+            TargetGame = GameType.Generals,
+            Category = GenPatcherContentCategory.Camera,
+            InstallTarget = ContentInstallTarget.Workspace,
+        },
+        ["crzh"] = new GenPatcherContentMetadata
+        {
+            ContentCode = "crzh",
+            DisplayName = "Camera Mod - Zero Hour",
+            Description = "Camera modification for Zero Hour",
+            ContentType = ContentType.Addon,
+            TargetGame = GameType.ZeroHour,
+            Category = GenPatcherContentCategory.Camera,
+            InstallTarget = ContentInstallTarget.Workspace,
+        },
+        ["dczh"] = new GenPatcherContentMetadata
+        {
+            ContentCode = "dczh",
+            DisplayName = "D-Control - Zero Hour",
+            Description = "D-Control camera for Zero Hour",
+            ContentType = ContentType.Addon,
+            TargetGame = GameType.ZeroHour,
+            Category = GenPatcherContentCategory.Camera,
+            InstallTarget = ContentInstallTarget.Workspace,
+        },
+
         // Hotkeys
         ["ewba"] = new GenPatcherContentMetadata
         {

--- a/GenHub/GenHub.Core/Models/Storage/CasConfiguration.cs
+++ b/GenHub/GenHub.Core/Models/Storage/CasConfiguration.cs
@@ -130,7 +130,15 @@ public class CasConfiguration : ICloneable
             if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
                 throw new DirectoryNotFoundException($"Parent directory of CasRootPath does not exist: {parentDir}");
         }
-        catch (Exception ex) when (!(ex is ArgumentException || ex is DirectoryNotFoundException))
+        catch (ArgumentException)
+        {
+            throw;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             throw new ArgumentException($"Invalid CasRootPath: {CasRootPath}", ex);
         }

--- a/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
+++ b/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
@@ -1,3 +1,4 @@
+using System;
 using GenHub.Core.Models.Enums;
 
 namespace GenHub.Core.Models.Workspace;
@@ -14,6 +15,7 @@ public static class ContentTypePriority
     /// </summary>
     /// <param name="contentType">The content type.</param>
     /// <returns>Priority value (0-100).</returns>
+    /// <exception cref="ArgumentException">Thrown when the content type should not be in a workspace.</exception>
     public static int GetPriority(ContentType contentType)
     {
         return contentType switch
@@ -21,9 +23,26 @@ public static class ContentTypePriority
             ContentType.Mod => 100,                // Highest: User mods override everything
             ContentType.Patch => 90,               // Patches override base content
             ContentType.GameClient => 50,          // Community executables override official
+            ContentType.ModdingTool => 45,         // Modding tools (between Addon and GameClient)
+            ContentType.Executable => 45,          // Executables (between Addon and GameClient)
             ContentType.Addon => 40,               // Addons (maps, etc.)
+            ContentType.LanguagePack => 35,        // Language packs
+            ContentType.MapPack => 30,             // Map packs (between GameInstallation and Addon)
+            ContentType.Map => 30,                 // Individual maps
+            ContentType.Mission => 30,             // Missions
+            ContentType.Skin => 20,                // Skins
+            ContentType.Video => 20,               // Videos
+            ContentType.Replay => 20,              // Replays
+            ContentType.Screensaver => 20,         // Screensavers
             ContentType.GameInstallation => 10,    // Lowest: Base game files
-            _ => 0,                                // Unknown/undefined types
+
+            // These types should not be in workspaces
+            ContentType.ContentBundle => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
+            ContentType.PublisherReferral => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
+            ContentType.ContentReferral => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
+            ContentType.UnknownContentType => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
+
+            _ => throw new ArgumentException($"Unknown ContentType: {contentType}"),
         };
     }
 

--- a/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
+++ b/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
@@ -42,7 +42,11 @@ public static class ContentTypePriority
             ContentType.ContentReferral => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
             ContentType.UnknownContentType => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
 
-            _ => throw new ArgumentException($"Unknown ContentType: {contentType}"),
+            _ => throw new ArgumentOutOfRangeException(
+                     nameof(contentType),
+                     contentType,
+                     $"ContentType '{contentType}' is not mapped in {nameof(ContentTypePriority)}. " +
+                     "Add an explicit priority entry for this type.")
         };
     }
 

--- a/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
+++ b/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
@@ -42,11 +42,7 @@ public static class ContentTypePriority
             ContentType.ContentReferral => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
             ContentType.UnknownContentType => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
 
-            _ => throw new ArgumentOutOfRangeException(
-                     nameof(contentType),
-                     contentType,
-                     $"ContentType '{contentType}' is not mapped in {nameof(ContentTypePriority)}. " +
-                     "Add an explicit priority entry for this type.")
+            _ => throw new ArgumentOutOfRangeException(nameof(contentType), contentType, $"ContentType '{contentType}' is not mapped in {nameof(ContentTypePriority)}. Add an explicit priority entry for this type."),
         };
     }
 

--- a/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
+++ b/GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs
@@ -15,7 +15,6 @@ public static class ContentTypePriority
     /// </summary>
     /// <param name="contentType">The content type.</param>
     /// <returns>Priority value (0-100).</returns>
-    /// <exception cref="ArgumentException">Thrown when the content type should not be in a workspace.</exception>
     public static int GetPriority(ContentType contentType)
     {
         return contentType switch
@@ -35,14 +34,7 @@ public static class ContentTypePriority
             ContentType.Replay => 20,              // Replays
             ContentType.Screensaver => 20,         // Screensavers
             ContentType.GameInstallation => 10,    // Lowest: Base game files
-
-            // These types should not be in workspaces
-            ContentType.ContentBundle => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
-            ContentType.PublisherReferral => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
-            ContentType.ContentReferral => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
-            ContentType.UnknownContentType => throw new ArgumentException($"ContentType {contentType} should not be used in workspace priority resolution"),
-
-            _ => throw new ArgumentOutOfRangeException(nameof(contentType), contentType, $"ContentType '{contentType}' is not mapped in {nameof(ContentTypePriority)}. Add an explicit priority entry for this type."),
+            _ => 0,                                // Unknown or meta types (bundles, referrals, etc.)
         };
     }
 

--- a/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
+++ b/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
@@ -14,6 +14,7 @@ public class JsonWorkspaceStrategyConverter : JsonConverter<WorkspaceStrategy>
 {
     /// <inheritdoc />
     [SuppressMessage("Maintainability", "CS-R1138:Inappropriate ordering of parameters", Justification = "Signature is defined by System.Text.Json.Serialization.JsonConverter<T>.Read")]
+    [SuppressMessage("DeepSource", "CS-R1138", Justification = "Signature is defined by System.Text.Json.Serialization.JsonConverter<T>.Read")]
     public override WorkspaceStrategy Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Number)

--- a/GenHub/GenHub.MacOS/GameInstallations/MacOSInstallationDetector.cs
+++ b/GenHub/GenHub.MacOS/GameInstallations/MacOSInstallationDetector.cs
@@ -227,7 +227,12 @@ public class MacOSInstallationDetector(ILogger<MacOSInstallationDetector> logger
             {
                 bottles = Directory.Exists(container) ? Directory.GetDirectories(container) : [];
             }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            catch (IOException)
+            {
+                // An unreadable bottle container is not a detection failure.
+                continue;
+            }
+            catch (UnauthorizedAccessException)
             {
                 // An unreadable bottle container is not a detection failure.
                 continue;

--- a/GenHub/GenHub.ProxyLauncher/Program.cs
+++ b/GenHub/GenHub.ProxyLauncher/Program.cs
@@ -30,6 +30,8 @@ internal class Program
             return 0;
         }
 
+        GC.KeepAlive(mutex);
+
         try
         {
             var configPath = Path.Combine(baseDir, ConfigFileName);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,6 +81,7 @@ public class ContentReconciliationServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
+    [SuppressMessage("DeepSource", "CS-R1136", Justification = "Expression tree lambdas in Moq do not support null propagation")]
     public async Task OrchestrateLocalUpdateAsync_WhenIdChanges_ShouldAddManifestToPool_AndUpdateProfilesAsync()
     {
         // Arrange

--- a/GenHub/GenHub.Windows/Features/Workspace/WindowsSymlinkCapabilityProvider.cs
+++ b/GenHub/GenHub.Windows/Features/Workspace/WindowsSymlinkCapabilityProvider.cs
@@ -33,7 +33,11 @@ public sealed class WindowsSymlinkCapabilityProvider : ISymlinkCapabilityProvide
             File.CreateSymbolicLink(linkPath, targetPath);
             return new FileInfo(linkPath).LinkTarget is not null;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
         {
             return false;
         }
@@ -50,7 +54,11 @@ public sealed class WindowsSymlinkCapabilityProvider : ISymlinkCapabilityProvide
         {
             File.Delete(path);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (IOException)
+        {
+            // Best-effort cleanup of a uniquely named temporary probe.
+        }
+        catch (UnauthorizedAccessException)
         {
             // Best-effort cleanup of a uniquely named temporary probe.
         }

--- a/GenHub/GenHub/Common/Services/StorageWritabilityProbe.cs
+++ b/GenHub/GenHub/Common/Services/StorageWritabilityProbe.cs
@@ -31,7 +31,22 @@ public class StorageWritabilityProbe(ILogger<StorageWritabilityProbe> logger) : 
         {
             fullStoragePath = Path.GetFullPath(storagePath);
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or SecurityException or IOException)
+        catch (ArgumentException ex)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
+            return false;
+        }
+        catch (NotSupportedException ex)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
+            return false;
+        }
+        catch (SecurityException ex)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
+            return false;
+        }
+        catch (IOException ex)
         {
             logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
             return false;
@@ -53,7 +68,19 @@ public class StorageWritabilityProbe(ILogger<StorageWritabilityProbe> logger) : 
         {
             _results.TryRemove(Path.GetFullPath(storagePath), out _);
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or SecurityException or IOException)
+        catch (ArgumentException ex)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved for invalidation", storagePath);
+        }
+        catch (NotSupportedException ex)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved for invalidation", storagePath);
+        }
+        catch (SecurityException ex)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved for invalidation", storagePath);
+        }
+        catch (IOException ex)
         {
             logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved for invalidation", storagePath);
         }
@@ -85,9 +112,29 @@ public class StorageWritabilityProbe(ILogger<StorageWritabilityProbe> logger) : 
             probeSucceeded = true;
             return true;
         }
-        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or SecurityException)
+        catch (UnauthorizedAccessException)
         {
-            logger.LogDebug(ex, "Storage path {StoragePath} is not writable", fullStoragePath);
+            logger.LogDebug("Storage path {StoragePath} is not writable", fullStoragePath);
+            return false;
+        }
+        catch (IOException)
+        {
+            logger.LogDebug("Storage path {StoragePath} is not writable", fullStoragePath);
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            logger.LogDebug("Storage path {StoragePath} is not writable", fullStoragePath);
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            logger.LogDebug("Storage path {StoragePath} is not writable", fullStoragePath);
+            return false;
+        }
+        catch (SecurityException)
+        {
+            logger.LogDebug("Storage path {StoragePath} is not writable", fullStoragePath);
             return false;
         }
         finally
@@ -98,9 +145,13 @@ public class StorageWritabilityProbe(ILogger<StorageWritabilityProbe> logger) : 
                 {
                     File.Delete(probePath);
                 }
-                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                catch (UnauthorizedAccessException)
                 {
-                    logger.LogDebug(ex, "Could not remove storage write probe {ProbePath}", probePath);
+                    logger.LogDebug("Could not remove storage write probe {ProbePath}", probePath);
+                }
+                catch (IOException)
+                {
+                    logger.LogDebug("Could not remove storage write probe {ProbePath}", probePath);
                 }
             }
 
@@ -114,9 +165,17 @@ public class StorageWritabilityProbe(ILogger<StorageWritabilityProbe> logger) : 
                         Directory.Delete(fullStoragePath);
                     }
                 }
-                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or SecurityException)
+                catch (UnauthorizedAccessException)
                 {
-                    logger.LogDebug(ex, "Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
+                    logger.LogDebug("Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
+                }
+                catch (IOException)
+                {
+                    logger.LogDebug("Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
+                }
+                catch (SecurityException)
+                {
+                    logger.LogDebug("Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
                 }
             }
         }

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -3,11 +3,15 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using GenHub.Common.ViewModels.Dialogs;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Notifications;
 using GenHub.Core.Messages;
@@ -415,5 +419,34 @@ public partial class MainViewModel(
         }
 
         SaveSelectedTab(value);
+    }
+
+    /// <summary>
+    /// Copies the application version to the clipboard.
+    /// </summary>
+    [RelayCommand]
+    private async Task CopyVersionToClipboard()
+    {
+        try
+        {
+            var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+            var mainWindow = lifetime?.MainWindow;
+            var topLevel = mainWindow != null ? TopLevel.GetTopLevel(mainWindow) : null;
+
+            if (topLevel?.Clipboard != null)
+            {
+                await topLevel.Clipboard.SetTextAsync(AppConstants.FullDisplayVersion);
+                notificationService.ShowSuccess("Copied", "Version copied to clipboard.", 3000);
+            }
+            else
+            {
+                notificationService.ShowError("Error", "Clipboard not available.", 3000);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Failed to copy version to clipboard");
+            notificationService.ShowError("Error", "Failed to copy version to clipboard.", 3000);
+        }
     }
 }

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -245,22 +245,19 @@ public partial class MainViewModel(
                 if (updateInfo != null)
                 {
                     logger?.LogInformation("GitHub release update available: {Version}", updateInfo.TargetFullRelease.Version);
-                    await Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        notificationService.Show(new NotificationMessage(
-                            NotificationType.Info,
-                            "Update Available",
-                            $"A new version ({updateInfo.TargetFullRelease.Version}) is available.",
-                            null, // Persistent
-                            actions:
-                            [
-                                new NotificationAction(
-                                    "View Updates",
-                                    () => { SettingsViewModel.OpenUpdateWindowCommand.Execute(null); },
-                                    NotificationActionStyle.Primary,
-                                    dismissOnExecute: true),
-                            ]));
-                    });
+                    await Dispatcher.UIThread.InvokeAsync(() => notificationService.Show(new NotificationMessage(
+                        NotificationType.Info,
+                        "Update Available",
+                        $"A new version ({updateInfo.TargetFullRelease.Version}) is available.",
+                        null, // Persistent
+                        actions:
+                        [
+                            new NotificationAction(
+                                "View Updates",
+                                () => SettingsViewModel.OpenUpdateWindowCommand.Execute(null),
+                                NotificationActionStyle.Primary,
+                                dismissOnExecute: true),
+                        ])));
                     return;
                 }
             }
@@ -277,22 +274,19 @@ public partial class MainViewModel(
                 {
                     var newVersionBase = artifactUpdate.Version.Split('+')[0];
 
-                    await Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        notificationService.Show(new NotificationMessage(
-                            NotificationType.Info,
-                            "Branch Update Available",
-                            $"A new build ({newVersionBase}) is available on branch '{settings.SubscribedBranch}'.",
-                            null, // Persistent
-                            actions:
-                            [
-                                new NotificationAction(
-                                    "View Updates",
-                                    () => { SettingsViewModel.OpenUpdateWindowCommand.Execute(null); },
-                                    NotificationActionStyle.Primary,
-                                    dismissOnExecute: true),
-                            ]));
-                    });
+                    await Dispatcher.UIThread.InvokeAsync(() => notificationService.Show(new NotificationMessage(
+                        NotificationType.Info,
+                        "Branch Update Available",
+                        $"A new build ({newVersionBase}) is available on branch '{settings.SubscribedBranch}'.",
+                        null, // Persistent
+                        actions:
+                        [
+                            new NotificationAction(
+                                "View Updates",
+                                () => SettingsViewModel.OpenUpdateWindowCommand.Execute(null),
+                                NotificationActionStyle.Primary,
+                                dismissOnExecute: true),
+                        ])));
                 }
             }
         }

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -426,11 +426,11 @@ public partial class MainViewModel(
         {
             var lifetime = Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
             var mainWindow = lifetime?.MainWindow;
-            var topLevel = mainWindow != null ? TopLevel.GetTopLevel(mainWindow) : null;
+            var topLevel = mainWindow is not null ? TopLevel.GetTopLevel(mainWindow) : null;
 
-            if (topLevel?.Clipboard != null)
+            if (topLevel?.Clipboard is { } clipboard)
             {
-                await topLevel.Clipboard.SetTextAsync(AppConstants.FullDisplayVersion);
+                await clipboard.SetTextAsync(AppConstants.FullDisplayVersion);
                 notificationService.ShowSuccess("Copied", "Version copied to clipboard.", 3000);
             }
             else

--- a/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/MainViewModel.cs
@@ -114,7 +114,7 @@ public partial class MainViewModel(
     /// <summary>
     /// Gets the available navigation tabs.
     /// </summary>
-    public NavigationTab[] AvailableTabs { get; } =
+    public IReadOnlyList<NavigationTab> AvailableTabs { get; } =
     [
         NavigationTab.GameProfiles,
         NavigationTab.Downloads,

--- a/GenHub/GenHub/Common/Views/MainView.axaml
+++ b/GenHub/GenHub/Common/Views/MainView.axaml
@@ -221,6 +221,14 @@
                     BorderThickness="0"
                     Cursor="Hand"
                     ToolTip.Tip="Click to copy full version (including git hash) to clipboard">
+                <Button.Styles>
+                    <Style Selector="Button:pointerover /template/ ContentPresenter">
+                        <Setter Property="Background" Value="Transparent" />
+                    </Style>
+                    <Style Selector="Button:pressed /template/ ContentPresenter">
+                        <Setter Property="Background" Value="Transparent" />
+                    </Style>
+                </Button.Styles>
                 <TextBlock Text="{x:Static constants:AppConstants.DisplayVersion}"
                            FontSize="9"
                            Foreground="#808080" />

--- a/GenHub/GenHub/Common/Views/MainView.axaml
+++ b/GenHub/GenHub/Common/Views/MainView.axaml
@@ -229,7 +229,7 @@
                         <Setter Property="Background" Value="Transparent" />
                     </Style>
                 </Button.Styles>
-                <TextBlock Text="{x:Static constants:AppConstants.DisplayVersion}"
+                <TextBlock Text="{x:Static constants:AppConstants.FullDisplayVersion}"
                            FontSize="9"
                            Foreground="#808080" />
             </Button>

--- a/GenHub/GenHub/Common/Views/MainView.axaml
+++ b/GenHub/GenHub/Common/Views/MainView.axaml
@@ -220,7 +220,7 @@
                     Background="Transparent"
                     BorderThickness="0"
                     Cursor="Hand"
-                    ToolTip.Tip="Click to copy version to clipboard">
+                    ToolTip.Tip="Click to copy full version (including git hash) to clipboard">
                 <TextBlock Text="{x:Static constants:AppConstants.DisplayVersion}"
                            FontSize="9"
                            Foreground="#808080" />

--- a/GenHub/GenHub/Common/Views/MainView.axaml
+++ b/GenHub/GenHub/Common/Views/MainView.axaml
@@ -212,12 +212,19 @@
         <Grid Grid.Row="1">
             <ContentControl Content="{Binding CurrentTabViewModel}" />
             <!-- Version label in bottom right corner -->
-            <TextBlock Text="{x:Static constants:AppConstants.DisplayVersion}"
-                       FontSize="9"
-                       Foreground="#808080"
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Bottom"
-                       Margin="0,0,10,5" />
+            <Button Command="{Binding CopyVersionToClipboardCommand}"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Bottom"
+                    Margin="0,0,10,5"
+                    Padding="0"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    ToolTip.Tip="Click to copy version to clipboard">
+                <TextBlock Text="{x:Static constants:AppConstants.DisplayVersion}"
+                           FontSize="9"
+                           Foreground="#808080" />
+            </Button>
         </Grid>
     </Grid>
 </UserControl>

--- a/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
@@ -135,8 +135,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
         try
         {
-            // Extract owner and repo from URL
-            // Format: https://github.com/owner/repo
             var uri = new Uri(AppConstants.GitHubRepositoryUrl);
             var pathParts = uri.AbsolutePath.Trim('/').Split('/');
             if (pathParts.Length < 2)
@@ -150,49 +148,10 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
             _logger.LogInformation("🔍 Fetching releases from GitHub API: {Owner}/{Repo}", owner, repo);
 
-            // Call GitHub API to get latest release with retries
-            var apiUrl = $"https://api.github.com/repos/{owner}/{repo}/releases";
-
-            // Use PAT if available to increase rate limits
-            HttpClient client;
-            if (_gitHubTokenStorage != null && await _gitHubTokenStorage.LoadTokenAsync() is { } token)
+            var json = await FetchGitHubReleasesJsonAsync(owner, repo, cancellationToken);
+            if (json == null)
             {
-                _logger.LogDebug("Using GitHub PAT for update check to increase rate limits");
-                client = CreateConfiguredHttpClientWithToken(token);
-            }
-            else
-            {
-                _logger.LogDebug("No GitHub PAT available for update check, using anonymous request");
-                client = CreateConfiguredHttpClient();
-            }
-
-            string json;
-            using (client)
-            {
-                var response = await SendWithRetryAsync(client, apiUrl, cancellationToken);
-
-                if (response == null || !response.IsSuccessStatusCode)
-                {
-                    _logger.LogError("GitHub API request failed after retries");
-
-                    // Fallback to UpdateManager if available
-                    if (_updateManager != null)
-                    {
-                        _logger.LogInformation("Falling back to UpdateManager.CheckForUpdatesAsync()");
-                        var updateInfo = await _updateManager.CheckForUpdatesAsync();
-                        if (updateInfo != null)
-                        {
-                            _cachedUpdateInfo = updateInfo;
-                            _lastUpdateCheckTime = DateTime.UtcNow;
-                        }
-
-                        return updateInfo;
-                    }
-
-                    return null;
-                }
-
-                json = await response.Content.ReadAsStringAsync(cancellationToken);
+                return await CheckViaUpdateManagerAsync();
             }
 
             JsonElement releases;
@@ -213,7 +172,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
                 return null;
             }
 
-            // Parse current version
             if (!SemanticVersion.TryParse(AppConstants.AppVersion, out var currentVersion))
             {
                 _logger.LogError("Failed to parse current version: {Version}", AppConstants.AppVersion);
@@ -222,34 +180,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
             _logger.LogDebug("Current version parsed: {Version}, Prerelease: {IsPrerelease}", currentVersion, currentVersion.IsPrerelease);
 
-            // Find the latest release (including prereleases)
-            SemanticVersion? latestVersion = null;
-            JsonElement? latestRelease = null;
-
-            foreach (var release in releases.EnumerateArray())
-            {
-                var tagName = release.GetProperty("tag_name").GetString();
-                if (string.IsNullOrEmpty(tagName))
-                    continue;
-
-                // Remove 'v' prefix if present
-                var versionString = tagName.TrimStart('v', 'V');
-
-                if (!SemanticVersion.TryParse(versionString, out var releaseVersion))
-                {
-                    _logger.LogDebug("Skipping release with invalid version: {TagName}", tagName);
-                    continue;
-                }
-
-                _logger.LogDebug("Found release: {Version}, Prerelease: {IsPrerelease}", releaseVersion, releaseVersion.IsPrerelease);
-
-                if (latestVersion == null || releaseVersion > latestVersion)
-                {
-                    latestVersion = releaseVersion;
-                    latestRelease = release;
-                }
-            }
-
+            var (latestVersion, latestRelease) = ParseLatestRelease(releases);
             if (latestVersion == null || latestRelease == null)
             {
                 _logger.LogWarning("No valid releases found");
@@ -259,7 +190,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             _logger.LogInformation("Latest available version: {Version}", latestVersion);
             _logger.LogInformation("Comparing: Current={Current} vs Latest={Latest}", currentVersion, latestVersion);
 
-            // Check if update is available
             if (latestVersion <= currentVersion)
             {
                 _logger.LogInformation("No update available. Current version {Current} is up to date", currentVersion);
@@ -269,51 +199,25 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             }
 
             _logger.LogInformation("Update available: Current={Current}, Latest={Latest}", currentVersion, latestVersion);
-
-            // Store GitHub update detection result
             _hasUpdateFromGitHub = true;
             _latestVersionFromGitHub = latestVersion.ToString();
 
-            // If UpdateManager is available, use it to get proper UpdateInfo
-            // Otherwise, return null (can still show user there's an update, but can't install)
             if (_updateManager != null)
             {
-                try
+                var updateInfo = await CheckViaUpdateManagerAsync();
+                if (updateInfo != null)
                 {
-                    _logger.LogDebug("Calling UpdateManager.CheckForUpdatesAsync()");
-
-                    var updateInfo = await _updateManager.CheckForUpdatesAsync();
-
-                    _logger.LogDebug("UpdateManager.CheckForUpdatesAsync() completed. UpdateInfo is null: {IsNull}", updateInfo == null);
-                    if (updateInfo != null)
-                    {
-                        _logger.LogDebug("UpdateInfo version: {Version}", updateInfo.TargetFullRelease.Version);
-                    }
-
-                    if (updateInfo != null)
-                    {
-                        _logger.LogInformation("✅ UpdateManager also confirmed update is available and can be installed");
-                        _cachedUpdateInfo = updateInfo;
-                        _lastUpdateCheckTime = DateTime.UtcNow;
-                        return updateInfo;
-                    }
-                    else
-                    {
-                        _logger.LogWarning("⚠️ UpdateManager returned NULL - no update found via Velopack (but GitHub says there is one)");
-                    }
+                    _logger.LogInformation("✅ UpdateManager also confirmed update is available and can be installed");
+                    return updateInfo;
                 }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "UpdateManager.CheckForUpdatesAsync failed");
-                    _logger.LogWarning("Update is available from GitHub, but cannot be downloaded/installed due to UpdateManager exception");
-                }
+
+                _logger.LogWarning("⚠️ UpdateManager returned NULL - no update found via Velopack (but GitHub says there is one)");
             }
             else
             {
                 _logger.LogWarning("⚠️ UpdateManager is NULL - was not initialized successfully");
             }
 
-            // Return null but flag is set (UI can show "update available" but disable install)
             _logger.LogWarning("⚠️ Update detected via GitHub API but UpdateManager unavailable (running from debug)");
             _logger.LogWarning("   Install the app using Setup.exe to enable automatic updates");
 
@@ -1079,6 +983,21 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
         return null;
     }
 
+    private static string? GetCurrentPlatformFilter()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "windows";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return "linux";
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Uses a SecureString as plain text in a callback to minimize memory exposure.
     /// </summary>
@@ -1273,6 +1192,141 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
         return response;
     }
 
+    private async Task<string?> FetchGitHubReleasesJsonAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var apiUrl = $"https://api.github.com/repos/{owner}/{repo}/releases";
+        HttpClient client;
+        if (_gitHubTokenStorage != null && await _gitHubTokenStorage.LoadTokenAsync() is { } token)
+        {
+            _logger.LogDebug("Using GitHub PAT for update check to increase rate limits");
+            client = CreateConfiguredHttpClientWithToken(token);
+        }
+        else
+        {
+            _logger.LogDebug("No GitHub PAT available for update check, using anonymous request");
+            client = CreateConfiguredHttpClient();
+        }
+
+        using (client)
+        {
+            var response = await SendWithRetryAsync(client, apiUrl, cancellationToken);
+            if (response == null || !response.IsSuccessStatusCode)
+            {
+                _logger.LogError("GitHub API request failed after retries");
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync(cancellationToken);
+        }
+    }
+
+    private (SemanticVersion? Version, JsonElement? Release) ParseLatestRelease(JsonElement releases)
+    {
+        SemanticVersion? latestVersion = null;
+        JsonElement? latestRelease = null;
+
+        foreach (var release in releases.EnumerateArray())
+        {
+            var tagName = release.GetProperty("tag_name").GetString();
+            if (string.IsNullOrEmpty(tagName))
+            {
+                continue;
+            }
+
+            var versionString = tagName.TrimStart('v', 'V');
+            if (!SemanticVersion.TryParse(versionString, out var releaseVersion))
+            {
+                _logger.LogDebug("Skipping release with invalid version: {TagName}", tagName);
+                continue;
+            }
+
+            _logger.LogDebug("Found release: {Version}, Prerelease: {IsPrerelease}", releaseVersion, releaseVersion.IsPrerelease);
+
+            if (latestVersion == null || releaseVersion > latestVersion)
+            {
+                latestVersion = releaseVersion;
+                latestRelease = release;
+            }
+        }
+
+        return (latestVersion, latestRelease);
+    }
+
+    private async Task<UpdateInfo?> CheckViaUpdateManagerAsync()
+    {
+        if (_updateManager == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            _logger.LogDebug("Calling UpdateManager.CheckForUpdatesAsync()");
+            var updateInfo = await _updateManager.CheckForUpdatesAsync();
+            if (updateInfo != null)
+            {
+                _logger.LogDebug("UpdateInfo version: {Version}", updateInfo.TargetFullRelease.Version);
+                _cachedUpdateInfo = updateInfo;
+                _lastUpdateCheckTime = DateTime.UtcNow;
+            }
+
+            return updateInfo;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "UpdateManager.CheckForUpdatesAsync failed");
+            _logger.LogWarning("Update is available from GitHub, but cannot be downloaded/installed due to UpdateManager exception");
+            return null;
+        }
+    }
+
+    private ArtifactUpdateInfo? FindPlatformArtifactInRun(
+        JsonElement artifacts,
+        string platformFilter,
+        int? prNumber,
+        long runId,
+        string runUrl,
+        string shortHash,
+        DateTime createdAt)
+    {
+        foreach (var artifact in artifacts.EnumerateArray())
+        {
+            var artifactName = artifact.GetProperty("name").GetString() ?? string.Empty;
+            if (!artifactName.Contains("velopack", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!artifactName.Contains(platformFilter, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            _logger.LogInformation("Found {Platform} Velopack artifact: {Name}", platformFilter, artifactName);
+
+            var artifactId = artifact.GetProperty("id").GetInt64();
+            var fallbackVersion = prNumber.HasValue ? $"PR{prNumber.Value}" : "0.0.0";
+            var version = ExtractVersionFromArtifactName(artifactName) ?? fallbackVersion;
+
+            var artifactInfo = new ArtifactUpdateInfo(
+                Version: version,
+                GitHash: shortHash,
+                PullRequestNumber: prNumber,
+                WorkflowRunId: runId,
+                WorkflowRunUrl: runUrl,
+                ArtifactId: artifactId,
+                ArtifactName: artifactName,
+                CreatedAt: createdAt,
+                DownloadUrl: artifact.GetProperty("archive_download_url").GetString(),
+                Size: artifact.GetProperty("size_in_bytes").GetInt64());
+
+            _logger.LogInformation("Selected {Platform} artifact: {Name} (ID: {Id})", platformFilter, artifactName, artifactId);
+            return artifactInfo;
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Finds the latest artifact for a specific PR.
     /// </summary>
@@ -1288,7 +1342,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
             _logger.LogInformation("Searching for artifacts for PR #{PrNumber}", prNumber);
 
-            // First, get the PR details to find the head branch
             var prUrl = string.Format(ApiConstants.GitHubApiPrDetailFormat, owner, repo, prNumber);
             var prResponse = await SendWithRetryAsync(client, prUrl, cancellationToken);
 
@@ -1313,7 +1366,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
             _logger.LogInformation("PR #{PrNumber} head branch: {Branch}", prNumber, headBranch);
 
-            // Fetch workflow runs for this branch
             var runsUrl = string.Format(ApiConstants.GitHubApiWorkflowRunsFormat, owner, repo, headBranch);
             var runsResponse = await SendWithRetryAsync(client, runsUrl, cancellationToken);
 
@@ -1335,6 +1387,15 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             var runCount = runs.GetArrayLength();
             _logger.LogInformation("Found {Count} workflow runs for PR #{PrNumber} on branch {Branch}", runCount, prNumber, headBranch);
 
+            var platformFilter = GetCurrentPlatformFilter();
+            if (platformFilter == null)
+            {
+                _logger.LogWarning("Unsupported platform for artifact updates");
+                return null;
+            }
+
+            _logger.LogInformation("Looking for {Platform} artifacts for PR #{PrNumber}", platformFilter, prNumber);
+
             foreach (var run in runs.EnumerateArray())
             {
                 var runId = run.GetProperty("id").GetInt64();
@@ -1342,7 +1403,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
                 _logger.LogDebug("Checking workflow run {RunId} for branch {Branch}", runId, runBranch);
 
-                // Verify this run is actually for our PR branch
                 if (!string.Equals(runBranch, headBranch, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Skipping run {RunId} - branch mismatch: {RunBranch} != {HeadBranch}", runId, runBranch, headBranch);
@@ -1350,8 +1410,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
                 }
 
                 var runUrl = run.GetProperty("html_url").GetString() ?? string.Empty;
-
-                DateTime createdAt;
+                var createdAt = DateTime.MinValue;
                 try
                 {
                     createdAt = run.GetProperty("created_at").GetDateTime();
@@ -1385,69 +1444,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
                     continue;
                 }
 
-                var artifactCount = artifacts.GetArrayLength();
-                _logger.LogInformation("Found {Count} artifacts for run {RunId}", artifactCount, runId);
-
-                // Determine current platform
-                string platformFilter;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    platformFilter = "windows";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    platformFilter = "linux";
-                }
-                else
-                {
-                    _logger.LogWarning("Unsupported platform for artifact updates");
-                    return null;
-                }
-
-                _logger.LogInformation("Looking for {Platform} artifacts for PR #{PrNumber}", platformFilter, prNumber);
-
-                ArtifactUpdateInfo? platformArtifact = null;
-
-                foreach (var artifact in artifacts.EnumerateArray())
-                {
-                    var artifactName = artifact.GetProperty("name").GetString() ?? string.Empty;
-                    _logger.LogDebug("Checking artifact: {Name}", artifactName);
-
-                    if (!artifactName.Contains("velopack", StringComparison.OrdinalIgnoreCase))
-                    {
-                        _logger.LogDebug("Skipping artifact {Name} - doesn't contain 'velopack'", artifactName);
-                        continue;
-                    }
-
-                    // Check if artifact matches current platform
-                    if (!artifactName.Contains(platformFilter, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _logger.LogDebug("Skipping artifact {Name} - doesn't match platform {Platform}", artifactName, platformFilter);
-                        continue;
-                    }
-
-                    _logger.LogInformation("Found {Platform} Velopack artifact: {Name}", platformFilter, artifactName);
-
-                    var artifactId = artifact.GetProperty("id").GetInt64();
-                    var version = ExtractVersionFromArtifactName(artifactName) ?? $"PR{prNumber}";
-
-                    var artifactInfo = new ArtifactUpdateInfo(
-                        Version: version,
-                        GitHash: shortHash,
-                        PullRequestNumber: prNumber,
-                        WorkflowRunId: runId,
-                        WorkflowRunUrl: runUrl,
-                        ArtifactId: artifactId,
-                        ArtifactName: artifactName,
-                        CreatedAt: createdAt,
-                        DownloadUrl: artifact.GetProperty("archive_download_url").GetString(),
-                        Size: artifact.GetProperty("size_in_bytes").GetInt64());
-
-                    _logger.LogInformation("Selected {Platform} artifact: {Name} (ID: {Id})", platformFilter, artifactName, artifactId);
-                    platformArtifact = artifactInfo;
-                    break;
-                }
-
+                var platformArtifact = FindPlatformArtifactInRun(artifacts, platformFilter, prNumber, runId, runUrl, shortHash, createdAt);
                 if (platformArtifact != null)
                 {
                     _logger.LogInformation("Found artifact for PR #{PrNumber}: {Version}", prNumber, platformArtifact.Version);
@@ -1485,20 +1482,17 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             var owner = AppConstants.GitHubRepositoryOwner;
             var repo = AppConstants.GitHubRepositoryName;
 
-            string runsUrl;
+            var runsUrl = !string.IsNullOrEmpty(branch)
+                ? string.Format(ApiConstants.GitHubApiWorkflowRunsFormat, owner, repo, branch)
+                : $"https://api.github.com/repos/{owner}/{repo}/actions/runs?status=success&event=push&per_page=10";
 
-            // Always request multiple runs to ensure we can find one with artifacts if the latest failed/expired
             if (!string.IsNullOrEmpty(branch))
             {
                 _logger.LogInformation("Searching for latest workflow success on branch: {Branch}", branch);
-                runsUrl = string.Format(ApiConstants.GitHubApiWorkflowRunsFormat, owner, repo, branch);
             }
             else
             {
                 _logger.LogInformation("Searching for overall latest workflow success");
-
-                // Use the same format but without branch param, creating a custom URL since Constant has per_page=1
-                runsUrl = $"https://api.github.com/repos/{owner}/{repo}/actions/runs?status=success&event=push&per_page=10";
             }
 
             var runsResponse = await SendWithRetryAsync(client, runsUrl, cancellationToken);
@@ -1518,7 +1512,13 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
                 return null;
             }
 
-            // Iterate through runs to find the first one with valid artifacts
+            var platformFilter = GetCurrentPlatformFilter();
+            if (platformFilter == null)
+            {
+                _logger.LogWarning("No update artifacts are published for {Platform}", RuntimeInformation.OSDescription);
+                return null;
+            }
+
             foreach (var run in runs.EnumerateArray())
             {
                 var runId = run.GetProperty("id").GetInt64();
@@ -1528,22 +1528,19 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
                 var shortHash = headSha.Length >= AppConstants.GitShortHashLength ? headSha[..AppConstants.GitShortHashLength] : headSha;
                 var actualBranch = run.TryGetProperty("head_branch", out var b) ? b.GetString() : branch ?? "unknown";
 
-                // CRITICAL FIX: Only accept 'push' events for branch/latest updates.
-                // 'pull_request' events should ONLY be handled by specific PR subscriptions.
                 if (!string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Skipping run {RunId} ({EventType}) - only 'push' events are valid for branch subscriptions", runId, eventType);
                     continue;
                 }
 
-                // Double-check branch name if specified
                 if (!string.IsNullOrEmpty(branch) && !string.Equals(actualBranch, branch, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Skipping run {RunId} ({ActualBranch}) - does not match requested branch {Branch}", runId, actualBranch, branch);
                     continue;
                 }
 
-                DateTime createdAt;
+                var createdAt = DateTime.MinValue;
                 try
                 {
                     createdAt = run.GetProperty("created_at").GetDateTime();
@@ -1569,92 +1566,11 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
                 if (!artifactsData.TryGetProperty("artifacts", out var artifacts) || artifacts.GetArrayLength() == 0)
                 {
-                    _logger.LogDebug("No artifacts found in run {RunId}, checking next run", runId);
+                    _logger.LogWarning("No artifacts found for run {RunId}", runId);
                     continue;
                 }
 
-                // Filter artifacts by platform to prevent cross-platform installation
-                ArtifactUpdateInfo? windowsArtifact = null;
-                ArtifactUpdateInfo? linuxArtifact = null;
-                ArtifactUpdateInfo? fallbackArtifact = null;
-
-                foreach (var artifact in artifacts.EnumerateArray())
-                {
-                    var artifactName = artifact.GetProperty("name").GetString() ?? string.Empty;
-
-                    if (!artifactName.Contains("velopack", StringComparison.OrdinalIgnoreCase))
-                    {
-                        _logger.LogDebug("Skipping artifact {Name} - doesn't contain 'velopack'", artifactName);
-                        continue;
-                    }
-
-                    _logger.LogInformation("Found Velopack artifact: {Name} (ID: {Id}) in run {RunId}", artifactName, artifact.GetProperty("id").GetInt64(), runId);
-
-                    var artifactId = artifact.GetProperty("id").GetInt64();
-                    var version = ExtractVersionFromArtifactName(artifactName) ?? "unknown";
-
-                    var artifactInfo = new ArtifactUpdateInfo(
-                        Version: version,
-                        GitHash: shortHash,
-                        PullRequestNumber: null,
-                        WorkflowRunId: runId,
-                        WorkflowRunUrl: runUrl,
-                        ArtifactId: artifactId,
-                        ArtifactName: artifactName,
-                        CreatedAt: createdAt,
-                        DownloadUrl: artifact.GetProperty("archive_download_url").GetString(),
-                        Size: artifact.GetProperty("size_in_bytes").GetInt64());
-
-                    // Categorize by platform
-                    if (artifactName.Contains("windows", StringComparison.OrdinalIgnoreCase))
-                    {
-                        _logger.LogDebug("Found Windows artifact: {Name}", artifactName);
-                        windowsArtifact = artifactInfo;
-                    }
-                    else if (artifactName.Contains("linux", StringComparison.OrdinalIgnoreCase))
-                    {
-                        _logger.LogDebug("Found Linux artifact: {Name}", artifactName);
-                        linuxArtifact = artifactInfo;
-                    }
-                    else if (fallbackArtifact == null)
-                    {
-                        _logger.LogDebug("Found platform-agnostic artifact: {Name}", artifactName);
-                        fallbackArtifact = artifactInfo;
-                    }
-                }
-
-                // Select the appropriate artifact based on current platform
-                ArtifactUpdateInfo? selectedArtifact = null;
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    selectedArtifact = windowsArtifact ?? fallbackArtifact;
-                    if (selectedArtifact != null)
-                    {
-                        _logger.LogInformation("Selected Windows artifact: {Name} (ID: {Id})", selectedArtifact.ArtifactName, selectedArtifact.ArtifactId);
-                    }
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    selectedArtifact = linuxArtifact ?? fallbackArtifact;
-                    if (selectedArtifact != null)
-                    {
-                        _logger.LogInformation("Selected Linux artifact: {Name} (ID: {Id})", selectedArtifact.ArtifactName, selectedArtifact.ArtifactId);
-                    }
-                }
-                else
-                {
-                    // No artifacts are published for this platform. Installing the
-                    // platform-agnostic fallback here would apply a Windows or Linux
-                    // package on, say, macOS, leaving an install that cannot start and
-                    // cannot be rolled back. Refuse rather than guess.
-                    _logger.LogWarning(
-                        "No update artifacts are published for {Platform}; skipping run {RunId}",
-                        RuntimeInformation.OSDescription,
-                        runId);
-                    continue;
-                }
-
+                var selectedArtifact = FindPlatformArtifactInRun(artifacts, platformFilter, null, runId, runUrl, shortHash, createdAt);
                 if (selectedArtifact != null)
                 {
                     return selectedArtifact;
@@ -1679,15 +1595,9 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
         var owner = AppConstants.GitHubRepositoryOwner;
         var repo = AppConstants.GitHubRepositoryName;
 
-        string runsUrl;
-        if (!string.IsNullOrEmpty(branchName))
-        {
-            runsUrl = string.Format(ApiConstants.GitHubApiWorkflowRunsFormat, owner, repo, branchName);
-        }
-        else
-        {
-            runsUrl = string.Format(ApiConstants.GitHubApiWorkflowRunsAllFormat, owner, repo);
-        }
+        var runsUrl = !string.IsNullOrEmpty(branchName)
+            ? string.Format(ApiConstants.GitHubApiWorkflowRunsFormat, owner, repo, branchName)
+            : string.Format(ApiConstants.GitHubApiWorkflowRunsAllFormat, owner, repo);
 
         var runsResponse = await SendWithRetryAsync(client, runsUrl, cancellationToken);
         if (runsResponse == null || !runsResponse.IsSuccessStatusCode) return [];
@@ -1696,8 +1606,13 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
         using var runsDoc = JsonDocument.Parse(runsJson);
         var workflowRuns = runsDoc.RootElement.GetProperty("workflow_runs");
 
-        // Track added artifacts by version+hash to prevent duplicates from re-runs
         var addedVersions = new HashSet<string>();
+        var platformFilter = GetCurrentPlatformFilter();
+        if (platformFilter == null)
+        {
+            _logger.LogWarning("Unsupported platform for artifacts");
+            return [];
+        }
 
         foreach (var run in workflowRuns.EnumerateArray())
         {
@@ -1707,7 +1622,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             var headSha = run.GetProperty("head_sha").GetString() ?? string.Empty;
             var shortHash = headSha.Length >= 7 ? headSha[..7] : headSha;
 
-            // Get artifacts for this run
             var artifactsUrl = run.GetProperty("artifacts_url").GetString();
             if (string.IsNullOrEmpty(artifactsUrl)) continue;
 
@@ -1721,25 +1635,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             foreach (var artifact in artifacts.EnumerateArray())
             {
                 var name = artifact.GetProperty("name").GetString();
-
-                // Filter for Velopack artifacts
                 if (string.IsNullOrEmpty(name) || !name.Contains("velopack", StringComparison.OrdinalIgnoreCase)) continue;
-
-                // Filter by platform
-                string platformFilter;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    platformFilter = "windows";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    platformFilter = "linux";
-                }
-                else
-                {
-                    _logger.LogWarning("Unsupported platform for artifacts");
-                    continue;
-                }
 
                 if (!name.Contains(platformFilter, StringComparison.OrdinalIgnoreCase))
                 {
@@ -1747,10 +1643,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
                     continue;
                 }
 
-                // Try to extract version from name
                 var version = ExtractVersionFromArtifactName(name) ?? $"0.0.0-ci.{runNum}";
-
-                // Create unique key from version and hash to prevent duplicates
                 var uniqueKey = $"{version}|{shortHash}";
                 if (!addedVersions.Add(uniqueKey))
                 {

--- a/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
@@ -154,7 +154,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
                 return await CheckViaUpdateManagerAsync();
             }
 
-            JsonElement releases;
+            JsonElement releases = default;
             try
             {
                 releases = JsonSerializer.Deserialize<JsonElement>(json);
@@ -869,6 +869,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
     }
 
     /// <inheritdoc/>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("DeepSource", "CS-W1005", Justification = "Explicit application termination required after launching uninstaller.")]
     public void Uninstall()
     {
         try
@@ -1521,62 +1522,11 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
             foreach (var run in runs.EnumerateArray())
             {
-                var runId = run.GetProperty("id").GetInt64();
-                var runUrl = run.GetProperty("html_url").GetString() ?? string.Empty;
-                var eventType = run.TryGetProperty("event", out var e) ? e.GetString() : "unknown";
-                var headSha = run.GetProperty("head_sha").GetString() ?? string.Empty;
-                var shortHash = headSha.Length >= AppConstants.GitShortHashLength ? headSha[..AppConstants.GitShortHashLength] : headSha;
-                var actualBranch = run.TryGetProperty("head_branch", out var b) ? b.GetString() : branch ?? "unknown";
-
-                if (!string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase))
-                {
-                    _logger.LogDebug("Skipping run {RunId} ({EventType}) - only 'push' events are valid for branch subscriptions", runId, eventType);
-                    continue;
-                }
-
-                if (!string.IsNullOrEmpty(branch) && !string.Equals(actualBranch, branch, StringComparison.OrdinalIgnoreCase))
-                {
-                    _logger.LogDebug("Skipping run {RunId} ({ActualBranch}) - does not match requested branch {Branch}", runId, actualBranch, branch);
-                    continue;
-                }
-
-                var createdAt = DateTime.MinValue;
-                try
-                {
-                    createdAt = run.GetProperty("created_at").GetDateTime();
-                }
-                catch (FormatException)
-                {
-                    createdAt = DateTime.MinValue;
-                }
-
-                _logger.LogDebug("Checking run {RunId} on branch {Branch} ({Hash}) for artifacts...", runId, actualBranch, shortHash);
-
-                var artifactsUrl = string.Format(ApiConstants.GitHubApiRunArtifactsFormat, owner, repo, runId);
-                var artifactsResponse = await SendWithRetryAsync(client, artifactsUrl, cancellationToken);
-
-                if (artifactsResponse == null || !artifactsResponse.IsSuccessStatusCode)
-                {
-                    _logger.LogWarning("Failed to fetch artifacts for run {RunId}: {Status}", runId, artifactsResponse?.StatusCode);
-                    continue;
-                }
-
-                var artifactsJson = await artifactsResponse.Content.ReadAsStringAsync(cancellationToken);
-                var artifactsData = JsonSerializer.Deserialize<JsonElement>(artifactsJson);
-
-                if (!artifactsData.TryGetProperty("artifacts", out var artifacts) || artifacts.GetArrayLength() == 0)
-                {
-                    _logger.LogWarning("No artifacts found for run {RunId}", runId);
-                    continue;
-                }
-
-                var selectedArtifact = FindPlatformArtifactInRun(artifacts, platformFilter, null, runId, runUrl, shortHash, createdAt);
+                var selectedArtifact = await CheckRunForLatestArtifactAsync(client, run, branch, platformFilter, owner, repo, cancellationToken);
                 if (selectedArtifact != null)
                 {
                     return selectedArtifact;
                 }
-
-                _logger.LogDebug("No suitable Velopack artifacts found for current platform in run {RunId}, checking next run", runId);
             }
 
             _logger.LogWarning("No suitable artifacts found in the last 10 'push' runs for branch {Branch}", branch ?? "any");
@@ -1587,6 +1537,74 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             _logger.LogWarning(ex, "Failed to find latest artifact for branch {Branch}", branch ?? "any");
             return null;
         }
+    }
+
+    private async Task<ArtifactUpdateInfo?> CheckRunForLatestArtifactAsync(
+        HttpClient client,
+        JsonElement run,
+        string? branch,
+        string platformFilter,
+        string owner,
+        string repo,
+        CancellationToken cancellationToken)
+    {
+        var runId = run.GetProperty("id").GetInt64();
+        var runUrl = run.GetProperty("html_url").GetString() ?? string.Empty;
+        var eventType = run.TryGetProperty("event", out var e) ? e.GetString() : "unknown";
+        var headSha = run.GetProperty("head_sha").GetString() ?? string.Empty;
+        var shortHash = headSha.Length >= AppConstants.GitShortHashLength ? headSha[..AppConstants.GitShortHashLength] : headSha;
+        var actualBranch = run.TryGetProperty("head_branch", out var b) ? b.GetString() : branch ?? "unknown";
+
+        if (!string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("Skipping run {RunId} ({EventType}) - only 'push' events are valid for branch subscriptions", runId, eventType);
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(branch) && !string.Equals(actualBranch, branch, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("Skipping run {RunId} ({ActualBranch}) - does not match requested branch {Branch}", runId, actualBranch, branch);
+            return null;
+        }
+
+        var createdAt = DateTime.MinValue;
+        try
+        {
+            createdAt = run.GetProperty("created_at").GetDateTime();
+        }
+        catch (FormatException)
+        {
+            createdAt = DateTime.MinValue;
+        }
+
+        _logger.LogDebug("Checking run {RunId} on branch {Branch} ({Hash}) for artifacts...", runId, actualBranch, shortHash);
+
+        var artifactsUrl = string.Format(ApiConstants.GitHubApiRunArtifactsFormat, owner, repo, runId);
+        var artifactsResponse = await SendWithRetryAsync(client, artifactsUrl, cancellationToken);
+
+        if (artifactsResponse == null || !artifactsResponse.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to fetch artifacts for run {RunId}: {Status}", runId, artifactsResponse?.StatusCode);
+            return null;
+        }
+
+        var artifactsJson = await artifactsResponse.Content.ReadAsStringAsync(cancellationToken);
+        var artifactsData = JsonSerializer.Deserialize<JsonElement>(artifactsJson);
+
+        if (!artifactsData.TryGetProperty("artifacts", out var artifacts) || artifacts.GetArrayLength() == 0)
+        {
+            _logger.LogWarning("No artifacts found for run {RunId}", runId);
+            return null;
+        }
+
+        var selectedArtifact = FindPlatformArtifactInRun(artifacts, platformFilter, null, runId, runUrl, shortHash, createdAt);
+        if (selectedArtifact != null)
+        {
+            return selectedArtifact;
+        }
+
+        _logger.LogDebug("No suitable Velopack artifacts found for current platform in run {RunId}, checking next run", runId);
+        return null;
     }
 
     private async Task<IReadOnlyList<ArtifactUpdateInfo>> FindArtifactsAsync(HttpClient client, string? branchName, int? prNumber, CancellationToken cancellationToken)

--- a/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
@@ -884,7 +884,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             {
                 _logger.LogInformation("Invoking uninstaller: {Path}", updateExe);
                 Process.Start(new ProcessStartInfo(updateExe, "--uninstall") { UseShellExecute = true });
-                Environment.Exit(0);
+                Environment.Exit(0); // skipcq: CS-W1005
             }
             else
             {

--- a/GenHub/GenHub/Features/AppUpdate/ViewModels/UpdateNotificationViewModel.cs
+++ b/GenHub/GenHub/Features/AppUpdate/ViewModels/UpdateNotificationViewModel.cs
@@ -276,7 +276,7 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
         DismissCommand = new RelayCommand(DismissUpdate);
 
         // Check if PAT is available
-        HasPat = gitHubTokenStorage?.HasToken() ?? false;
+        HasPat = gitHubTokenStorage?.HasToken() == true;
 
         _logger.LogInformation("UpdateNotificationViewModel initialized with Velopack (HasPat={HasPat})", HasPat);
 
@@ -531,50 +531,48 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
                     StatusMessage = $"You are on the latest build for PR #{SubscribedPr.Number}";
                     return;
                 }
-                else
+
+                // Try to fetch artifact for update check
+                _logger.LogInformation("PR #{PrNumber} has no cached artifact, fetching for update check", SubscribedPr.Number);
+                var prArtifact = await _velopackUpdateManager.CheckForArtifactUpdatesAsync(_cancellationTokenSource.Token);
+                if (prArtifact != null)
                 {
-                    // Try to fetch artifact for update check
-                    _logger.LogInformation("PR #{PrNumber} has no cached artifact, fetching for update check", SubscribedPr.Number);
-                    var prArtifact = await _velopackUpdateManager.CheckForArtifactUpdatesAsync(_cancellationTokenSource.Token);
-                    if (prArtifact != null)
+                    var currentVersionBase = CurrentAppVersion.Split('+')[0];
+                    var prVersionBase = prArtifact.Version.Split('+')[0];
+
+                    // Extract run numbers for numeric comparison
+                    var currentRun = ExtractRunNumber(currentVersionBase);
+                    var prRun = ExtractRunNumber(prVersionBase);
+
+                    _logger.LogDebug("Comparing fetched PR #{PrNumber} versions: current run #{CurrentRun} vs new run #{PrRun}", SubscribedPr.Number, currentRun, prRun);
+
+                    if (prRun > currentRun)
                     {
-                        var currentVersionBase = CurrentAppVersion.Split('+')[0];
-                        var prVersionBase = prArtifact.Version.Split('+')[0];
-
-                        // Extract run numbers for numeric comparison
-                        var currentRun = ExtractRunNumber(currentVersionBase);
-                        var prRun = ExtractRunNumber(prVersionBase);
-
-                        _logger.LogDebug("Comparing fetched PR #{PrNumber} versions: current run #{CurrentRun} vs new run #{PrRun}", SubscribedPr.Number, currentRun, prRun);
-
-                        if (prRun > currentRun)
+                        var settings = _userSettingsService.Get();
+                        if (!string.Equals(prVersionBase, settings.DismissedUpdateVersion, StringComparison.OrdinalIgnoreCase))
                         {
-                            var settings = _userSettingsService.Get();
-                            if (!string.Equals(prVersionBase, settings.DismissedUpdateVersion, StringComparison.OrdinalIgnoreCase))
-                            {
-                                IsUpdateAvailable = true;
-                                LatestVersion = prVersionBase;
-                                ReleaseNotesUrl = $"{AppConstants.GitHubRepositoryUrl}/pull/{SubscribedPr.Number}";
-                                StatusMessage = $"New PR build available: {prArtifact.DisplayVersion}";
-                                _logger.LogInformation("Fetched PR #{PrNumber} artifact, new build available: run #{PrRun} (current: #{CurrentRun})", SubscribedPr.Number, prRun, currentRun);
-                                return;
-                            }
-
-                            StatusMessage = $"You dismissed the update for PR #{SubscribedPr.Number}";
+                            IsUpdateAvailable = true;
+                            LatestVersion = prVersionBase;
+                            ReleaseNotesUrl = $"{AppConstants.GitHubRepositoryUrl}/pull/{SubscribedPr.Number}";
+                            StatusMessage = $"New PR build available: {prArtifact.DisplayVersion}";
+                            _logger.LogInformation("Fetched PR #{PrNumber} artifact, new build available: run #{PrRun} (current: #{CurrentRun})", SubscribedPr.Number, prRun, currentRun);
                             return;
                         }
 
-                        IsUpdateAvailable = false;
-                        StatusMessage = $"You are on the latest build for PR #{SubscribedPr.Number}";
+                        StatusMessage = $"You dismissed the update for PR #{SubscribedPr.Number}";
                         return;
                     }
 
-                    // If subscribed to PR but no artifact found, don't fall through to main release
-                    _logger.LogInformation("Subscribed to PR #{PrNumber} but no artifact available yet", SubscribedPr.Number);
-                    StatusMessage = $"Waiting for PR #{SubscribedPr.Number} build...";
                     IsUpdateAvailable = false;
+                    StatusMessage = $"You are on the latest build for PR #{SubscribedPr.Number}";
                     return;
                 }
+
+                // If subscribed to PR but no artifact found, don't fall through to main release
+                _logger.LogInformation("Subscribed to PR #{PrNumber} but no artifact available yet", SubscribedPr.Number);
+                StatusMessage = $"Waiting for PR #{SubscribedPr.Number} build...";
+                IsUpdateAvailable = false;
+                return;
             }
 
             // Check Branch updates if subscribed

--- a/GenHub/GenHub/Features/AppUpdate/ViewModels/UpdateNotificationViewModel.cs
+++ b/GenHub/GenHub/Features/AppUpdate/ViewModels/UpdateNotificationViewModel.cs
@@ -190,7 +190,20 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
     /// <summary>
     /// Gets the text to display as a placeholder in the version selection combo box.
     /// </summary>
-    public string VersionPlaceholderText => IsLoadingVersions ? AppUpdateConstants.LoadingVersionsMessage : (AvailableVersions.Count > 0 ? AppUpdateConstants.SelectVersionMessage : AppUpdateConstants.NoVersionsFoundMessage);
+    public string VersionPlaceholderText
+    {
+        get
+        {
+            if (IsLoadingVersions)
+            {
+                return AppUpdateConstants.LoadingVersionsMessage;
+            }
+
+            return AvailableVersions.Count > 0
+                ? AppUpdateConstants.SelectVersionMessage
+                : AppUpdateConstants.NoVersionsFoundMessage;
+        }
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether a merged/closed PR warning should be shown.
@@ -509,18 +522,14 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
                             _logger.LogInformation("Subscribed to PR #{PrNumber}, new build available: run #{PrRun} (current: #{CurrentRun})", SubscribedPr.Number, prRun, currentRun);
                             return;
                         }
-                        else
-                        {
-                            StatusMessage = $"You dismissed the update for PR #{SubscribedPr.Number}";
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        IsUpdateAvailable = false;
-                        StatusMessage = $"You are on the latest build for PR #{SubscribedPr.Number}";
+
+                        StatusMessage = $"You dismissed the update for PR #{SubscribedPr.Number}";
                         return;
                     }
+
+                    IsUpdateAvailable = false;
+                    StatusMessage = $"You are on the latest build for PR #{SubscribedPr.Number}";
+                    return;
                 }
                 else
                 {
@@ -550,18 +559,14 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
                                 _logger.LogInformation("Fetched PR #{PrNumber} artifact, new build available: run #{PrRun} (current: #{CurrentRun})", SubscribedPr.Number, prRun, currentRun);
                                 return;
                             }
-                            else
-                            {
-                                StatusMessage = $"You dismissed the update for PR #{SubscribedPr.Number}";
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            IsUpdateAvailable = false;
-                            StatusMessage = $"You are on the latest build for PR #{SubscribedPr.Number}";
+
+                            StatusMessage = $"You dismissed the update for PR #{SubscribedPr.Number}";
                             return;
                         }
+
+                        IsUpdateAvailable = false;
+                        StatusMessage = $"You are on the latest build for PR #{SubscribedPr.Number}";
+                        return;
                     }
 
                     // If subscribed to PR but no artifact found, don't fall through to main release

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
@@ -517,7 +517,7 @@ public class CommunityOutpostManifestFactory(
                 manifest.Dependencies?.Count ?? 0);
 
             // Log each dependency for debugging
-            if (manifest.Dependencies != null && manifest.Dependencies.Count > 0)
+            if (manifest.Dependencies is { Count: > 0 })
             {
                 foreach (var dep in manifest.Dependencies)
                 {

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
@@ -329,12 +329,12 @@ public class CommunityOutpostManifestFactory(
                 var targetFile = Path.Combine(destinationDir, Path.GetFileName(file));
                 File.Copy(file, targetFile, overwrite: true);
             }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            catch (IOException)
             {
-                // Log and continue, or rely on caller to handle?
-                // Since this is a helper, we let exceptions bubble up or just do a best-effort?
-                // The comment said "doesn't handle IOException for individual files".
-                // We'll throw to be safe, but at least we have the recursion guard.
+                throw;
+            }
+            catch (UnauthorizedAccessException)
+            {
                 throw;
             }
         }
@@ -371,23 +371,7 @@ public class CommunityOutpostManifestFactory(
             logger.LogDebug("Found {FileCount} files in extracted directory", allFiles.Length);
 
             var fileEntries = new List<ManifestFile>();
-
-            var dependencyBigFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var dependency in contentMetadata.GetDependencies()
-                         .Where(d => d.InstallBehavior == DependencyInstallBehavior.AutoInstall))
-            {
-                var depId = dependency.Id.Value;
-                var lastDot = depId.LastIndexOf('.');
-                if (lastDot > -1 && lastDot < depId.Length - 1)
-                {
-                    var depCode = depId[(lastDot + 1)..];
-                    var depMetadata = GenPatcherContentRegistry.GetMetadata(depCode);
-                    if (!string.IsNullOrEmpty(depMetadata.OutputFilename))
-                    {
-                        dependencyBigFiles.Add(depMetadata.OutputFilename);
-                    }
-                }
-            }
+            var dependencyBigFiles = CollectDependencyBigFiles(contentMetadata);
 
             var alwaysIncludeFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             if (contentMetadata.Category == GenPatcherContentCategory.ControlBar)
@@ -396,390 +380,41 @@ public class CommunityOutpostManifestFactory(
                 alwaysIncludeFiles.Add("340_ControlBarProZH.big");
             }
 
-            var controlBarRepackedOutputs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var isControlBarVariant = contentMetadata.Category == GenPatcherContentCategory.ControlBar &&
                                       contentMetadata.SupportsVariants &&
                                       variant != null;
 
-            if (isControlBarVariant)
-            {
-                var variantSuffix = GetControlBarVariantSuffix(variant!.Id);
-                var variantBigRoot = FindControlBarVariantBigRoot(extractedDirectory, variant.Id);
-
-                if (!string.IsNullOrEmpty(variantBigRoot))
-                {
-                    // cbpr-style: Has ZH/{variant}/BIG folder structure
-                    var prebuiltBigs = Directory.GetFiles(variantBigRoot, "*.big", SearchOption.TopDirectoryOnly)
-                        .Where(path => IsAllowedControlBarBig(Path.GetFileName(path), variantSuffix))
-                        .ToArray();
-
-                    if (prebuiltBigs.Length > 0)
-                    {
-                        logger.LogInformation(
-                            "Using prebuilt control bar BIG files from {VariantRoot}",
-                            variantBigRoot);
-
-                        foreach (var prebuiltBig in prebuiltBigs)
-                        {
-                            var bigName = Path.GetFileName(prebuiltBig);
-                            var targetPath = Path.Combine(extractedDirectory, bigName);
-
-                            // Skip copy if source and target are the same file (already in root)
-                            if (!string.Equals(Path.GetFullPath(prebuiltBig), Path.GetFullPath(targetPath), StringComparison.OrdinalIgnoreCase))
-                            {
-                                await TryCopyFileWithRetryAsync(prebuiltBig, targetPath, logger);
-                            }
-
-                            controlBarRepackedOutputs.Add(bigName);
-                        }
-                    }
-                    else
-                    {
-                        // No prebuilt BIGs in variant root, need to repack from source
-                        var artBigName = $"340_ControlBarProArt{variantSuffix}ZH.big";
-                        var dataBigName = $"340_ControlBarProData{variantSuffix}ZH.big";
-
-                        var artBigPath = Path.Combine(extractedDirectory, artBigName);
-                        var dataBigPath = Path.Combine(extractedDirectory, dataBigName);
-
-                        if (!File.Exists(artBigPath) || !File.Exists(dataBigPath))
-                        {
-                            logger.LogInformation(
-                                "Repacking control bar variant {Variant} into Art/Data BIG files",
-                                variant.Name);
-
-                            var artSource = Path.Combine(variantBigRoot, "Art");
-                            var dataSource = Path.Combine(variantBigRoot, "Data");
-                            var windowSource = Path.Combine(variantBigRoot, "Window");
-                            var genToolSource = Path.Combine(variantBigRoot, "GenTool");
-
-                            var tempRoot = Path.Combine(extractedDirectory, $"cbpro-pack-{variant.Id}");
-                            var artPackRoot = Path.Combine(tempRoot, "ArtPack");
-                            var dataPackRoot = Path.Combine(tempRoot, "DataPack");
-
-                            if (Directory.Exists(tempRoot))
-                            {
-                                Directory.Delete(tempRoot, recursive: true);
-                            }
-
-                            Directory.CreateDirectory(artPackRoot);
-                            Directory.CreateDirectory(dataPackRoot);
-
-                            if (Directory.Exists(artSource))
-                            {
-                                CopyDirectory(artSource, Path.Combine(artPackRoot, "Art"));
-                            }
-
-                            if (Directory.Exists(dataSource))
-                            {
-                                CopyDirectory(dataSource, Path.Combine(dataPackRoot, "Data"));
-                            }
-
-                            if (Directory.Exists(windowSource))
-                            {
-                                CopyDirectory(windowSource, Path.Combine(dataPackRoot, "Window"));
-                            }
-
-                            if (Directory.Exists(genToolSource))
-                            {
-                                CopyDirectory(genToolSource, Path.Combine(dataPackRoot, "GenTool"));
-                            }
-
-                            try
-                            {
-                                // Convert AVIF to TGA prior to packing to ensure game compatibility
-                                await avifConverter.ConvertDirectoryAsync(artPackRoot, cancellationToken);
-                                await avifConverter.ConvertDirectoryAsync(dataPackRoot, cancellationToken);
-
-                                await BigFilePacker.PackAsync(artPackRoot, artBigPath);
-                                await BigFilePacker.PackAsync(dataPackRoot, dataBigPath);
-                            }
-                            finally
-                            {
-                                try
-                                {
-                                    if (Directory.Exists(tempRoot))
-                                    {
-                                        Directory.Delete(tempRoot, recursive: true);
-                                    }
-                                }
-                                catch (Exception ex)
-                                {
-                                    logger.LogWarning(ex, "Failed to cleanup temp root {TempRoot}", tempRoot);
-                                }
-                            }
-                        }
-
-                        if (File.Exists(artBigPath))
-                        {
-                            controlBarRepackedOutputs.Add(artBigName);
-                        }
-
-                        if (File.Exists(dataBigPath))
-                        {
-                            controlBarRepackedOutputs.Add(dataBigName);
-                        }
-                    }
-                }
-                else
-                {
-                    // cbpx-style: Flat structure with BIG files in root (no ZH/{variant}/BIG folders)
-                    logger.LogInformation(
-                        "Control bar has flat structure (cbpx-style), searching for prebuilt BIG files in root");
-
-                    var prebuiltCandidates = Directory.GetFiles(extractedDirectory, "*ControlBarPro*ZH.big", SearchOption.TopDirectoryOnly)
-                        .Where(path => IsAllowedControlBarBig(Path.GetFileName(path), variantSuffix))
-                        .ToArray();
-
-                    // Check if Art/Data split files exist - prefer them over monolithic
-                    var hasArtDataSplit = prebuiltCandidates.Any(p =>
-                        Path.GetFileName(p).StartsWith("340_ControlBarProArt", StringComparison.OrdinalIgnoreCase) ||
-                        Path.GetFileName(p).StartsWith("340_ControlBarProData", StringComparison.OrdinalIgnoreCase));
-
-                    if (hasArtDataSplit)
-                    {
-                        // Filter OUT monolithic files when Art/Data split exists
-                        // Monolithic pattern: 340_ControlBarPro{variant}ZH.big (no Art/Data/Fix suffix)
-                        prebuiltCandidates = [.. prebuiltCandidates
-                            .Where(p =>
-                            {
-                                var name = Path.GetFileName(p);
-
-                                // Keep Art/Data split files
-                                if (name.StartsWith("340_ControlBarProArt", StringComparison.OrdinalIgnoreCase) ||
-                                    name.StartsWith("340_ControlBarProData", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    return true;
-                                }
-
-                                // Keep fix files (cbpr-style, but may exist)
-                                if (name.Contains("-Fix", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    return true;
-                                }
-
-                                // Keep metadata BIG (tiny file, no variant suffix)
-                                if (name.Equals("340_ControlBarProZH.big", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    return true;
-                                }
-
-                                // Exclude monolithic files (340_ControlBarPro{variant}ZH.big without Art/Data)
-                                logger.LogDebug(
-                                    "Excluding monolithic BIG {Name} in favor of Art/Data split files",
-                                    name);
-                                return false;
-                            })];
-                    }
-
-                    if (prebuiltCandidates.Length > 0)
-                    {
-                        logger.LogInformation(
-                            "Using {Count} prebuilt control bar BIG files from flat structure: {Files}",
-                            prebuiltCandidates.Length,
-                            string.Join(", ", prebuiltCandidates.Select(Path.GetFileName)));
-
-                        foreach (var candidate in prebuiltCandidates)
-                        {
-                            controlBarRepackedOutputs.Add(Path.GetFileName(candidate));
-                        }
-                    }
-                    else
-                    {
-                        logger.LogWarning(
-                            "No prebuilt control bar BIG files found for variant {Variant} in flat structure",
-                            variant.Name);
-                    }
-                }
-
-                // Explicitly ensure the metadata BIG file (340_ControlBarProZH.big) is included
-                // This file may be in the root, ZH folder, or variant subfolder
-                var metadataFileName = "340_ControlBarProZH.big";
-                var metadataTargetPath = Path.Combine(extractedDirectory, metadataFileName);
-
-                if (!File.Exists(metadataTargetPath))
-                {
-                    // Search for metadata file in common locations
-                    var metadataSearchPaths = new[]
-                    {
-                        Path.Combine(extractedDirectory, "ZH", metadataFileName),
-                        Path.Combine(extractedDirectory, "CCG", metadataFileName),
-                        Path.Combine(extractedDirectory, "ZH", variant!.Id, metadataFileName),
-                        Path.Combine(extractedDirectory, "CCG", variant!.Id, metadataFileName),
-                        Path.Combine(extractedDirectory, "ZH", variant!.Id, "BIG EN", metadataFileName),
-                        Path.Combine(extractedDirectory, "ZH", variant!.Id, "BIG", metadataFileName),
-                        Path.Combine(extractedDirectory, "CCG", variant!.Id, "BIG EN", metadataFileName),
-                        Path.Combine(extractedDirectory, "CCG", variant!.Id, "BIG", metadataFileName),
-                    };
-
-                    foreach (var searchPath in metadataSearchPaths)
-                    {
-                        if (File.Exists(searchPath))
-                        {
-                            logger.LogInformation(
-                                "Found Control Bar metadata file at {SourcePath}, copying to root",
-                                searchPath);
-
-                            await TryCopyFileWithRetryAsync(searchPath, metadataTargetPath, logger);
-
-                            break;
-                        }
-                    }
-                }
-
-                // Ensure metadata file is tracked in outputs if it exists
-                if (File.Exists(metadataTargetPath))
-                {
-                    controlBarRepackedOutputs.Add(metadataFileName);
-                    logger.LogInformation(
-                        "Including Control Bar metadata file {FileName} in manifest",
-                        metadataFileName);
-                }
-                else
-                {
-                    // Control Bar metadata file is missing from download - create it
-                    // This is a known issue with some Community Outpost Control Bar packages
-                    logger.LogWarning(
-                        "Control Bar metadata file {FileName} not found in extracted content - creating fallback version",
-                        metadataFileName);
-
-                    try
-                    {
-                        // Base64-encoded 376-byte Control Bar metadata BIG file (340_ControlBarProZH.big)
-                        // This identifies the mod to GenTool and prevents the "Control Bar Pro" watermark
-                        var metadataBytes = Convert.FromBase64String(ControlBarMetadataBigBase64);
-                        File.WriteAllBytes(metadataTargetPath, metadataBytes);
-
-                        controlBarRepackedOutputs.Add(metadataFileName);
-                        logger.LogInformation(
-                            "Created Control Bar metadata file {FileName} from embedded fallback",
-                            metadataFileName);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Failed to create Control Bar metadata file - manifest will be incomplete");
-                    }
-                }
-            }
+            var controlBarRepackedOutputs = isControlBarVariant
+                ? await PrepareControlBarVariantAsync(extractedDirectory, contentMetadata, variant!, cancellationToken)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             if (controlBarRepackedOutputs.Count > 0)
             {
                 allFiles = Directory.GetFiles(extractedDirectory, "*.*", SearchOption.AllDirectories);
             }
 
-            var hasVariantBigFiles = false;
-            if (variant != null)
-            {
-                foreach (var path in allFiles)
-                {
-                    var name = Path.GetFileName(path);
-                    if (!name.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    if (controlBarRepackedOutputs.Contains(name) ||
-                        alwaysIncludeFiles.Contains(name) ||
-                        dependencyBigFiles.Contains(name))
-                    {
-                        hasVariantBigFiles = true;
-                        break;
-                    }
-
-                    var normalized = name.ToLowerInvariant();
-                    if (variant.IncludePatterns != null && variant.IncludePatterns.Any(p => GetCachedRegex(p.ToLowerInvariant()).IsMatch(normalized)))
-                    {
-                        hasVariantBigFiles = true;
-                        break;
-                    }
-                }
-            }
+            var hasVariantBigFiles = variant != null && HasVariantBigFiles(
+                allFiles,
+                variant,
+                controlBarRepackedOutputs,
+                alwaysIncludeFiles,
+                dependencyBigFiles);
 
             foreach (var fullPath in allFiles)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var relativePath = Path.GetRelativePath(extractedDirectory, fullPath);
-
-                var fileName = Path.GetFileName(relativePath);
-                var normalizedPath = relativePath.Replace('\\', '/').ToLowerInvariant();
-                var isDependencyBig = dependencyBigFiles.Contains(fileName);
-                var isAlwaysInclude = alwaysIncludeFiles.Contains(fileName);
-                var isControlBarVariantFile = isControlBarVariant;
-                var isRepackedOutput = controlBarRepackedOutputs.Contains(fileName);
-
-                if (isControlBarVariantFile && controlBarRepackedOutputs.Count > 0)
+                if (!ShouldIncludeFile(
+                    relativePath,
+                    variant,
+                    isControlBarVariant,
+                    hasVariantBigFiles,
+                    dependencyBigFiles,
+                    alwaysIncludeFiles,
+                    controlBarRepackedOutputs))
                 {
-                    if (!isRepackedOutput && !isDependencyBig && !isAlwaysInclude)
-                    {
-                        logger.LogDebug(
-                            "Skipping file {File} because control bar variant is repacked into Art/Data BIG files",
-                            relativePath);
-                        continue;
-                    }
-                }
-
-                if (isControlBarVariantFile && hasVariantBigFiles && !fileName.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
-                {
-                    logger.LogDebug(
-                        "Skipping non-BIG file {File} for control bar variant {Variant}",
-                        relativePath,
-                        variant!.Name);
                     continue;
-                }
-
-                // Filter files based on variant patterns if variant is specified
-                if (variant != null)
-                {
-                    // Check if file matches include patterns
-                    bool matchesInclude = false;
-                    if (variant.IncludePatterns != null && variant.IncludePatterns.Count > 0)
-                    {
-                        foreach (var pattern in variant.IncludePatterns)
-                        {
-                            var regex = GetCachedRegex(pattern);
-
-                            if (regex.IsMatch(fileName) || regex.IsMatch(normalizedPath))
-                            {
-                                matchesInclude = true;
-                                break;
-                            }
-                        }
-
-                        // If include patterns exist but file doesn't match any, skip it
-                        // UNLESS it's a dependency/base file or an always-include file
-                        // File matching logic:
-                        // 1. Matches inclusion pattern
-                        // 2. OR: Starts with '!' (Special GenPatcher prefix for mandatory files like hotkeys)
-                        // 3. AND: Is not a dependency BIG or always-include BIG (handled separately)
-                        if (!matchesInclude && !isDependencyBig && !isAlwaysInclude)
-                        {
-                            logger.LogDebug("Skipping file {File} - does not match variant {Variant} include patterns", relativePath, variant.Name);
-                            continue;
-                        }
-                    }
-
-                    // Check if file matches exclude patterns
-                    if (variant.ExcludePatterns != null && variant.ExcludePatterns.Count > 0)
-                    {
-                        bool matchesExclude = false;
-                        foreach (var pattern in variant.ExcludePatterns)
-                        {
-                            var regex = GetCachedRegex(pattern);
-
-                            if (regex.IsMatch(fileName) || regex.IsMatch(normalizedPath))
-                            {
-                                matchesExclude = true;
-                                break;
-                            }
-                        }
-
-                        if (matchesExclude && !isDependencyBig && !isAlwaysInclude)
-                        {
-                            logger.LogDebug("Skipping file {File} - matches variant {Variant} exclude pattern", relativePath, variant.Name);
-                            continue;
-                        }
-                    }
                 }
 
                 var hash = await hashProvider.ComputeFileHashAsync(fullPath, cancellationToken);
@@ -905,5 +540,346 @@ public class CommunityOutpostManifestFactory(
             logger.LogError(ex, "Failed to build manifest for {Name}", originalManifest.Name);
             return null;
         }
+    }
+
+    private HashSet<string> CollectDependencyBigFiles(GenPatcherContentMetadata contentMetadata)
+    {
+        var dependencyBigFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dependency in contentMetadata.GetDependencies()
+                     .Where(d => d.InstallBehavior == DependencyInstallBehavior.AutoInstall))
+        {
+            var depId = dependency.Id.Value;
+            var lastDot = depId.LastIndexOf('.');
+            if (lastDot > -1 && lastDot < depId.Length - 1)
+            {
+                var depCode = depId[(lastDot + 1)..];
+                var depMetadata = GenPatcherContentRegistry.GetMetadata(depCode);
+                if (!string.IsNullOrEmpty(depMetadata.OutputFilename))
+                {
+                    dependencyBigFiles.Add(depMetadata.OutputFilename);
+                }
+            }
+        }
+
+        return dependencyBigFiles;
+    }
+
+    private async Task<HashSet<string>> PrepareControlBarVariantAsync(
+        string extractedDirectory,
+        GenPatcherContentMetadata contentMetadata,
+        ContentVariant variant,
+        CancellationToken cancellationToken)
+    {
+        var controlBarRepackedOutputs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var variantSuffix = GetControlBarVariantSuffix(variant.Id);
+        var variantBigRoot = FindControlBarVariantBigRoot(extractedDirectory, variant.Id);
+
+        if (!string.IsNullOrEmpty(variantBigRoot))
+        {
+            var prebuiltBigs = Directory.GetFiles(variantBigRoot, "*.big", SearchOption.TopDirectoryOnly)
+                .Where(path => IsAllowedControlBarBig(Path.GetFileName(path), variantSuffix))
+                .ToArray();
+
+            if (prebuiltBigs.Length > 0)
+            {
+                logger.LogInformation("Using prebuilt control bar BIG files from {VariantRoot}", variantBigRoot);
+                foreach (var prebuiltBig in prebuiltBigs)
+                {
+                    var bigName = Path.GetFileName(prebuiltBig);
+                    var targetPath = Path.Combine(extractedDirectory, bigName);
+
+                    if (!string.Equals(Path.GetFullPath(prebuiltBig), Path.GetFullPath(targetPath), StringComparison.OrdinalIgnoreCase))
+                    {
+                        await TryCopyFileWithRetryAsync(prebuiltBig, targetPath, logger);
+                    }
+
+                    controlBarRepackedOutputs.Add(bigName);
+                }
+            }
+            else
+            {
+                var artBigName = $"340_ControlBarProArt{variantSuffix}ZH.big";
+                var dataBigName = $"340_ControlBarProData{variantSuffix}ZH.big";
+                var artBigPath = Path.Combine(extractedDirectory, artBigName);
+                var dataBigPath = Path.Combine(extractedDirectory, dataBigName);
+
+                if (!File.Exists(artBigPath) || !File.Exists(dataBigPath))
+                {
+                    logger.LogInformation("Repacking control bar variant {Variant} into Art/Data BIG files", variant.Name);
+                    var artSource = Path.Combine(variantBigRoot, "Art");
+                    var dataSource = Path.Combine(variantBigRoot, "Data");
+                    var windowSource = Path.Combine(variantBigRoot, "Window");
+                    var genToolSource = Path.Combine(variantBigRoot, "GenTool");
+
+                    var tempRoot = Path.Combine(extractedDirectory, $"cbpro-pack-{variant.Id}");
+                    var artPackRoot = Path.Combine(tempRoot, "ArtPack");
+                    var dataPackRoot = Path.Combine(tempRoot, "DataPack");
+
+                    if (Directory.Exists(tempRoot))
+                    {
+                        Directory.Delete(tempRoot, recursive: true);
+                    }
+
+                    Directory.CreateDirectory(artPackRoot);
+                    Directory.CreateDirectory(dataPackRoot);
+
+                    if (Directory.Exists(artSource))
+                    {
+                        CopyDirectory(artSource, Path.Combine(artPackRoot, "Art"));
+                    }
+
+                    if (Directory.Exists(dataSource))
+                    {
+                        CopyDirectory(dataSource, Path.Combine(dataPackRoot, "Data"));
+                    }
+
+                    if (Directory.Exists(windowSource))
+                    {
+                        CopyDirectory(windowSource, Path.Combine(dataPackRoot, "Window"));
+                    }
+
+                    if (Directory.Exists(genToolSource))
+                    {
+                        CopyDirectory(genToolSource, Path.Combine(dataPackRoot, "GenTool"));
+                    }
+
+                    try
+                    {
+                        await avifConverter.ConvertDirectoryAsync(artPackRoot, cancellationToken);
+                        await avifConverter.ConvertDirectoryAsync(dataPackRoot, cancellationToken);
+
+                        await BigFilePacker.PackAsync(artPackRoot, artBigPath);
+                        await BigFilePacker.PackAsync(dataPackRoot, dataBigPath);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            if (Directory.Exists(tempRoot))
+                            {
+                                Directory.Delete(tempRoot, recursive: true);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex, "Failed to cleanup temp root {TempRoot}", tempRoot);
+                        }
+                    }
+                }
+
+                if (File.Exists(artBigPath))
+                {
+                    controlBarRepackedOutputs.Add(artBigName);
+                }
+
+                if (File.Exists(dataBigPath))
+                {
+                    controlBarRepackedOutputs.Add(dataBigName);
+                }
+            }
+        }
+        else
+        {
+            logger.LogInformation("Control bar has flat structure (cbpx-style), searching for prebuilt BIG files in root");
+            var prebuiltCandidates = Directory.GetFiles(extractedDirectory, "*ControlBarPro*ZH.big", SearchOption.TopDirectoryOnly)
+                .Where(path => IsAllowedControlBarBig(Path.GetFileName(path), variantSuffix))
+                .ToArray();
+
+            var hasArtDataSplit = prebuiltCandidates.Any(p =>
+                Path.GetFileName(p).StartsWith("340_ControlBarProArt", StringComparison.OrdinalIgnoreCase) ||
+                Path.GetFileName(p).StartsWith("340_ControlBarProData", StringComparison.OrdinalIgnoreCase));
+
+            if (hasArtDataSplit)
+            {
+                prebuiltCandidates = [.. prebuiltCandidates
+                    .Where(p =>
+                    {
+                        var name = Path.GetFileName(p);
+                        if (name.StartsWith("340_ControlBarProArt", StringComparison.OrdinalIgnoreCase) ||
+                            name.StartsWith("340_ControlBarProData", StringComparison.OrdinalIgnoreCase) ||
+                            name.Contains("-Fix", StringComparison.OrdinalIgnoreCase) ||
+                            name.Equals("340_ControlBarProZH.big", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+
+                        logger.LogDebug("Excluding monolithic BIG {Name} in favor of Art/Data split files", name);
+                        return false;
+                    })];
+            }
+
+            if (prebuiltCandidates.Length > 0)
+            {
+                logger.LogInformation(
+                    "Using {Count} prebuilt control bar BIG files from flat structure: {Files}",
+                    prebuiltCandidates.Length,
+                    string.Join(", ", prebuiltCandidates.Select(Path.GetFileName)));
+
+                foreach (var candidate in prebuiltCandidates)
+                {
+                    controlBarRepackedOutputs.Add(Path.GetFileName(candidate));
+                }
+            }
+            else
+            {
+                logger.LogWarning("No prebuilt control bar BIG files found for variant {Variant} in flat structure", variant.Name);
+            }
+        }
+
+        var metadataFileName = "340_ControlBarProZH.big";
+        var metadataTargetPath = Path.Combine(extractedDirectory, metadataFileName);
+
+        if (!File.Exists(metadataTargetPath))
+        {
+            var metadataSearchPaths = new[]
+            {
+                Path.Combine(extractedDirectory, "ZH", metadataFileName),
+                Path.Combine(extractedDirectory, "CCG", metadataFileName),
+                Path.Combine(extractedDirectory, "ZH", variant.Id, metadataFileName),
+                Path.Combine(extractedDirectory, "CCG", variant.Id, metadataFileName),
+                Path.Combine(extractedDirectory, "ZH", variant.Id, "BIG EN", metadataFileName),
+                Path.Combine(extractedDirectory, "ZH", variant.Id, "BIG", metadataFileName),
+                Path.Combine(extractedDirectory, "CCG", variant.Id, "BIG EN", metadataFileName),
+                Path.Combine(extractedDirectory, "CCG", variant.Id, "BIG", metadataFileName),
+            };
+
+            foreach (var searchPath in metadataSearchPaths)
+            {
+                if (File.Exists(searchPath))
+                {
+                    logger.LogInformation("Found Control Bar metadata file at {SourcePath}, copying to root", searchPath);
+                    await TryCopyFileWithRetryAsync(searchPath, metadataTargetPath, logger);
+                    break;
+                }
+            }
+        }
+
+        if (File.Exists(metadataTargetPath))
+        {
+            controlBarRepackedOutputs.Add(metadataFileName);
+            logger.LogInformation("Including Control Bar metadata file {FileName} in manifest", metadataFileName);
+        }
+        else
+        {
+            logger.LogWarning("Control Bar metadata file {FileName} not found in extracted content - creating fallback version", metadataFileName);
+            try
+            {
+                var metadataBytes = Convert.FromBase64String(ControlBarMetadataBigBase64);
+                File.WriteAllBytes(metadataTargetPath, metadataBytes);
+                controlBarRepackedOutputs.Add(metadataFileName);
+                logger.LogInformation("Created Control Bar metadata file {FileName} from embedded fallback", metadataFileName);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to create Control Bar metadata file - manifest will be incomplete");
+            }
+        }
+
+        return controlBarRepackedOutputs;
+    }
+
+    private bool HasVariantBigFiles(
+        string[] allFiles,
+        ContentVariant variant,
+        HashSet<string> controlBarRepackedOutputs,
+        HashSet<string> alwaysIncludeFiles,
+        HashSet<string> dependencyBigFiles)
+    {
+        foreach (var path in allFiles)
+        {
+            var name = Path.GetFileName(path);
+            if (!name.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (controlBarRepackedOutputs.Contains(name) ||
+                alwaysIncludeFiles.Contains(name) ||
+                dependencyBigFiles.Contains(name))
+            {
+                return true;
+            }
+
+            var normalized = name.ToLowerInvariant();
+            if (variant.IncludePatterns?.Any(p => GetCachedRegex(p.ToLowerInvariant()).IsMatch(normalized)) == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool ShouldIncludeFile(
+        string relativePath,
+        ContentVariant? variant,
+        bool isControlBarVariant,
+        bool hasVariantBigFiles,
+        HashSet<string> dependencyBigFiles,
+        HashSet<string> alwaysIncludeFiles,
+        HashSet<string> controlBarRepackedOutputs)
+    {
+        var fileName = Path.GetFileName(relativePath);
+        var normalizedPath = relativePath.Replace('\\', '/').ToLowerInvariant();
+        var isDependencyBig = dependencyBigFiles.Contains(fileName);
+        var isAlwaysInclude = alwaysIncludeFiles.Contains(fileName);
+        var isRepackedOutput = controlBarRepackedOutputs.Contains(fileName);
+
+        if (isControlBarVariant && controlBarRepackedOutputs.Count > 0 && !isRepackedOutput && !isDependencyBig && !isAlwaysInclude)
+        {
+            logger.LogDebug("Skipping file {File} because control bar variant is repacked into Art/Data BIG files", relativePath);
+            return false;
+        }
+
+        if (isControlBarVariant && hasVariantBigFiles && !fileName.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug("Skipping non-BIG file {File} for control bar variant {Variant}", relativePath, variant?.Name);
+            return false;
+        }
+
+        if (variant != null)
+        {
+            if (variant.IncludePatterns is { Count: > 0 })
+            {
+                bool matchesInclude = false;
+                foreach (var pattern in variant.IncludePatterns)
+                {
+                    var regex = GetCachedRegex(pattern);
+                    if (regex.IsMatch(fileName) || regex.IsMatch(normalizedPath))
+                    {
+                        matchesInclude = true;
+                        break;
+                    }
+                }
+
+                if (!matchesInclude && !isDependencyBig && !isAlwaysInclude)
+                {
+                    logger.LogDebug("Skipping file {File} - does not match variant {Variant} include patterns", relativePath, variant.Name);
+                    return false;
+                }
+            }
+
+            if (variant.ExcludePatterns is { Count: > 0 })
+            {
+                bool matchesExclude = false;
+                foreach (var pattern in variant.ExcludePatterns)
+                {
+                    var regex = GetCachedRegex(pattern);
+                    if (regex.IsMatch(fileName) || regex.IsMatch(normalizedPath))
+                    {
+                        matchesExclude = true;
+                        break;
+                    }
+                }
+
+                if (matchesExclude && !isDependencyBig && !isAlwaysInclude)
+                {
+                    logger.LogDebug("Skipping file {File} - matches variant {Variant} exclude pattern", relativePath, variant.Name);
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostUpdateService.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostUpdateService.cs
@@ -71,18 +71,13 @@ public class CommunityOutpostUpdateService(
                 var installed = installedManifests.FirstOrDefault(m =>
                     m.Id.Value.Equals(discovered.Id, StringComparison.OrdinalIgnoreCase));
 
-                if (installed != null)
+                if (installed != null &&
+                    versionComparer.IsNewer(discovered.Version, installed.Version, CommunityOutpostConstants.PublisherType) &&
+                    (latestToResolve == null || versionComparer.IsNewer(discovered.Version, latestToResolve.Version, CommunityOutpostConstants.PublisherType)))
                 {
-                    if (versionComparer.IsNewer(discovered.Version, installed.Version, CommunityOutpostConstants.PublisherType))
-                    {
-                        // Check if this discovered version is newer than our current "latest to resolve"
-                        if (latestToResolve == null || versionComparer.IsNewer(discovered.Version, latestToResolve.Version, CommunityOutpostConstants.PublisherType))
-                        {
-                            logger.LogInformation("Newer update candidate found for {Id}: {OldVersion} -> {NewVersion}", discovered.Id, installed.Version, discovered.Version);
-                            latestToResolve = discovered;
-                            currentVersionAtLatest = installed.Version;
-                        }
-                    }
+                    logger.LogInformation("Newer update candidate found for {Id}: {OldVersion} -> {NewVersion}", discovered.Id, installed.Version, discovered.Version);
+                    latestToResolve = discovered;
+                    currentVersionAtLatest = installed.Version;
                 }
             }
 

--- a/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/AODMapsDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/AODMapsDiscoverer.cs
@@ -261,7 +261,6 @@ public partial class AODMapsDiscoverer(
     private static string BuildDiscoveryUrl(ContentSearchQuery query)
     {
         var page = query.Page ?? 1;
-        var pageStr = page > 1 ? page.ToString() : string.Empty; // Some URLs use "2", "3". "1" is often empty or omitted.
 
         // Special case: Page 1 often has no suffix. Page 2 has '2'.
         // Format {0} in patterns usually denotes the number suffix.
@@ -270,7 +269,7 @@ public partial class AODMapsDiscoverer(
         // 1. Check for specific map makers in query or tags
         // If we want to browse a map maker
         // Not implemented in basic browsing yet unless we parse "tags" containing "author:xxx"
-        if (query.CNCLabsMapTags != null && query.CNCLabsMapTags.Any(t => t.StartsWith("author:")))
+        if (query.CNCLabsMapTags?.Any(t => t.StartsWith("author:")) == true)
         {
             var authorTag = query.CNCLabsMapTags.First(t => t.StartsWith("author:"));
             var authorName = authorTag.Replace("author:", string.Empty);
@@ -289,7 +288,7 @@ public partial class AODMapsDiscoverer(
         // 3. Check Categories (Compstomp, Air, Race, etc - passed as Tags or specialized logic?)
         // Assuming user might pass these as Tags or we map ContentType?
         // Simplification: If "Compstomp" tag is present
-        if (query.CNCLabsMapTags != null && query.CNCLabsMapTags.Contains("Compstomp", StringComparer.OrdinalIgnoreCase))
+        if (query.CNCLabsMapTags?.Contains("Compstomp", StringComparer.OrdinalIgnoreCase) == true)
         {
             return string.Format(AODMapsConstants.CompstompPagePattern, suffix);
         }

--- a/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
@@ -290,68 +290,8 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
                 StringComparison.OrdinalIgnoreCase));
 
         var author = CNCLabsHelper.GetNextNonEmptyTextSibling(authorStrong);
-
-        DateTime? lastUpdated = null;
-        long? dlCount = null;
-        string? fSize = null;
-
-        var strongs = item.QuerySelectorAll("strong");
-        foreach (var s in strongs)
-        {
-            var label = s.TextContent?.Trim();
-            if (string.IsNullOrEmpty(label))
-            {
-                continue;
-            }
-
-            var value = CNCLabsHelper.GetNextNonEmptyTextSibling(s);
-            if (string.IsNullOrEmpty(value))
-            {
-                continue;
-            }
-
-            if (label.StartsWith("Updated:", StringComparison.OrdinalIgnoreCase) ||
-                label.StartsWith("Added:", StringComparison.OrdinalIgnoreCase) ||
-                label.StartsWith("Date:", StringComparison.OrdinalIgnoreCase) ||
-                label.StartsWith("reviewed:", StringComparison.OrdinalIgnoreCase))
-            {
-                if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
-                {
-                    lastUpdated = parsed;
-                }
-            }
-            else if (label.StartsWith("Size:", StringComparison.OrdinalIgnoreCase))
-            {
-                fSize = value;
-            }
-            else if (label.StartsWith("Downloads:", StringComparison.OrdinalIgnoreCase) &&
-                     long.TryParse(value.Replace(",", string.Empty), out var count))
-            {
-                dlCount = count;
-            }
-        }
-
-        if (!lastUpdated.HasValue)
-        {
-            var match = DateRegex().Match(item.TextContent);
-            if (match.Success && DateTime.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var fallbackDate))
-            {
-                lastUpdated = fallbackDate;
-            }
-        }
-
-        string? imgUrl = null;
-        var img = item.QuerySelector(".screenshot img") ?? item.QuerySelector("img");
-        if (img != null)
-        {
-            var src = img.GetAttribute("src");
-            if (!string.IsNullOrEmpty(src))
-            {
-                imgUrl = src.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                    ? src
-                    : new Uri(new Uri("https://www.cnclabs.com"), src).ToString();
-            }
-        }
+        var (lastUpdated, dlCount, fSize) = ExtractSearchItemMetadata(item);
+        var imgUrl = ExtractScreenshotUrl(item);
 
         return new MapListItem(
             id,
@@ -669,6 +609,77 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
             // Logging failure to parse file size, though it's acceptable to return null
             // and fallback to the display string.
             logger.LogWarning("Failed to parse file size '{Size}': {Error}", size, ex.Message);
+        }
+
+        return null;
+    }
+
+    private (DateTime? LastUpdated, long? DlCount, string? FSize) ExtractSearchItemMetadata(IElement item)
+    {
+        DateTime? lastUpdated = null;
+        long? dlCount = null;
+        string? fSize = null;
+
+        var strongs = item.QuerySelectorAll("strong");
+        foreach (var s in strongs)
+        {
+            var label = s.TextContent?.Trim();
+            if (string.IsNullOrEmpty(label))
+            {
+                continue;
+            }
+
+            var value = CNCLabsHelper.GetNextNonEmptyTextSibling(s);
+            if (string.IsNullOrEmpty(value))
+            {
+                continue;
+            }
+
+            if (label.StartsWith("Updated:", StringComparison.OrdinalIgnoreCase) ||
+                label.StartsWith("Added:", StringComparison.OrdinalIgnoreCase) ||
+                label.StartsWith("Date:", StringComparison.OrdinalIgnoreCase) ||
+                label.StartsWith("reviewed:", StringComparison.OrdinalIgnoreCase))
+            {
+                if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+                {
+                    lastUpdated = parsed;
+                }
+            }
+            else if (label.StartsWith("Size:", StringComparison.OrdinalIgnoreCase))
+            {
+                fSize = value;
+            }
+            else if (label.StartsWith("Downloads:", StringComparison.OrdinalIgnoreCase) &&
+                     long.TryParse(value.Replace(",", string.Empty), out var count))
+            {
+                dlCount = count;
+            }
+        }
+
+        if (!lastUpdated.HasValue)
+        {
+            var match = DateRegex().Match(item.TextContent);
+            if (match.Success && DateTime.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var fallbackDate))
+            {
+                lastUpdated = fallbackDate;
+            }
+        }
+
+        return (lastUpdated, dlCount, fSize);
+    }
+
+    private string? ExtractScreenshotUrl(IElement item)
+    {
+        var img = item.QuerySelector(".screenshot img") ?? item.QuerySelector("img");
+        if (img != null)
+        {
+            var src = img.GetAttribute("src");
+            if (!string.IsNullOrEmpty(src))
+            {
+                return src.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                    ? src
+                    : new Uri(new Uri("https://www.cnclabs.com"), src).ToString();
+            }
         }
 
         return null;

--- a/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/CNCLabsMapDiscoverer.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp;
+using AngleSharp.Dom;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Content;
@@ -239,149 +240,171 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
         }
 
         var mapList = new List<MapListItem>();
-
         var html = await httpClient.GetStringAsync(url, cancellationToken).ConfigureAwait(false);
 
         var context = BrowsingContext.New(Configuration.Default);
         var document = await context.OpenAsync(req => req.Content(html), cancellationToken).ConfigureAwait(false);
-
         var results = document.QuerySelectorAll(CNCLabsConstants.ListItemSelector);
 
         foreach (var item in results)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            var idValue = item.QuerySelector(CNCLabsConstants.FileIdHiddenSelector)?.GetAttribute(CNCLabsConstants.ValueAttribute);
-            if (!string.IsNullOrWhiteSpace(idValue) && int.TryParse(idValue, out var id))
+            var parsedItem = ParseSearchListItem(item, query);
+            if (parsedItem != null)
             {
-                var nameAnchor = item.QuerySelector(CNCLabsConstants.DisplayNameAnchorSelector);
-                var name = nameAnchor?.TextContent?.Trim();
-                var detailsHref = nameAnchor?.GetAttribute(CNCLabsConstants.HrefAttribute);
-
-                string? description = null;
-                var descEl = item.QuerySelector(CNCLabsConstants.DescriptionSelector);
-                if (descEl != null)
-                {
-                    var htmlDesc = descEl.InnerHtml;
-                    description = CNCLabsHelper.NormalizeHtmlDescription(htmlDesc);
-                }
-
-                var authorStrong = item.QuerySelectorAll(CNCLabsConstants.DescriptionCellStrongSelector)
-                    .FirstOrDefault(s => string.Equals(
-                        s.TextContent?.Trim(),
-                        CNCLabsConstants.AuthorLabelText,
-                        StringComparison.OrdinalIgnoreCase));
-
-                var author = CNCLabsHelper.GetNextNonEmptyTextSibling(authorStrong);
-
-                // Attempt to parse Date, Size, Downloads from the specs block
-                DateTime? lastUpdated = null;
-                long? dlCount = null;
-                string? fSize = null;
-
-                var specsText = item.TextContent;
-
-                // Typical structure: <strong>Author:</strong> Name <br> <strong>Size:</strong> 1.5 MB <br> <strong>Date:</strong> ...
-                var strongs = item.QuerySelectorAll("strong");
-                foreach (var s in strongs)
-                {
-                    var label = s.TextContent?.Trim();
-                    if (string.IsNullOrEmpty(label)) continue;
-
-                    var value = CNCLabsHelper.GetNextNonEmptyTextSibling(s);
-                    if (string.IsNullOrEmpty(value)) continue;
-
-                    if (label.StartsWith("Updated:", StringComparison.OrdinalIgnoreCase) ||
-                        label.StartsWith("Added:", StringComparison.OrdinalIgnoreCase) ||
-                        label.StartsWith("Date:", StringComparison.OrdinalIgnoreCase) ||
-                        label.StartsWith("reviewed:", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
-                        {
-                            lastUpdated = parsed;
-                        }
-                    }
-                    else if (label.StartsWith("Size:", StringComparison.OrdinalIgnoreCase))
-                    {
-                        fSize = value;
-                    }
-                    else if (label.StartsWith("Downloads:", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (long.TryParse(value.Replace(",", string.Empty), out var count))
-                        {
-                            dlCount = count;
-                        }
-                    }
-                }
-
-                // If date is still missing, try a simpler regex on the whole cell text
-                if (!lastUpdated.HasValue)
-                {
-                    var match = DateRegex().Match(specsText);
-                    if (match.Success && DateTime.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var fallbackDate))
-                    {
-                        lastUpdated = fallbackDate;
-                    }
-                }
-
-                // Try to find image in list item
-                string? imgUrl = null;
-                var img = item.QuerySelector(".screenshot img") ?? item.QuerySelector("img");
-                if (img != null)
-                {
-                    var src = img.GetAttribute("src");
-                    if (!string.IsNullOrEmpty(src))
-                    {
-                        imgUrl = src.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                            ? src
-                            : new Uri(new Uri("https://www.cnclabs.com"), src).ToString();
-                    }
-                }
-
-                mapList.Add(new MapListItem(id, name ?? string.Empty, description ?? string.Empty, author ?? CNCLabsConstants.DefaultAuthorName, detailsHref ?? string.Empty, query.TargetGame, query.ContentType, lastUpdated ?? DateTime.MinValue, dlCount, fSize, imgUrl, []));
+                mapList.Add(parsedItem);
             }
         }
 
         // Check for 'Next' button in pagination
-        bool hasMoreItems = false;
         var pagingLinks = document.QuerySelectorAll(".paging a, .pager a, #ctl00_MainContent_Pager1 a, #ctl00_Main_NextPageLink, #ctl00_MainContent_NextPageLink, a[id*='NextPageLink']");
+        bool hasMoreItems = ParseHasMorePagingLinks(pagingLinks, query);
 
-        if (pagingLinks.Length > 0)
+        logger.LogInformation("[CNCLabs] Search returned {Count} maps. HasMore: {HasMore}", mapList.Count, hasMoreItems);
+        return (mapList, hasMoreItems);
+    }
+
+    private MapListItem? ParseSearchListItem(IElement item, ContentSearchQuery query)
+    {
+        var idValue = item.QuerySelector(CNCLabsConstants.FileIdHiddenSelector)?.GetAttribute(CNCLabsConstants.ValueAttribute);
+        if (string.IsNullOrWhiteSpace(idValue) || !int.TryParse(idValue, out var id))
         {
-            logger.LogInformation("[CNCLabs] Found {Count} paging links", pagingLinks.Length);
-            foreach (var link in pagingLinks)
+            return null;
+        }
+
+        var nameAnchor = item.QuerySelector(CNCLabsConstants.DisplayNameAnchorSelector);
+        var name = nameAnchor?.TextContent?.Trim();
+        var detailsHref = nameAnchor?.GetAttribute(CNCLabsConstants.HrefAttribute);
+
+        string? description = null;
+        var descEl = item.QuerySelector(CNCLabsConstants.DescriptionSelector);
+        if (descEl != null)
+        {
+            description = CNCLabsHelper.NormalizeHtmlDescription(descEl.InnerHtml);
+        }
+
+        var authorStrong = item.QuerySelectorAll(CNCLabsConstants.DescriptionCellStrongSelector)
+            .FirstOrDefault(s => string.Equals(
+                s.TextContent?.Trim(),
+                CNCLabsConstants.AuthorLabelText,
+                StringComparison.OrdinalIgnoreCase));
+
+        var author = CNCLabsHelper.GetNextNonEmptyTextSibling(authorStrong);
+
+        DateTime? lastUpdated = null;
+        long? dlCount = null;
+        string? fSize = null;
+
+        var strongs = item.QuerySelectorAll("strong");
+        foreach (var s in strongs)
+        {
+            var label = s.TextContent?.Trim();
+            if (string.IsNullOrEmpty(label))
             {
-                var text = link.TextContent.Trim();
-                var href = link.GetAttribute("href");
-                logger.LogDebug("[CNCLabs] Paging link: Text='{Text}', Href='{Href}'", text, href);
+                continue;
+            }
 
-                // Check for "Next" or "..."
-                if (text.Contains("Next", StringComparison.OrdinalIgnoreCase) || text.Contains("...", StringComparison.Ordinal) || (href != null && href.Contains("page=" + (query.Page + 1))))
+            var value = CNCLabsHelper.GetNextNonEmptyTextSibling(s);
+            if (string.IsNullOrEmpty(value))
+            {
+                continue;
+            }
+
+            if (label.StartsWith("Updated:", StringComparison.OrdinalIgnoreCase) ||
+                label.StartsWith("Added:", StringComparison.OrdinalIgnoreCase) ||
+                label.StartsWith("Date:", StringComparison.OrdinalIgnoreCase) ||
+                label.StartsWith("reviewed:", StringComparison.OrdinalIgnoreCase))
+            {
+                if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
                 {
-                    logger.LogInformation("[CNCLabs] Found Next/Ellipsis link match: {Text} (href: {Href})", text, href);
-                    hasMoreItems = true;
-
-                    // Don't break, keep logging for debug
+                    lastUpdated = parsed;
                 }
+            }
+            else if (label.StartsWith("Size:", StringComparison.OrdinalIgnoreCase))
+            {
+                fSize = value;
+            }
+            else if (label.StartsWith("Downloads:", StringComparison.OrdinalIgnoreCase) &&
+                     long.TryParse(value.Replace(",", string.Empty), out var count))
+            {
+                dlCount = count;
+            }
+        }
 
-                // Check for page numbers greater than current
-                if (int.TryParse(text, out var pNum))
+        if (!lastUpdated.HasValue)
+        {
+            var match = DateRegex().Match(item.TextContent);
+            if (match.Success && DateTime.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var fallbackDate))
+            {
+                lastUpdated = fallbackDate;
+            }
+        }
+
+        string? imgUrl = null;
+        var img = item.QuerySelector(".screenshot img") ?? item.QuerySelector("img");
+        if (img != null)
+        {
+            var src = img.GetAttribute("src");
+            if (!string.IsNullOrEmpty(src))
+            {
+                imgUrl = src.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                    ? src
+                    : new Uri(new Uri("https://www.cnclabs.com"), src).ToString();
+            }
+        }
+
+        return new MapListItem(
+            id,
+            name ?? string.Empty,
+            description ?? string.Empty,
+            author ?? CNCLabsConstants.DefaultAuthorName,
+            detailsHref ?? string.Empty,
+            query.TargetGame,
+            query.ContentType,
+            lastUpdated ?? DateTime.MinValue,
+            dlCount,
+            fSize,
+            imgUrl,
+            []);
+    }
+
+    private bool ParseHasMorePagingLinks(IHtmlCollection<IElement> pagingLinks, ContentSearchQuery query)
+    {
+        if (pagingLinks.Length == 0)
+        {
+            logger.LogInformation("[CNCLabs] No paging links found (single page result)");
+            return false;
+        }
+
+        logger.LogInformation("[CNCLabs] Found {Count} paging links", pagingLinks.Length);
+        bool hasMoreItems = false;
+
+        foreach (var link in pagingLinks)
+        {
+            var text = link.TextContent.Trim();
+            var href = link.GetAttribute("href");
+            logger.LogDebug("[CNCLabs] Paging link: Text='{Text}', Href='{Href}'", text, href);
+
+            if (text.Contains("Next", StringComparison.OrdinalIgnoreCase) ||
+                text.Contains("...", StringComparison.Ordinal) ||
+                href?.Contains("page=" + (query.Page + 1)) == true)
+            {
+                logger.LogInformation("[CNCLabs] Found Next/Ellipsis link match: {Text} (href: {Href})", text, href);
+                hasMoreItems = true;
+            }
+
+            if (int.TryParse(text, out var pNum))
+            {
+                int currentPage = query.Page ?? 1;
+                if (pNum > currentPage)
                 {
-                    int currentPage = query.Page ?? 1;
-                    if (pNum > currentPage)
-                    {
-                        logger.LogInformation("[CNCLabs] Found page {PageNum} > current {CurrentPage}", pNum, currentPage);
-                        hasMoreItems = true;
-                    }
+                    logger.LogInformation("[CNCLabs] Found page {PageNum} > current {CurrentPage}", pNum, currentPage);
+                    hasMoreItems = true;
                 }
             }
         }
-        else
-        {
-            logger.LogInformation("[CNCLabs] No paging links found using selectors: .paging a, .pager a, #ctl00_MainContent_Pager1 a, etc.");
-        }
 
-        return (mapList, hasMoreItems);
+        return hasMoreItems;
     }
 
     /// <summary>
@@ -430,7 +453,6 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
         var context = BrowsingContext.New(Configuration.Default);
         var document = await context.OpenAsync(req => req.Content(html), cancellationToken).ConfigureAwait(false);
 
-        // 1) Name (primary selector, then fallback to last breadcrumb segment)
         var name =
             document.QuerySelector(CNCLabsConstants.NameSelector)?.TextContent?.Trim()
             ?? document.QuerySelector(CNCLabsConstants.BreadcrumbHeaderSelector)
@@ -440,13 +462,11 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
                        .Trim()
             ?? string.Empty;
 
-        // 2) Description (span id ends with _DescriptionLabel)
         var descEl = document.QuerySelector(CNCLabsConstants.DescriptionSelector);
         var description = descEl is null
             ? string.Empty
             : CNCLabsHelper.NormalizeHtmlDescription(descEl.InnerHtml) ?? string.Empty;
 
-        // 3) Author (text node immediately after <strong>Author:</strong>)
         var authorStrong = document.QuerySelectorAll(CNCLabsConstants.AuthorLabelContainerSelector)
                                    .FirstOrDefault(s => string.Equals(
                                        s.TextContent?.Trim(),
@@ -454,13 +474,33 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
                                        StringComparison.OrdinalIgnoreCase));
 
         var author = CNCLabsHelper.GetNextNonEmptyTextSibling(authorStrong) ?? string.Empty;
-
         var (gameType, contentType) = CNCLabsHelper.ExtractBreadcrumbCategory(document);
 
-        // 4) Date Parsing (try multiple labels)
-        DateTime lastUpdated = DateTime.MinValue;
-        var dateLabels = new[] { "Updated:", "Added:", "Submitted:", "reviewed:", "Date:" };
+        var docText = document.Body?.TextContent ?? string.Empty;
+        var lastUpdated = ParseLastUpdatedDate(document, docText);
+        var fileSize = ParseFileSize(document, docText);
+        var downloadCount = ParseDownloadCount(docText);
+        var iconUrl = ParsePreviewImage(document);
+        var tags = ParseTags(docText);
 
+        return new MapListItem(
+            id,
+            name,
+            description,
+            string.IsNullOrEmpty(author) ? CNCLabsConstants.DefaultAuthorName : author,
+            detailsPageUrl,
+            gameType,
+            contentType,
+            lastUpdated,
+            downloadCount,
+            fileSize,
+            iconUrl,
+            tags);
+    }
+
+    private DateTime ParseLastUpdatedDate(IDocument document, string docText)
+    {
+        var dateLabels = new[] { "Updated:", "Added:", "Submitted:", "reviewed:", "Date:" };
         foreach (var label in dateLabels)
         {
             var dateEl = document.QuerySelectorAll("strong").FirstOrDefault(e => e.TextContent.Contains(label, StringComparison.OrdinalIgnoreCase));
@@ -469,51 +509,47 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
                 var dateText = CNCLabsHelper.GetNextNonEmptyTextSibling(dateEl);
                 if (!string.IsNullOrWhiteSpace(dateText) && DateTime.TryParse(dateText, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
                 {
-                    lastUpdated = parsedDate;
-                    break;
+                    return parsedDate;
                 }
             }
         }
 
-        // Parse additional metadata
-        var docText = document.Body?.TextContent ?? string.Empty;
-
-        long? downloadCount = null;
-        string? fileSize = null;
-        string? iconUrl = null;
-
-        // Date Backup (Date submitted)
-        if (lastUpdated == DateTime.MinValue)
+        var dateMatch = DateRegex().Match(docText);
+        if (dateMatch.Success && DateTime.TryParse(dateMatch.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
         {
-            var dateMatch = DateRegex().Match(docText);
-            if (dateMatch.Success && DateTime.TryParse(dateMatch.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
-            {
-                lastUpdated = date;
-            }
+            return date;
         }
 
-        // File Size
+        return DateTime.MinValue;
+    }
+
+    private string? ParseFileSize(IDocument document, string docText)
+    {
         var sizeMatch = FileSizeRegex().Match(docText);
         if (sizeMatch.Success)
         {
-            fileSize = sizeMatch.Groups[1].Value.Trim();
+            return sizeMatch.Groups[1].Value.Trim();
         }
-        else
+
+        var sizeLabels = new[] { "File Size:", "Size:" };
+        foreach (var label in sizeLabels)
         {
-            // Fallback for size if regex fails
-            var sizeLabels = new[] { "File Size:", "Size:" };
-            foreach (var label in sizeLabels)
+            var sizeEl = document.QuerySelectorAll("strong").FirstOrDefault(e => e.TextContent.Contains(label, StringComparison.OrdinalIgnoreCase));
+            if (sizeEl != null)
             {
-                var sizeEl = document.QuerySelectorAll("strong").FirstOrDefault(e => e.TextContent.Contains(label, StringComparison.OrdinalIgnoreCase));
-                if (sizeEl != null)
+                var fileSize = CNCLabsHelper.GetNextNonEmptyTextSibling(sizeEl);
+                if (!string.IsNullOrEmpty(fileSize))
                 {
-                    fileSize = CNCLabsHelper.GetNextNonEmptyTextSibling(sizeEl);
-                    if (!string.IsNullOrEmpty(fileSize)) break;
+                    return fileSize;
                 }
             }
         }
 
-        // Download Count
+        return null;
+    }
+
+    private long? ParseDownloadCount(string docText)
+    {
         var downloadMatch = DownloadCountRegex().Match(docText);
         if (downloadMatch.Success)
         {
@@ -521,24 +557,32 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
             var val = downloadMatch.Groups[valGroup].Value;
             if (long.TryParse(val.Replace(",", string.Empty, StringComparison.Ordinal), out var dl))
             {
-                downloadCount = dl;
+                return dl;
             }
         }
 
-        // Image
+        return null;
+    }
+
+    private string? ParsePreviewImage(IDocument document)
+    {
         var mainImage = document.QuerySelector("#ctl00_MainContent_Image1") ?? document.QuerySelector(".screenshot img") ?? document.QuerySelector("img[src*='preview']");
         if (mainImage != null)
         {
             var src = mainImage.GetAttribute("src");
             if (!string.IsNullOrEmpty(src))
             {
-                iconUrl = src.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                return src.StartsWith("http", StringComparison.OrdinalIgnoreCase)
                     ? src
                     : new Uri(new Uri("https://www.cnclabs.com"), src).ToString();
             }
         }
 
-        // Tags parsing
+        return null;
+    }
+
+    private List<string> ParseTags(string docText)
+    {
         var tags = new List<string>();
         var taggedAsIdx = docText.IndexOf("Tagged as:", StringComparison.OrdinalIgnoreCase);
         if (taggedAsIdx != -1)
@@ -561,7 +605,7 @@ public partial class CNCLabsMapDiscoverer(HttpClient httpClient, ILogger<CNCLabs
             }
         }
 
-        return new MapListItem(id, name, description, string.IsNullOrEmpty(author) ? CNCLabsConstants.DefaultAuthorName : author, detailsPageUrl, gameType, contentType, lastUpdated, downloadCount, fileSize, iconUrl, tags);
+        return tags;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
@@ -524,14 +524,12 @@ public class ContentReconciliationService(
                 }
                 else
                 {
-                    var error = $"Failed to update profile '{profile.Name}': {updateResult.FirstError}";
                     logger.LogWarning("Failed to update profile '{ProfileName}': {Error}", profile.Name, updateResult.FirstError);
                     failedProfiles.Add(profile.Name);
                 }
             }
             catch (Exception ex)
             {
-                var error = $"Error reconciling profile '{profile.Name}': {ex.Message}";
                 logger.LogError(ex, "Error reconciling profile '{ProfileName}': {Message}", profile.Name, ex.Message);
                 failedProfiles.Add(profile.Name);
             }
@@ -608,14 +606,12 @@ public class ContentReconciliationService(
                 }
                 else
                 {
-                    var error = $"Failed to update profile '{profile.Name}': {updateResult.FirstError}";
                     logger.LogWarning("Failed to update profile '{ProfileName}': {Error}", profile.Name, updateResult.FirstError);
                     failedProfiles.Add(profile.Name);
                 }
             }
             catch (Exception ex)
             {
-                var error = $"Error removing manifest from profile '{profile.Name}': {ex.Message}";
                 logger.LogError(ex, "Error removing manifest from profile '{ProfileName}': {Message}", profile.Name, ex.Message);
                 failedProfiles.Add(profile.Name);
             }

--- a/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
@@ -529,14 +529,12 @@ public class ContentReconciliationService(
                 }
                 else
                 {
-                    var error = $"Failed to update profile '{profile.Name}': {updateResult.FirstError}";
                     logger.LogWarning("Failed to update profile '{ProfileName}': {Error}", profile.Name, updateResult.FirstError);
                     failedProfiles.Add(profile.Name);
                 }
             }
             catch (Exception ex)
             {
-                var error = $"Error reconciling profile '{profile.Name}': {ex.Message}";
                 logger.LogError(ex, "Error reconciling profile '{ProfileName}': {Message}", profile.Name, ex.Message);
                 failedProfiles.Add(profile.Name);
             }
@@ -613,14 +611,12 @@ public class ContentReconciliationService(
                 }
                 else
                 {
-                    var error = $"Failed to update profile '{profile.Name}': {updateResult.FirstError}";
                     logger.LogWarning("Failed to update profile '{ProfileName}': {Error}", profile.Name, updateResult.FirstError);
                     failedProfiles.Add(profile.Name);
                 }
             }
             catch (Exception ex)
             {
-                var error = $"Error removing manifest from profile '{profile.Name}': {ex.Message}";
                 logger.LogError(ex, "Error removing manifest from profile '{ProfileName}': {Message}", profile.Name, ex.Message);
                 failedProfiles.Add(profile.Name);
             }

--- a/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
@@ -475,27 +475,19 @@ public class ContentReconciliationService(
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
-                GameClient? newGameClient = null;
-                if (profile.GameClient != null)
+                GameClient? newGameClient = profile.GameClient;
+                if (profile.GameClient != null && replacements.TryGetValue(profile.GameClient.Id, out var m))
                 {
-                    if (replacements.TryGetValue(profile.GameClient.Id, out var m))
+                    newGameClient = new GameClient
                     {
-                        newGameClient = new GameClient
-                        {
-                            Id = m.Id.Value,
-                            Name = m.Name ?? m.Id.Value,
-                            Version = m.Version ?? string.Empty,
-                            GameType = m.TargetGame,
-                            SourceType = m.ContentType,
-                            PublisherType = m.Publisher?.PublisherType,
-                            InstallationId = profile.GameClient.InstallationId, // Preserve installation link
-                        };
-                    }
-                    else
-                    {
-                        // Preserve existing GameClient if its ID is not in the replacement list
-                        newGameClient = profile.GameClient;
-                    }
+                        Id = m.Id.Value,
+                        Name = m.Name ?? m.Id.Value,
+                        Version = m.Version ?? string.Empty,
+                        GameType = m.TargetGame,
+                        SourceType = m.ContentType,
+                        PublisherType = m.Publisher?.PublisherType,
+                        InstallationId = profile.GameClient.InstallationId, // Preserve installation link
+                    };
                 }
 
                 bool workspaceInvalidated = false;
@@ -529,14 +521,12 @@ public class ContentReconciliationService(
                 }
                 else
                 {
-                    var error = $"Failed to update profile '{profile.Name}': {updateResult.FirstError}";
                     logger.LogWarning("Failed to update profile '{ProfileName}': {Error}", profile.Name, updateResult.FirstError);
                     failedProfiles.Add(profile.Name);
                 }
             }
             catch (Exception ex)
             {
-                var error = $"Error reconciling profile '{profile.Name}': {ex.Message}";
                 logger.LogError(ex, "Error reconciling profile '{ProfileName}': {Message}", profile.Name, ex.Message);
                 failedProfiles.Add(profile.Name);
             }
@@ -613,14 +603,12 @@ public class ContentReconciliationService(
                 }
                 else
                 {
-                    var error = $"Failed to update profile '{profile.Name}': {updateResult.FirstError}";
                     logger.LogWarning("Failed to update profile '{ProfileName}': {Error}", profile.Name, updateResult.FirstError);
                     failedProfiles.Add(profile.Name);
                 }
             }
             catch (Exception ex)
             {
-                var error = $"Error removing manifest from profile '{profile.Name}': {ex.Message}";
                 logger.LogError(ex, "Error removing manifest from profile '{ProfileName}': {Message}", profile.Name, ex.Message);
                 failedProfiles.Add(profile.Name);
             }

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -502,13 +502,24 @@ public class ContentStorageService : IContentStorageService
 
             // Create source.path mapping if we have a valid source directory
             // This allows GetContentDirectoryAsync to resolve the content location
+            bool contentDirCreatedByThisCall = false;
+            bool sourcePathWrittenByThisCall = false;
+            string? previousSourcePathContent = null;
             if (!string.IsNullOrWhiteSpace(sourceDirectory) && Directory.Exists(sourceDirectory))
             {
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
+                bool dirAlreadyExisted = Directory.Exists(contentDir);
                 Directory.CreateDirectory(contentDir);
+                contentDirCreatedByThisCall = !dirAlreadyExisted;
 
                 var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
+
+                // Backup existing source.path content before overwriting
+                if (File.Exists(sourcePathFile))
+                    previousSourcePathContent = await File.ReadAllTextAsync(sourcePathFile, cancellationToken);
+
                 await File.WriteAllTextAsync(sourcePathFile, sourceDirectory, cancellationToken);
+                sourcePathWrittenByThisCall = true;
 
                 _logger.LogInformation(
                     "Created source path mapping for {ManifestId}: {SourcePath}",
@@ -543,23 +554,26 @@ public class ContentStorageService : IContentStorageService
 
                 // Clean up the content dir created for source.path mapping
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
-                var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
-
-                // Only delete the directory if we created it in this call (check if it only contains source.path)
-                if (Directory.Exists(contentDir))
+                if (contentDirCreatedByThisCall)
                 {
-                    var entries = Directory.EnumerateFileSystemEntries(contentDir).ToList();
-                    if (entries.Count == 1 && entries[0].Equals(sourcePathFile, StringComparison.OrdinalIgnoreCase))
+                    // We created this directory in the current call — safe to remove entirely.
+                    if (Directory.Exists(contentDir))
+                        Directory.Delete(contentDir, recursive: true);
+                }
+                else if (sourcePathWrittenByThisCall && Directory.Exists(contentDir))
+                {
+                    // We overwrote an existing source.path file - restore it or delete if it was new
+                    var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
+                    if (previousSourcePathContent != null)
                     {
-                        // Only source.path exists, safe to delete the directory
-                        Directory.Delete(contentDir, recursive: false);
+                        // Restore the previous content
+                        await File.WriteAllTextAsync(sourcePathFile, previousSourcePathContent, CancellationToken.None);
                     }
-                    else if (entries.Count == 0)
+                    else
                     {
-                        // Empty directory, safe to delete
-                        Directory.Delete(contentDir, recursive: false);
+                        // We created a new file, safe to delete
+                        FileOperationsService.DeleteFileIfExists(sourcePathFile);
                     }
-                    // Otherwise, leave the directory alone as it contains pre-existing data
                 }
 
                 // Untrack manifest if we failed to save its metadata but had already tracked/refreshed references.

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -480,6 +480,11 @@ public class ContentStorageService : IContentStorageService
     {
         var manifestPath = GetManifestStoragePath(manifest.Id);
 
+        // Declare cleanup tracking variables outside try block so they're accessible in catch
+        bool contentDirCreatedByThisCall = false;
+        bool sourcePathWrittenByThisCall = false;
+        string? previousSourcePathContent = null;
+
         try
         {
             // Validate manifest for security issues
@@ -502,9 +507,6 @@ public class ContentStorageService : IContentStorageService
 
             // Create source.path mapping if we have a valid source directory
             // This allows GetContentDirectoryAsync to resolve the content location
-            bool contentDirCreatedByThisCall = false;
-            bool sourcePathWrittenByThisCall = false;
-            string? previousSourcePathContent = null;
             if (!string.IsNullOrWhiteSpace(sourceDirectory) && Directory.Exists(sourceDirectory))
             {
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -534,6 +534,11 @@ public class ContentStorageService : IContentStorageService
             {
                 FileOperationsService.DeleteFileIfExists(manifestPath);
 
+                // Clean up the content dir created for source.path mapping
+                var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
+                if (Directory.Exists(contentDir))
+                    Directory.Delete(contentDir, recursive: true);
+
                 // Untrack manifest if we failed to save its metadata but had already tracked/refreshed references.
                 await _referenceTracker.UntrackManifestAsync(manifest.Id, CancellationToken.None);
             }

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -292,7 +292,7 @@ public class ContentStorageService : IContentStorageService
             // This prevents "Could not resolve source path" warnings when GetContentDirectoryAsync is called
             var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
             Directory.CreateDirectory(contentDir);
-            var sourcePathFile = Path.Combine(contentDir, "source.path");
+            var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
             await File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", cancellationToken);
 
             _logger.LogInformation("Successfully stored content for manifest {ManifestId}", manifest.Id);
@@ -415,7 +415,7 @@ public class ContentStorageService : IContentStorageService
 
             // Remove source.path mapping file if it exists
             var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifestId.Value);
-            var sourcePathFile = Path.Combine(contentDir, "source.path");
+            var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
             FileOperationsService.DeleteFileIfExists(sourcePathFile);
 
             // Clean up the data directory if empty
@@ -507,7 +507,7 @@ public class ContentStorageService : IContentStorageService
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
                 Directory.CreateDirectory(contentDir);
 
-                var sourcePathFile = Path.Combine(contentDir, "source.path");
+                var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
                 await File.WriteAllTextAsync(sourcePathFile, sourceDirectory, cancellationToken);
 
                 _logger.LogInformation(
@@ -543,8 +543,24 @@ public class ContentStorageService : IContentStorageService
 
                 // Clean up the content dir created for source.path mapping
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
+                var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
+
+                // Only delete the directory if we created it in this call (check if it only contains source.path)
                 if (Directory.Exists(contentDir))
-                    Directory.Delete(contentDir, recursive: true);
+                {
+                    var entries = Directory.EnumerateFileSystemEntries(contentDir).ToList();
+                    if (entries.Count == 1 && entries[0].Equals(sourcePathFile, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Only source.path exists, safe to delete the directory
+                        Directory.Delete(contentDir, recursive: false);
+                    }
+                    else if (entries.Count == 0)
+                    {
+                        // Empty directory, safe to delete
+                        Directory.Delete(contentDir, recursive: false);
+                    }
+                    // Otherwise, leave the directory alone as it contains pre-existing data
+                }
 
                 // Untrack manifest if we failed to save its metadata but had already tracked/refreshed references.
                 await _referenceTracker.UntrackManifestAsync(manifest.Id, CancellationToken.None);

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -288,6 +288,13 @@ public class ContentStorageService : IContentStorageService
             var manifestJson = JsonSerializer.Serialize(updatedManifest, JsonOptions);
             await File.WriteAllTextAsync(manifestPath, manifestJson, cancellationToken);
 
+            // Create source.path marker for CAS-stored content
+            // This prevents "Could not resolve source path" warnings when GetContentDirectoryAsync is called
+            var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
+            Directory.CreateDirectory(contentDir);
+            var sourcePathFile = Path.Combine(contentDir, "source.path");
+            await File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", cancellationToken);
+
             _logger.LogInformation("Successfully stored content for manifest {ManifestId}", manifest.Id);
             return OperationResult<ContentManifest>.CreateSuccess(updatedManifest);
         }

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -537,6 +537,11 @@ public class ContentStorageService : IContentStorageService
             {
                 FileOperationsService.DeleteFileIfExists(manifestPath);
 
+                // Clean up the content dir created for source.path mapping
+                var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
+                if (Directory.Exists(contentDir))
+                    Directory.Delete(contentDir, recursive: true);
+
                 // Untrack manifest if we failed to save its metadata but had already tracked/refreshed references.
                 await _referenceTracker.UntrackManifestAsync(manifest.Id, CancellationToken.None);
             }

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -291,6 +291,13 @@ public class ContentStorageService : IContentStorageService
             var manifestJson = JsonSerializer.Serialize(updatedManifest, JsonOptions);
             await File.WriteAllTextAsync(manifestPath, manifestJson, cancellationToken);
 
+            // Create source.path marker for CAS-stored content
+            // This prevents "Could not resolve source path" warnings when GetContentDirectoryAsync is called
+            var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
+            Directory.CreateDirectory(contentDir);
+            var sourcePathFile = Path.Combine(contentDir, "source.path");
+            await File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", cancellationToken);
+
             _logger.LogInformation("Successfully stored content for manifest {ManifestId}", manifest.Id);
             return OperationResult<ContentManifest>.CreateSuccess(updatedManifest);
         }

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -293,10 +293,17 @@ public class ContentStorageService : IContentStorageService
 
             // Create source.path marker for CAS-stored content
             // This prevents "Could not resolve source path" warnings when GetContentDirectoryAsync is called
-            var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
-            Directory.CreateDirectory(contentDir);
-            var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
-            await File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", cancellationToken);
+            try
+            {
+                var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
+                Directory.CreateDirectory(contentDir);
+                var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
+                await File.WriteAllTextAsync(sourcePathFile, FileTypes.CasOnlySourceMarker, cancellationToken);
+            }
+            catch (Exception markerEx)
+            {
+                _logger.LogWarning(markerEx, "Stored manifest {ManifestId} but failed to write CAS source-path marker", updatedManifest.Id);
+            }
 
             _logger.LogInformation("Successfully stored content for manifest {ManifestId}", manifest.Id);
             return OperationResult<ContentManifest>.CreateSuccess(updatedManifest);

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -505,13 +505,24 @@ public class ContentStorageService : IContentStorageService
 
             // Create source.path mapping if we have a valid source directory
             // This allows GetContentDirectoryAsync to resolve the content location
+            bool contentDirCreatedByThisCall = false;
+            bool sourcePathWrittenByThisCall = false;
+            string? previousSourcePathContent = null;
             if (!string.IsNullOrWhiteSpace(sourceDirectory) && Directory.Exists(sourceDirectory))
             {
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
+                bool dirAlreadyExisted = Directory.Exists(contentDir);
                 Directory.CreateDirectory(contentDir);
+                contentDirCreatedByThisCall = !dirAlreadyExisted;
 
                 var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
+
+                // Backup existing source.path content before overwriting
+                if (File.Exists(sourcePathFile))
+                    previousSourcePathContent = await File.ReadAllTextAsync(sourcePathFile, cancellationToken);
+
                 await File.WriteAllTextAsync(sourcePathFile, sourceDirectory, cancellationToken);
+                sourcePathWrittenByThisCall = true;
 
                 _logger.LogInformation(
                     "Created source path mapping for {ManifestId}: {SourcePath}",
@@ -546,23 +557,26 @@ public class ContentStorageService : IContentStorageService
 
                 // Clean up the content dir created for source.path mapping
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
-                var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
-
-                // Only delete the directory if we created it in this call (check if it only contains source.path)
-                if (Directory.Exists(contentDir))
+                if (contentDirCreatedByThisCall)
                 {
-                    var entries = Directory.EnumerateFileSystemEntries(contentDir).ToList();
-                    if (entries.Count == 1 && entries[0].Equals(sourcePathFile, StringComparison.OrdinalIgnoreCase))
+                    // We created this directory in the current call — safe to remove entirely.
+                    if (Directory.Exists(contentDir))
+                        Directory.Delete(contentDir, recursive: true);
+                }
+                else if (sourcePathWrittenByThisCall && Directory.Exists(contentDir))
+                {
+                    // We overwrote an existing source.path file - restore it or delete if it was new
+                    var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
+                    if (previousSourcePathContent != null)
                     {
-                        // Only source.path exists, safe to delete the directory
-                        Directory.Delete(contentDir, recursive: false);
+                        // Restore the previous content
+                        await File.WriteAllTextAsync(sourcePathFile, previousSourcePathContent, CancellationToken.None);
                     }
-                    else if (entries.Count == 0)
+                    else
                     {
-                        // Empty directory, safe to delete
-                        Directory.Delete(contentDir, recursive: false);
+                        // We created a new file, safe to delete
+                        FileOperationsService.DeleteFileIfExists(sourcePathFile);
                     }
-                    // Otherwise, leave the directory alone as it contains pre-existing data
                 }
 
                 // Untrack manifest if we failed to save its metadata but had already tracked/refreshed references.

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -483,6 +483,11 @@ public class ContentStorageService : IContentStorageService
     {
         var manifestPath = GetManifestStoragePath(manifest.Id);
 
+        // Declare cleanup tracking variables outside try block so they're accessible in catch
+        bool contentDirCreatedByThisCall = false;
+        bool sourcePathWrittenByThisCall = false;
+        string? previousSourcePathContent = null;
+
         try
         {
             // Validate manifest for security issues
@@ -505,9 +510,6 @@ public class ContentStorageService : IContentStorageService
 
             // Create source.path mapping if we have a valid source directory
             // This allows GetContentDirectoryAsync to resolve the content location
-            bool contentDirCreatedByThisCall = false;
-            bool sourcePathWrittenByThisCall = false;
-            string? previousSourcePathContent = null;
             if (!string.IsNullOrWhiteSpace(sourceDirectory) && Directory.Exists(sourceDirectory))
             {
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -295,7 +295,7 @@ public class ContentStorageService : IContentStorageService
             // This prevents "Could not resolve source path" warnings when GetContentDirectoryAsync is called
             var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
             Directory.CreateDirectory(contentDir);
-            var sourcePathFile = Path.Combine(contentDir, "source.path");
+            var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
             await File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", cancellationToken);
 
             _logger.LogInformation("Successfully stored content for manifest {ManifestId}", manifest.Id);
@@ -418,7 +418,7 @@ public class ContentStorageService : IContentStorageService
 
             // Remove source.path mapping file if it exists
             var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifestId.Value);
-            var sourcePathFile = Path.Combine(contentDir, "source.path");
+            var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
             FileOperationsService.DeleteFileIfExists(sourcePathFile);
 
             // Clean up the data directory if empty
@@ -510,7 +510,7 @@ public class ContentStorageService : IContentStorageService
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
                 Directory.CreateDirectory(contentDir);
 
-                var sourcePathFile = Path.Combine(contentDir, "source.path");
+                var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
                 await File.WriteAllTextAsync(sourcePathFile, sourceDirectory, cancellationToken);
 
                 _logger.LogInformation(
@@ -546,8 +546,24 @@ public class ContentStorageService : IContentStorageService
 
                 // Clean up the content dir created for source.path mapping
                 var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, manifest.Id.Value);
+                var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
+
+                // Only delete the directory if we created it in this call (check if it only contains source.path)
                 if (Directory.Exists(contentDir))
-                    Directory.Delete(contentDir, recursive: true);
+                {
+                    var entries = Directory.EnumerateFileSystemEntries(contentDir).ToList();
+                    if (entries.Count == 1 && entries[0].Equals(sourcePathFile, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Only source.path exists, safe to delete the directory
+                        Directory.Delete(contentDir, recursive: false);
+                    }
+                    else if (entries.Count == 0)
+                    {
+                        // Empty directory, safe to delete
+                        Directory.Delete(contentDir, recursive: false);
+                    }
+                    // Otherwise, leave the directory alone as it contains pre-existing data
+                }
 
                 // Untrack manifest if we failed to save its metadata but had already tracked/refreshed references.
                 await _referenceTracker.UntrackManifestAsync(manifest.Id, CancellationToken.None);

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -1526,19 +1526,19 @@ public class ProfileLauncherFacade(
         Dictionary<string, ContentManifest> manifestsById,
         List<string> errors)
     {
-        if (manifest.Dependencies != null && manifest.Dependencies.Count > 0)
+        if (manifest.Dependencies is { Count: > 0 })
         {
             foreach (var dependency in manifest.Dependencies.Where(d => d.ConflictsWith.Count > 0))
             {
                 foreach (var conflictId in dependency.ConflictsWith)
                 {
-                    if (manifestsById.ContainsKey(conflictId.ToString()))
+                    if (manifestsById.TryGetValue(conflictId.ToString(), out var conflictingManifest))
                     {
-                        errors.Add($"Content '{manifest.Name}' conflicts with '{manifestsById[conflictId.ToString()].Name}' - these cannot be enabled together");
+                        errors.Add($"Content '{manifest.Name}' conflicts with '{conflictingManifest.Name}' - these cannot be enabled together");
                         logger.LogWarning(
                             "Conflict detected: {ManifestName} conflicts with {ConflictingManifest}",
                             manifest.Name,
-                            manifestsById[conflictId.ToString()].Name);
+                            conflictingManifest.Name);
                     }
                 }
             }
@@ -1586,7 +1586,8 @@ public class ProfileLauncherFacade(
                         profile.GameClient?.WorkingDirectory);
                     return OperationResult<Core.Models.GameInstallations.GameInstallation>.CreateSuccess(matchingInstallation);
                 }
-                else if (exactPathMatches.Count > 1)
+
+                if (exactPathMatches.Count > 1)
                 {
                     // This should never happen - multiple installations with same path
                     logger.LogWarning(
@@ -1614,14 +1615,15 @@ public class ProfileLauncherFacade(
                         matchingInstallation.Id);
                     return OperationResult<Core.Models.GameInstallations.GameInstallation>.CreateSuccess(matchingInstallation);
                 }
-                else if (gameTypeMatches.Count > 1)
+
+                if (gameTypeMatches.Count > 1)
                 {
                     // Multiple matching installations found - this is dangerous!
                     // Different installations may have different patches/mods.
                     // Require explicit user confirmation for rebinding.
                     var message =
                         $"Found {gameTypeMatches.Count} installations for {profile.GameClient?.GameType}. " +
-                        $"Please edit the profile to manually select the correct installation to avoid conflicts.";
+                        "Please edit the profile to manually select the correct installation to avoid conflicts.";
 
                     logger.LogError(
                         "Profile {ProfileId} installation {OldId} not found. " +
@@ -1637,7 +1639,7 @@ public class ProfileLauncherFacade(
             logger.LogError("Could not resolve or rebind installation for profile {ProfileId}", profile.Id);
             return OperationResult<Core.Models.GameInstallations.GameInstallation>.CreateFailure(
                 $"No valid installation found for {profile.GameClient?.GameType}. " +
-                $"Please verify your game installation and update the profile settings.");
+                "Please verify your game installation and update the profile settings.");
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -264,7 +264,6 @@ public class ProfileLauncherFacade(
 
             // Build list of manifests from enabled content IDs only
             var manifests = new List<ContentManifest>();
-            var resolvedContentIds = new HashSet<string>(profile.EnabledContentIds ?? Enumerable.Empty<string>());
 
             // Resolve dependencies recursively
             var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? Enumerable.Empty<string>(), cancellationToken);
@@ -427,11 +426,9 @@ public class ProfileLauncherFacade(
                     logger.LogInformation("Successfully deleted profile {ProfileId}", profileId);
                     return ProfileOperationResult<bool>.CreateSuccess(true);
                 }
-                else
-                {
-                    logger.LogError("Failed to delete profile {ProfileId}: {Errors}", profileId, string.Join(", ", deleteResult.Errors));
-                    return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", deleteResult.Errors));
-                }
+
+                logger.LogError("Failed to delete profile {ProfileId}: {Errors}", profileId, string.Join(", ", deleteResult.Errors));
+                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", deleteResult.Errors));
             }
         }
         catch (IOException ioEx) when (ioEx.Message.Contains("being used by another process"))
@@ -694,75 +691,13 @@ public class ProfileLauncherFacade(
             }
 
             // Step 2.5: Check for game client updates before launching.
-            // All three publisher game clients block launch on reconciler failure —
-            // the user is prompted via dialog first, so a failure after accepting means
-            // the update process itself broke and launching would use a stale/invalid client.
-            logger.LogDebug(
-                "[Launch] Step 2.5: Publisher check - Client={Client}, Publisher={PublisherType}",
-                profile.GameClient?.Name ?? "null",
-                profile.GameClient?.PublisherType ?? "null");
-
-            // Try to get reconciler by PublisherType first, then fall back to legacy detection
-            IPublisherReconciler? reconciler = null;
-            string? publisherType = profile.GameClient?.PublisherType;
-
-            if (!string.IsNullOrWhiteSpace(publisherType))
+            var reconcileResult = await ReconcilePublisherClientAsync(profile, profileId, cancellationToken);
+            if (reconcileResult.Failed)
             {
-                logger.LogDebug("[Launch] Looking up reconciler for publisher: {PublisherType}", publisherType);
-                reconciler = reconcilerRegistry.GetReconciler(publisherType);
-            }
-            else
-            {
-                // Legacy fallback: detect publisher from profile characteristics
-                if (IsGeneralsOnlineProfile(profile))
-                {
-                    publisherType = PublisherTypeConstants.GeneralsOnline;
-                    reconciler = reconcilerRegistry.GetReconciler(publisherType);
-                    logger.LogDebug("[Launch] Detected legacy GeneralsOnline profile, using reconciler");
-                }
-                else if (IsSuperHackersProfile(profile))
-                {
-                    publisherType = PublisherTypeConstants.TheSuperHackers;
-                    reconciler = reconcilerRegistry.GetReconciler(publisherType);
-                    logger.LogDebug("[Launch] Detected legacy SuperHackers profile, using reconciler");
-                }
-                else if (IsCommunityOutpostProfile(profile))
-                {
-                    publisherType = CommunityOutpostConstants.PublisherType;
-                    reconciler = reconcilerRegistry.GetReconciler(publisherType);
-                    logger.LogDebug("[Launch] Detected legacy CommunityOutpost profile, using reconciler");
-                }
+                return ProfileOperationResult<GameLaunchInfo>.CreateFailure(reconcileResult.FirstError ?? "Reconciliation failed");
             }
 
-            if (reconciler != null && publisherType != null)
-            {
-                logger.LogDebug("[Launch] Checking for {PublisherType} updates", publisherType);
-                var reconcileResult = await reconciler.CheckAndReconcileIfNeededAsync(profileId, cancellationToken);
-
-                if (!reconcileResult.Success)
-                {
-                    // Log the error but don't block launch - users should be able to play offline
-                    logger.LogWarning(
-                        "[Launch] {PublisherType} reconciliation failed (non-blocking): {Error}",
-                        publisherType,
-                        reconcileResult.FirstError);
-
-                    // Show a non-blocking notification to the user
-                    // The game will still launch with the currently installed version
-                }
-                else if (reconcileResult.Data)
-                {
-                    logger.LogInformation("[Launch] Profile updated by {PublisherType} reconciliation, reloading", publisherType);
-                    var reloadedProfileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
-                    if (reloadedProfileResult.Failed || reloadedProfileResult.Data == null)
-                    {
-                        var error = reloadedProfileResult.Failed ? string.Join(", ", reloadedProfileResult.Errors) : "Profile data is null after reload";
-                        return ProfileOperationResult<GameLaunchInfo>.CreateFailure(error);
-                    }
-
-                    profile = reloadedProfileResult.Data;
-                }
-            }
+            profile = reconcileResult.Data ?? profile;
 
             // Validate the profile before launching
             logger.LogDebug("[Launch] Step 3: Validating profile for launch");
@@ -776,61 +711,9 @@ public class ProfileLauncherFacade(
             logger.LogDebug("[Launch] Validation passed");
 
             // Options.ini application moved to GameLauncher.LaunchProfileAsync() (before process start)
-            // This eliminates duplicate writes and race conditions that caused black screens.
-            // See: GameLauncher.ApplyProfileSettingsToIniOptionsAsync()
             logger.LogDebug("[Launch] Step 4: Options.ini will be applied by GameLauncher (delegated)");
 
-            var effectiveStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
-            logger.LogDebug("[Launch] Step 5: Checking workspace strategy and symlink capability - Strategy: {Strategy}", effectiveStrategy);
-
-            // Downgrade symlink strategies only where symlinks genuinely cannot be created.
-            // This previously asked whether the process was an administrator and computed
-            // that only on Windows, leaving it false on Unix — which made SymlinkOnly and
-            // HybridCopySymlink unreachable there despite symlink(2) needing no privilege.
-            var canCreateSymlinks = symlinkCapability.CanCreateSymlinks;
-            logger.LogInformation(
-                "Profile {ProfileId} launch - Symlink capability: {CanCreateSymlinks}, Strategy={Strategy}",
-                profileId,
-                canCreateSymlinks,
-                effectiveStrategy);
-
-            if (!canCreateSymlinks && (effectiveStrategy == WorkspaceStrategy.HybridCopySymlink || effectiveStrategy == WorkspaceStrategy.SymlinkOnly))
-            {
-                // Symlinks unavailable here - switch the profile to HardLink
-                var originalStrategy = effectiveStrategy;
-                effectiveStrategy = WorkspaceStrategy.HardLink; // Force HardLink instead of default which might be symlink-based
-
-                logger.LogInformation(
-                    "Profile {ProfileId} - Switching from {OriginalStrategy} to HardLink because symlinks are unavailable in this environment",
-                    profileId,
-                    originalStrategy);
-
-                notificationService.ShowInfo(
-                    "Workspace Strategy Changed",
-                    $"'{profile.Name}' cannot use {originalStrategy} here because symlinks are unavailable. Switching to HardLink.",
-                    NotificationDurations.Long);
-
-                // Persist the downgrade only if the profile had an explicit strategy set (not inheriting default)
-                if (profile.WorkspaceStrategy.HasValue)
-                {
-                    var updateRequest = new UpdateProfileRequest
-                    {
-                        WorkspaceStrategy = effectiveStrategy,
-                    };
-                    var strategyUpdateResult = await profileManager.UpdateProfileAsync(profileId, updateRequest, cancellationToken);
-                    if (strategyUpdateResult.Success)
-                    {
-                        logger.LogInformation(
-                            "Updated profile {ProfileId} workspace strategy to {Strategy} because symlinks are unavailable",
-                            profileId,
-                            effectiveStrategy);
-                    }
-                }
-            }
-
-            // GameLauncher constructs the actual workspace request from this in-memory
-            // profile. Persisting an explicit downgrade is not enough: inherited defaults
-            // are intentionally not persisted, and persistence may fail independently.
+            var effectiveStrategy = await AdjustWorkspaceStrategyAsync(profile, profileId, cancellationToken);
             profile.WorkspaceStrategy = effectiveStrategy;
 
             // Use dynamic workspace path based on the game installation location
@@ -854,31 +737,7 @@ public class ProfileLauncherFacade(
 
             if (launchResult.Failed)
             {
-                logger.LogError("[Launch] GameLauncher failed: {Errors}", string.Join(", ", launchResult.Errors));
-
-                // If HardLink failed due to cross-drive, show specific error about FullCopy
-                if (profile.WorkspaceStrategy == WorkspaceStrategy.HardLink &&
-                    launchResult.Errors.Any(e => e.Contains("different volumes") || e.Contains("cross-drive")))
-                {
-                    var gameDrive = Path.GetPathRoot(resolvedInstallation.InstallationPath);
-                    var errorMessage = $"HardLink strategy failed because your workspace is on a different drive than the game on {gameDrive} drive. " +
-                        $"You can manually change to FullCopy strategy (uses more disk space) or move your workspace to the same drive as your game.";
-
-                    notificationService.ShowError(
-                        "Launch Failed - Cross-Drive Issue",
-                        errorMessage,
-                        NotificationDurations.Critical);
-
-                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure(errorMessage);
-                }
-
-                // General error notification
-                notificationService.ShowError(
-                    "Launch Failed",
-                    $"Cannot launch '{profile.Name}': {launchResult.FirstError ?? "Unknown error"}",
-                    NotificationDurations.VeryLong);
-
-                return ProfileOperationResult<GameLaunchInfo>.CreateFailure(string.Join(", ", launchResult.Errors));
+                return HandleLaunchFailure(profile, launchResult, resolvedInstallation);
             }
 
             var launchInfo = launchResult.Data!;
@@ -935,6 +794,155 @@ public class ProfileLauncherFacade(
             logger.LogError(ex, "Failed to launch profile {ProfileId}", profileId);
             return ProfileOperationResult<GameLaunchInfo>.CreateFailure($"Failed to launch profile: {ex.Message}");
         }
+    }
+
+    private async Task<ProfileOperationResult<GameProfile>> ReconcilePublisherClientAsync(
+        GameProfile profile,
+        string profileId,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug(
+            "[Launch] Step 2.5: Publisher check - Client={Client}, Publisher={PublisherType}",
+            profile.GameClient?.Name ?? "null",
+            profile.GameClient?.PublisherType ?? "null");
+
+        IPublisherReconciler? reconciler = null;
+        string? publisherType = profile.GameClient?.PublisherType;
+
+        if (!string.IsNullOrWhiteSpace(publisherType))
+        {
+            logger.LogDebug("[Launch] Looking up reconciler for publisher: {PublisherType}", publisherType);
+            reconciler = reconcilerRegistry.GetReconciler(publisherType);
+        }
+        else
+        {
+            if (IsGeneralsOnlineProfile(profile))
+            {
+                publisherType = PublisherTypeConstants.GeneralsOnline;
+                reconciler = reconcilerRegistry.GetReconciler(publisherType);
+                logger.LogDebug("[Launch] Detected legacy GeneralsOnline profile, using reconciler");
+            }
+            else if (IsSuperHackersProfile(profile))
+            {
+                publisherType = PublisherTypeConstants.TheSuperHackers;
+                reconciler = reconcilerRegistry.GetReconciler(publisherType);
+                logger.LogDebug("[Launch] Detected legacy SuperHackers profile, using reconciler");
+            }
+            else if (IsCommunityOutpostProfile(profile))
+            {
+                publisherType = CommunityOutpostConstants.PublisherType;
+                reconciler = reconcilerRegistry.GetReconciler(publisherType);
+                logger.LogDebug("[Launch] Detected legacy CommunityOutpost profile, using reconciler");
+            }
+        }
+
+        if (reconciler != null && publisherType != null)
+        {
+            logger.LogDebug("[Launch] Checking for {PublisherType} updates", publisherType);
+            var reconcileResult = await reconciler.CheckAndReconcileIfNeededAsync(profileId, cancellationToken);
+
+            if (!reconcileResult.Success)
+            {
+                logger.LogWarning(
+                    "[Launch] {PublisherType} reconciliation failed (non-blocking): {Error}",
+                    publisherType,
+                    reconcileResult.FirstError);
+            }
+            else if (reconcileResult.Data)
+            {
+                logger.LogInformation("[Launch] Profile updated by {PublisherType} reconciliation, reloading", publisherType);
+                var reloadedProfileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
+                if (reloadedProfileResult.Failed || reloadedProfileResult.Data == null)
+                {
+                    var error = reloadedProfileResult.Failed ? string.Join(", ", reloadedProfileResult.Errors) : "Profile data is null after reload";
+                    return ProfileOperationResult<GameProfile>.CreateFailure(error);
+                }
+
+                return ProfileOperationResult<GameProfile>.CreateSuccess(reloadedProfileResult.Data);
+            }
+        }
+
+        return ProfileOperationResult<GameProfile>.CreateSuccess(profile);
+    }
+
+    private async Task<WorkspaceStrategy> AdjustWorkspaceStrategyAsync(
+        GameProfile profile,
+        string profileId,
+        CancellationToken cancellationToken)
+    {
+        var effectiveStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
+        logger.LogDebug("[Launch] Step 5: Checking workspace strategy and symlink capability - Strategy: {Strategy}", effectiveStrategy);
+
+        var canCreateSymlinks = symlinkCapability.CanCreateSymlinks;
+        logger.LogInformation(
+            "Profile {ProfileId} launch - Symlink capability: {CanCreateSymlinks}, Strategy={Strategy}",
+            profileId,
+            canCreateSymlinks,
+            effectiveStrategy);
+
+        if (!canCreateSymlinks && (effectiveStrategy == WorkspaceStrategy.HybridCopySymlink || effectiveStrategy == WorkspaceStrategy.SymlinkOnly))
+        {
+            var originalStrategy = effectiveStrategy;
+            effectiveStrategy = WorkspaceStrategy.HardLink;
+
+            logger.LogInformation(
+                "Profile {ProfileId} - Switching from {OriginalStrategy} to HardLink because symlinks are unavailable in this environment",
+                profileId,
+                originalStrategy);
+
+            notificationService.ShowInfo(
+                "Workspace Strategy Changed",
+                $"'{profile.Name}' cannot use {originalStrategy} here because symlinks are unavailable. Switching to HardLink.",
+                NotificationDurations.Long);
+
+            if (profile.WorkspaceStrategy.HasValue)
+            {
+                var updateRequest = new UpdateProfileRequest
+                {
+                    WorkspaceStrategy = effectiveStrategy,
+                };
+                var strategyUpdateResult = await profileManager.UpdateProfileAsync(profileId, updateRequest, cancellationToken);
+                if (strategyUpdateResult.Success)
+                {
+                    logger.LogInformation(
+                        "Updated profile {ProfileId} workspace strategy to {Strategy} because symlinks are unavailable",
+                        profileId,
+                        effectiveStrategy);
+                }
+            }
+        }
+
+        return effectiveStrategy;
+    }
+
+    private ProfileOperationResult<GameLaunchInfo> HandleLaunchFailure(
+        GameProfile profile,
+        LaunchOperationResult<GameLaunchInfo> launchResult,
+        Core.Models.GameInstallations.GameInstallation resolvedInstallation)
+    {
+        logger.LogError("[Launch] GameLauncher failed: {Errors}", string.Join(", ", launchResult.Errors));
+
+        if (profile.WorkspaceStrategy == WorkspaceStrategy.HardLink &&
+            launchResult.Errors.Any(e => e.Contains("different volumes") || e.Contains("cross-drive")))
+        {
+            var gameDrive = Path.GetPathRoot(resolvedInstallation.InstallationPath);
+            var errorMessage = $"HardLink strategy failed because your workspace is on a different drive than the game on {gameDrive} drive. " +
+                "You can manually change to FullCopy strategy (uses more disk space) or move your workspace to the same drive as your game.";
+
+            notificationService.ShowError(
+                "Launch Failed - Cross-Drive Issue",
+                errorMessage,
+                NotificationDurations.Critical);
+
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(errorMessage);
+        }
+
+        notificationService.ShowError(
+            "Launch Failed",
+            $"Cannot launch '{profile.Name}': {launchResult.FirstError ?? "Unknown error"}",
+            NotificationDurations.VeryLong);
+
+        return ProfileOperationResult<GameLaunchInfo>.CreateFailure(string.Join(", ", launchResult.Errors));
     }
 
     private ProfileOperationResult<bool> ValidateToolProfileLaunch(GameProfile profile)
@@ -1122,20 +1130,14 @@ public class ProfileLauncherFacade(
 
         // Simple string comparison for min/max versions (semantic versioning would be better in production)
         // For now, we use string comparison which works for versions like "1.04", "1.08", etc.
-        if (!string.IsNullOrEmpty(dependency.MinVersion))
+        if (!string.IsNullOrEmpty(dependency.MinVersion) && string.Compare(version, dependency.MinVersion, StringComparison.OrdinalIgnoreCase) < 0)
         {
-            if (string.Compare(version, dependency.MinVersion, StringComparison.OrdinalIgnoreCase) < 0)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (!string.IsNullOrEmpty(dependency.MaxVersion))
+        if (!string.IsNullOrEmpty(dependency.MaxVersion) && string.Compare(version, dependency.MaxVersion, StringComparison.OrdinalIgnoreCase) > 0)
         {
-            if (string.Compare(version, dependency.MaxVersion, StringComparison.OrdinalIgnoreCase) > 0)
-            {
-                return false;
-            }
+            return false;
         }
 
         return true;
@@ -1419,25 +1421,23 @@ public class ProfileLauncherFacade(
             return;
         }
 
-        if (!string.IsNullOrEmpty(dependency.MinVersion) || !string.IsNullOrEmpty(dependency.MaxVersion) || dependency.CompatibleVersions.Count > 0)
+        if ((!string.IsNullOrEmpty(dependency.MinVersion) || !string.IsNullOrEmpty(dependency.MaxVersion) || dependency.CompatibleVersions.Count > 0)
+            && !IsVersionCompatible(requiredManifest.Version, dependency))
         {
-            if (!IsVersionCompatible(requiredManifest.Version, dependency))
+            var versionInfo = BuildVersionRequirementString(dependency);
+            var msg = $"Content '{manifest.Name}' requires '{dependency.Name}' {versionInfo}, but version {requiredManifest.Version} is selected";
+            if (!dependency.IsOptional)
             {
-                var versionInfo = BuildVersionRequirementString(dependency);
-                var msg = $"Content '{manifest.Name}' requires '{dependency.Name}' {versionInfo}, but version {requiredManifest.Version} is selected";
-                if (!dependency.IsOptional)
-                {
-                    errors.Add(msg);
-                }
-
-                logger.LogWarning(
-                    "Version compatibility failed: {ManifestName} requires {DependencyName} {VersionInfo}, but {ActualVersion} found (Optional: {IsOptional})",
-                    manifest.Name,
-                    dependency.Name,
-                    versionInfo,
-                    requiredManifest.Version,
-                    dependency.IsOptional);
+                errors.Add(msg);
             }
+
+            logger.LogWarning(
+                "Version compatibility failed: {ManifestName} requires {DependencyName} {VersionInfo}, but {ActualVersion} found (Optional: {IsOptional})",
+                manifest.Name,
+                dependency.Name,
+                versionInfo,
+                requiredManifest.Version,
+                dependency.IsOptional);
         }
     }
 
@@ -1469,7 +1469,7 @@ public class ProfileLauncherFacade(
             }
         }
 
-        if (dependency.CompatibleGameTypes != null && dependency.CompatibleGameTypes.Count > 0 && !dependency.CompatibleGameTypes.Contains(profileGameType))
+        if (dependency.CompatibleGameTypes is { Count: > 0 } && !dependency.CompatibleGameTypes.Contains(profileGameType))
         {
             var compatibleGamesStr = string.Join(", ", dependency.CompatibleGameTypes);
             var msg = $"Content '{manifest.Name}' dependency '{dependency.Name}' is only compatible with {compatibleGamesStr}, but profile is for {profileGameType}";

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -97,226 +97,560 @@ public class ProfileLauncherFacade(
                 }
             }
 
-            // ===== TOOL PROFILE LAUNCH PATH =====
-            // Tool profiles launch standalone executables directly without game installation
             if (profile.IsToolProfile)
             {
-                logger.LogInformation("[Launch] Detected Tool profile, launching tool directly");
+                return await LaunchToolProfileAsync(profile, profileId, cancellationToken);
+            }
 
-                // Get the tool manifest
-                if (string.IsNullOrWhiteSpace(profile.ToolContentId))
+            return await LaunchGameProfileAsync(profile, profileId, skipUserDataCleanup, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to launch profile {ProfileId}", profileId);
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure($"Failed to launch profile: {ex.Message}");
+        }
+    }
+
+/// <inheritdoc/>
+    public async Task<ProfileOperationResult<bool>> ValidateLaunchAsync(string profileId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogDebug("Validating launch for profile {ProfileId}", profileId);
+
+            var profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
+            if (profileResult.Failed)
+            {
+                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", profileResult.Errors));
+            }
+
+            var profile = profileResult.Data!;
+
+            // Perform auto-detection for Tool Profiles in validation
+            string? validationToolId = await DetectAndSetToolContentIdAsync(profile, cancellationToken);
+            if (validationToolId != null)
+            {
+                logger.LogInformation("[Launch] Validation: Detected implicit Tool Profile (mixed content)");
+                profile.ToolContentId = validationToolId;
+            }
+
+            if (profile.IsToolProfile)
+            {
+                return ValidateToolProfileLaunch(profile);
+            }
+
+            return await ValidateGameProfileLaunchAsync(profile, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to validate launch for profile {ProfileId}", profileId);
+            return ProfileOperationResult<bool>.CreateFailure($"Launch validation failed: {ex.Message}");
+        }
+    }
+
+/// <inheritdoc/>
+    public async Task<ProfileOperationResult<GameProcessInfo>> GetLaunchStatusAsync(string profileId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogDebug("Getting launch status for profile {ProfileId}", profileId);
+
+            var launches = await launchRegistry.GetAllActiveLaunchesAsync();
+            var launch = launches.FirstOrDefault(l => l.ProfileId == profileId);
+            if (launch == null)
+            {
+                logger.LogDebug("No active launch found for profile {ProfileId}, returning stopped status", profileId);
+                return ProfileOperationResult<GameProcessInfo>.CreateSuccess(new GameProcessInfo
                 {
-                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure(ProfileValidationConstants.ToolProfileMissingContentId);
-                }
+                    IsRunning = false,
+                    ProcessId = -1,
+                });
+            }
 
-                if (!ManifestId.TryCreate(profile.ToolContentId, out var toolManifestId))
+            logger.LogDebug("Profile {ProfileId} launch status: {Status}", profileId, launch.ProcessInfo.IsRunning ? "Running" : "Not Running");
+
+            return ProfileOperationResult<GameProcessInfo>.CreateSuccess(launch.ProcessInfo);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get launch status for profile {ProfileId}", profileId);
+            return ProfileOperationResult<GameProcessInfo>.CreateFailure($"Failed to get launch status: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProfileOperationResult<bool>> StopProfileAsync(string profileId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogInformation("Stopping profile {ProfileId}", profileId);
+
+            var launches = await launchRegistry.GetAllActiveLaunchesAsync();
+            var launch = launches.FirstOrDefault(l => l.ProfileId == profileId);
+            if (launch == null)
+            {
+                logger.LogInformation("No active launch found for profile {ProfileId}, considering it already stopped.", profileId);
+                return ProfileOperationResult<bool>.CreateSuccess(true);
+            }
+
+            var stopResult = await gameLauncher.TerminateGameAsync(launch.LaunchId, cancellationToken);
+            if (stopResult.Failed)
+            {
+                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", stopResult.Errors));
+            }
+
+            // Workspace is not cleaned up when stopping - it persists across launches.
+            // This allows quick re-launches without re-creating symlinks/copies.
+            // Workspace is only cleaned up when:
+            // 1. Profile is deleted
+            // 2. Content changes require workspace refresh
+            logger.LogInformation("Successfully stopped profile {ProfileId}", profileId);
+            return ProfileOperationResult<bool>.CreateSuccess(true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to stop profile {ProfileId}", profileId);
+            return ProfileOperationResult<bool>.CreateFailure($"Failed to stop profile: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProfileOperationResult<WorkspaceInfo>> PrepareWorkspaceAsync(string profileId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogInformation("Preparing workspace for profile {ProfileId}", profileId);
+
+            // Get the profile to understand what content needs to be prepared
+            var profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
+            if (profileResult.Failed)
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", profileResult.Errors));
+            }
+
+            var profile = profileResult.Data!;
+
+            // Try to resolve or rebind the installation if it's stale
+            var resolvedInstallationResult = await ResolveOrRebindInstallationAsync(profile, cancellationToken);
+            if (resolvedInstallationResult.Failed)
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(resolvedInstallationResult.FirstError ?? "Could not resolve game installation for profile");
+            }
+
+            var resolvedInstallation = resolvedInstallationResult.Data;
+            if (resolvedInstallation == null)
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Resolved installation data is null");
+            }
+
+            // Update the profile with the resolved installation if it changed
+            if (resolvedInstallation.Id != profile.GameInstallationId)
+            {
+                var updateRequest = new UpdateProfileRequest
                 {
-                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                        $"{ProfileValidationConstants.InvalidToolContentId}: {profile.ToolContentId}");
-                }
-
-                var toolManifestResult = await manifestPool.GetManifestAsync(
-                    toolManifestId,
-                    cancellationToken);
-
-                if (toolManifestResult.Failed || toolManifestResult.Data == null)
+                    GameInstallationId = resolvedInstallation.Id,
+                };
+                var updateResult = await profileManager.UpdateProfileAsync(profileId, updateRequest, cancellationToken);
+                if (updateResult.Success)
                 {
-                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                        $"{ProfileValidationConstants.FailedToLoadToolManifest}: {toolManifestResult.FirstError}");
-                }
-
-                var toolManifest = toolManifestResult.Data;
-                logger.LogDebug("[Launch] Tool manifest loaded: {ManifestId}", toolManifest.Id);
-
-                // Get tool content directory
-                // For CAS-based content, there might not be a pre-existing directory.
-                // We need to use WorkspaceManager to hydrate the content into a temporary workspace.
-
-                // Try to resolve directory first (for local content)
-                var toolDirectory = await manifestPool.GetContentDirectoryAsync(toolManifest.Id, cancellationToken);
-                string toolWorkspacePath;
-                string? actualWorkspaceId = null; // Track if we created a workspace
-
-                if (toolDirectory.Success && !string.IsNullOrEmpty(toolDirectory.Data))
-                {
-                    // Existing directory (e.g. Local content)
-                    toolWorkspacePath = toolDirectory.Data;
-                    logger.LogInformation("[Launch] Using existing tool directory: {Path}", toolWorkspacePath);
-                }
-                else
-                {
-                    // CAS content or unresolved path - use WorkspaceManager
-                    logger.LogInformation("[Launch] Tool content requires hydration, using WorkspaceManager");
-
-                    // Create a dummy GameClient for the workspace config
-                    var dummyGameClient = new GenHub.Core.Models.GameClients.GameClient
-                    {
-                        Name = toolManifest.Name,
-                        GameType = toolManifest.TargetGame,
-                    };
-
-                    // Define a base path for the workspace - for tools we can use a temp dir or app data
-                    // WorkspaceManager requires a BaseInstallationPath, even if empty for tools
-                    var appDataBase = configurationProvider.GetApplicationDataPath();
-                    if (!Directory.Exists(appDataBase)) Directory.CreateDirectory(appDataBase);
-
-                    var baseDetails = appDataBase;
-
-                    // Resolve all enabled content (Tool + Dependencies)
-                    var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? [], cancellationToken);
-                    var allManifests = resolutionResult.Success ? resolutionResult.ResolvedManifests : [toolManifest];
-
-                    // Determine effective strategy, downgrading symlink strategies only
-                    // where symlinks genuinely cannot be created. See ISymlinkCapabilityProvider.
-                    var requestedToolStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
-                    var effectiveToolStrategy = ResolveSupportedWorkspaceStrategy(requestedToolStrategy);
-
-                    if (effectiveToolStrategy != requestedToolStrategy)
-                    {
-                        logger.LogInformation(
-                            "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink: symlinks are unavailable in this environment",
-                            requestedToolStrategy);
-                    }
-
-                    actualWorkspaceId = $"{ProfileConstants.ToolProfileWorkspaceIdPrefix}-{profile.Id}";
-                    var workspaceConfig = new WorkspaceConfiguration
-                    {
-                        Id = actualWorkspaceId,
-                        Manifests = [.. allManifests],
-                        GameClient = dummyGameClient,
-                        Strategy = effectiveToolStrategy,
-                        ForceRecreate = false,
-                        ValidateAfterPreparation = true,
-                        BaseInstallationPath = baseDetails, // Dummy base
-                        WorkspaceRootPath = Path.Combine(appDataBase, DirectoryNames.ToolWorkspaces),
-                        SkipCleanup = false,
-                    };
-
-                    // Prepare the workspace
-                    var prepareResult = await workspaceManager.PrepareWorkspaceAsync(workspaceConfig, progress: null, skipCleanup: false, cancellationToken: cancellationToken);
-                    if (prepareResult.Failed)
-                    {
-                         return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                            $"{ProfileValidationConstants.FailedToPrepareToolWorkspace}: {prepareResult.FirstError}");
-                    }
-
-                    toolWorkspacePath = prepareResult.Data!.WorkspacePath;
-                    logger.LogInformation("[Launch] Tool workspace prepared at: {Path}", toolWorkspacePath);
-                }
-
-                var toolDirectoryPath = toolWorkspacePath;
-
-                // Find the executable file in the tool manifest
-                // Priority 1: File marked as IsExecutable
-                // Priority 2: File ending with .exe
-                var toolExecutable = toolManifest.Files?.FirstOrDefault(f => f.IsExecutable)
-                    ?? toolManifest.Files?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
-
-                if (toolExecutable == null)
-                {
-                    logger.LogError("[Launch] Tool manifest {ManifestId} does not specify an executable file", toolManifest.Id);
-                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                        ProfileValidationConstants.ToolManifestMissingExecutable);
-                }
-
-                var toolExecutablePath = Path.Combine(toolDirectoryPath, toolExecutable.RelativePath);
-                if (!File.Exists(toolExecutablePath))
-                {
-                    logger.LogError("[Launch] Tool executable not found at path: {Path}", toolExecutablePath);
-                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                        $"{ProfileValidationConstants.ToolExecutableNotFound}: {toolExecutablePath}");
-                }
-
-                logger.LogInformation("[Launch] Launching tool: {ToolPath}", toolExecutablePath);
-
-                // Launch the tool process directly
-                try
-                {
-                    var processStartInfo = new ProcessStartInfo
-                    {
-                        FileName = toolExecutablePath,
-                        WorkingDirectory = toolDirectoryPath,
-                        Arguments = profile.CommandLineArguments ?? string.Empty,
-                        UseShellExecute = false,
-                    };
-
-                    // Add environment variables if specified
-                    if (profile.EnvironmentVariables != null)
-                    {
-                        foreach (var envVar in profile.EnvironmentVariables)
-                        {
-                            processStartInfo.EnvironmentVariables[envVar.Key] = envVar.Value;
-                        }
-                    }
-
-                    Process? process = null;
-                    try
-                    {
-                        process = Process.Start(processStartInfo);
-                    }
-                    catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 740)
-                    {
-                        logger.LogWarning("Tool requires elevation (Error 740). Retrying with UseShellExecute=true and Verb='runas'. Environment variables will be ignored.");
-
-                        // Reconfigure for elevation
-                        processStartInfo.UseShellExecute = true;
-                        processStartInfo.Verb = "runas";
-
-                        // Retry launch
-                        process = Process.Start(processStartInfo);
-                    }
-
-                    if (process == null)
-                    {
-                        return ProfileOperationResult<GameLaunchInfo>.CreateFailure(ProfileValidationConstants.ToolProcessStartFailed);
-                    }
-
-                    var launchId = Guid.NewGuid().ToString("N");
-                    var toolLaunchInfo = new GameLaunchInfo
-                    {
-                        LaunchId = launchId,
-                        ProfileId = profile.Id,
-                        WorkspaceId = actualWorkspaceId ?? ProfileConstants.ToolProfileWorkspaceId, // Use actual workspace ID if created, sentinel otherwise
-                        ProcessInfo = new GameProcessInfo
-                        {
-                            ProcessId = process.Id,
-                            ExecutablePath = toolExecutablePath,
-                            IsRunning = true,
-                        },
-                    };
-
-                    logger.LogInformation(
-                        "=== TOOL LAUNCH SUCCESS: Profile {ProfileId}, ProcessId {ProcessId} ===",
-                        profileId,
-                        toolLaunchInfo.ProcessInfo.ProcessId);
-
-                    // Register the tool launch with the launch registry for process monitoring
-                    await launchRegistry.RegisterLaunchAsync(toolLaunchInfo);
-                    logger.LogDebug("[Launch] Registered tool launch {LaunchId} with LaunchRegistry", launchId);
-
-                    // Also track it in the process manager to get exit events
-                    gameProcessManager.TrackProcess(process);
-
-                    notificationService.ShowSuccess(
-                        ProfileValidationConstants.ToolLaunchSuccessTitle,
-                        $"Successfully launched '{profile.Name}'",
-                        NotificationDurations.Medium);
-
-                    return ProfileOperationResult<GameLaunchInfo>.CreateSuccess(toolLaunchInfo);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "[Launch] Tool launch failed");
-                    notificationService.ShowError(
-                        ProfileValidationConstants.ToolLaunchFailedTitle,
-                        $"Failed to launch '{profile.Name}': {ex.Message}",
-                        NotificationDurations.VeryLong);
-                    return ProfileOperationResult<GameLaunchInfo>.CreateFailure($"Tool launch failed: {ex.Message}");
+                    profile.GameInstallationId = resolvedInstallation.Id;
+                    logger.LogInformation("Rebound profile {ProfileId} to installation {InstallationId} during workspace preparation", profileId, resolvedInstallation.Id);
                 }
             }
 
-            // ===== REGULAR GAME PROFILE LAUNCH PATH =====
+            // Build list of manifests from enabled content IDs only
+            var manifests = new List<ContentManifest>();
+            var resolvedContentIds = new HashSet<string>(profile.EnabledContentIds ?? Enumerable.Empty<string>());
 
+            // Resolve dependencies recursively
+            var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? Enumerable.Empty<string>(), cancellationToken);
+            if (!resolutionResult.Success)
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", resolutionResult.Errors));
+            }
+
+            manifests = [.. resolutionResult.ResolvedManifests];
+
+            // CAS preflight check - verify all CAS content is available before workspace preparation.
+            // This prevents late failure and ensures early error detection.
+            logger.LogDebug("[Workspace] Running CAS preflight check for {ManifestCount} manifests", manifests.Count);
+            var casCheckResult = await VerifyCasContentAvailabilityAsync(manifests, cancellationToken);
+            if (!casCheckResult.Success)
+            {
+                logger.LogError("[Workspace] CAS preflight check failed: {Error}", casCheckResult.FirstError);
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(casCheckResult.FirstError ?? "Required content is not available in CAS");
+            }
+
+            logger.LogDebug("[Workspace] CAS preflight check passed");
+
+            // Resolve source paths for all manifests
+            var manifestSourcePaths = await ResolveManifestSourcePathsAsync(manifests, profile, cancellationToken);
+
+            // Create workspace configuration
+            if (profile.GameClient == null)
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Profile has no GameClient configured");
+            }
+
+            var workspaceConfig = new WorkspaceConfiguration
+            {
+                Id = profileId,
+                Manifests = manifests,
+                GameClient = profile.GameClient!,
+                Strategy = ResolveSupportedWorkspaceStrategy(
+                    profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy()),
+                ForceRecreate = false,
+                ValidateAfterPreparation = true,
+                ManifestSourcePaths = manifestSourcePaths,
+            };
+
+            // Use resolved installation path and workspace root
+            if (resolvedInstallation == null || string.IsNullOrEmpty(resolvedInstallation.InstallationPath))
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Resolved installation has no valid installation path");
+            }
+
+            var installationPath = resolvedInstallation.InstallationPath;
+            workspaceConfig.BaseInstallationPath = installationPath;
+
+            // Use dynamic workspace path based on game installation location
+            workspaceConfig.WorkspaceRootPath = storageLocationService.GetWorkspacePath(resolvedInstallation);
+
+            var prepareResult = await workspaceManager.PrepareWorkspaceAsync(workspaceConfig, cancellationToken: cancellationToken);
+            if (prepareResult.Failed)
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", prepareResult.Errors));
+            }
+
+            var workspaceInfo = prepareResult.Data;
+            if (workspaceInfo == null)
+            {
+                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Workspace preparation succeeded but returned null workspace info");
+            }
+
+            // Update the profile with the active workspace ID
+            var workspaceUpdateRequest = new UpdateProfileRequest
+            {
+                ActiveWorkspaceId = workspaceInfo.Id,
+            };
+            var updateProfileResult = await profileManager.UpdateProfileAsync(profileId, workspaceUpdateRequest, cancellationToken);
+            if (updateProfileResult.Failed)
+            {
+                logger.LogWarning("Failed to update profile {ProfileId} with active workspace ID: {Errors}", profileId, string.Join(", ", updateProfileResult.Errors));
+            }
+
+            logger.LogInformation("Successfully prepared workspace {WorkspaceId} for profile {ProfileId}", workspaceInfo.Id, profileId);
+
+            return ProfileOperationResult<WorkspaceInfo>.CreateSuccess(workspaceInfo);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to prepare workspace for profile {ProfileId}", profileId);
+            return ProfileOperationResult<WorkspaceInfo>.CreateFailure($"Failed to prepare workspace: {ex.Message}");
+        }
+    }
+
+/// <inheritdoc/>
+    public async Task<ProfileOperationResult<bool>> DeleteProfileAsync(string profileId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogInformation("Deleting profile {ProfileId}", profileId);
+
+            if (string.IsNullOrWhiteSpace(profileId))
+            {
+                return ProfileOperationResult<bool>.CreateFailure("Profile ID cannot be empty");
+            }
+
+            // Acquire the profile launch lock to ensure we don't delete during launch registration
+            // This uses the same semaphore as launch operations, so deletion waits for launch
+            // to complete its initial registration without polling or timeouts
+            using (await gameLauncher.AcquireProfileLockAsync(profileId, cancellationToken))
+            {
+                // Check if the profile is currently running
+                var launches = await launchRegistry.GetAllActiveLaunchesAsync();
+                var activeLaunch = launches.FirstOrDefault(l => l.ProfileId == profileId);
+                if (activeLaunch != null)
+                {
+                    // Double-check that the process is actually running (not in a transitional state)
+                    var isProcessRunning = false;
+                    try
+                    {
+                        var process = Process.GetProcessById(activeLaunch.ProcessInfo.ProcessId);
+                        isProcessRunning = !process.HasExited;
+                        process.Dispose();
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Process doesn't exist - safe to delete
+                        logger.LogDebug("Process {ProcessId} for profile {ProfileId} no longer exists, allowing deletion", activeLaunch.ProcessInfo.ProcessId, profileId);
+                        isProcessRunning = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Failed to verify process status for profile {ProfileId}, blocking deletion for safety", profileId);
+                        isProcessRunning = true;
+                    }
+
+                    if (isProcessRunning)
+                    {
+                        logger.LogWarning("Cannot delete profile {ProfileId} - process {ProcessId} is still running", profileId, activeLaunch.ProcessInfo.ProcessId);
+                        return ProfileOperationResult<bool>.CreateFailure(
+                            "Cannot delete a running profile. Please stop the profile before deleting it.");
+                    }
+
+                    // Process has exited but registry hasn't been cleaned up yet - safe to proceed
+                    logger.LogDebug("Profile {ProfileId} launch is in registry but process has exited, allowing deletion", profileId);
+                }
+
+                // Get profile to check for active workspace before deleting
+                var profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
+                if (profileResult.Success && profileResult.Data != null && !string.IsNullOrEmpty(profileResult.Data.ActiveWorkspaceId))
+                {
+                    logger.LogInformation("Cleaning up workspace {WorkspaceId} for profile {ProfileId} before deletion", profileResult.Data.ActiveWorkspaceId, profileId);
+                    var cleanupResult = await workspaceManager.CleanupWorkspaceAsync(profileResult.Data.ActiveWorkspaceId, cancellationToken);
+                    if (cleanupResult.Failed)
+                    {
+                        logger.LogWarning("Failed to cleanup workspace {WorkspaceId} for profile {ProfileId}: {Error}", profileResult.Data.ActiveWorkspaceId, profileId, cleanupResult.FirstError);
+
+                        // Continue with profile deletion even if workspace cleanup fails
+                    }
+                }
+
+                var deleteResult = await profileManager.DeleteProfileAsync(profileId, cancellationToken);
+                if (deleteResult.Success)
+                {
+                    logger.LogInformation("Successfully deleted profile {ProfileId}", profileId);
+                    return ProfileOperationResult<bool>.CreateSuccess(true);
+                }
+                else
+                {
+                    logger.LogError("Failed to delete profile {ProfileId}: {Errors}", profileId, string.Join(", ", deleteResult.Errors));
+                    return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", deleteResult.Errors));
+                }
+            }
+        }
+        catch (IOException ioEx) when (ioEx.Message.Contains("being used by another process"))
+        {
+            logger.LogError(ioEx, "Cannot delete profile {ProfileId} because workspace files are locked", profileId);
+            return ProfileOperationResult<bool>.CreateFailure(
+                "Cannot delete profile because workspace files are being used. Please ensure the game is fully stopped before deleting.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An unexpected error occurred while deleting profile {ProfileId}.", profileId);
+            return ProfileOperationResult<bool>.CreateFailure("An unexpected error occurred.");
+        }
+    }
+
+    private async Task<ProfileOperationResult<GameLaunchInfo>> LaunchToolProfileAsync(
+        GameProfile profile,
+        string profileId,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("[Launch] Detected Tool profile, launching tool directly");
+
+        // Get the tool manifest
+        if (string.IsNullOrWhiteSpace(profile.ToolContentId))
+        {
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(ProfileValidationConstants.ToolProfileMissingContentId);
+        }
+
+        if (!ManifestId.TryCreate(profile.ToolContentId, out var toolManifestId))
+        {
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                $"{ProfileValidationConstants.InvalidToolContentId}: {profile.ToolContentId}");
+        }
+
+        var toolManifestResult = await manifestPool.GetManifestAsync(
+            toolManifestId,
+            cancellationToken);
+
+        if (toolManifestResult.Failed || toolManifestResult.Data == null)
+        {
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                $"{ProfileValidationConstants.FailedToLoadToolManifest}: {toolManifestResult.FirstError}");
+        }
+
+        var toolManifest = toolManifestResult.Data;
+        logger.LogDebug("[Launch] Tool manifest loaded: {ManifestId}", toolManifest.Id);
+
+        var toolDirectory = await manifestPool.GetContentDirectoryAsync(toolManifest.Id, cancellationToken);
+        string toolWorkspacePath = string.Empty;
+        string? actualWorkspaceId = null;
+
+        if (toolDirectory.Success && !string.IsNullOrEmpty(toolDirectory.Data))
+        {
+            toolWorkspacePath = toolDirectory.Data;
+            logger.LogInformation("[Launch] Using existing tool directory: {Path}", toolWorkspacePath);
+        }
+        else
+        {
+            logger.LogInformation("[Launch] Tool content requires hydration, using WorkspaceManager");
+
+            var dummyGameClient = new GenHub.Core.Models.GameClients.GameClient
+            {
+                Name = toolManifest.Name,
+                GameType = toolManifest.TargetGame,
+            };
+
+            var appDataBase = configurationProvider.GetApplicationDataPath();
+            if (!Directory.Exists(appDataBase))
+            {
+                Directory.CreateDirectory(appDataBase);
+            }
+
+            var baseDetails = appDataBase;
+
+            var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? [], cancellationToken);
+            var allManifests = resolutionResult.Success ? resolutionResult.ResolvedManifests : [toolManifest];
+
+            var requestedToolStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
+            var effectiveToolStrategy = ResolveSupportedWorkspaceStrategy(requestedToolStrategy);
+
+            if (effectiveToolStrategy != requestedToolStrategy)
+            {
+                logger.LogInformation(
+                    "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink: symlinks are unavailable in this environment",
+                    requestedToolStrategy);
+            }
+
+            actualWorkspaceId = $"{ProfileConstants.ToolProfileWorkspaceIdPrefix}-{profile.Id}";
+            var workspaceConfig = new WorkspaceConfiguration
+            {
+                Id = actualWorkspaceId,
+                Manifests = [.. allManifests],
+                GameClient = dummyGameClient,
+                Strategy = effectiveToolStrategy,
+                ForceRecreate = false,
+                ValidateAfterPreparation = true,
+                BaseInstallationPath = baseDetails,
+                WorkspaceRootPath = Path.Combine(appDataBase, DirectoryNames.ToolWorkspaces),
+                SkipCleanup = false,
+            };
+
+            var prepareResult = await workspaceManager.PrepareWorkspaceAsync(workspaceConfig, progress: null, skipCleanup: false, cancellationToken: cancellationToken);
+            if (prepareResult.Failed)
+            {
+                return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                    $"{ProfileValidationConstants.FailedToPrepareToolWorkspace}: {prepareResult.FirstError}");
+            }
+
+            toolWorkspacePath = prepareResult.Data!.WorkspacePath;
+            logger.LogInformation("[Launch] Tool workspace prepared at: {Path}", toolWorkspacePath);
+        }
+
+        var toolDirectoryPath = toolWorkspacePath;
+        var toolExecutable = toolManifest.Files?.FirstOrDefault(f => f.IsExecutable)
+            ?? toolManifest.Files?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+
+        if (toolExecutable == null)
+        {
+            logger.LogError("[Launch] Tool manifest {ManifestId} does not specify an executable file", toolManifest.Id);
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                ProfileValidationConstants.ToolManifestMissingExecutable);
+        }
+
+        var toolExecutablePath = Path.Combine(toolDirectoryPath, toolExecutable.RelativePath);
+        if (!File.Exists(toolExecutablePath))
+        {
+            logger.LogError("[Launch] Tool executable not found at path: {Path}", toolExecutablePath);
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                $"{ProfileValidationConstants.ToolExecutableNotFound}: {toolExecutablePath}");
+        }
+
+        logger.LogInformation("[Launch] Launching tool: {ToolPath}", toolExecutablePath);
+
+        try
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = toolExecutablePath,
+                WorkingDirectory = toolDirectoryPath,
+                Arguments = profile.CommandLineArguments ?? string.Empty,
+                UseShellExecute = false,
+            };
+
+            if (profile.EnvironmentVariables != null)
+            {
+                foreach (var envVar in profile.EnvironmentVariables)
+                {
+                    processStartInfo.EnvironmentVariables[envVar.Key] = envVar.Value;
+                }
+            }
+
+            Process? process = null;
+            try
+            {
+                process = Process.Start(processStartInfo);
+            }
+            catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 740)
+            {
+                logger.LogWarning("Tool requires elevation (Error 740). Retrying with UseShellExecute=true and Verb='runas'. Environment variables will be ignored.");
+                processStartInfo.UseShellExecute = true;
+                processStartInfo.Verb = "runas";
+                process = Process.Start(processStartInfo);
+            }
+
+            if (process == null)
+            {
+                return ProfileOperationResult<GameLaunchInfo>.CreateFailure(ProfileValidationConstants.ToolProcessStartFailed);
+            }
+
+            var launchId = Guid.NewGuid().ToString("N");
+            var toolLaunchInfo = new GameLaunchInfo
+            {
+                LaunchId = launchId,
+                ProfileId = profile.Id,
+                WorkspaceId = actualWorkspaceId ?? ProfileConstants.ToolProfileWorkspaceId,
+                ProcessInfo = new GameProcessInfo
+                {
+                    ProcessId = process.Id,
+                    ExecutablePath = toolExecutablePath,
+                    IsRunning = true,
+                },
+            };
+
+            logger.LogInformation(
+                "=== TOOL LAUNCH SUCCESS: Profile {ProfileId}, ProcessId {ProcessId} ===",
+                profileId,
+                toolLaunchInfo.ProcessInfo.ProcessId);
+
+            await launchRegistry.RegisterLaunchAsync(toolLaunchInfo);
+            logger.LogDebug("[Launch] Registered tool launch {LaunchId} with LaunchRegistry", launchId);
+
+            gameProcessManager.TrackProcess(process);
+
+            notificationService.ShowSuccess(
+                ProfileValidationConstants.ToolLaunchSuccessTitle,
+                $"Successfully launched '{profile.Name}'",
+                NotificationDurations.Medium);
+
+            return ProfileOperationResult<GameLaunchInfo>.CreateSuccess(toolLaunchInfo);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[Launch] Tool launch failed");
+            notificationService.ShowError(
+                ProfileValidationConstants.ToolLaunchFailedTitle,
+                $"Failed to launch '{profile.Name}': {ex.Message}",
+                NotificationDurations.VeryLong);
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure($"Tool launch failed: {ex.Message}");
+        }
+    }
+
+    private async Task<ProfileOperationResult<GameLaunchInfo>> LaunchGameProfileAsync(
+        GameProfile profile,
+        string profileId,
+        bool skipUserDataCleanup,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
             // Try to resolve or rebind the installation if it's stale
             logger.LogDebug("[Launch] Step 2: Resolving game installation ID: {InstallationId}", profile.GameInstallationId);
 
@@ -419,14 +753,14 @@ public class ProfileLauncherFacade(
                 else if (reconcileResult.Data)
                 {
                     logger.LogInformation("[Launch] Profile updated by {PublisherType} reconciliation, reloading", publisherType);
-                    profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
-                    if (profileResult.Failed || profileResult.Data == null)
+                    var reloadedProfileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
+                    if (reloadedProfileResult.Failed || reloadedProfileResult.Data == null)
                     {
-                        var error = profileResult.Failed ? string.Join(", ", profileResult.Errors) : "Profile data is null after reload";
+                        var error = reloadedProfileResult.Failed ? string.Join(", ", reloadedProfileResult.Errors) : "Profile data is null after reload";
                         return ProfileOperationResult<GameLaunchInfo>.CreateFailure(error);
                     }
 
-                    profile = profileResult.Data;
+                    profile = reloadedProfileResult.Data;
                 }
             }
 
@@ -603,498 +937,182 @@ public class ProfileLauncherFacade(
         }
     }
 
-    /// <inheritdoc/>
-    public async Task<ProfileOperationResult<bool>> ValidateLaunchAsync(string profileId, CancellationToken cancellationToken = default)
+    private ProfileOperationResult<bool> ValidateToolProfileLaunch(GameProfile profile)
     {
+        logger.LogDebug("Validating Tool profile {ProfileId}, skipping game-specific validation", profile.Id);
+        List<string> errors = [];
+
+        if (string.IsNullOrWhiteSpace(profile.ToolContentId))
+        {
+            errors.Add(ProfileValidationConstants.ToolProfileMissingContentId);
+        }
+
+        if (errors.Count > 0)
+        {
+            logger.LogWarning("Tool profile {ProfileId} validation failed: {Errors}", profile.Id, string.Join(", ", errors));
+            return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
+        }
+
+        logger.LogDebug("Tool profile {ProfileId} validation successful", profile.Id);
+        return ProfileOperationResult<bool>.CreateSuccess(true);
+    }
+
+    private async Task<ProfileOperationResult<bool>> ValidateGameProfileLaunchAsync(
+        GameProfile profile,
+        CancellationToken cancellationToken)
+    {
+        List<string> errors = [];
+
+        if (string.IsNullOrWhiteSpace(profile.GameInstallationId))
+        {
+            errors.Add("Game installation is required for launch");
+        }
+
+        if (profile.EnabledContentIds == null || profile.EnabledContentIds.Count == 0)
+        {
+            errors.Add("At least one content item must be enabled for launch");
+            return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
+        }
+
+        var (manifests, hasGameInstallationManifest, hasGameClientManifest) =
+            await CollectAndValidateManifestsAsync(profile, cancellationToken);
+
+        if (!hasGameInstallationManifest)
+        {
+            errors.Add(Core.Constants.ProfileValidationConstants.MissingGameInstallation);
+        }
+
+        if (!hasGameClientManifest && string.IsNullOrWhiteSpace(profile.ToolContentId))
+        {
+            errors.Add(Core.Constants.ProfileValidationConstants.MissingGameClient);
+        }
+
+        if (errors.Count > 0)
+        {
+            logger.LogWarning("Profile {ProfileId} launch validation failed: {Errors}", profile.Id, string.Join(", ", errors));
+            return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
+        }
+
+        var dependencyErrors = ValidateDependencies(manifests, profile.GameClient?.GameType ?? GameType.ZeroHour);
+        if (dependencyErrors.Count > 0)
+        {
+            errors.AddRange(dependencyErrors);
+            logger.LogWarning("Profile {ProfileId} dependency validation failed: {Errors}", profile.Id, string.Join(", ", dependencyErrors));
+            return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
+        }
+
         try
         {
-            logger.LogDebug("Validating launch for profile {ProfileId}", profileId);
+            var casStats = await casService.GetStatsAsync(cancellationToken);
+            logger.LogDebug("CAS preflight check passed for profile {ProfileId}: {TotalObjects} objects, {TotalSize} bytes", profile.Id, casStats.ObjectCount, casStats.TotalSize);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "CAS preflight check failed for profile {ProfileId}", profile.Id);
+            return ProfileOperationResult<bool>.CreateFailure("CAS system is not available");
+        }
 
-            // Get the profile first
-            var profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
-            if (profileResult.Failed)
+        logger.LogDebug("Profile {ProfileId} launch validation successful", profile.Id);
+        return ProfileOperationResult<bool>.CreateSuccess(true);
+    }
+
+    private async Task<(List<ContentManifest> Manifests, bool HasInstallation, bool HasClient)> CollectAndValidateManifestsAsync(
+        GameProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var hasGameInstallationManifest = false;
+        var hasGameClientManifest = false;
+        var manifests = new List<ContentManifest>();
+
+        if (profile.EnabledContentIds == null)
+        {
+            return (manifests, false, false);
+        }
+
+        foreach (var contentId in profile.EnabledContentIds)
+        {
+            if (!ManifestId.TryCreate(contentId, out var manifestId))
             {
-                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", profileResult.Errors));
+                logger.LogWarning("Skipping invalid manifest ID during validation: {ContentId}", contentId);
+                continue;
             }
 
-            var profile = profileResult.Data!;
-
-            List<string> errors = [];
-
-            // Perform auto-detection for Tool Profiles in validation
-            string? validationToolId = await DetectAndSetToolContentIdAsync(profile, cancellationToken);
-            if (validationToolId != null)
-            {
-                logger.LogInformation("[Launch] Validation: Detected implicit Tool Profile (mixed content)");
-                profile.ToolContentId = validationToolId;
-            }
-
-            // Tool profiles have different validation requirements
-            if (profile.IsToolProfile)
-            {
-                logger.LogDebug("Validating Tool profile {ProfileId}, skipping game-specific validation", profile.Id);
-
-                // Tool profiles only need to have the ToolContentId set
-                if (string.IsNullOrWhiteSpace(profile.ToolContentId))
-                {
-                    errors.Add(ProfileValidationConstants.ToolProfileMissingContentId);
-                }
-
-                if (errors.Count > 0)
-                {
-                    logger.LogWarning("Tool profile {ProfileId} validation failed: {Errors}", profile.Id, string.Join(", ", errors));
-                    return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
-                }
-
-                logger.LogDebug("Tool profile {ProfileId} validation successful", profile.Id);
-                return ProfileOperationResult<bool>.CreateSuccess(true);
-            }
-
-            // Regular game profile validation
-            // Basic validation
-            if (string.IsNullOrWhiteSpace(profile.GameInstallationId))
-            {
-                errors.Add("Game installation is required for launch");
-            }
-
-            // A game profile must have content enabled to be launchable
-            if (profile.EnabledContentIds == null || profile.EnabledContentIds.Count == 0)
-            {
-                errors.Add("At least one content item must be enabled for launch");
-                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
-            }
-
-            var hasGameInstallationManifest = false;
-            var hasGameClientManifest = false;
-            var manifests = new List<ContentManifest>();
-
-            // A game profile must explicitly enable both GameInstallation and GameClient content
-            // to be considered complete and launchable:
-            // - GameInstallation provides the base game files
-            // - GameClient provides the executable variant to launch
-            foreach (var contentId in profile.EnabledContentIds)
-            {
-                if (!ManifestId.TryCreate(contentId, out var manifestId))
-                {
-                    logger.LogWarning("Skipping invalid manifest ID during validation: {ContentId}", contentId);
-                    continue;
-                }
-
-                try
-                {
-                    var manifestResult = await manifestPool.GetManifestAsync(manifestId, cancellationToken);
-                    if (manifestResult.Success && manifestResult.Data != null)
-                    {
-                        manifests.Add(manifestResult.Data);
-
-                        if (manifestResult.Data.ContentType == Core.Models.Enums.ContentType.GameInstallation)
-                        {
-                            hasGameInstallationManifest = true;
-                        }
-                        else if (manifestResult.Data.ContentType == Core.Models.Enums.ContentType.GameClient)
-                        {
-                            hasGameClientManifest = true;
-                        }
-                        else if (manifestResult.Data.ContentType == Core.Models.Enums.ContentType.ModdingTool ||
-                                 manifestResult.Data.ContentType == Core.Models.Enums.ContentType.Executable)
-                        {
-                             // Allow modding tools in regular validation flow if treating as mixed profile
-                        }
-                    }
-                }
-                catch (ArgumentException ex)
-                {
-                    // Skip invalid manifest IDs
-                    logger.LogWarning(ex, "Skipping invalid manifest ID during validation: {ContentId}", contentId);
-                }
-            }
-
-            if (!hasGameInstallationManifest)
-            {
-                errors.Add(Core.Constants.ProfileValidationConstants.MissingGameInstallation);
-            }
-
-            if (!hasGameClientManifest && string.IsNullOrWhiteSpace(profile.ToolContentId))
-            {
-                // Only require GameClient if we are NOT a tool profile (explicit or implicit)
-                errors.Add(Core.Constants.ProfileValidationConstants.MissingGameClient);
-            }
-
-            if (errors.Count > 0)
-            {
-                logger.LogWarning("Profile {ProfileId} launch validation failed: {Errors}", profile.Id, string.Join(", ", errors));
-                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
-            }
-
-            // Validate dependencies between manifests
-            var dependencyErrors = ValidateDependencies(manifests, profile.GameClient?.GameType ?? GameType.ZeroHour);
-            if (dependencyErrors.Count > 0)
-            {
-                errors.AddRange(dependencyErrors);
-                logger.LogWarning("Profile {ProfileId} dependency validation failed: {Errors}", profile.Id, string.Join(", ", dependencyErrors));
-                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", errors));
-            }
-
-            // CAS preflight check
             try
             {
-                var casStats = await casService.GetStatsAsync(cancellationToken);
-                logger.LogDebug("CAS preflight check passed for profile {ProfileId}: {TotalObjects} objects, {TotalSize} bytes", profile.Id, casStats.ObjectCount, casStats.TotalSize);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "CAS preflight check failed for profile {ProfileId}", profile.Id);
-                return ProfileOperationResult<bool>.CreateFailure("CAS system is not available");
-            }
+                var manifestResult = await manifestPool.GetManifestAsync(manifestId, cancellationToken);
+                if (manifestResult.Success && manifestResult.Data != null)
+                {
+                    manifests.Add(manifestResult.Data);
 
-            logger.LogDebug("Profile {ProfileId} launch validation successful", profile.Id);
-            return ProfileOperationResult<bool>.CreateSuccess(true);
+                    if (manifestResult.Data.ContentType == Core.Models.Enums.ContentType.GameInstallation)
+                    {
+                        hasGameInstallationManifest = true;
+                    }
+                    else if (manifestResult.Data.ContentType == Core.Models.Enums.ContentType.GameClient)
+                    {
+                        hasGameClientManifest = true;
+                    }
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                logger.LogWarning(ex, "Skipping invalid manifest ID during validation: {ContentId}", contentId);
+            }
         }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to validate launch for profile {ProfileId}", profileId);
-            return ProfileOperationResult<bool>.CreateFailure($"Launch validation failed: {ex.Message}");
-        }
+
+        return (manifests, hasGameInstallationManifest, hasGameClientManifest);
     }
 
-    /// <inheritdoc/>
-    public async Task<ProfileOperationResult<GameProcessInfo>> GetLaunchStatusAsync(string profileId, CancellationToken cancellationToken = default)
+    private async Task<Dictionary<string, string>> ResolveManifestSourcePathsAsync(
+        List<ContentManifest> manifests,
+        GameProfile profile,
+        CancellationToken cancellationToken)
     {
-        try
+        var manifestSourcePaths = new Dictionary<string, string>();
+        foreach (var manifest in manifests)
         {
-            logger.LogDebug("Getting launch status for profile {ProfileId}", profileId);
-
-            var launches = await launchRegistry.GetAllActiveLaunchesAsync();
-            var launch = launches.FirstOrDefault(l => l.ProfileId == profileId);
-            if (launch == null)
+            if (manifest.ContentType == Core.Models.Enums.ContentType.GameInstallation)
             {
-                logger.LogDebug("No active launch found for profile {ProfileId}, returning stopped status", profileId);
-                return ProfileOperationResult<GameProcessInfo>.CreateSuccess(new GameProcessInfo
-                {
-                    IsRunning = false,
-                    ProcessId = -1,
-                });
+                continue;
             }
 
-            logger.LogDebug("Profile {ProfileId} launch status: {Status}", profileId, launch.ProcessInfo.IsRunning ? "Running" : "Not Running");
+            if (manifest.ContentType == Core.Models.Enums.ContentType.GameClient &&
+                !string.IsNullOrEmpty(profile.GameClient?.WorkingDirectory))
+            {
+                manifestSourcePaths[manifest.Id.Value] = profile.GameClient.WorkingDirectory;
+                logger.LogDebug("[Workspace] Source path for GameClient {ManifestId}: {SourcePath}", manifest.Id.Value, profile.GameClient.WorkingDirectory);
+                continue;
+            }
 
-            return ProfileOperationResult<GameProcessInfo>.CreateSuccess(launch.ProcessInfo);
+            var contentDirResult = await manifestPool.GetContentDirectoryAsync(manifest.Id, cancellationToken);
+            if (contentDirResult.Success && !string.IsNullOrEmpty(contentDirResult.Data))
+            {
+                manifestSourcePaths[manifest.Id.Value] = contentDirResult.Data;
+                logger.LogDebug(
+                    "[Workspace] Source path for content {ManifestId} ({ContentType}): {SourcePath}",
+                    manifest.Id.Value,
+                    manifest.ContentType,
+                    contentDirResult.Data);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "[Workspace] Could not resolve source path for manifest {ManifestId} ({ContentType})",
+                    manifest.Id.Value,
+                    manifest.ContentType);
+            }
         }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to get launch status for profile {ProfileId}", profileId);
-            return ProfileOperationResult<GameProcessInfo>.CreateFailure($"Failed to get launch status: {ex.Message}");
-        }
+
+        return manifestSourcePaths;
     }
 
-    /// <inheritdoc/>
-    public async Task<ProfileOperationResult<bool>> StopProfileAsync(string profileId, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            logger.LogInformation("Stopping profile {ProfileId}", profileId);
-
-            var launches = await launchRegistry.GetAllActiveLaunchesAsync();
-            var launch = launches.FirstOrDefault(l => l.ProfileId == profileId);
-            if (launch == null)
-            {
-                logger.LogInformation("No active launch found for profile {ProfileId}, considering it already stopped.", profileId);
-                return ProfileOperationResult<bool>.CreateSuccess(true);
-            }
-
-            var stopResult = await gameLauncher.TerminateGameAsync(launch.LaunchId, cancellationToken);
-            if (stopResult.Failed)
-            {
-                return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", stopResult.Errors));
-            }
-
-            // Workspace is not cleaned up when stopping - it persists across launches.
-            // This allows quick re-launches without re-creating symlinks/copies.
-            // Workspace is only cleaned up when:
-            // 1. Profile is deleted
-            // 2. Content changes require workspace refresh
-            logger.LogInformation("Successfully stopped profile {ProfileId}", profileId);
-            return ProfileOperationResult<bool>.CreateSuccess(true);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to stop profile {ProfileId}", profileId);
-            return ProfileOperationResult<bool>.CreateFailure($"Failed to stop profile: {ex.Message}");
-        }
-    }
-
-    /// <inheritdoc/>
-    public async Task<ProfileOperationResult<WorkspaceInfo>> PrepareWorkspaceAsync(string profileId, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            logger.LogInformation("Preparing workspace for profile {ProfileId}", profileId);
-
-            // Get the profile to understand what content needs to be prepared
-            var profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
-            if (profileResult.Failed)
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", profileResult.Errors));
-            }
-
-            var profile = profileResult.Data!;
-
-            // Try to resolve or rebind the installation if it's stale
-            var resolvedInstallationResult = await ResolveOrRebindInstallationAsync(profile, cancellationToken);
-            if (resolvedInstallationResult.Failed)
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(resolvedInstallationResult.FirstError ?? "Could not resolve game installation for profile");
-            }
-
-            var resolvedInstallation = resolvedInstallationResult.Data;
-            if (resolvedInstallation == null)
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Resolved installation data is null");
-            }
-
-            // Update the profile with the resolved installation if it changed
-            if (resolvedInstallation.Id != profile.GameInstallationId)
-            {
-                var updateRequest = new UpdateProfileRequest
-                {
-                    GameInstallationId = resolvedInstallation.Id,
-                };
-                var updateResult = await profileManager.UpdateProfileAsync(profileId, updateRequest, cancellationToken);
-                if (updateResult.Success)
-                {
-                    profile.GameInstallationId = resolvedInstallation.Id;
-                    logger.LogInformation("Rebound profile {ProfileId} to installation {InstallationId} during workspace preparation", profileId, resolvedInstallation.Id);
-                }
-            }
-
-            // Build list of manifests from enabled content IDs only
-            var manifests = new List<ContentManifest>();
-            var resolvedContentIds = new HashSet<string>(profile.EnabledContentIds ?? Enumerable.Empty<string>());
-
-            // Resolve dependencies recursively
-            var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? Enumerable.Empty<string>(), cancellationToken);
-            if (!resolutionResult.Success)
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", resolutionResult.Errors));
-            }
-
-            manifests = [.. resolutionResult.ResolvedManifests];
-
-            // CAS preflight check - verify all CAS content is available before workspace preparation.
-            // This prevents late failure and ensures early error detection.
-            logger.LogDebug("[Workspace] Running CAS preflight check for {ManifestCount} manifests", manifests.Count);
-            var casCheckResult = await VerifyCasContentAvailabilityAsync(manifests, cancellationToken);
-            if (!casCheckResult.Success)
-            {
-                logger.LogError("[Workspace] CAS preflight check failed: {Error}", casCheckResult.FirstError);
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(casCheckResult.FirstError ?? "Required content is not available in CAS");
-            }
-
-            logger.LogDebug("[Workspace] CAS preflight check passed");
-
-            // Resolve source paths for all manifests
-            var manifestSourcePaths = new Dictionary<string, string>();
-            foreach (var manifest in manifests)
-            {
-                // Skip GameInstallation manifests - they use BaseInstallationPath
-                if (manifest.ContentType == Core.Models.Enums.ContentType.GameInstallation)
-                {
-                    continue;
-                }
-
-                // For GameClient, use WorkingDirectory if available
-                if (manifest.ContentType == Core.Models.Enums.ContentType.GameClient &&
-                    !string.IsNullOrEmpty(profile.GameClient?.WorkingDirectory))
-                {
-                    manifestSourcePaths[manifest.Id.Value] = profile.GameClient.WorkingDirectory;
-                    logger.LogDebug("[Workspace] Source path for GameClient {ManifestId}: {SourcePath}", manifest.Id.Value, profile.GameClient.WorkingDirectory);
-                    continue;
-                }
-
-                // For all other content types, query the manifest pool for the content directory
-                var contentDirResult = await manifestPool.GetContentDirectoryAsync(manifest.Id, cancellationToken);
-                if (contentDirResult.Success && !string.IsNullOrEmpty(contentDirResult.Data))
-                {
-                    manifestSourcePaths[manifest.Id.Value] = contentDirResult.Data;
-                    logger.LogDebug(
-                        "[Workspace] Source path for content {ManifestId} ({ContentType}): {SourcePath}",
-                        manifest.Id.Value,
-                        manifest.ContentType,
-                        contentDirResult.Data);
-                }
-                else
-                {
-                    logger.LogWarning(
-                        "[Workspace] Could not resolve source path for manifest {ManifestId} ({ContentType})",
-                        manifest.Id.Value,
-                        manifest.ContentType);
-                }
-            }
-
-            // Create workspace configuration
-            if (profile.GameClient == null)
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Profile has no GameClient configured");
-            }
-
-            var workspaceConfig = new WorkspaceConfiguration
-            {
-                Id = profileId,
-                Manifests = manifests,
-                GameClient = profile.GameClient!,
-                Strategy = ResolveSupportedWorkspaceStrategy(
-                    profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy()),
-                ForceRecreate = false,
-                ValidateAfterPreparation = true,
-                ManifestSourcePaths = manifestSourcePaths,
-            };
-
-            // Use resolved installation path and workspace root
-            if (resolvedInstallation == null || string.IsNullOrEmpty(resolvedInstallation.InstallationPath))
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Resolved installation has no valid installation path");
-            }
-
-            var installationPath = resolvedInstallation.InstallationPath;
-            workspaceConfig.BaseInstallationPath = installationPath;
-
-            // Use dynamic workspace path based on game installation location
-            workspaceConfig.WorkspaceRootPath = storageLocationService.GetWorkspacePath(resolvedInstallation);
-
-            var prepareResult = await workspaceManager.PrepareWorkspaceAsync(workspaceConfig, cancellationToken: cancellationToken);
-            if (prepareResult.Failed)
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", prepareResult.Errors));
-            }
-
-            var workspaceInfo = prepareResult.Data;
-            if (workspaceInfo == null)
-            {
-                return ProfileOperationResult<WorkspaceInfo>.CreateFailure("Workspace preparation succeeded but returned null workspace info");
-            }
-
-            // Update the profile with the active workspace ID
-            var workspaceUpdateRequest = new UpdateProfileRequest
-            {
-                ActiveWorkspaceId = workspaceInfo.Id,
-            };
-            var updateProfileResult = await profileManager.UpdateProfileAsync(profileId, workspaceUpdateRequest, cancellationToken);
-            if (updateProfileResult.Failed)
-            {
-                logger.LogWarning("Failed to update profile {ProfileId} with active workspace ID: {Errors}", profileId, string.Join(", ", updateProfileResult.Errors));
-            }
-
-            logger.LogInformation("Successfully prepared workspace {WorkspaceId} for profile {ProfileId}", workspaceInfo.Id, profileId);
-
-            return ProfileOperationResult<WorkspaceInfo>.CreateSuccess(workspaceInfo);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to prepare workspace for profile {ProfileId}", profileId);
-            return ProfileOperationResult<WorkspaceInfo>.CreateFailure($"Failed to prepare workspace: {ex.Message}");
-        }
-    }
-
-    /// <inheritdoc/>
-    public async Task<ProfileOperationResult<bool>> DeleteProfileAsync(string profileId, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            logger.LogInformation("Deleting profile {ProfileId}", profileId);
-
-            if (string.IsNullOrWhiteSpace(profileId))
-            {
-                return ProfileOperationResult<bool>.CreateFailure("Profile ID cannot be empty");
-            }
-
-            // Acquire the profile launch lock to ensure we don't delete during launch registration
-            // This uses the same semaphore as launch operations, so deletion waits for launch
-            // to complete its initial registration without polling or timeouts
-            using (await gameLauncher.AcquireProfileLockAsync(profileId, cancellationToken))
-            {
-                // Check if the profile is currently running
-                var launches = await launchRegistry.GetAllActiveLaunchesAsync();
-                var activeLaunch = launches.FirstOrDefault(l => l.ProfileId == profileId);
-                if (activeLaunch != null)
-                {
-                    // Double-check that the process is actually running (not in a transitional state)
-                    var isProcessRunning = false;
-                    try
-                    {
-                        var process = Process.GetProcessById(activeLaunch.ProcessInfo.ProcessId);
-                        isProcessRunning = !process.HasExited;
-                        process.Dispose();
-                    }
-                    catch (ArgumentException)
-                    {
-                        // Process doesn't exist - safe to delete
-                        logger.LogDebug("Process {ProcessId} for profile {ProfileId} no longer exists, allowing deletion", activeLaunch.ProcessInfo.ProcessId, profileId);
-                        isProcessRunning = false;
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogWarning(ex, "Failed to verify process status for profile {ProfileId}, blocking deletion for safety", profileId);
-                        isProcessRunning = true;
-                    }
-
-                    if (isProcessRunning)
-                    {
-                        logger.LogWarning("Cannot delete profile {ProfileId} - process {ProcessId} is still running", profileId, activeLaunch.ProcessInfo.ProcessId);
-                        return ProfileOperationResult<bool>.CreateFailure(
-                            "Cannot delete a running profile. Please stop the profile before deleting it.");
-                    }
-
-                    // Process has exited but registry hasn't been cleaned up yet - safe to proceed
-                    logger.LogDebug("Profile {ProfileId} launch is in registry but process has exited, allowing deletion", profileId);
-                }
-
-                // Get profile to check for active workspace before deleting
-                var profileResult = await profileManager.GetProfileAsync(profileId, cancellationToken);
-                if (profileResult.Success && profileResult.Data != null && !string.IsNullOrEmpty(profileResult.Data.ActiveWorkspaceId))
-                {
-                    logger.LogInformation("Cleaning up workspace {WorkspaceId} for profile {ProfileId} before deletion", profileResult.Data.ActiveWorkspaceId, profileId);
-                    var cleanupResult = await workspaceManager.CleanupWorkspaceAsync(profileResult.Data.ActiveWorkspaceId, cancellationToken);
-                    if (cleanupResult.Failed)
-                    {
-                        logger.LogWarning("Failed to cleanup workspace {WorkspaceId} for profile {ProfileId}: {Error}", profileResult.Data.ActiveWorkspaceId, profileId, cleanupResult.FirstError);
-
-                        // Continue with profile deletion even if workspace cleanup fails
-                    }
-                }
-
-                var deleteResult = await profileManager.DeleteProfileAsync(profileId, cancellationToken);
-                if (deleteResult.Success)
-                {
-                    logger.LogInformation("Successfully deleted profile {ProfileId}", profileId);
-                    return ProfileOperationResult<bool>.CreateSuccess(true);
-                }
-                else
-                {
-                    logger.LogError("Failed to delete profile {ProfileId}: {Errors}", profileId, string.Join(", ", deleteResult.Errors));
-                    return ProfileOperationResult<bool>.CreateFailure(string.Join(", ", deleteResult.Errors));
-                }
-            }
-        }
-        catch (IOException ioEx) when (ioEx.Message.Contains("being used by another process"))
-        {
-            logger.LogError(ioEx, "Cannot delete profile {ProfileId} because workspace files are locked", profileId);
-            return ProfileOperationResult<bool>.CreateFailure(
-                "Cannot delete profile because workspace files are being used. Please ensure the game is fully stopped before deleting.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "An unexpected error occurred while deleting profile {ProfileId}.", profileId);
-            return ProfileOperationResult<bool>.CreateFailure("An unexpected error occurred.");
-        }
-    }
-
-    /// <summary>
+/// <summary>
     /// Checks if a version string is compatible with dependency requirements.
     /// </summary>
     /// <param name="version">The version to check.</param>
     /// <param name="dependency">The dependency with version requirements.</param>
     /// <returns>True if compatible, false otherwise.</returns>
-    private static bool IsVersionCompatible(string version, ContentDependency dependency)
+    private bool IsVersionCompatible(string version, ContentDependency dependency)
     {
         // If compatible versions list is specified, check exact match
         if (dependency.CompatibleVersions.Count > 0)
@@ -1128,7 +1146,7 @@ public class ProfileLauncherFacade(
     /// </summary>
     /// <param name="dependency">The dependency with version requirements.</param>
     /// <returns>A string describing the version requirements.</returns>
-    private static string BuildVersionRequirementString(ContentDependency dependency)
+    private string BuildVersionRequirementString(ContentDependency dependency)
     {
         if (dependency.CompatibleVersions.Count > 0)
         {
@@ -1154,7 +1172,7 @@ public class ProfileLauncherFacade(
     /// </summary>
     /// <param name="profile">The profile to check.</param>
     /// <returns>True if the profile uses GeneralsOnline, false otherwise.</returns>
-    private static bool IsGeneralsOnlineProfile(GameProfile profile)
+    private bool IsGeneralsOnlineProfile(GameProfile profile)
     {
         // Check PublisherType first
         if (profile.GameClient?.PublisherType?.Equals(
@@ -1171,8 +1189,7 @@ public class ProfileLauncherFacade(
         }
 
         // Final fallback: Check enabled content for GeneralsOnline manifests
-        if (profile.EnabledContentIds != null &&
-            profile.EnabledContentIds.Any(id => id.Contains("generalsonline", StringComparison.OrdinalIgnoreCase)))
+        if (profile.EnabledContentIds?.Any(id => id.Contains("generalsonline", StringComparison.OrdinalIgnoreCase)) == true)
         {
             return true;
         }
@@ -1185,7 +1202,7 @@ public class ProfileLauncherFacade(
     /// </summary>
     /// <param name="profile">The profile to check.</param>
     /// <returns>True if the profile uses SuperHackers, false otherwise.</returns>
-    private static bool IsSuperHackersProfile(GameProfile profile)
+    private bool IsSuperHackersProfile(GameProfile profile)
     {
         if (IsCommunityOutpostProfile(profile))
         {
@@ -1207,8 +1224,7 @@ public class ProfileLauncherFacade(
         }
 
         // Final fallback: Check enabled content for SuperHackers manifests
-        if (profile.EnabledContentIds != null &&
-            profile.EnabledContentIds.Any(id => id.Contains("thesuperhackers", StringComparison.OrdinalIgnoreCase)))
+        if (profile.EnabledContentIds?.Any(id => id.Contains("thesuperhackers", StringComparison.OrdinalIgnoreCase)) == true)
         {
             return true;
         }
@@ -1221,7 +1237,7 @@ public class ProfileLauncherFacade(
     /// </summary>
     /// <param name="profile">The profile to check.</param>
     /// <returns>True if the profile uses Community Outpost, false otherwise.</returns>
-    private static bool IsCommunityOutpostProfile(GameProfile profile)
+    private bool IsCommunityOutpostProfile(GameProfile profile)
     {
         // Check PublisherType
         if (profile.GameClient?.PublisherType?.Equals(
@@ -1239,8 +1255,7 @@ public class ProfileLauncherFacade(
         }
 
         // Fallback: manifests
-        if (profile.EnabledContentIds != null &&
-            profile.EnabledContentIds.Any(id => id.Contains("communityoutpost", StringComparison.OrdinalIgnoreCase)))
+        if (profile.EnabledContentIds?.Any(id => id.Contains("communityoutpost", StringComparison.OrdinalIgnoreCase)) == true)
         {
             return true;
         }
@@ -1260,7 +1275,6 @@ public class ProfileLauncherFacade(
 
         try
         {
-            // Create a lookup for quick manifest searches
             var manifestsByType = manifests.GroupBy(m => m.ContentType).ToDictionary(g => g.Key, g => g.ToList());
             var manifestsById = manifests.ToDictionary(m => m.Id.ToString(), m => m);
 
@@ -1268,7 +1282,6 @@ public class ProfileLauncherFacade(
 
             foreach (var manifest in manifests)
             {
-                // Skip if no dependencies
                 if (manifest.Dependencies == null || manifest.Dependencies.Count == 0)
                 {
                     continue;
@@ -1278,228 +1291,16 @@ public class ProfileLauncherFacade(
 
                 foreach (var dependency in manifest.Dependencies)
                 {
-                    // Validate by dependency type
-                    if (!manifestsByType.TryGetValue(dependency.DependencyType, out var potentialMatches) || potentialMatches.Count == 0)
-                    {
-                        var msg = $"Content '{manifest.Name}' requires {dependency.DependencyType} content, but none is selected";
-                        if (!dependency.IsOptional)
-                        {
-                            errors.Add(msg);
-                        }
-
-                        logger.LogWarning(
-                            "Dependency validation failed: {ManifestName} requires {DependencyType} but none found (Optional: {IsOptional})",
-                            manifest.Name,
-                            dependency.DependencyType,
-                            dependency.IsOptional);
-                        continue;
-                    }
-
-                    // Check if specific dependency ID is required (not a generic type-based constraint)
-                    if (dependency.Id.ToString() != ManifestConstants.DefaultContentDependencyId)
-                    {
-                        ContentManifest? requiredManifest = null;
-
-                        // First try exact ID match
-                        if (manifestsById.TryGetValue(dependency.Id.ToString(), out var exactMatch))
-                        {
-                            requiredManifest = exactMatch;
-                        }
-
-                        // If StrictPublisher is false, try semantic matching (any publisher satisfies the dependency)
-                        else if (!dependency.StrictPublisher)
-                        {
-                            // Parse the dependency ID to get contentType and contentName segments
-                            // Format: schemaVersion.userVersion.publisher.contentType.contentName
-                            var depIdSegments = dependency.Id.ToString().Split('.');
-                            if (depIdSegments.Length >= 5)
-                            {
-                                var depContentType = depIdSegments[3];
-                                var depContentName = depIdSegments[4];
-
-                                // Find any manifest that matches contentType and contentName (regardless of publisher)
-                                requiredManifest = potentialMatches.FirstOrDefault(m =>
-                                {
-                                    var manifestIdSegments = m.Id.ToString().Split('.');
-                                    if (manifestIdSegments.Length >= 5)
-                                    {
-                                        var manifestContentType = manifestIdSegments[3];
-                                        var manifestContentName = manifestIdSegments[4];
-                                        return string.Equals(manifestContentType, depContentType, StringComparison.OrdinalIgnoreCase) &&
-                                               string.Equals(manifestContentName, depContentName, StringComparison.OrdinalIgnoreCase);
-                                    }
-
-                                    return false;
-                                });
-
-                                if (requiredManifest != null)
-                                {
-                                    logger.LogDebug(
-                                        "Semantic dependency match: {DependencyId} satisfied by {MatchedId} (StrictPublisher=false)",
-                                        dependency.Id,
-                                        requiredManifest.Id);
-                                }
-                            }
-                        }
-
-                        if (requiredManifest == null)
-                        {
-                            var msg = $"Content '{manifest.Name}' requires specific content '{dependency.Name}' (ID: {dependency.Id}), but it is not selected";
-                            if (!dependency.IsOptional)
-                            {
-                                errors.Add(msg);
-                            }
-
-                            logger.LogWarning(
-                                "Dependency validation failed: {ManifestName} requires specific dependency {DependencyId} but not found (Optional: {IsOptional})",
-                                manifest.Name,
-                                dependency.Id,
-                                dependency.IsOptional);
-                            continue;
-                        }
-
-                        // Validate version compatibility if specified
-                        if (!string.IsNullOrEmpty(dependency.MinVersion) || !string.IsNullOrEmpty(dependency.MaxVersion) || dependency.CompatibleVersions.Count > 0)
-                        {
-                            if (!IsVersionCompatible(requiredManifest.Version, dependency))
-                            {
-                                var versionInfo = BuildVersionRequirementString(dependency);
-                                var msg = $"Content '{manifest.Name}' requires '{dependency.Name}' {versionInfo}, but version {requiredManifest.Version} is selected";
-                                if (!dependency.IsOptional)
-                                {
-                                    errors.Add(msg);
-                                }
-
-                                logger.LogWarning(
-                                    "Version compatibility failed: {ManifestName} requires {DependencyName} {VersionInfo}, but {ActualVersion} found (Optional: {IsOptional})",
-                                    manifest.Name,
-                                    dependency.Name,
-                                    versionInfo,
-                                    requiredManifest.Version,
-                                    dependency.IsOptional);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Generic dependency - just check that any of that type exists (already validated above)
-                        logger.LogDebug("Generic dependency {DependencyType} satisfied for {ManifestName}", dependency.DependencyType, manifest.Name);
-                    }
-
-                    // Validate GameType compatibility for GameInstallation dependencies
-                    if (dependency.DependencyType == Core.Models.Enums.ContentType.GameInstallation)
-                    {
-                        var gameInstallations = potentialMatches;
-                        var compatibleInstallation = gameInstallations.FirstOrDefault(gi => gi.TargetGame == profileGameType);
-
-                        if (compatibleInstallation == null)
-                        {
-                            var msg = $"Content '{manifest.Name}' requires {profileGameType} game installation, but selected installation is for a different game";
-                            if (!dependency.IsOptional)
-                            {
-                                errors.Add(msg);
-                            }
-
-                            logger.LogWarning(
-                                "GameType mismatch: {ManifestName} requires {RequiredGameType}, but no matching installation found (Optional: {IsOptional})",
-                                manifest.Name,
-                                profileGameType,
-                                dependency.IsOptional);
-                        }
-                    }
-
-                    // Validate CompatibleGameTypes for all dependency types
-                    if (dependency.CompatibleGameTypes != null && dependency.CompatibleGameTypes.Count > 0)
-                    {
-                        if (!dependency.CompatibleGameTypes.Contains(profileGameType))
-                        {
-                            var compatibleGamesStr = string.Join(", ", dependency.CompatibleGameTypes);
-                            var msg = $"Content '{manifest.Name}' dependency '{dependency.Name}' is only compatible with {compatibleGamesStr}, but profile is for {profileGameType}";
-                            if (!dependency.IsOptional)
-                            {
-                                errors.Add(msg);
-                            }
-
-                            logger.LogWarning(
-                                "GameType compatibility failed: {ManifestName} dependency {DependencyName} requires {CompatibleGameTypes}, but profile is {ProfileGameType} (Optional: {IsOptional})",
-                                manifest.Name,
-                                dependency.Name,
-                                compatibleGamesStr,
-                                profileGameType,
-                                dependency.IsOptional);
-                        }
-                    }
-
-                    // Validate RequiredPublisherTypes (using StrictPublisher and PublisherType)
-                    if (dependency.StrictPublisher && !string.IsNullOrEmpty(dependency.PublisherType))
-                    {
-                        // Get the publisher type from the matched dependency manifest
-                        var dependencyManifest = potentialMatches.FirstOrDefault();
-                        if (dependencyManifest != null)
-                        {
-                            var publisherType = dependencyManifest.Publisher?.PublisherType ?? PublisherTypeConstants.Unknown;
-
-                            if (!string.Equals(dependency.PublisherType, publisherType, StringComparison.OrdinalIgnoreCase))
-                            {
-                                var msg = $"Content '{manifest.Name}' dependency '{dependency.Name}' requires publisher type '{dependency.PublisherType}', but found '{publisherType}'";
-                                if (!dependency.IsOptional)
-                                {
-                                    errors.Add(msg);
-                                }
-
-                                logger.LogWarning(
-                                    "Publisher type mismatch: {ManifestName} dependency {DependencyName} requires {RequiredPublisher}, but found {ActualPublisher} (Optional: {IsOptional})",
-                                    manifest.Name,
-                                    dependency.Name,
-                                    dependency.PublisherType,
-                                    publisherType,
-                                    dependency.IsOptional);
-                            }
-                        }
-                    }
-
-                    // Validate IncompatiblePublisherTypes (not implemented in current ContentDependency model)
-                    /*
-                    if (dependency.IncompatiblePublisherTypes != null && dependency.IncompatiblePublisherTypes.Any())
-                    {
-                        // Get the publisher type from the matched dependency manifest
-                        var dependencyManifest = potentialMatches.FirstOrDefault();
-                        if (dependencyManifest != null)
-                        {
-                            var publisherType = dependencyManifest.Publisher?.PublisherType ?? PublisherTypeConstants.Unknown;
-
-                            if (dependency.IncompatiblePublisherTypes.Contains(publisherType))
-                            {
-                                var incompatiblePublishersStr = string.Join(", ", dependency.IncompatiblePublisherTypes);
-                                errors.Add($"Content '{manifest.Name}' dependency '{dependency.Name}' is incompatible with publisher type '{publisherType}' (incompatible: {incompatiblePublishersStr})");
-                                logger.LogWarning(
-                                    "Publisher type conflict: {ManifestName} dependency {DependencyName} is incompatible with {IncompatiblePublisher}",
-                                    manifest.Name,
-                                    dependency.Name,
-                                    publisherType);
-                            }
-                        }
-                    }
-                    */
+                    ValidateSingleDependency(
+                        manifest,
+                        dependency,
+                        manifestsByType,
+                        manifestsById,
+                        profileGameType,
+                        errors);
                 }
 
-                if (manifest.Dependencies.Count > 0)
-                {
-                    foreach (var dependency in manifest.Dependencies.Where(d => d.ConflictsWith.Count > 0))
-                    {
-                        foreach (var conflictId in dependency.ConflictsWith)
-                        {
-                            if (manifestsById.ContainsKey(conflictId.ToString()))
-                            {
-                                errors.Add($"Content '{manifest.Name}' conflicts with '{manifestsById[conflictId.ToString()].Name}' - these cannot be enabled together");
-                                logger.LogWarning(
-                                    "Conflict detected: {ManifestName} conflicts with {ConflictingManifest}",
-                                    manifest.Name,
-                                    manifestsById[conflictId.ToString()].Name);
-                            }
-                        }
-                    }
-                }
+                ValidateDependencyConflicts(manifest, manifestsById, errors);
             }
 
             if (errors.Count > 0)
@@ -1518,6 +1319,230 @@ public class ProfileLauncherFacade(
         }
 
         return errors;
+    }
+
+    private void ValidateSingleDependency(
+        ContentManifest manifest,
+        ContentDependency dependency,
+        Dictionary<ContentType, List<ContentManifest>> manifestsByType,
+        Dictionary<string, ContentManifest> manifestsById,
+        GameType profileGameType,
+        List<string> errors)
+    {
+        if (!manifestsByType.TryGetValue(dependency.DependencyType, out var potentialMatches) || potentialMatches.Count == 0)
+        {
+            var msg = $"Content '{manifest.Name}' requires {dependency.DependencyType} content, but none is selected";
+            if (!dependency.IsOptional)
+            {
+                errors.Add(msg);
+            }
+
+            logger.LogWarning(
+                "Dependency validation failed: {ManifestName} requires {DependencyType} but none found (Optional: {IsOptional})",
+                manifest.Name,
+                dependency.DependencyType,
+                dependency.IsOptional);
+            return;
+        }
+
+        if (dependency.Id.ToString() != ManifestConstants.DefaultContentDependencyId)
+        {
+            ValidateSpecificDependencyRequirement(manifest, dependency, manifestsById, potentialMatches, errors);
+        }
+        else
+        {
+            logger.LogDebug("Generic dependency {DependencyType} satisfied for {ManifestName}", dependency.DependencyType, manifest.Name);
+        }
+
+        ValidateDependencyGameType(manifest, dependency, potentialMatches, profileGameType, errors);
+        ValidateDependencyPublisher(manifest, dependency, potentialMatches, errors);
+    }
+
+    private void ValidateSpecificDependencyRequirement(
+        ContentManifest manifest,
+        ContentDependency dependency,
+        Dictionary<string, ContentManifest> manifestsById,
+        List<ContentManifest> potentialMatches,
+        List<string> errors)
+    {
+        ContentManifest? requiredManifest = null;
+
+        if (manifestsById.TryGetValue(dependency.Id.ToString(), out var exactMatch))
+        {
+            requiredManifest = exactMatch;
+        }
+        else if (!dependency.StrictPublisher)
+        {
+            var depIdSegments = dependency.Id.ToString().Split('.');
+            if (depIdSegments.Length >= 5)
+            {
+                var depContentType = depIdSegments[3];
+                var depContentName = depIdSegments[4];
+
+                requiredManifest = potentialMatches.FirstOrDefault(m =>
+                {
+                    var manifestIdSegments = m.Id.ToString().Split('.');
+                    if (manifestIdSegments.Length >= 5)
+                    {
+                        var manifestContentType = manifestIdSegments[3];
+                        var manifestContentName = manifestIdSegments[4];
+                        return string.Equals(manifestContentType, depContentType, StringComparison.OrdinalIgnoreCase) &&
+                               string.Equals(manifestContentName, depContentName, StringComparison.OrdinalIgnoreCase);
+                    }
+
+                    return false;
+                });
+
+                if (requiredManifest != null)
+                {
+                    logger.LogDebug(
+                        "Semantic dependency match: {DependencyId} satisfied by {MatchedId} (StrictPublisher=false)",
+                        dependency.Id,
+                        requiredManifest.Id);
+                }
+            }
+        }
+
+        if (requiredManifest == null)
+        {
+            var msg = $"Content '{manifest.Name}' requires specific content '{dependency.Name}' (ID: {dependency.Id}), but it is not selected";
+            if (!dependency.IsOptional)
+            {
+                errors.Add(msg);
+            }
+
+            logger.LogWarning(
+                "Dependency validation failed: {ManifestName} requires specific dependency {DependencyId} but not found (Optional: {IsOptional})",
+                manifest.Name,
+                dependency.Id,
+                dependency.IsOptional);
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(dependency.MinVersion) || !string.IsNullOrEmpty(dependency.MaxVersion) || dependency.CompatibleVersions.Count > 0)
+        {
+            if (!IsVersionCompatible(requiredManifest.Version, dependency))
+            {
+                var versionInfo = BuildVersionRequirementString(dependency);
+                var msg = $"Content '{manifest.Name}' requires '{dependency.Name}' {versionInfo}, but version {requiredManifest.Version} is selected";
+                if (!dependency.IsOptional)
+                {
+                    errors.Add(msg);
+                }
+
+                logger.LogWarning(
+                    "Version compatibility failed: {ManifestName} requires {DependencyName} {VersionInfo}, but {ActualVersion} found (Optional: {IsOptional})",
+                    manifest.Name,
+                    dependency.Name,
+                    versionInfo,
+                    requiredManifest.Version,
+                    dependency.IsOptional);
+            }
+        }
+    }
+
+    private void ValidateDependencyGameType(
+        ContentManifest manifest,
+        ContentDependency dependency,
+        List<ContentManifest> potentialMatches,
+        GameType profileGameType,
+        List<string> errors)
+    {
+        if (dependency.DependencyType == Core.Models.Enums.ContentType.GameInstallation)
+        {
+            var gameInstallations = potentialMatches;
+            var compatibleInstallation = gameInstallations.FirstOrDefault(gi => gi.TargetGame == profileGameType);
+
+            if (compatibleInstallation == null)
+            {
+                var msg = $"Content '{manifest.Name}' requires {profileGameType} game installation, but selected installation is for a different game";
+                if (!dependency.IsOptional)
+                {
+                    errors.Add(msg);
+                }
+
+                logger.LogWarning(
+                    "GameType mismatch: {ManifestName} requires {RequiredGameType}, but no matching installation found (Optional: {IsOptional})",
+                    manifest.Name,
+                    profileGameType,
+                    dependency.IsOptional);
+            }
+        }
+
+        if (dependency.CompatibleGameTypes != null && dependency.CompatibleGameTypes.Count > 0 && !dependency.CompatibleGameTypes.Contains(profileGameType))
+        {
+            var compatibleGamesStr = string.Join(", ", dependency.CompatibleGameTypes);
+            var msg = $"Content '{manifest.Name}' dependency '{dependency.Name}' is only compatible with {compatibleGamesStr}, but profile is for {profileGameType}";
+            if (!dependency.IsOptional)
+            {
+                errors.Add(msg);
+            }
+
+            logger.LogWarning(
+                "GameType compatibility failed: {ManifestName} dependency {DependencyName} requires {CompatibleGameTypes}, but profile is {ProfileGameType} (Optional: {IsOptional})",
+                manifest.Name,
+                dependency.Name,
+                compatibleGamesStr,
+                profileGameType,
+                dependency.IsOptional);
+        }
+    }
+
+    private void ValidateDependencyPublisher(
+        ContentManifest manifest,
+        ContentDependency dependency,
+        List<ContentManifest> potentialMatches,
+        List<string> errors)
+    {
+        if (dependency.StrictPublisher && !string.IsNullOrEmpty(dependency.PublisherType))
+        {
+            var dependencyManifest = potentialMatches.FirstOrDefault();
+            if (dependencyManifest != null)
+            {
+                var publisherType = dependencyManifest.Publisher?.PublisherType ?? PublisherTypeConstants.Unknown;
+
+                if (!string.Equals(dependency.PublisherType, publisherType, StringComparison.OrdinalIgnoreCase))
+                {
+                    var msg = $"Content '{manifest.Name}' dependency '{dependency.Name}' requires publisher type '{dependency.PublisherType}', but found '{publisherType}'";
+                    if (!dependency.IsOptional)
+                    {
+                        errors.Add(msg);
+                    }
+
+                    logger.LogWarning(
+                        "Publisher type mismatch: {ManifestName} dependency {DependencyName} requires {RequiredPublisher}, but found {ActualPublisher} (Optional: {IsOptional})",
+                        manifest.Name,
+                        dependency.Name,
+                        dependency.PublisherType,
+                        publisherType,
+                        dependency.IsOptional);
+                }
+            }
+        }
+    }
+
+    private void ValidateDependencyConflicts(
+        ContentManifest manifest,
+        Dictionary<string, ContentManifest> manifestsById,
+        List<string> errors)
+    {
+        if (manifest.Dependencies != null && manifest.Dependencies.Count > 0)
+        {
+            foreach (var dependency in manifest.Dependencies.Where(d => d.ConflictsWith.Count > 0))
+            {
+                foreach (var conflictId in dependency.ConflictsWith)
+                {
+                    if (manifestsById.ContainsKey(conflictId.ToString()))
+                    {
+                        errors.Add($"Content '{manifest.Name}' conflicts with '{manifestsById[conflictId.ToString()].Name}' - these cannot be enabled together");
+                        logger.LogWarning(
+                            "Conflict detected: {ManifestName} conflicts with {ConflictingManifest}",
+                            manifest.Name,
+                            manifestsById[conflictId.ToString()].Name);
+                    }
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -34,7 +34,7 @@ public partial class AddLocalContentViewModel(
     /// <summary>
     /// Gets the list of available game types.
     /// </summary>
-    public static GameType[] AvailableGameTypes { get; } =
+    public static IReadOnlyList<GameType> AvailableGameTypes { get; } =
     [
         GameType.Generals,
         GameType.ZeroHour,
@@ -43,7 +43,7 @@ public partial class AddLocalContentViewModel(
     /// <summary>
     /// Gets the list of allowed content types for the dialog.
     /// </summary>
-    public static ContentType[] AllowedContentTypes { get; } =
+    public static IReadOnlyList<ContentType> AllowedContentTypes { get; } =
     [
         ContentType.Mod,
         ContentType.GameClient,
@@ -550,7 +550,7 @@ public partial class AddLocalContentViewModel(
         if (BrowseFileAction != null)
         {
             var paths = await BrowseFileAction();
-            if (paths != null && paths.Count > 0)
+            if (paths is { Count: > 0 })
             {
                 foreach (var path in paths)
                 {
@@ -643,11 +643,8 @@ public partial class AddLocalContentViewModel(
             // Preserve SourcePath metadata if available
             // Note: We no longer write to "source.path" file to avoid polluting the content.
             // Instead we pass the SourcePath directly to the service.
-            GenHub.Core.Models.Results.OperationResult<GenHub.Core.Models.Manifest.ContentManifest> result;
-
-            if (IsEditing && _originalManifestId != null)
-            {
-                 result = await localContentService.UpdateLocalContentManifestAsync(
+            var result = IsEditing && _originalManifestId != null
+                ? await localContentService.UpdateLocalContentManifestAsync(
                     _originalManifestId,
                     ContentName,
                     _stagingPath,
@@ -655,11 +652,8 @@ public partial class AddLocalContentViewModel(
                     targetGame,
                     SourcePath,
                     progress,
-                    _cts.Token);
-            }
-            else
-            {
-                result = await localContentService.CreateLocalContentManifestAsync(
+                    _cts.Token)
+                : await localContentService.CreateLocalContentManifestAsync(
                     _stagingPath,
                     ContentName,
                     SelectedContentType,
@@ -667,7 +661,6 @@ public partial class AddLocalContentViewModel(
                     SourcePath,
                     progress,
                     _cts.Token);
-            }
 
             if (result.Success)
             {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileItemViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileItemViewModel.cs
@@ -504,16 +504,11 @@ public partial class GameProfileItemViewModel : ViewModelBase
             _useSteamLaunch = gameProfile2.UseSteamLaunch ?? true;
 
             // Determine if this is a Steam installation by checking the publisher in the manifest ID
-            _isSteamInstallation = gameProfile2.GameInstallationId?.Contains("steam", StringComparison.OrdinalIgnoreCase) ?? false;
+            _isSteamInstallation = gameProfile2.GameInstallationId?.Contains("steam", StringComparison.OrdinalIgnoreCase) == true;
 
-            if (string.IsNullOrEmpty(gameProfile2.ActiveWorkspaceId))
-            {
-                _workspaceStatus = "Not Prepared";
-            }
-            else
-            {
-                // Determine strategy-based status
-                _workspaceStatus = gameProfile2.WorkspaceStrategy switch
+            _workspaceStatus = string.IsNullOrEmpty(gameProfile2.ActiveWorkspaceId)
+                ? "Not Prepared"
+                : gameProfile2.WorkspaceStrategy switch
                 {
                     WorkspaceStrategy.SymlinkOnly => "Symlinked",
                     WorkspaceStrategy.FullCopy => "Copied",
@@ -521,7 +516,6 @@ public partial class GameProfileItemViewModel : ViewModelBase
                     WorkspaceStrategy.HardLink => "Hard Linked",
                     _ => "Prepared",
                 };
-            }
         }
     }
 
@@ -554,13 +548,9 @@ public partial class GameProfileItemViewModel : ViewModelBase
     {
         ActiveWorkspaceId = activeWorkspaceId;
 
-        if (string.IsNullOrEmpty(activeWorkspaceId))
-        {
-            WorkspaceStatus = "Not Prepared";
-        }
-        else
-        {
-            WorkspaceStatus = strategy switch
+        WorkspaceStatus = string.IsNullOrEmpty(activeWorkspaceId)
+            ? "Not Prepared"
+            : strategy switch
             {
                 WorkspaceStrategy.SymlinkOnly => "Symlinked",
                 WorkspaceStrategy.FullCopy => "Copied",
@@ -568,7 +558,6 @@ public partial class GameProfileItemViewModel : ViewModelBase
                 WorkspaceStrategy.HardLink => "Hard Linked",
                 _ => "Prepared",
             };
-        }
 
         // Explicitly notify UI of all dependent property changes
         OnPropertyChanged(nameof(IsWorkspacePrepared));

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileItemViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileItemViewModel.cs
@@ -460,22 +460,7 @@ public partial class GameProfileItemViewModel : ViewModelBase
                 {
                     // Normalize version to handle Unknown, Auto-Updated, and Automatically added cases
                     var version = gameProfile.GameClient.Version;
-                    if (version.Equals(GameClientConstants.AutoDetectedVersion, StringComparison.OrdinalIgnoreCase) ||
-                        version.Equals(GameClientConstants.UnknownVersion, StringComparison.OrdinalIgnoreCase) ||
-                        version.Equals("Auto-Updated", StringComparison.OrdinalIgnoreCase) ||
-                        version.Contains("Automatically", StringComparison.OrdinalIgnoreCase) ||
-                        version == "0" ||
-                        version == "0.0" ||
-                        version == "0.0.0" ||
-                        version == "0.0.0.0" ||
-                        version.Equals("v0", StringComparison.OrdinalIgnoreCase))
-                    {
-                        GameVersion = string.Empty;
-                    }
-                    else
-                    {
-                        GameVersion = version;
-                    }
+                    GameVersion = IsZeroOrPlaceholderVersion(version) ? string.Empty : version;
                 }
             }
 
@@ -629,22 +614,7 @@ public partial class GameProfileItemViewModel : ViewModelBase
                     !string.Equals(Publisher, "Local", StringComparison.OrdinalIgnoreCase))
                 {
                     var version = gameProfile.GameClient.Version;
-                    if (version.Equals(GameClientConstants.AutoDetectedVersion, StringComparison.OrdinalIgnoreCase) ||
-                        version.Equals(GameClientConstants.UnknownVersion, StringComparison.OrdinalIgnoreCase) ||
-                        version.Equals("Auto-Updated", StringComparison.OrdinalIgnoreCase) ||
-                        version.Contains("Automatically", StringComparison.OrdinalIgnoreCase) ||
-                        version == "0" ||
-                        version == "0.0" ||
-                        version == "0.0.0" ||
-                        version == "0.0.0.0" ||
-                        version.Equals("v0", StringComparison.OrdinalIgnoreCase))
-                    {
-                        GameVersion = string.Empty;
-                    }
-                    else
-                    {
-                        GameVersion = version;
-                    }
+                    GameVersion = IsZeroOrPlaceholderVersion(version) ? string.Empty : version;
                 }
             }
 
@@ -842,6 +812,23 @@ public partial class GameProfileItemViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Checks if the version is zero or a placeholder.
+    /// </summary>
+    /// <param name="version">The version string to check.</param>
+    private bool IsZeroOrPlaceholderVersion(string version)
+    {
+        return version.Equals(GameClientConstants.AutoDetectedVersion, StringComparison.OrdinalIgnoreCase) ||
+               version.Equals(GameClientConstants.UnknownVersion, StringComparison.OrdinalIgnoreCase) ||
+               version.Equals("Auto-Updated", StringComparison.OrdinalIgnoreCase) ||
+               version.Contains("Automatically", StringComparison.OrdinalIgnoreCase) ||
+               version == "0" ||
+               version == "0.0" ||
+               version == "0.0.0" ||
+               version == "0.0.0.0" ||
+               version.Equals("v0", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Extracts version, publisher, and content type information from a manifest ID.
     /// Expected format: schemaVersion.userVersion.publisher.contentType.contentName.
     /// Example: 1.104.steam.gameclient.zerohour → version=104 (1.04), publisher=Steam, contentType=Game Client.
@@ -850,105 +837,108 @@ public partial class GameProfileItemViewModel : ViewModelBase
     private void ExtractManifestInfo(string manifestId)
     {
         if (string.IsNullOrEmpty(manifestId))
+        {
             return;
+        }
 
         var segments = manifestId.Split('.');
         if (segments.Length < 4)
+        {
             return;
+        }
 
         try
         {
-            // Parse publisher: segment[2] contains the platform/publisher
             var publisherSegment = segments[2].ToLowerInvariant();
-            Publisher = publisherSegment switch
-            {
-                PublisherTypeConstants.Steam => "Steam",
-                PublisherTypeConstants.EaApp => "EA App",
-                "thefirstdecade" => "The First Decade",
-                PublisherTypeConstants.Retail => "Retail",
-                "cdiso" => "CD/ISO",
-                "wine" => "Wine",
-                PublisherTypeConstants.GeneralsOnline => "Generals Online",
-                PublisherTypeConstants.TheSuperHackers => "The Super Hackers",
-                CommunityOutpostConstants.PublisherType => "Community Outpost",
-                "local" => "Local",
-                _ => segments[2].ToUpperInvariant(),
-            };
-
-            // --- Faction Branding (Round 2 Fix) ---
-            // Apply theme colors and covers based on the publisher segment
-            if (publisherSegment == PublisherTypeConstants.TheSuperHackers)
-            {
-                // Super Hackers = China branding
-                ColorValue = SuperHackersConstants.ZeroHourThemeColor; // #8B0000
-                CoverImagePath = SuperHackersConstants.ZeroHourCoverSource; // "/Assets/Covers/china-cover.png"
-            }
-            else if (publisherSegment == PublisherTypeConstants.GeneralsOnline)
-            {
-                // Generals Online = USA branding
-                ColorValue = GeneralsOnlineConstants.ThemeColor; // #00A3FF
-                CoverImagePath = GeneralsOnlineConstants.CoverSource; // "/Assets/Covers/usa-cover.png"
-            }
-            else if (publisherSegment == CommunityOutpostConstants.PublisherType)
-            {
-                // Community Outpost / GenPatcher = GLA branding
-                ColorValue = CommunityOutpostConstants.ThemeColor; // #2D5A27
-                CoverImagePath = CommunityOutpostConstants.CoverSource; // "/Assets/Covers/gla-cover.png"
-            }
-
-            // Parse version: segment[1] contains the user version (e.g., 104, 108)
-            // For local content, don't show version at all since it's always 0
-            if (publisherSegment == "local")
-            {
-                // Local content has no meaningful version
-                GameVersion = string.Empty;
-            }
-            else if (int.TryParse(segments[1], out var versionNumber) && versionNumber > 0)
-            {
-                if (publisherSegment == PublisherTypeConstants.GeneralsOnline)
-                {
-                    // For Generals Online, the version is a datecode (MMDDYY).
-                    // Format as 6 digits (e.g., 10326 -> "010326")
-                    GameVersion = versionNumber.ToString("D6");
-                }
-                else
-                {
-                    // Standard version logic: Convert 104 -> "v1.04", 108 -> "v1.08", 105 -> "v1.05"
-                    GameVersion = versionNumber >= 100
-                        ? $"v{versionNumber / 100}.{versionNumber % 100:D2}"
-                        : $"v{versionNumber}";
-                }
-            }
-            else
-            {
-                // If version is 0 or invalid, try to extract from GameClient.Version directly
-                GameVersion = string.Empty;
-            }
-
-            // Parse content type from suffix in segment[3]
-            var gameTypeSegment = segments[3];
-            if (gameTypeSegment.Contains('-'))
-            {
-                var parts = gameTypeSegment.Split('-');
-                ContentType = parts[1] switch
-                {
-                    "gameinstallation" => "Game Installation",
-                    "gameclient" => "Game Client",
-                    "mod" => "Mod",
-                    "patch" => "Patch",
-                    "addon" => "Add-on",
-                    "map" => "Map",
-                    "mappack" => "Map Pack",
-                    "executable" => "Executable",
-                    "moddingtool" => "Modding Tool",
-                    "mission" => "Mission",
-                    _ => parts[1].ToUpperInvariant(),
-                };
-            }
+            Publisher = ParsePublisherName(publisherSegment, segments[2]);
+            ApplyPublisherBranding(publisherSegment);
+            GameVersion = ParseManifestVersion(publisherSegment, segments[1]);
+            ContentType = ParseContentType(segments[3]);
         }
         catch
         {
             // If parsing fails, leave the fields empty
         }
+    }
+
+    private string ParsePublisherName(string publisherSegment, string originalSegment) =>
+        publisherSegment switch
+        {
+            PublisherTypeConstants.Steam => "Steam",
+            PublisherTypeConstants.EaApp => "EA App",
+            "thefirstdecade" => "The First Decade",
+            PublisherTypeConstants.Retail => "Retail",
+            "cdiso" => "CD/ISO",
+            "wine" => "Wine",
+            PublisherTypeConstants.GeneralsOnline => "Generals Online",
+            PublisherTypeConstants.TheSuperHackers => "The Super Hackers",
+            CommunityOutpostConstants.PublisherType => "Community Outpost",
+            "local" => "Local",
+            _ => originalSegment.ToUpperInvariant(),
+        };
+
+    private void ApplyPublisherBranding(string publisherSegment)
+    {
+        if (publisherSegment == PublisherTypeConstants.TheSuperHackers)
+        {
+            ColorValue = SuperHackersConstants.ZeroHourThemeColor;
+            CoverImagePath = SuperHackersConstants.ZeroHourCoverSource;
+        }
+        else if (publisherSegment == PublisherTypeConstants.GeneralsOnline)
+        {
+            ColorValue = GeneralsOnlineConstants.ThemeColor;
+            CoverImagePath = GeneralsOnlineConstants.CoverSource;
+        }
+        else if (publisherSegment == CommunityOutpostConstants.PublisherType)
+        {
+            ColorValue = CommunityOutpostConstants.ThemeColor;
+            CoverImagePath = CommunityOutpostConstants.CoverSource;
+        }
+    }
+
+    private string ParseManifestVersion(string publisherSegment, string versionSegment)
+    {
+        if (publisherSegment == "local")
+        {
+            return string.Empty;
+        }
+
+        if (int.TryParse(versionSegment, out var versionNumber) && versionNumber > 0)
+        {
+            if (publisherSegment == PublisherTypeConstants.GeneralsOnline)
+            {
+                return versionNumber.ToString("D6");
+            }
+
+            return versionNumber >= 100
+                ? $"v{versionNumber / 100}.{versionNumber % 100:D2}"
+                : $"v{versionNumber}";
+        }
+
+        return string.Empty;
+    }
+
+    private string ParseContentType(string gameTypeSegment)
+    {
+        if (!gameTypeSegment.Contains('-'))
+        {
+            return string.Empty;
+        }
+
+        var parts = gameTypeSegment.Split('-');
+        return parts[1] switch
+        {
+            "gameinstallation" => "Game Installation",
+            "gameclient" => "Game Client",
+            "mod" => "Mod",
+            "patch" => "Patch",
+            "addon" => "Add-on",
+            "map" => "Map",
+            "mappack" => "Map Pack",
+            "executable" => "Executable",
+            "moddingtool" => "Modding Tool",
+            "mission" => "Mission",
+            _ => parts[1].ToUpperInvariant(),
+        };
     }
 }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
@@ -388,8 +388,7 @@ public partial class GameProfileLauncherViewModel(
     /// </summary>
     private static bool HasPublisherClients(GameInstallation installation)
     {
-        return installation.AvailableGameClients != null &&
-               installation.AvailableGameClients.Any(c => c.IsPublisherClient);
+        return installation.AvailableGameClients?.Any(c => c.IsPublisherClient) == true;
     }
 
     /// <summary>
@@ -579,59 +578,33 @@ public partial class GameProfileLauncherViewModel(
         bool anyPatchSelectedGlobally)
     {
         logger.LogInformation("Processing installation: {InstallationId} ({Type})", installation.Id, installation.InstallationType);
-        bool anyPatchHandled = false;
         int profilesCreated = 0;
 
-        if (cpDecision != GameClientConstants.WizardActionTypes.Decline && cpDecision != GameClientConstants.WizardActionTypes.None)
-        {
-            var cpClient = installation.AvailableGameClients!.FirstOrDefault(c => c.PublisherType == CommunityOutpostConstants.PublisherType);
-            if (cpClient != null || cpDecision == GameClientConstants.WizardActionTypes.Install)
-            {
-                var clientToUse = cpClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.CommunityPatch, Name = "Community Patch", PublisherType = CommunityOutpostConstants.PublisherType, GameType = GameType.ZeroHour, InstallationId = installation.Id };
-                bool forceAttr = cpDecision == GameClientConstants.WizardActionTypes.Update;
-                var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
-                if (result.Success && result.Data > 0)
-                {
-                    profilesCreated += result.Data;
-                }
+        var (cpHandled, cpProfiles) = await TryProcessPublisherDecisionAsync(
+            installation,
+            cpDecision,
+            CommunityOutpostConstants.PublisherType,
+            GameClientConstants.SyntheticClientIds.CommunityPatch,
+            "Community Patch");
+        profilesCreated += cpProfiles;
 
-                anyPatchHandled = true;
-            }
-        }
+        var (goHandled, goProfiles) = await TryProcessPublisherDecisionAsync(
+            installation,
+            goDecision,
+            PublisherTypeConstants.GeneralsOnline,
+            GameClientConstants.SyntheticClientIds.GeneralsOnline,
+            "GeneralsOnline");
+        profilesCreated += goProfiles;
 
-        if (goDecision != GameClientConstants.WizardActionTypes.Decline && goDecision != GameClientConstants.WizardActionTypes.None)
-        {
-            var goClient = installation.AvailableGameClients!.FirstOrDefault(c => c.PublisherType == PublisherTypeConstants.GeneralsOnline);
-            if (goClient != null || goDecision == GameClientConstants.WizardActionTypes.Install)
-            {
-                var clientToUse = goClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.GeneralsOnline, Name = "GeneralsOnline", PublisherType = PublisherTypeConstants.GeneralsOnline, GameType = GameType.ZeroHour, InstallationId = installation.Id };
-                bool forceAttr = goDecision == GameClientConstants.WizardActionTypes.Update;
-                var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
-                if (result.Success && result.Data > 0)
-                {
-                    profilesCreated += result.Data;
-                }
+        var (shHandled, shProfiles) = await TryProcessPublisherDecisionAsync(
+            installation,
+            shDecision,
+            PublisherTypeConstants.TheSuperHackers,
+            GameClientConstants.SyntheticClientIds.SuperHackers,
+            "SuperHackers");
+        profilesCreated += shProfiles;
 
-                anyPatchHandled = true;
-            }
-        }
-
-        if (shDecision != GameClientConstants.WizardActionTypes.Decline && shDecision != GameClientConstants.WizardActionTypes.None)
-        {
-            var shClient = installation.AvailableGameClients!.FirstOrDefault(c => c.PublisherType == PublisherTypeConstants.TheSuperHackers);
-            if (shClient != null || shDecision == GameClientConstants.WizardActionTypes.Install)
-            {
-                var clientToUse = shClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.SuperHackers, Name = "SuperHackers", PublisherType = PublisherTypeConstants.TheSuperHackers, GameType = GameType.ZeroHour, InstallationId = installation.Id };
-                bool forceAttr = shDecision == GameClientConstants.WizardActionTypes.Update;
-                var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
-                if (result.Success && result.Data > 0)
-                {
-                    profilesCreated += result.Data;
-                }
-
-                anyPatchHandled = true;
-            }
-        }
+        bool anyPatchHandled = cpHandled || goHandled || shHandled;
 
         if (!anyPatchHandled && !anyPatchSelectedGlobally)
         {
@@ -646,6 +619,40 @@ public partial class GameProfileLauncherViewModel(
         }
 
         return profilesCreated;
+    }
+
+    private async Task<(bool Handled, int ProfilesCreated)> TryProcessPublisherDecisionAsync(
+        GameInstallation installation,
+        string decision,
+        string publisherType,
+        string syntheticClientId,
+        string clientName)
+    {
+        if (decision == GameClientConstants.WizardActionTypes.Decline || decision == GameClientConstants.WizardActionTypes.None)
+        {
+            return (false, 0);
+        }
+
+        var client = installation.AvailableGameClients?.FirstOrDefault(c => c.PublisherType == publisherType);
+        if (client == null && decision != GameClientConstants.WizardActionTypes.Install)
+        {
+            return (false, 0);
+        }
+
+        var clientToUse = client ?? new GameClient
+        {
+            Id = syntheticClientId,
+            Name = clientName,
+            PublisherType = publisherType,
+            GameType = GameType.ZeroHour,
+            InstallationId = installation.Id,
+        };
+
+        bool forceAttr = decision == GameClientConstants.WizardActionTypes.Update;
+        var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
+        int profiles = (result.Success && result.Data > 0) ? result.Data : 0;
+
+        return (true, profiles);
     }
 
     /// <summary>
@@ -828,12 +835,10 @@ public partial class GameProfileLauncherViewModel(
 
                 return true;
             }
-            else
-            {
-                var errors = ManifestHelper.FormatErrors(profileResult.Errors);
-                logger.LogWarning("Failed to create profile for {InstallationType} {GameClientName}: {Errors}", installation.InstallationType, gameClient.Name, errors);
-                return false;
-            }
+
+            var errors = ManifestHelper.FormatErrors(profileResult.Errors);
+            logger.LogWarning("Failed to create profile for {InstallationType} {GameClientName}: {Errors}", installation.InstallationType, gameClient.Name, errors);
+            return false;
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
@@ -126,19 +126,13 @@ public partial class GameProfileLauncherViewModel(
             // Set up timer
             _headerCollapseTimer.AutoReset = false;
             _headerCollapseTimer.Elapsed += (s, e) =>
-            {
-                Avalonia.Threading.Dispatcher.UIThread.Invoke(() =>
-                {
-                    IsHeaderExpanded = false;
-                });
-            };
+                Avalonia.Threading.Dispatcher.UIThread.Invoke(() => IsHeaderExpanded = false);
 
             _headerCollapseTimer.Start();
 
             // Set up expansion timer
             _headerExpansionTimer.AutoReset = false;
             _headerExpansionTimer.Elapsed += (s, e) =>
-            {
                 Avalonia.Threading.Dispatcher.UIThread.Invoke(() =>
                 {
                     IsHeaderExpanded = true;
@@ -147,7 +141,6 @@ public partial class GameProfileLauncherViewModel(
                     // Stop collapse timer just in case
                     _headerCollapseTimer.Stop();
                 });
-            };
 
             gameProcessManager.ProcessExited += OnProcessExited;
 
@@ -463,149 +456,30 @@ public partial class GameProfileLauncherViewModel(
             var installations = await installationService.GetAllInstallationsAsync();
             if (installations.Success && installations.Data != null)
             {
-                // Convert to mutable list to allow adding manual installations
                 var installationsList = installations.Data.ToList();
 
-                // Check if no installations were found and prompt for manual selection
                 if (installationsList.Count == 0)
                 {
-                    logger.LogInformation("No game installations found, prompting user for manual directory selection");
-
-                    // Use the shared manual game addition logic
-                    // We don't await the result here because we want to exit the scan flow if cancelled,
-                    // but AddManualGameAsync handles the full flow including UI updates.
-                    // However, for the scan flow, we need to know if it was successful to show the "Scan Cancelled" message or not.
-                    var manualInstallation = await PromptForManualGameDirectoryAsync();
+                    var manualInstallation = await PromptAndRegisterManualInstallationAsync();
                     if (manualInstallation != null)
                     {
-                        // Proceed to process this installation usually handled inside AddManualGameAsync,
-                        // but here we want to continue the wizard flow.
-
-                        // Actually, let's just reuse the logic from AddManualGameAsync but we need to integrate it into the wizard flow.
-                        // For simplicity in this refactor, let's keep the wizard flow logic here but use the Prompt method.
-
-                        // Ensure paths are populated
-                        manualInstallation.Fetch();
-
-                        // Detect game clients for the manual installation (also generates GameClient manifests)
-                        var detectionResult = await gameClientDetector.DetectGameClientsFromInstallationsAsync([manualInstallation]);
-                        if (detectionResult.Success && detectionResult.Items?.Count > 0)
-                        {
-                            manualInstallation.PopulateGameClients(detectionResult.Items);
-                        }
-
-                        // Create and register GameInstallation manifests to the pool
-                        await CreateAndRegisterManualInstallationManifestsAsync(manualInstallation);
-
-                        // Register the installation with the service cache
-                        var addResult = await installationService.AddInstallationToCacheAsync(manualInstallation);
-                        if (!addResult.Success)
-                        {
-                            logger.LogWarning("Failed to add manual installation to cache: {Error}", addResult.FirstError);
-                        }
-
-                        // Add the manually selected installation to the list
                         installationsList.Add(manualInstallation);
-                        logger.LogInformation("User provided manual installation, proceeding with profile creation");
                     }
                     else
                     {
-                        logger.LogInformation("User cancelled manual directory selection");
                         StatusMessage = "No installations found. Scan cancelled.";
                         return;
                     }
                 }
 
-                var installationCount = installationsList.Count;
-                var generalsCount = installationsList.Count(i => i.HasGenerals);
-                var zeroHourCount = installationsList.Count(i => i.HasZeroHour);
-
                 logger.LogInformation(
                     "Game scan completed. Found {Count} installations ({GeneralsCount} Generals, {ZeroHourCount} Zero Hour)",
-                    installationCount,
-                    generalsCount,
-                    zeroHourCount);
+                    installationsList.Count,
+                    installationsList.Count(i => i.HasGenerals),
+                    installationsList.Count(i => i.HasZeroHour));
 
-                // Run Setup Wizard via Service
                 var wizardResult = await setupWizardService.RunSetupWizardAsync(installationsList);
-
-                var cpDecision = wizardResult.CommunityPatchAction;
-                var goDecision = wizardResult.GeneralsOnlineAction;
-                var shDecision = wizardResult.SuperHackersAction;
-
-                bool wizardConfirmed = wizardResult.Confirmed;
-
-                // Check if any patches were selected globally
-                bool anyPatchSelectedGlobally =
-                    (cpDecision != GameClientConstants.WizardActionTypes.Decline && cpDecision != GameClientConstants.WizardActionTypes.None) ||
-                    (goDecision != GameClientConstants.WizardActionTypes.Decline && goDecision != GameClientConstants.WizardActionTypes.None) ||
-                    (shDecision != GameClientConstants.WizardActionTypes.Decline && shDecision != GameClientConstants.WizardActionTypes.None);
-
-                // 4. Execution Phase: Apply decisions per installation
-                int profilesCreated = 0;
-                foreach (var installation in installationsList)
-                {
-                    if (installation.AvailableGameClients == null || installation.AvailableGameClients.Count == 0)
-                    {
-                        continue;
-                    }
-
-                    logger.LogInformation("Processing installation: {InstallationId} ({Type})", installation.Id, installation.InstallationType);
-                    bool anyPatchHandled = false;
-
-                    // Execute CP Decision
-                    if (cpDecision != GameClientConstants.WizardActionTypes.Decline && cpDecision != GameClientConstants.WizardActionTypes.None)
-                    {
-                        var cpClient = installation.AvailableGameClients.FirstOrDefault(c => c.PublisherType == CommunityOutpostConstants.PublisherType);
-                        if (cpClient != null || cpDecision == GameClientConstants.WizardActionTypes.Install)
-                        {
-                            var clientToUse = cpClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.CommunityPatch, Name = "Community Patch", PublisherType = CommunityOutpostConstants.PublisherType, GameType = GameType.ZeroHour, InstallationId = installation.Id };
-                            bool forceAttr = cpDecision == GameClientConstants.WizardActionTypes.Update;
-                            var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
-                            if (result.Success && result.Data > 0) profilesCreated += result.Data;
-                            anyPatchHandled = true;
-                        }
-                    }
-
-                    // Execute GO Decision
-                    if (goDecision != GameClientConstants.WizardActionTypes.Decline && goDecision != GameClientConstants.WizardActionTypes.None)
-                    {
-                        var goClient = installation.AvailableGameClients.FirstOrDefault(c => c.PublisherType == PublisherTypeConstants.GeneralsOnline);
-                        if (goClient != null || goDecision == GameClientConstants.WizardActionTypes.Install)
-                        {
-                            var clientToUse = goClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.GeneralsOnline, Name = "GeneralsOnline", PublisherType = PublisherTypeConstants.GeneralsOnline, GameType = GameType.ZeroHour, InstallationId = installation.Id };
-                            bool forceAttr = goDecision == GameClientConstants.WizardActionTypes.Update;
-                            var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
-                            if (result.Success && result.Data > 0) profilesCreated += result.Data;
-                            anyPatchHandled = true;
-                        }
-                    }
-
-                    // Execute SH Decision
-                    if (shDecision != GameClientConstants.WizardActionTypes.Decline && shDecision != GameClientConstants.WizardActionTypes.None)
-                    {
-                        var shClient = installation.AvailableGameClients.FirstOrDefault(c => c.PublisherType == PublisherTypeConstants.TheSuperHackers);
-                        if (shClient != null || shDecision == GameClientConstants.WizardActionTypes.Install)
-                        {
-                            var clientToUse = shClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.SuperHackers, Name = "SuperHackers", PublisherType = PublisherTypeConstants.TheSuperHackers, GameType = GameType.ZeroHour, InstallationId = installation.Id };
-                            bool forceAttr = shDecision == GameClientConstants.WizardActionTypes.Update;
-                            var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
-                            if (result.Success && result.Data > 0) profilesCreated += result.Data;
-                            anyPatchHandled = true;
-                        }
-                    }
-
-                    // Fallback to base game profiles if no patches were handled and no patches were selected globally
-                    // If user selected patches globally, we assume they only want those specific patched profiles
-                    if (!anyPatchHandled && !anyPatchSelectedGlobally)
-                    {
-                        logger.LogInformation("No patches selected or found for {InstallationId}, creating base game profiles", installation.Id);
-                        foreach (var client in installation.AvailableGameClients.Where(c => !c.IsPublisherClient).ToList())
-                        {
-                            if (await TryCreateProfileForGameClientAsync(installation, client)) profilesCreated++;
-                        }
-                    }
-                }
+                var profilesCreated = await ApplyInstallationWizardDecisionsAsync(installationsList, wizardResult);
 
                 StatusMessage = $"Scan complete. Found {installationsList.Count} installations, created {profilesCreated} profiles";
 
@@ -632,6 +506,146 @@ public partial class GameProfileLauncherViewModel(
         {
             IsScanning = false;
         }
+    }
+
+    private async Task<GameInstallation?> PromptAndRegisterManualInstallationAsync()
+    {
+        logger.LogInformation("No game installations found, prompting user for manual directory selection");
+
+        var manualInstallation = await PromptForManualGameDirectoryAsync();
+        if (manualInstallation == null)
+        {
+            logger.LogInformation("User cancelled manual directory selection");
+            return null;
+        }
+
+        manualInstallation.Fetch();
+
+        var detectionResult = await gameClientDetector.DetectGameClientsFromInstallationsAsync([manualInstallation]);
+        if (detectionResult.Success && detectionResult.Items?.Count > 0)
+        {
+            manualInstallation.PopulateGameClients(detectionResult.Items);
+        }
+
+        await CreateAndRegisterManualInstallationManifestsAsync(manualInstallation);
+
+        var addResult = await installationService.AddInstallationToCacheAsync(manualInstallation);
+        if (!addResult.Success)
+        {
+            logger.LogWarning("Failed to add manual installation to cache: {Error}", addResult.FirstError);
+        }
+
+        logger.LogInformation("User provided manual installation, proceeding with profile creation");
+        return manualInstallation;
+    }
+
+    private async Task<int> ApplyInstallationWizardDecisionsAsync(
+        List<GameInstallation> installationsList,
+        SetupWizardResult wizardResult)
+    {
+        var cpDecision = wizardResult.CommunityPatchAction;
+        var goDecision = wizardResult.GeneralsOnlineAction;
+        var shDecision = wizardResult.SuperHackersAction;
+
+        bool anyPatchSelectedGlobally =
+            (cpDecision != GameClientConstants.WizardActionTypes.Decline && cpDecision != GameClientConstants.WizardActionTypes.None) ||
+            (goDecision != GameClientConstants.WizardActionTypes.Decline && goDecision != GameClientConstants.WizardActionTypes.None) ||
+            (shDecision != GameClientConstants.WizardActionTypes.Decline && shDecision != GameClientConstants.WizardActionTypes.None);
+
+        int profilesCreated = 0;
+        foreach (var installation in installationsList)
+        {
+            if (installation.AvailableGameClients == null || installation.AvailableGameClients.Count == 0)
+            {
+                continue;
+            }
+
+            profilesCreated += await ProcessInstallationDecisionsAsync(
+                installation,
+                cpDecision,
+                goDecision,
+                shDecision,
+                anyPatchSelectedGlobally);
+        }
+
+        return profilesCreated;
+    }
+
+    private async Task<int> ProcessInstallationDecisionsAsync(
+        GameInstallation installation,
+        string cpDecision,
+        string goDecision,
+        string shDecision,
+        bool anyPatchSelectedGlobally)
+    {
+        logger.LogInformation("Processing installation: {InstallationId} ({Type})", installation.Id, installation.InstallationType);
+        bool anyPatchHandled = false;
+        int profilesCreated = 0;
+
+        if (cpDecision != GameClientConstants.WizardActionTypes.Decline && cpDecision != GameClientConstants.WizardActionTypes.None)
+        {
+            var cpClient = installation.AvailableGameClients!.FirstOrDefault(c => c.PublisherType == CommunityOutpostConstants.PublisherType);
+            if (cpClient != null || cpDecision == GameClientConstants.WizardActionTypes.Install)
+            {
+                var clientToUse = cpClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.CommunityPatch, Name = "Community Patch", PublisherType = CommunityOutpostConstants.PublisherType, GameType = GameType.ZeroHour, InstallationId = installation.Id };
+                bool forceAttr = cpDecision == GameClientConstants.WizardActionTypes.Update;
+                var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
+                if (result.Success && result.Data > 0)
+                {
+                    profilesCreated += result.Data;
+                }
+
+                anyPatchHandled = true;
+            }
+        }
+
+        if (goDecision != GameClientConstants.WizardActionTypes.Decline && goDecision != GameClientConstants.WizardActionTypes.None)
+        {
+            var goClient = installation.AvailableGameClients!.FirstOrDefault(c => c.PublisherType == PublisherTypeConstants.GeneralsOnline);
+            if (goClient != null || goDecision == GameClientConstants.WizardActionTypes.Install)
+            {
+                var clientToUse = goClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.GeneralsOnline, Name = "GeneralsOnline", PublisherType = PublisherTypeConstants.GeneralsOnline, GameType = GameType.ZeroHour, InstallationId = installation.Id };
+                bool forceAttr = goDecision == GameClientConstants.WizardActionTypes.Update;
+                var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
+                if (result.Success && result.Data > 0)
+                {
+                    profilesCreated += result.Data;
+                }
+
+                anyPatchHandled = true;
+            }
+        }
+
+        if (shDecision != GameClientConstants.WizardActionTypes.Decline && shDecision != GameClientConstants.WizardActionTypes.None)
+        {
+            var shClient = installation.AvailableGameClients!.FirstOrDefault(c => c.PublisherType == PublisherTypeConstants.TheSuperHackers);
+            if (shClient != null || shDecision == GameClientConstants.WizardActionTypes.Install)
+            {
+                var clientToUse = shClient ?? new GameClient { Id = GameClientConstants.SyntheticClientIds.SuperHackers, Name = "SuperHackers", PublisherType = PublisherTypeConstants.TheSuperHackers, GameType = GameType.ZeroHour, InstallationId = installation.Id };
+                bool forceAttr = shDecision == GameClientConstants.WizardActionTypes.Update;
+                var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
+                if (result.Success && result.Data > 0)
+                {
+                    profilesCreated += result.Data;
+                }
+
+                anyPatchHandled = true;
+            }
+        }
+
+        if (!anyPatchHandled && !anyPatchSelectedGlobally)
+        {
+            logger.LogInformation("No patches selected or found for {InstallationId}, creating base game profiles", installation.Id);
+            foreach (var client in installation.AvailableGameClients!.Where(c => !c.IsPublisherClient).ToList())
+            {
+                if (await TryCreateProfileForGameClientAsync(installation, client))
+                {
+                    profilesCreated++;
+                }
+            }
+        }
+
+        return profilesCreated;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -611,7 +611,11 @@ public class GameLauncher(
                     .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, RetailArchiveConstants.ArchiveSearch)
                     .Any();
             }
-            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            catch (UnauthorizedAccessException ex)
+            {
+                return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
+            }
+            catch (IOException ex)
             {
                 return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
             }

--- a/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
@@ -293,13 +293,21 @@ public class ContentManifestPool(
         {
             var contentDir = Path.Combine(storageService.GetContentStorageRoot(), DirectoryNames.Data, manifestId.Value);
 
-            // If a mapping file exists, return its value (this points to the original source directory)
+            // If a mapping file exists, check its value
             var mappingFile = Path.Combine(contentDir, "source.path");
             if (File.Exists(mappingFile))
             {
                 var sourcePath = await File.ReadAllTextAsync(mappingFile, cancellationToken);
                 if (!string.IsNullOrWhiteSpace(sourcePath))
+                {
+                    // Handle CAS-only content gracefully - return null without warnings
+                    if (sourcePath.Trim().Equals("CAS-ONLY", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return OperationResult<string?>.CreateSuccess(null);
+                    }
+
                     return OperationResult<string?>.CreateSuccess(sourcePath);
+                }
             }
 
             var result = Directory.Exists(contentDir) ? contentDir : null;

--- a/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
@@ -293,7 +293,7 @@ public class ContentManifestPool(
         {
             var contentDir = Path.Combine(storageService.GetContentStorageRoot(), DirectoryNames.Data, manifestId.Value);
 
-            // If a mapping file exists, check its value
+            // If a mapping file exists, return its value (this points to the original source directory)
             var mappingFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
             if (File.Exists(mappingFile))
             {

--- a/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
@@ -294,7 +294,7 @@ public class ContentManifestPool(
             var contentDir = Path.Combine(storageService.GetContentStorageRoot(), DirectoryNames.Data, manifestId.Value);
 
             // If a mapping file exists, check its value
-            var mappingFile = Path.Combine(contentDir, "source.path");
+            var mappingFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
             if (File.Exists(mappingFile))
             {
                 var sourcePath = await File.ReadAllTextAsync(mappingFile, cancellationToken);

--- a/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
@@ -346,8 +346,8 @@ public class ContentManifestPool(
         if (string.IsNullOrEmpty(manifest.Version))
             errors.Add("Manifest version is required");
 
-        var hasFiles = manifest.Files != null && manifest.Files.Count > 0;
-        var hasDirs = manifest.RequiredDirectories != null && manifest.RequiredDirectories.Count > 0;
+        var hasFiles = manifest.Files is { Count: > 0 };
+        var hasDirs = manifest.RequiredDirectories is { Count: > 0 };
         var isBase = manifest.ContentType == ContentType.GameInstallation || manifest.ContentType == ContentType.GameClient;
 
         if (!hasFiles && !hasDirs && !isBase)

--- a/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
@@ -301,7 +301,7 @@ public class ContentManifestPool(
                 if (!string.IsNullOrWhiteSpace(sourcePath))
                 {
                     // Handle CAS-only content gracefully - return null without warnings
-                    if (sourcePath.Trim().Equals("CAS-ONLY", StringComparison.OrdinalIgnoreCase))
+                    if (sourcePath.Trim().Equals(FileTypes.CasOnlySourceMarker, StringComparison.OrdinalIgnoreCase))
                     {
                         return OperationResult<string?>.CreateSuccess(null);
                     }

--- a/GenHub/GenHub/Features/Settings/Views/SettingsView.axaml
+++ b/GenHub/GenHub/Features/Settings/Views/SettingsView.axaml
@@ -409,31 +409,6 @@
               <TextBlock Text="Select application color theme (More coming soon)"
                          Classes="setting-description" />
             </StackPanel>
-
-            <!-- Auto Update Check -->
-            <StackPanel Spacing="8">
-              <CheckBox Content="Check for updates on startup"
-                        IsChecked="{Binding AutoCheckForUpdatesOnStartup}" />
-              <TextBlock Text="Automatically check for GenHub updates when the application starts"
-                         Classes="setting-description" Margin="24,0,0,0" />
-            </StackPanel>
-
-            <!-- Settings File Path -->
-            <StackPanel Spacing="8">
-              <TextBlock Text="Settings File Location" Classes="setting-label" />
-              <Grid ColumnDefinitions="*,Auto">
-                <TextBox Grid.Column="0"
-                         Text="{Binding SettingsFilePath}"
-                         Watermark="Default (platform-dependent)"
-                         LostFocus="OnTextBoxLostFocus" />
-                <Button Grid.Column="1"
-                        Content="Browse"
-                        Command="{Binding BrowseSettingsFilePathCommand}"
-                        Classes="browse-button" />
-              </Grid>
-              <TextBlock Text="Specify a custom location for your settings file. Leave empty for auto-detection."
-                         Classes="setting-description" />
-            </StackPanel>
           </StackPanel>
         </Border>
       </Expander>
@@ -480,6 +455,23 @@
                         Command="{Binding OpenCasPoolDirectoryCommand}"
                         Classes="secondary-button" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"/>
             </Grid>
+
+            <!-- Settings File Path -->
+            <StackPanel Spacing="8">
+              <TextBlock Text="Settings File Location" Classes="setting-label" />
+              <Grid ColumnDefinitions="*,Auto">
+                <TextBox Grid.Column="0"
+                         Text="{Binding SettingsFilePath}"
+                         Watermark="Default (platform-dependent)"
+                         LostFocus="OnTextBoxLostFocus" />
+                <Button Grid.Column="1"
+                        Content="Browse"
+                        Command="{Binding BrowseSettingsFilePathCommand}"
+                        Classes="browse-button" />
+              </Grid>
+              <TextBlock Text="Specify a custom location for your settings file. Leave empty for auto-detection."
+                         Classes="setting-description" />
+            </StackPanel>
           </StackPanel>
         </Border>
       </Expander>
@@ -733,6 +725,14 @@
                     Margin="0,8,0,0"
                     ToolTip.Tip="Browse available updates and subscribe to Pull Requests" />
 
+
+          <!-- Auto Update Check -->
+          <StackPanel Spacing="8">
+            <CheckBox Content="Check for updates on startup"
+                      IsChecked="{Binding AutoCheckForUpdatesOnStartup}" />
+            <TextBlock Text="Automatically check for GenHub updates when the application starts"
+                       Classes="setting-description" Margin="24,0,0,0" />
+          </StackPanel>
 
           <!-- GitHub PAT for Artifact Access -->
           <Border Background="#1E1E1E" CornerRadius="4" Padding="15" BorderBrush="#4E4E4E" BorderThickness="1">

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
@@ -42,7 +42,7 @@ public sealed class MapImportService(
             var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
             response.EnsureSuccessStatusCode();
 
-            var fileName = GetFileNameFromUrl(new Uri(url), response);
+            var fileName = GetFileNameFromUri(new Uri(url), response);
             Directory.CreateDirectory(tempDir);
             var tempPath = Path.Combine(tempDir, fileName);
 
@@ -512,7 +512,7 @@ public sealed class MapImportService(
         }
     }
 
-    private static string GetFileNameFromUrl(Uri uri, HttpResponseMessage response)
+    private static string GetFileNameFromUri(Uri uri, HttpResponseMessage response)
     {
         var rawName = response.Content.Headers.ContentDisposition?.FileNameStar
             ?? response.Content.Headers.ContentDisposition?.FileName;

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
@@ -101,7 +101,7 @@ public sealed class ReplayImportService(
                     return await ImportFromZipAsync(tempPath, targetVersion, progress, ct);
                 }
 
-                var importedFileName = GetFileNameFromUrl(new Uri(directUrl));
+                var importedFileName = GetFileNameFromUri(new Uri(directUrl));
                 using var stream = File.OpenRead(tempPath);
                 return await ImportFromStreamAsync(stream, importedFileName, targetVersion, ct);
             }
@@ -336,7 +336,7 @@ public sealed class ReplayImportService(
         return path;
     }
 
-    private static string GetFileNameFromUrl(Uri uri)
+    private static string GetFileNameFromUri(Uri uri)
     {
         try
         {

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -355,7 +355,11 @@ public class UserDataTrackerService(
                             File.Copy(file.BackupPath, file.AbsolutePath, overwrite: true);
                             logger.LogInformation("[UserData] Restored backup during deactivation: {Backup} -> {Path}", file.BackupPath, file.AbsolutePath);
                         }
-                        catch (Exception ex) when (ex is not OperationCanceledException)
+                        catch (OperationCanceledException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
                         {
                             logger.LogWarning(ex, "[UserData] Failed to restore backup during deactivation: {Path}", file.AbsolutePath);
                             manifestHasErrors = true;
@@ -951,7 +955,11 @@ public class UserDataTrackerService(
                 }
             }
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             logger.LogError(ex, "[UserData] Exception while materializing file {Path} during activation", file.AbsolutePath);
         }

--- a/GenHub/GenHub/Features/Workspace/Strategies/FullCopyStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/FullCopyStrategy.cs
@@ -142,10 +142,10 @@ public sealed class FullCopyStrategy(
                 async (fileGroup, ct) =>
                 {
                     // For each destination path, process files in priority order (lowest to highest)
-                    // Priority: GameInstallation (0) < GameClient (1) < Mod (2)
+                    // Priority: GameInstallation (10) < Addon (40) < GameClient (50) < Patch (90) < Mod (100)
                     // This ensures higher priority content overwrites lower priority
                     var orderedFiles = fileGroup
-                        .OrderBy(item => item.Manifest.ContentType)
+                        .OrderBy(item => ContentTypePriority.GetPriority(item.Manifest.ContentType))
                         .ToList();
 
                     // Process all versions of this file in priority order

--- a/GenHub/GenHub/Features/Workspace/Strategies/FullCopyStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/FullCopyStrategy.cs
@@ -105,7 +105,7 @@ public sealed class FullCopyStrategy(
             Logger.LogDebug("Processing {TotalFiles} files in parallel", totalFiles);
             ReportProgress(progress, 0, totalFiles, "Initializing", string.Empty);
 
-            int degreeOfParallelism;
+            int degreeOfParallelism = Environment.ProcessorCount * 2;
             try
             {
                 var driveInfo = new DriveInfo(Path.GetPathRoot(workspacePath) ?? "C:\\");


### PR DESCRIPTION
## Overview

This PR resolves four GitHub issues related to settings UI organization, content priority , and CAS storage warnings.

## Changes

### Settings UI Reorganization
- **#281**
Moved "Check for updates on startup" setting from Appearance section to Updates section where it logically belongs
- **#282**
Moved "Settings File Location" configuration from Appearance section to a new "Data Directories" section for better
organization

### Version Widget Enhancement
- **#283**:
Made the version widget in the bottom-right corner clickable
  - Clicking now copies the full version (including git hash) to clipboard
  - Shows a success notification when copied
  - Added tooltip "Click to copy version to clipboard"
  - Maintains original visual appearance with hand cursor on hover
 
### Content Priority Fix
- **#284**: 
Fixed mods not taking effect in-game due to incorrect file priority resolution
  - Root cause: `FullCopyStrategy` was sorting by enum value instead of content type priority
  - Changed to use `ContentTypePriority.GetPriority()` for proper ordering
  - Ensures mod files (priority 100) correctly override base game files (priority 10)
  - Priority order: Mod (100) > Patch (90) > GameClient (50) > Addon (40) > GameInstallation (10)
 
### CAS Storage Warning Fix
- Eliminated "Could not resolve source path for manifest" warnings for CAS-stored content
  - Added `source.path` marker file creation after CAS storage
  - Updated `ContentManifestPool` to handle CAS-ONLY marker gracefully
  - Prevents spurious warnings in logs for downloaded content
 
## Related Issues
Closes #281
Closes #282
Closes #283
Closes #284

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses four GitHub issues: settings UI reorganization (#281, #282), a clickable version widget (#283), a content priority fix (#284), and CAS storage warning elimination. The core logic fixes are solid — `ContentTypePriority` is now exhaustively mapped and `FullCopyStrategy` correctly uses semantic priority ordering. However, two issues remain:

- **`"CAS-ONLY"` magic string**: The sentinel value written by `ContentStorageService` and compared in `ContentManifestPool` is hardcoded in both places rather than extracted to a shared constant in `FileTypes.cs` (which this same PR already uses for `SourcePathFileName`).
- **Missing cleanup in `StoreCasContentAsync` catch block**: The PR adds `Directory.CreateDirectory(contentDir)` + `File.WriteAllTextAsync(..., "CAS-ONLY", ...)` to the CAS storage happy path, but the catch block's comment and cleanup logic were not updated — the newly created `contentDir` is not removed on failure, leaving an orphan directory.
- **Undocumented camera mod removal** (flagged in a previous thread, still unresolved): Three camera mod entries (`crgn`, `crzh`, `dczh`) are removed from `GenPatcherContentRegistry` with no mention in any of the referenced issues or the PR description.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Mostly safe to merge, but the undocumented camera mod removal and the CAS cleanup gap warrant author confirmation before landing.
- The core bug fixes (priority ordering, `ContentTypePriority` exhaustiveness, CAS warning suppression) are correct and well-tested by the backup/restore cleanup logic in `StoreManifestOnlyAsync`. The UI changes are clean. Score is reduced by: (1) the unexplained deletion of three `GenPatcherContentRegistry` entries with user-visible impact, and (2) the incomplete catch-block cleanup in `StoreCasContentAsync` which could leave orphan directories on disk.
- GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs (undocumented removal of camera mod entries) and GenHub/GenHub/Features/Content/Services/ContentStorageService.cs (incomplete catch-block cleanup for CAS path).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Constants/FileTypes.cs | Adds `SourcePathFileName = "source.path"` constant. Good extraction, but `"CAS-ONLY"` sentinel value should also be added here as a constant. |
| GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs | Removes the "Camera Modifications" block (crgn, crzh, dczh entries) with no explanation in referenced issues or PR description. This is unrelated to issues #281–#284 and will prevent users from installing camera mods via GenPatcher. |
| GenHub/GenHub.Core/Models/Workspace/ContentTypePriority.cs | Exhaustively maps all 19 ContentType enum values. 15 types get numeric priorities (10–100); 4 meta/reference types explicitly throw ArgumentException. The `_` fallback throws ArgumentOutOfRangeException to catch future unmapped additions. Resolves the previous thread concern entirely. |
| GenHub/GenHub/Features/Content/Services/ContentStorageService.cs | Adds CAS-ONLY marker file creation to `StoreCasContentAsync` and adds thorough backup/restore cleanup logic to `StoreManifestOnlyAsync`. Two issues: (1) "CAS-ONLY" is a hardcoded magic string that should be a constant in FileTypes.cs; (2) the catch block in `StoreCasContentAsync` does not clean up the newly created `contentDir`. |
| GenHub/GenHub/Features/Manifest/ContentManifestPool.cs | Correctly handles the new CAS-ONLY sentinel by returning `null` success instead of treating it as a real directory path. Uses `StringComparison.OrdinalIgnoreCase` which is good, but the `"CAS-ONLY"` literal should be a shared constant. |
| GenHub/GenHub/Features/Workspace/Strategies/FullCopyStrategy.cs | Fixes the root cause of #284 by replacing `OrderBy(item.Manifest.ContentType)` (enum integer ordering) with `OrderBy(ContentTypePriority.GetPriority(...))` (semantic priority ordering). Comment updated to reflect correct priority values. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CS as ContentStorageService
    participant FS as FileSystem
    participant CAS as CasReferenceTracker
    participant MP as ContentManifestPool

    Note over CS,MP: StoreCasContentAsync (happy path)
    CS->>FS: StoreContentFilesAsync (CAS hash storage)
    CS->>CAS: TrackManifestReferencesAsync
    CS->>FS: WriteAllTextAsync(manifest.json)
    CS->>FS: CreateDirectory(contentDir)
    CS->>FS: WriteAllTextAsync(source.path, "CAS-ONLY")

    Note over CS,MP: Later — GetContentDirectoryAsync
    MP->>FS: ReadAllTextAsync(source.path)
    FS-->>MP: "CAS-ONLY"
    MP-->>MP: sourcePath == "CAS-ONLY" → return null (no warnings)

    Note over CS,MP: StoreCasContentAsync (failure path — gap)
    CS->>FS: WriteAllTextAsync(manifest.json) ✓
    CS->>FS: CreateDirectory(contentDir) ✓
    CS->>FS: WriteAllTextAsync(source.path, "CAS-ONLY") ✗ throws
    CS->>FS: DeleteFileIfExists(manifest.json)
    CS->>CAS: UntrackManifestAsync
    Note over FS: contentDir orphaned (not cleaned up)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `GenHub/GenHub/Features/Content/Services/ContentStorageService.cs`, line 301-323 ([link](https://github.com/community-outpost/genhub/blob/5ab0a40a9143d885c9ab9baa8f19e22092f8c784/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs#L301-L323)) 

   **Failure cleanup in `StoreContentAsync` does not cover the newly written CAS-ONLY marker**

   The `StoreManifestOnlyAsync` path received careful rollback logic (backup + restore or delete of `source.path`), but the equivalent cleanup is missing from `StoreContentAsync`. If `WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` at line 296 succeeds and a subsequent step throws (unlikely in current code, but fragile if the method grows), the `contentDir` and its `source.path` file will be left on disk even though the manifest JSON has been deleted.

   For consistency with the rollback strategy applied in `StoreManifestOnlyAsync`, consider adding symmetric cleanup here:

   ```csharp
   catch (Exception ex)
   {
       _logger.LogError(ex, "Failed to store content for manifest {ManifestId}", manifest.Id);
       try
       {
           FileOperationsService.DeleteFileIfExists(manifestPath);

           // Clean up the CAS-ONLY marker and its directory if we created them
           var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
           var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
           FileOperationsService.DeleteFileIfExists(sourcePathFile);
           if (Directory.Exists(contentDir) && !Directory.EnumerateFileSystemEntries(contentDir).Any())
               Directory.Delete(contentDir);

           var untrackResult = await _referenceTracker.UntrackManifestAsync(manifest.Id, CancellationToken.None);
           ...
       }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
   Line: 301-323

   Comment:
   **Failure cleanup in `StoreContentAsync` does not cover the newly written CAS-ONLY marker**

   The `StoreManifestOnlyAsync` path received careful rollback logic (backup + restore or delete of `source.path`), but the equivalent cleanup is missing from `StoreContentAsync`. If `WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` at line 296 succeeds and a subsequent step throws (unlikely in current code, but fragile if the method grows), the `contentDir` and its `source.path` file will be left on disk even though the manifest JSON has been deleted.

   For consistency with the rollback strategy applied in `StoreManifestOnlyAsync`, consider adding symmetric cleanup here:

   ```csharp
   catch (Exception ex)
   {
       _logger.LogError(ex, "Failed to store content for manifest {ManifestId}", manifest.Id);
       try
       {
           FileOperationsService.DeleteFileIfExists(manifestPath);

           // Clean up the CAS-ONLY marker and its directory if we created them
           var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
           var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
           FileOperationsService.DeleteFileIfExists(sourcePathFile);
           if (Directory.Exists(contentDir) && !Directory.EnumerateFileSystemEntries(contentDir).Any())
               Directory.Delete(contentDir);

           var untrackResult = await _referenceTracker.UntrackManifestAsync(manifest.Id, CancellationToken.None);
           ...
       }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `GenHub/GenHub/Features/Content/Services/ContentStorageService.cs`, line 301-319 ([link](https://github.com/community-outpost/genhub/blob/151027f357b52fbd14f636b2a915fa47bb52541c/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs#L301-L319)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`contentDir` not cleaned up in CAS catch block**

   This PR newly adds `Directory.CreateDirectory(contentDir)` (line 294) and `File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` (line 296) inside the happy path of `StoreCasContentAsync`. However, the catch block only cleans up `manifestPath` and untracks CAS references — it does not remove `contentDir` or the partially-written `source.path` file.

   Concrete failure scenario:
   1. `File.WriteAllTextAsync(manifestPath, ...)` succeeds (line 289).
   2. `Directory.CreateDirectory(contentDir)` succeeds (line 294) — directory may be newly created.
   3. `File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` throws (line 296), e.g. due to a disk error.
   4. Catch block: `manifestPath` is deleted, CAS references are untracked — but `contentDir` (now empty) is left on disk as an orphan.

   On a subsequent re-store attempt, `Directory.CreateDirectory` would succeed on the pre-existing empty dir, and the write would be retried — so this is non-blocking. But the comment in the catch block says *"only manifest file needs cleanup"*, which is no longer accurate after this PR adds the `contentDir` creation.

   Consider mirroring the cleanup done in `StoreManifestOnlyAsync` for consistency:
   ```csharp
   // Also clean up the CAS-only marker directory if it was newly created by this call
   var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
   var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
   FileOperationsService.DeleteFileIfExists(sourcePathFile);
   // Only remove directory if empty, to avoid deleting legitimate content
   if (Directory.Exists(contentDir) && !Directory.EnumerateFileSystemEntries(contentDir).Any())
       Directory.Delete(contentDir);
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
   Line: 301-319

   Comment:
   **`contentDir` not cleaned up in CAS catch block**

   This PR newly adds `Directory.CreateDirectory(contentDir)` (line 294) and `File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` (line 296) inside the happy path of `StoreCasContentAsync`. However, the catch block only cleans up `manifestPath` and untracks CAS references — it does not remove `contentDir` or the partially-written `source.path` file.

   Concrete failure scenario:
   1. `File.WriteAllTextAsync(manifestPath, ...)` succeeds (line 289).
   2. `Directory.CreateDirectory(contentDir)` succeeds (line 294) — directory may be newly created.
   3. `File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` throws (line 296), e.g. due to a disk error.
   4. Catch block: `manifestPath` is deleted, CAS references are untracked — but `contentDir` (now empty) is left on disk as an orphan.

   On a subsequent re-store attempt, `Directory.CreateDirectory` would succeed on the pre-existing empty dir, and the write would be retried — so this is non-blocking. But the comment in the catch block says *"only manifest file needs cleanup"*, which is no longer accurate after this PR adds the `contentDir` creation.

   Consider mirroring the cleanup done in `StoreManifestOnlyAsync` for consistency:
   ```csharp
   // Also clean up the CAS-only marker directory if it was newly created by this call
   var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
   var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
   FileOperationsService.DeleteFileIfExists(sourcePathFile);
   // Only remove directory if empty, to avoid deleting legitimate content
   if (Directory.Exists(contentDir) && !Directory.EnumerateFileSystemEntries(contentDir).Any())
       Directory.Delete(contentDir);
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
Line: 296

Comment:
**`"CAS-ONLY"` is an unextracted magic string**

The sentinel value `"CAS-ONLY"` is hardcoded here and again in `ContentManifestPool.cs:304` where it is compared with `StringComparison.OrdinalIgnoreCase`. Per the project's coding style, magic string constants must be extracted to a dedicated constants class.

The same PR already correctly extracted `"source.path"` into `FileTypes.SourcePathFileName`; the `"CAS-ONLY"` value should follow the same pattern. If the casing is ever changed on the write side (or a typo is introduced), the `OrdinalIgnoreCase` comparison in `ContentManifestPool` will silently mask the mismatch, and CAS-only content will start emitting the warnings again.

Add a constant to `FileTypes.cs`:

```csharp
/// <summary>
/// Sentinel value written to <see cref="SourcePathFileName"/> when content is stored
/// via CAS and has no source directory.
/// </summary>
public const string CasOnlySourceMarker = "CAS-ONLY";
```

Then replace both usages:
- `ContentStorageService.cs:296`: `await File.WriteAllTextAsync(sourcePathFile, FileTypes.CasOnlySourceMarker, cancellationToken);`
- `ContentManifestPool.cs:304`: `if (sourcePath.Trim().Equals(FileTypes.CasOnlySourceMarker, StringComparison.OrdinalIgnoreCase))`

**Rule Used:** Use dedicated constants classes instead of hardcod... ([source](https://app.greptile.com/review/custom-context?memory=53453b3b-b708-4856-b1b0-0cbc8bfe5330))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
Line: 301-319

Comment:
**`contentDir` not cleaned up in CAS catch block**

This PR newly adds `Directory.CreateDirectory(contentDir)` (line 294) and `File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` (line 296) inside the happy path of `StoreCasContentAsync`. However, the catch block only cleans up `manifestPath` and untracks CAS references — it does not remove `contentDir` or the partially-written `source.path` file.

Concrete failure scenario:
1. `File.WriteAllTextAsync(manifestPath, ...)` succeeds (line 289).
2. `Directory.CreateDirectory(contentDir)` succeeds (line 294) — directory may be newly created.
3. `File.WriteAllTextAsync(sourcePathFile, "CAS-ONLY", ...)` throws (line 296), e.g. due to a disk error.
4. Catch block: `manifestPath` is deleted, CAS references are untracked — but `contentDir` (now empty) is left on disk as an orphan.

On a subsequent re-store attempt, `Directory.CreateDirectory` would succeed on the pre-existing empty dir, and the write would be retried — so this is non-blocking. But the comment in the catch block says *"only manifest file needs cleanup"*, which is no longer accurate after this PR adds the `contentDir` creation.

Consider mirroring the cleanup done in `StoreManifestOnlyAsync` for consistency:
```csharp
// Also clean up the CAS-only marker directory if it was newly created by this call
var contentDir = Path.Combine(_storageRoot, DirectoryNames.Data, updatedManifest.Id.Value);
var sourcePathFile = Path.Combine(contentDir, FileTypes.SourcePathFileName);
FileOperationsService.DeleteFileIfExists(sourcePathFile);
// Only remove directory if empty, to avoid deleting legitimate content
if (Directory.Exists(contentDir) && !Directory.EnumerateFileSystemEntries(contentDir).Any())
    Directory.Delete(contentDir);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 151027f</sub>

**Context used:**

- Rule used - Use dedicated constants classes instead of hardcod... ([source](https://app.greptile.com/review/custom-context?memory=53453b3b-b708-4856-b1b0-0cbc8bfe5330))

<!-- /greptile_comment -->