### PR TITLE
fix: support extended GeneralsOnline version format with build suffixes

### DIFF
--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -100,6 +100,9 @@ public static class GeneralsOnlineConstants
     /// <summary>Subdirectory within the portable ZIP containing maps.</summary>
     public const string MapsSubdirectory = "Maps";
 
+    /// <summary>Subdirectory within the portable ZIP containing plugins (EAC, etc.).</summary>
+    public const string PluginsSubdirectory = "plugins";
+
     // ===== Component Identifiers =====
 
     /// <summary>Source name for Generals Online discoverer.</summary>

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -100,9 +100,6 @@ public static class GeneralsOnlineConstants
     /// <summary>Subdirectory within the portable ZIP containing maps.</summary>
     public const string MapsSubdirectory = "Maps";
 
-    /// <summary>Subdirectory within the portable ZIP containing plugins (EAC, etc.).</summary>
-    public const string PluginsSubdirectory = "plugins";
-
     // ===== Component Identifiers =====
 
     /// <summary>Source name for Generals Online discoverer.</summary>

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -52,6 +52,7 @@ public static class GeneralsOnlineConstants
     public const string VersionDateFormat = "MMddyy";
 
     /// <summary>Separator between date and QFE number in versions.</summary>
+    /// <remarks>Used by catalog parser for date extraction. Version comparison uses underscore split.</remarks>
     public const string QfeSeparator = "_QFE";
 
     /// <summary>Prefix for QFE markers in version strings.</summary>

--- a/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
+using GenHub.Core.Constants;
 
 namespace GenHub.Core.Helpers;
 
@@ -145,7 +146,7 @@ public static partial class GameVersionHelper
             }
 
             var datePart = parts[0];
-            var qfePart = parts[1].Replace("QFE", string.Empty, StringComparison.OrdinalIgnoreCase);
+            var qfePart = parts[1].Replace(GeneralsOnlineConstants.QfeMarkerPrefix, string.Empty, StringComparison.OrdinalIgnoreCase);
 
             if (datePart.Length != 6 || !int.TryParse(qfePart, out var qfe))
             {

--- a/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
@@ -168,6 +168,13 @@ public static partial class GameVersionHelper
     /// Gets a sortable integer version for Generals Online versions.
     /// Converts "101525_QFE2" to 1015252, "042826_QFE3_EAC" to 428263.
     /// Build suffixes (e.g. _EAC) are ignored — only date and QFE affect ordering.
+    /// <para>
+    /// Note: The encoding uses <c>dateValue * 10 + QFE</c>, which limits QFE to 0–9
+    /// without colliding with the next date. This is intentional — the value is embedded
+    /// in manifest IDs and changing the encoding would break installed content references.
+    /// Version ordering uses <see cref="ParseGeneralsOnlineVersion"/> directly via
+    /// <c>VersionComparer.CompareGeneralsOnlineVersions</c>, which has no such limitation.
+    /// </para>
     /// </summary>
     /// <param name="version">The version string to convert.</param>
     /// <returns>A sortable integer, or 0 if parsing fails.</returns>

--- a/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
@@ -122,7 +122,9 @@ public static partial class GameVersionHelper
     }
 
     /// <summary>
-    /// Parses a version string (MMDDYY_QFE#) used by Generals Online.
+    /// Parses a version string (MMDDYY_QFE#[_SUFFIX]) used by Generals Online.
+    /// Supports extended formats like "042826_QFE3_EAC" — extra segments after
+    /// the QFE number are build metadata and do not affect version ordering.
     /// </summary>
     /// <param name="version">The version string to parse.</param>
     /// <returns>A tuple containing the extracted date and QFE number, or null if parsing fails.</returns>
@@ -135,9 +137,9 @@ public static partial class GameVersionHelper
 
         try
         {
-            // Format: MMDDYY_QFE# or DDMMYY_QFE# (General Online CDN uses MMDDYY)
+            // Format: MMDDYY_QFE#[_SUFFIX...] (Generals Online CDN uses MMDDYY)
             var parts = version.Split('_', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (parts.Length != 2)
+            if (parts.Length < 2)
             {
                 return null;
             }
@@ -164,7 +166,8 @@ public static partial class GameVersionHelper
 
     /// <summary>
     /// Gets a sortable integer version for Generals Online versions.
-    /// Converts "101525_QFE2" to 1015252.
+    /// Converts "101525_QFE2" to 1015252, "042826_QFE3_EAC" to 428263.
+    /// Build suffixes (e.g. _EAC) are ignored — only date and QFE affect ordering.
     /// </summary>
     /// <param name="version">The version string to convert.</param>
     /// <returns>A sortable integer, or 0 if parsing fails.</returns>

--- a/GenHub/GenHub.Core/Helpers/VersionComparer.cs
+++ b/GenHub/GenHub.Core/Helpers/VersionComparer.cs
@@ -62,19 +62,21 @@ public static class VersionComparer
         var parsed1 = GameVersionHelper.ParseGeneralsOnlineVersion(version1);
         var parsed2 = GameVersionHelper.ParseGeneralsOnlineVersion(version2);
 
-        if (parsed1 != null && parsed2 != null)
-        {
-            int dateCompare = parsed1.Value.Date.CompareTo(parsed2.Value.Date);
-            if (dateCompare != 0)
-            {
-                return dateCompare;
-            }
+        // Both unparseable — fall back to generic numeric comparison
+        if (parsed1 == null && parsed2 == null)
+            return CompareNumericVersions(version1, version2);
 
-            return parsed1.Value.Qfe.CompareTo(parsed2.Value.Qfe);
+        // Exactly one unparseable — treat unparseable as always older
+        if (parsed1 == null) return -1;
+        if (parsed2 == null) return 1;
+
+        int dateCompare = parsed1.Value.Date.CompareTo(parsed2.Value.Date);
+        if (dateCompare != 0)
+        {
+            return dateCompare;
         }
 
-        // Fallback for unparseable versions (e.g. "Unknown", semantic versions)
-        return CompareNumericVersions(version1, version2);
+        return parsed1.Value.Qfe.CompareTo(parsed2.Value.Qfe);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Helpers/VersionComparer.cs
+++ b/GenHub/GenHub.Core/Helpers/VersionComparer.cs
@@ -22,11 +22,19 @@ public static class VersionComparer
     {
         // Handle null/empty cases
         if (string.IsNullOrWhiteSpace(version1) && string.IsNullOrWhiteSpace(version2))
+        {
             return 0;
+        }
+
         if (string.IsNullOrWhiteSpace(version1))
+        {
             return -1;
+        }
+
         if (string.IsNullOrWhiteSpace(version2))
+        {
             return 1;
+        }
 
         // Determine comparison strategy based on publisher type
         if (string.Equals(publisherType, CommunityOutpostConstants.PublisherType, StringComparison.OrdinalIgnoreCase))
@@ -64,11 +72,20 @@ public static class VersionComparer
 
         // Both unparseable — fall back to generic numeric comparison
         if (parsed1 == null && parsed2 == null)
+        {
             return CompareNumericVersions(version1, version2);
+        }
 
         // Exactly one unparseable — treat unparseable as always older
-        if (parsed1 == null) return -1;
-        if (parsed2 == null) return 1;
+        if (parsed1 == null)
+        {
+            return -1;
+        }
+
+        if (parsed2 == null)
+        {
+            return 1;
+        }
 
         int dateCompare = parsed1.Value.Date.CompareTo(parsed2.Value.Date);
         if (dateCompare != 0)
@@ -200,22 +217,30 @@ public static class VersionComparer
     private static string NormalizeVersionString(string version)
     {
         if (string.IsNullOrWhiteSpace(version))
+        {
             return string.Empty;
+        }
 
         // Remove common prefixes that publishers use
         var normalized = version;
 
         // Remove weekly- prefix (SuperHackers)
         if (normalized.StartsWith("weekly-", StringComparison.OrdinalIgnoreCase))
+        {
             normalized = normalized.Substring(8); // Remove "weekly-"
+        }
 
         // Remove release- prefix
         if (normalized.StartsWith("release-", StringComparison.OrdinalIgnoreCase))
+        {
             normalized = normalized.Substring(9); // Remove "release-"
+        }
 
         // Remove version- prefix
         if (normalized.StartsWith("version-", StringComparison.OrdinalIgnoreCase))
+        {
             normalized = normalized.Substring(9); // Remove "version-"
+        }
 
         // Remove 'v' or 'V' prefix
         normalized = normalized.TrimStart('v', 'V');
@@ -267,13 +292,19 @@ public static class VersionComparer
 
             if (isDigit1 && isDigit2 && long.TryParse(segment1, out var num1) && long.TryParse(segment2, out var num2))
             {
-                if (num1 != num2) return num1.CompareTo(num2);
+                if (num1 != num2)
+                {
+                    return num1.CompareTo(num2);
+                }
             }
             else
             {
                 // For non-pure-numeric segments, compare the full original strings (case-insensitive)
                 var strCompare = string.Compare(rawSegment1, rawSegment2, StringComparison.OrdinalIgnoreCase);
-                if (strCompare != 0) return strCompare;
+                if (strCompare != 0)
+                {
+                    return strCompare;
+                }
             }
         }
 
@@ -307,7 +338,9 @@ public static class VersionComparer
     private static long? ExtractNumericFromDate(string dateStr)
     {
         if (string.IsNullOrWhiteSpace(dateStr))
+        {
             return null;
+        }
 
         // Remove common date separators
         var digits = dateStr.Replace("-", string.Empty)
@@ -328,7 +361,9 @@ public static class VersionComparer
     private static string ExtractDigits(string version)
     {
         if (string.IsNullOrWhiteSpace(version))
+        {
             return string.Empty;
+        }
 
         var result = new System.Text.StringBuilder();
         foreach (var c in version)

--- a/GenHub/GenHub.Core/Helpers/VersionComparer.cs
+++ b/GenHub/GenHub.Core/Helpers/VersionComparer.cs
@@ -41,11 +41,39 @@ public static class VersionComparer
         }
         else if (string.Equals(publisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase))
         {
-            // GeneralsOnline uses numeric versions
-            return CompareNumericVersions(version1, version2);
+            // GeneralsOnline uses MMDDYY_QFE#[_SUFFIX] format — parse for accurate comparison
+            return CompareGeneralsOnlineVersions(version1, version2);
         }
 
         // Default: Use the robust numeric/semantic comparison logic
+        return CompareNumericVersions(version1, version2);
+    }
+
+    /// <summary>
+    /// Compares two GeneralsOnline version strings (MMDDYY_QFE#[_SUFFIX]).
+    /// Extra suffix segments (e.g. _EAC) are build metadata and do not affect ordering.
+    /// Falls back to <see cref="CompareNumericVersions"/> when parsing fails.
+    /// </summary>
+    /// <param name="version1">The first version.</param>
+    /// <param name="version2">The second version.</param>
+    /// <returns>Comparison result.</returns>
+    private static int CompareGeneralsOnlineVersions(string version1, string version2)
+    {
+        var parsed1 = GameVersionHelper.ParseGeneralsOnlineVersion(version1);
+        var parsed2 = GameVersionHelper.ParseGeneralsOnlineVersion(version2);
+
+        if (parsed1 != null && parsed2 != null)
+        {
+            int dateCompare = parsed1.Value.Date.CompareTo(parsed2.Value.Date);
+            if (dateCompare != 0)
+            {
+                return dateCompare;
+            }
+
+            return parsed1.Value.Qfe.CompareTo(parsed2.Value.Qfe);
+        }
+
+        // Fallback for unparseable versions (e.g. "Unknown", semantic versions)
         return CompareNumericVersions(version1, version2);
     }
 

--- a/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineApiResponse.cs
+++ b/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineApiResponse.cs
@@ -8,8 +8,9 @@ namespace GenHub.Core.Models.GeneralsOnline;
 public class GeneralsOnlineApiResponse
 {
     /// <summary>
-    /// Gets or sets the version string (e.g., "111825_QFE2" for November 18, 2025).
-    /// Format: MMDDYY_QFE# where MM=month, DD=day, YY=year, #=QFE number.
+    /// Gets or sets the version string (e.g., "111825_QFE2" or "042826_QFE3_EAC").
+    /// Format: MMDDYY_QFE#[_SUFFIX] where MM=month, DD=day, YY=year, #=QFE number.
+    /// The optional suffix (e.g. "_EAC") is build metadata that does not affect version ordering.
     /// </summary>
     [JsonPropertyName("version")]
     public string Version { get; set; } = string.Empty;

--- a/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
+++ b/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
@@ -10,7 +10,7 @@ namespace GenHub.Core.Models.GeneralsOnline;
 public class GeneralsOnlineRelease
 {
     /// <summary>
-    /// Gets version string in format: MMDDYY_QFE# (e.g., "101525_QFE5").
+    /// Gets version string in format: MMDDYY_QFE#[_SUFFIX] (e.g., "101525_QFE5", "042826_QFE3_EAC").
     /// </summary>
     public required string Version { get; init; }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParserTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParserTests.cs
@@ -1,5 +1,6 @@
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Providers;
+using GenHub.Core.Models.GeneralsOnline;
 using GenHub.Core.Models.Providers;
 using GenHub.Features.Content.Services.GeneralsOnline;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -90,5 +91,52 @@ public class GeneralsOnlineJsonCatalogParserTests
         Assert.True(result.Success);
         var item = result.Data.First();
         Assert.Equal("111825_QFE2", item.Version);
+    }
+
+    /// <summary>
+    /// Tests that ParseAsync correctly parses extended version format with build suffix.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ParseAsync_WithExtendedVersion_ParsesCorrectly()
+    {
+        // Arrange
+        var json = @"{
+            ""version"": ""042826_QFE3_EAC"",
+            ""download_url"": ""https://cdn.playgenerals.online/GeneralsOnline_portable_042826_QFE3_EAC.zip"",
+            ""size"": 28277693,
+            ""release_notes"": ""www.playgenerals.online/updates"",
+            ""sha256"": ""abc123""
+        }";
+
+        var wrapper = $"{{\"source\":\"manifest\",\"data\":{json}}}";
+
+        // Act
+        var result = await _parser.ParseAsync(wrapper, _provider);
+
+        // Assert
+        Assert.True(result.Success);
+        var item = result.Data!.First();
+        Assert.Equal("042826_QFE3_EAC", item.Version);
+        Assert.Equal("https://cdn.playgenerals.online/GeneralsOnline_portable_042826_QFE3_EAC.zip", item.GetData<GeneralsOnlineRelease>()!.PortableUrl);
+    }
+
+    /// <summary>
+    /// Tests that ParseAsync correctly handles latest.txt fallback with extended version.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ParseAsync_LatestFallbackExtendedVersion_ParsesCorrectly()
+    {
+        // Arrange
+        var wrapper = "{\"source\":\"latest\",\"version\":\"042826_QFE3_EAC\"}";
+
+        // Act
+        var result = await _parser.ParseAsync(wrapper, _provider);
+
+        // Assert
+        Assert.True(result.Success);
+        var item = result.Data!.First();
+        Assert.Equal("042826_QFE3_EAC", item.Version);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameVersionHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameVersionHelperTests.cs
@@ -1,0 +1,134 @@
+using GenHub.Core.Helpers;
+
+namespace GenHub.Tests.Core.Helpers;
+
+/// <summary>
+/// Tests for <see cref="GameVersionHelper"/> Generals Online version parsing.
+/// </summary>
+public class GameVersionHelperTests
+{
+    // ==== ParseGeneralsOnlineVersion — legacy format (MMDDYY_QFE#) ====
+
+    /// <summary>
+    /// Verifies that legacy two-segment versions parse correctly.
+    /// </summary>
+    [Fact]
+    public void ParseGeneralsOnlineVersion_LegacyFormat_ParsesCorrectly()
+    {
+        var result = GameVersionHelper.ParseGeneralsOnlineVersion("101525_QFE2");
+
+        Assert.NotNull(result);
+        Assert.Equal(new DateTime(2025, 10, 15), result.Value.Date);
+        Assert.Equal(2, result.Value.Qfe);
+    }
+
+    // ==== ParseGeneralsOnlineVersion — extended format (MMDDYY_QFE#_SUFFIX) ====
+
+    /// <summary>
+    /// Verifies that extended format with build suffix parses date and QFE correctly.
+    /// </summary>
+    [Fact]
+    public void ParseGeneralsOnlineVersion_ExtendedFormat_ParsesDateAndQfe()
+    {
+        var result = GameVersionHelper.ParseGeneralsOnlineVersion("042826_QFE3_EAC");
+
+        Assert.NotNull(result);
+        Assert.Equal(new DateTime(2026, 4, 28), result.Value.Date);
+        Assert.Equal(3, result.Value.Qfe);
+    }
+
+    /// <summary>
+    /// Verifies that versions with multiple suffix segments still parse correctly.
+    /// </summary>
+    [Fact]
+    public void ParseGeneralsOnlineVersion_MultipleSuffixes_ParsesDateAndQfe()
+    {
+        var result = GameVersionHelper.ParseGeneralsOnlineVersion("011526_QFE1_EAC_X86");
+
+        Assert.NotNull(result);
+        Assert.Equal(new DateTime(2026, 1, 15), result.Value.Date);
+        Assert.Equal(1, result.Value.Qfe);
+    }
+
+    // ==== ParseGeneralsOnlineVersion — edge cases ====
+
+    /// <summary>
+    /// Verifies that null or empty versions return null.
+    /// </summary>
+    /// <param name="version">The version string to test.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseGeneralsOnlineVersion_NullOrEmpty_ReturnsNull(string? version)
+    {
+        var result = GameVersionHelper.ParseGeneralsOnlineVersion(version);
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies that versions missing the underscore separator return null.
+    /// </summary>
+    [Fact]
+    public void ParseGeneralsOnlineVersion_NoUnderscore_ReturnsNull()
+    {
+        var result = GameVersionHelper.ParseGeneralsOnlineVersion("042826");
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies that versions with malformed dates return null.
+    /// </summary>
+    [Fact]
+    public void ParseGeneralsOnlineVersion_InvalidDate_ReturnsNull()
+    {
+        var result = GameVersionHelper.ParseGeneralsOnlineVersion("ABCDEF_QFE1");
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies that versions with non-numeric QFE return null.
+    /// </summary>
+    [Fact]
+    public void ParseGeneralsOnlineVersion_NonNumericQfe_ReturnsNull()
+    {
+        var result = GameVersionHelper.ParseGeneralsOnlineVersion("042826_QFEx");
+        Assert.Null(result);
+    }
+
+    // ==== GetGeneralsOnlineSortableVersion ====
+
+    /// <summary>
+    /// Verifies that sortable version is computed correctly for legacy format.
+    /// </summary>
+    [Fact]
+    public void GetGeneralsOnlineSortableVersion_LegacyFormat_ReturnsCorrectValue()
+    {
+        // "101525_QFE2" -> date=101525, qfe=2 -> 101525*10 + 2 = 1015252
+        var result = GameVersionHelper.GetGeneralsOnlineSortableVersion("101525_QFE2");
+        Assert.Equal(1015252, result);
+    }
+
+    /// <summary>
+    /// Verifies that sortable version ignores build suffixes in extended format.
+    /// </summary>
+    [Fact]
+    public void GetGeneralsOnlineSortableVersion_ExtendedFormat_IgnoresSuffix()
+    {
+        // "042826_QFE3_EAC" -> date=042826, qfe=3 -> 42826*10 + 3 = 428263
+        var result = GameVersionHelper.GetGeneralsOnlineSortableVersion("042826_QFE3_EAC");
+        Assert.Equal(428263, result);
+    }
+
+    /// <summary>
+    /// Verifies that legacy and extended formats with same date+QFE produce the same sortable value.
+    /// </summary>
+    [Fact]
+    public void GetGeneralsOnlineSortableVersion_SameVersionDifferentFormat_ProducesEqualValue()
+    {
+        var legacy = GameVersionHelper.GetGeneralsOnlineSortableVersion("042826_QFE3");
+        var extended = GameVersionHelper.GetGeneralsOnlineSortableVersion("042826_QFE3_EAC");
+
+        Assert.Equal(legacy, extended);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/VersionComparerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/VersionComparerTests.cs
@@ -194,4 +194,42 @@ public class VersionComparerTests
         // Assert
         Assert.Equal(expected, Math.Sign(result));
     }
+
+    /// <summary>
+    /// Verifies that when only one GeneralsOnline version is parseable,
+    /// the unparseable version is always treated as older.
+    /// </summary>
+    /// <param name="version1">The first version string.</param>
+    /// <param name="version2">The second version string.</param>
+    /// <param name="expected">The expected comparison result.</param>
+    [Theory]
+    [InlineData("042826_QFE3_EAC", "Unknown", 1)] // Parseable vs unparseable
+    [InlineData("Unknown", "042826_QFE3_EAC", -1)] // Unparseable vs parseable
+    [InlineData("042826_QFE2", "garbage", 1)] // Legacy parseable vs unparseable
+    [InlineData("garbage", "042826_QFE2", -1)] // Unparseable vs legacy parseable
+    public void CompareVersions_GeneralsOnline_MixedParseable_UnparseableIsOlder(
+        string version1,
+        string version2,
+        int expected)
+    {
+        // Act
+        var result = VersionComparer.CompareVersions(version1, version2, PublisherTypeConstants.GeneralsOnline);
+
+        // Assert
+        Assert.Equal(expected, Math.Sign(result));
+    }
+
+    /// <summary>
+    /// Verifies that when both GeneralsOnline versions are unparseable,
+    /// the method falls back to numeric/string comparison.
+    /// </summary>
+    [Fact]
+    public void CompareVersions_GeneralsOnline_BothUnparseable_FallsBackToNumeric()
+    {
+        // Act
+        var result = VersionComparer.CompareVersions("Unknown", "Unknown", PublisherTypeConstants.GeneralsOnline);
+
+        // Assert — same unparseable strings should compare as equal
+        Assert.Equal(0, result);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/VersionComparerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/VersionComparerTests.cs
@@ -169,4 +169,29 @@ public class VersionComparerTests
         // Assert
         Assert.Equal(expected, Math.Sign(result));
     }
+
+    /// <summary>
+    /// Verifies that GeneralsOnline versions with extended format (build suffix) compare correctly.
+    /// Versions like "042826_QFE3_EAC" should compare by date+QFE only, ignoring the suffix.
+    /// </summary>
+    /// <param name="version1">The first version string.</param>
+    /// <param name="version2">The second version string.</param>
+    /// <param name="expected">The expected comparison result.</param>
+    [Theory]
+    [InlineData("042826_QFE3_EAC", "042826_QFE3_EAC", 0)] // Same extended version
+    [InlineData("042826_QFE4_EAC", "042826_QFE3_EAC", 1)] // Same date, higher QFE
+    [InlineData("042826_QFE3_EAC", "042826_QFE2", 1)] // Extended vs legacy, higher QFE
+    [InlineData("042826_QFE2", "042826_QFE2_EAC", 0)] // Legacy vs extended, same date+QFE
+    [InlineData("042926_QFE1_EAC", "042826_QFE3_EAC", 1)] // Newer date wins regardless of QFE
+    public void CompareVersions_GeneralsOnline_ExtendedFormat_ReturnsCorrectComparison(
+        string version1,
+        string version2,
+        int expected)
+    {
+        // Act
+        var result = VersionComparer.CompareVersions(version1, version2, PublisherTypeConstants.GeneralsOnline);
+
+        // Assert
+        Assert.Equal(expected, Math.Sign(result));
+    }
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -408,11 +408,15 @@ public class GeneralsOnlineManifestFactory(
         var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
         logger.LogInformation("Processing {Count} files", allFiles.Length);
 
-        List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap)> filesWithHashes = [];
+        List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsPlugin)> filesWithHashes = [];
 
         // Detect Maps directory (case-insensitive)
         var mapsDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
             .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.MapsSubdirectory, StringComparison.OrdinalIgnoreCase));
+
+        // Detect plugins directory (case-insensitive) for EAC and other plugins
+        var pluginsDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
+            .FirstOrDefault(d => Path.GetFileName(d).Equals("plugins", StringComparison.OrdinalIgnoreCase));
 
         foreach (var filePath in allFiles)
         {
@@ -427,6 +431,9 @@ public class GeneralsOnlineManifestFactory(
             // Determine if this file is inside the Maps directory
             var isMap = mapsDirectory != null && filePath.StartsWith(mapsDirectory, StringComparison.OrdinalIgnoreCase);
 
+            // Determine if this file is inside the plugins directory (EAC, etc.)
+            var isPlugin = pluginsDirectory != null && filePath.StartsWith(pluginsDirectory, StringComparison.OrdinalIgnoreCase);
+
             string hash;
             using (var stream = File.OpenRead(filePath))
             {
@@ -434,8 +441,8 @@ public class GeneralsOnlineManifestFactory(
                 hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
             }
 
-            filesWithHashes.Add((relativePath, fileInfo, hash, isMap));
-            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap})", relativePath, fileInfo.Length, hash[..8], isMap);
+            filesWithHashes.Add((relativePath, fileInfo, hash, isMap, isPlugin));
+            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap}, isPlugin: {IsPlugin})", relativePath, fileInfo.Length, hash[..8], isMap, isPlugin);
         }
 
         List<ContentManifest> updatedManifests = [];
@@ -448,7 +455,7 @@ public class GeneralsOnlineManifestFactory(
             if (isMapPackManifest)
             {
                 // MapPack manifest: only include map files with UserMapsDirectory install target
-                foreach (var (relativePath, fileInfo, hash, isMap) in filesWithHashes)
+                foreach (var (relativePath, fileInfo, hash, isMap, isPlugin) in filesWithHashes)
                 {
                     if (!isMap)
                     {
@@ -462,11 +469,12 @@ public class GeneralsOnlineManifestFactory(
             }
             else
             {
-                // Game client manifest: include executables, shared files, AND map files
-                // Map files are included with UserMapsDirectory install target so they install to Documents
+                // Game client manifest: include executables, shared files, plugin files (EAC), but NOT maps
+                // Map files are handled by the MapPack manifest
+                // Plugin files (EAC DLLs, etc.) are included so they're copied to the workspace
                 var targetExecutable = GameClientConstants.GeneralsOnline60HzExecutable;
 
-                foreach (var (relativePath, fileInfo, hash, isMap) in filesWithHashes)
+                foreach (var (relativePath, fileInfo, hash, isMap, isPlugin) in filesWithHashes)
                 {
                     var fileName = Path.GetFileName(relativePath);
                     var isExecutable = false;
@@ -498,7 +506,7 @@ public class GeneralsOnlineManifestFactory(
                     });
                 }
 
-                logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
+                logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files (including plugins)", manifest.Name, manifestFiles.Count);
             }
 
             updatedManifests.Add(new ContentManifest

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -408,6 +408,9 @@ public class GeneralsOnlineManifestFactory(
         var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
         logger.LogInformation("Processing {Count} files", allFiles.Length);
 
+        // Track file metadata including isPlugin flag for diagnostic logging.
+        // Note: isPlugin is currently used only for logging; all non-map files
+        // (including plugins) are routed to GameClient manifests with Workspace install target.
         List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsPlugin)> filesWithHashes = [];
 
         // Detect Maps directory (case-insensitive)
@@ -416,7 +419,7 @@ public class GeneralsOnlineManifestFactory(
 
         // Detect plugins directory (case-insensitive) for EAC and other plugins
         var pluginsDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
-            .FirstOrDefault(d => Path.GetFileName(d).Equals("plugins", StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.PluginsSubdirectory, StringComparison.OrdinalIgnoreCase));
 
         foreach (var filePath in allFiles)
         {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -408,18 +408,13 @@ public class GeneralsOnlineManifestFactory(
         var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
         logger.LogInformation("Processing {Count} files", allFiles.Length);
 
-        // Track file metadata including isPlugin flag for diagnostic logging.
-        // Note: isPlugin is currently used only for logging; all non-map files
-        // (including plugins) are routed to GameClient manifests with Workspace install target.
-        List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsPlugin)> filesWithHashes = [];
+        // Track file metadata for manifest generation. Maps are routed to the MapPack
+        // manifest; all other files (executables, shared files) go to the GameClient manifest.
+        List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap)> filesWithHashes = [];
 
         // Detect Maps directory (case-insensitive)
         var mapsDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
             .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.MapsSubdirectory, StringComparison.OrdinalIgnoreCase));
-
-        // Detect plugins directory (case-insensitive) for EAC and other plugins
-        var pluginsDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
-            .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.PluginsSubdirectory, StringComparison.OrdinalIgnoreCase));
 
         foreach (var filePath in allFiles)
         {
@@ -434,9 +429,6 @@ public class GeneralsOnlineManifestFactory(
             // Determine if this file is inside the Maps directory
             var isMap = mapsDirectory != null && filePath.StartsWith(mapsDirectory, StringComparison.OrdinalIgnoreCase);
 
-            // Determine if this file is inside the plugins directory (EAC, etc.)
-            var isPlugin = pluginsDirectory != null && filePath.StartsWith(pluginsDirectory, StringComparison.OrdinalIgnoreCase);
-
             string hash;
             using (var stream = File.OpenRead(filePath))
             {
@@ -444,8 +436,8 @@ public class GeneralsOnlineManifestFactory(
                 hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
             }
 
-            filesWithHashes.Add((relativePath, fileInfo, hash, isMap, isPlugin));
-            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap}, isPlugin: {IsPlugin})", relativePath, fileInfo.Length, hash[..8], isMap, isPlugin);
+            filesWithHashes.Add((relativePath, fileInfo, hash, isMap));
+            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap})", relativePath, fileInfo.Length, hash[..8], isMap);
         }
 
         List<ContentManifest> updatedManifests = [];
@@ -458,7 +450,7 @@ public class GeneralsOnlineManifestFactory(
             if (isMapPackManifest)
             {
                 // MapPack manifest: only include map files with UserMapsDirectory install target
-                foreach (var (relativePath, fileInfo, hash, isMap, isPlugin) in filesWithHashes)
+                foreach (var (relativePath, fileInfo, hash, isMap) in filesWithHashes)
                 {
                     if (!isMap)
                     {
@@ -472,12 +464,11 @@ public class GeneralsOnlineManifestFactory(
             }
             else
             {
-                // Game client manifest: include executables, shared files, plugin files (EAC), but NOT maps
+                // Game client manifest: include executables and shared files, but NOT maps
                 // Map files are handled by the MapPack manifest
-                // Plugin files (EAC DLLs, etc.) are included so they're copied to the workspace
                 var targetExecutable = GameClientConstants.GeneralsOnline60HzExecutable;
 
-                foreach (var (relativePath, fileInfo, hash, isMap, isPlugin) in filesWithHashes)
+                foreach (var (relativePath, fileInfo, hash, isMap) in filesWithHashes)
                 {
                     var fileName = Path.GetFileName(relativePath);
                     var isExecutable = false;
@@ -509,7 +500,7 @@ public class GeneralsOnlineManifestFactory(
                     });
                 }
 
-                logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files (including plugins)", manifest.Name, manifestFiles.Count);
+                logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
             }
 
             updatedManifests.Add(new ContentManifest

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateService.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateService.cs
@@ -91,7 +91,7 @@ public class GeneralsOnlineUpdateService(
             return true; // Any version is newer than nothing
         }
 
-        // Parse MMddyy_QFE# format
+        // Parse MMddyy_QFE#[_SUFFIX] format (suffixes like _EAC are build metadata, ignored for comparison)
         var latest = GameVersionHelper.ParseGeneralsOnlineVersion(latestVersion);
         var current = GameVersionHelper.ParseGeneralsOnlineVersion(currentVersion);
 


### PR DESCRIPTION
## Summary

- **Root cause**: The Generals Online CDN changed the version format from `MMDDYY_QFE#` (2 segments) to `MMDDYY_QFE#_SUFFIX` (3+ segments, e.g. `"042826_QFE3_EAC"`). `ParseGeneralsOnlineVersion` required exactly 2 underscore-delimited parts, so it returned `null` for all new versions — update detection, version comparison, and sortable version IDs all silently broke.
- **Fix**: Changed the parser to accept 2+ segments, treating extra segments as build metadata that don't affect version ordering. Added a dedicated `CompareGeneralsOnlineVersions` method in `VersionComparer` that uses the structured parser instead of generic numeric comparison, ensuring `"042826_QFE2"` and `"042826_QFE2_EAC"` compare as equal.
- **Impact**: All 53 tests pass (existing + new). No changes to public API signatures — fully backward compatible with legacy 2-segment versions.

## Changes

| File | Change |
|---|---|
| `GameVersionHelper.cs` | `parts.Length != 2` → `parts.Length < 2` — accept extended format |
| `VersionComparer.cs` | New `CompareGeneralsOnlineVersions()` — structured date+QFE comparison with fallback |
| `GeneralsOnlineUpdateService.cs` | Updated comment to reflect extended format |
| `GeneralsOnlineApiResponse.cs` | Updated doc comment for version format |
| `GeneralsOnlineRelease.cs` | Updated doc comment for version format |
| `GeneralsOnlineConstants.cs` | Added remark clarifying separator usage |

## Tests added

| Test file | Coverage |
|---|---|
| `GameVersionHelperTests.cs` (new) | Legacy format, extended format, multiple suffixes, null/empty, invalid date, non-numeric QFE, sortable version equality across formats |
| `VersionComparerTests.cs` | Extended format theory: same version, higher QFE, legacy vs extended equality, newer date |
| `GeneralsOnlineJsonCatalogParserTests.cs` | manifest.json with extended version, latest.txt fallback with extended version |

## Test plan

- [x] All 53 version/comparison tests pass (20 new + 33 existing)
- [x] Build succeeds with 0 warnings, 0 errors
- [x] Backward compatible: legacy `MMDDYY_QFE#` versions still parse and compare correctly
- [x] Forward compatible: extended `MMDDYY_QFE#_SUFFIX` versions parse date+QFE correctly
- [x] Cross-format: legacy vs extended versions with same date+QFE compare as equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 🤖 OpenClaw Changes

**Files changed:** 2
**Lines added:** 7
**Lines removed:** 1
**Branch:** `fix/go-version-extended-format`
**Commit:** `c88bdda0`

*Last updated: 2026-05-04T09:14:14.969Z*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a version parsing regression caused by the Generals Online CDN switching from a 2-segment format (`MMDDYY_QFE#`) to a 3+-segment format (`MMDDYY_QFE#_SUFFIX`). The single-character guard change (`!= 2` → `< 2`) in `ParseGeneralsOnlineVersion` restores update detection, and the new `CompareGeneralsOnlineVersions` method in `VersionComparer` ensures structured date+QFE ordering is used instead of opaque numeric fallback.

- **`GameVersionHelper.cs`**: Relaxes the segment-count guard from exactly 2 to at least 2, and replaces the hardcoded `\"QFE\"` literal with `GeneralsOnlineConstants.QfeMarkerPrefix`, aligning with the project's constants convention.
- **`VersionComparer.cs`**: Introduces `CompareGeneralsOnlineVersions` with explicit handling for both-null (generic fallback), single-null (unparseable treated as older), and fully-parsed (date then QFE) cases — directly addressing the asymmetric fallback identified in a prior review.
- **Tests**: 20 new tests across three files cover legacy format, extended format, multi-suffix, null/empty, invalid inputs, mixed-parseable comparison, and catalog-parser integration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-tested relaxation of a length guard that restores broken version detection for the new CDN format.

The one-character logic fix is narrow and its correctness is directly validated by 20 new tests covering legacy, extended, multi-suffix, and edge-case inputs. The new CompareGeneralsOnlineVersions method explicitly handles all null-combination states, closing the asymmetric-fallback gap flagged in a prior review. No public API signatures changed, backward compatibility with existing 2-segment versions is confirmed, and the previously-hardcoded QFE literal is now correctly referenced through the constants class.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Helpers/GameVersionHelper.cs | Core fix: relaxes parts.Length != 2 to < 2, uses QfeMarkerPrefix constant instead of hardcoded QFE, and updates doc comments for extended format support |
| GenHub/GenHub.Core/Helpers/VersionComparer.cs | Adds CompareGeneralsOnlineVersions() using structured date+QFE parsing; correctly handles both-null (fallback to numeric), single-null (unparseable treated as older), and fully-parsed cases; braces-only style cleanup elsewhere |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameVersionHelperTests.cs | New test file with comprehensive coverage of legacy, extended, multi-suffix, null/empty, invalid date, non-numeric QFE, and sortable version equality cases |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/VersionComparerTests.cs | New theory-based tests for extended format comparison, mixed-parseable fallback, and both-unparseable fallback; all assertions use Math.Sign correctly |
| GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs | Comment-only changes: adds tracking context for filesWithHashes and corrects a stale comment that incorrectly described the game-client manifest as including map files |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Version string input\ne.g. 042826_QFE3_EAC"] --> B["Split on underscore\nRemoveEmptyEntries"]
    B --> C{parts.Length less than 2?}
    C -- Yes --> D["Return null"]
    C -- No --> E["datePart = parts 0\nqfePart = parts 1 minus QFE prefix"]
    E --> F{Valid 6-char date\nand numeric QFE?}
    F -- No --> D
    F -- Yes --> G["Return DateTime + Qfe\nExtra suffix parts ignored"]

    G --> H["CompareGeneralsOnlineVersions"]
    H --> I{Parsed results?}
    I -- Both null --> J["CompareNumericVersions fallback"]
    I -- One null --> K["Null treated as older"]
    I -- Both parsed --> L["Compare Date then QFE"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Version string input\ne.g. 042826_QFE3_EAC"] --> B["Split on underscore\nRemoveEmptyEntries"]
    B --> C{parts.Length less than 2?}
    C -- Yes --> D["Return null"]
    C -- No --> E["datePart = parts 0\nqfePart = parts 1 minus QFE prefix"]
    E --> F{Valid 6-char date\nand numeric QFE?}
    F -- No --> D
    F -- Yes --> G["Return DateTime + Qfe\nExtra suffix parts ignored"]

    G --> H["CompareGeneralsOnlineVersions"]
    H --> I{Parsed results?}
    I -- Both null --> J["CompareNumericVersions fallback"]
    I -- One null --> K["Null treated as older"]
    I -- Both parsed --> L["Compare Date then QFE"]
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["OpenClaw: Address review feedback from @..."](https://github.com/community-outpost/genhub/commit/b981f10eee562cc42802db170f1beb264eaee8ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30537655)</sub>

<!-- /greptile_comment -->