### PR TITLE
fix(linux): resolve optional token storage at startup

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Linux/Infrastructure/DependencyInjection/ApplicationCompositionCollection.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Linux/Infrastructure/DependencyInjection/ApplicationCompositionCollection.cs
@@ -1,0 +1,13 @@
+namespace GenHub.Tests.Linux.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// Prevents temporary process environment changes from overlapping other tests.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class ApplicationCompositionCollection
+{
+    /// <summary>
+    /// The xUnit collection name.
+    /// </summary>
+    public const string Name = "Application composition";
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Linux/Infrastructure/DependencyInjection/LinuxApplicationCompositionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Linux/Infrastructure/DependencyInjection/LinuxApplicationCompositionTests.cs
@@ -1,0 +1,96 @@
+using System.Runtime.Versioning;
+using GenHub.Common.ViewModels;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GitHub;
+using GenHub.Core.Interfaces.Shortcuts;
+using GenHub.Features.GameProfiles.ViewModels;
+using GenHub.Features.Settings.ViewModels;
+using GenHub.Infrastructure.DependencyInjection;
+using GenHub.Linux.GameInstallations;
+using GenHub.Linux.Infrastructure.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GenHub.Tests.Linux.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// Verifies the Linux application dependency injection composition.
+/// </summary>
+[Collection(ApplicationCompositionCollection.Name)]
+public class LinuxApplicationCompositionTests
+{
+    private sealed class TemporaryApplicationEnvironment : IDisposable
+    {
+        private readonly Dictionary<string, string?> _originalValues = [];
+
+        internal TemporaryApplicationEnvironment()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), $"GenHub.Tests.{Guid.NewGuid():N}");
+            AppDataPath = Path.Combine(RootPath, "AppData");
+            Directory.CreateDirectory(AppDataPath);
+
+            SetEnvironmentVariable("GENHUB_GenHub__AppDataPath", AppDataPath);
+            SetEnvironmentVariable("APPDATA", Path.Combine(RootPath, "RoamingAppData"));
+            SetEnvironmentVariable("LOCALAPPDATA", Path.Combine(RootPath, "LocalAppData"));
+            SetEnvironmentVariable("USERPROFILE", RootPath);
+            SetEnvironmentVariable("HOME", RootPath);
+            SetEnvironmentVariable("XDG_CONFIG_HOME", Path.Combine(RootPath, "Config"));
+            SetEnvironmentVariable("XDG_DATA_HOME", Path.Combine(RootPath, "Data"));
+        }
+
+        internal string AppDataPath { get; }
+
+        private string RootPath { get; }
+
+        void IDisposable.Dispose()
+        {
+            foreach (var pair in _originalValues)
+            {
+                Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+            }
+
+            Directory.Delete(RootPath, recursive: true);
+        }
+
+        private void SetEnvironmentVariable(string name, string value)
+        {
+            _originalValues[name] = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the real shared and Linux registrations resolve the startup view model graph.
+    /// </summary>
+    /// <remarks>
+    /// This is dependency injection composition coverage. It does not launch Avalonia or a packaged
+    /// Linux application.
+    /// </remarks>
+    [Fact]
+    [SupportedOSPlatform("linux")]
+    public void ConfigureApplicationServices_ResolvesStartupViewModels()
+    {
+        using var testEnvironment = new TemporaryApplicationEnvironment();
+        var services = new ServiceCollection();
+        services.ConfigureApplicationServices(platformServices => platformServices.AddLinuxServices());
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.Equal(
+            testEnvironment.AppDataPath,
+            serviceProvider.GetRequiredService<IConfigurationProviderService>().GetRootAppDataPath());
+        Assert.IsType<LinuxInstallationDetector>(
+            serviceProvider.GetRequiredService<IGameInstallationDetector>());
+        Assert.NotNull(serviceProvider.GetRequiredService<IShortcutService>());
+        Assert.Null(serviceProvider.GetService<IGitHubTokenStorage>());
+
+        var settingsViewModel = serviceProvider.GetRequiredService<SettingsViewModel>();
+        Assert.NotNull(serviceProvider.GetRequiredService<GameProfileSettingsViewModel>());
+
+        var mainViewModel = serviceProvider.GetRequiredService<MainViewModel>();
+        Assert.Same(settingsViewModel, mainViewModel.SettingsViewModel);
+        Assert.NotNull(mainViewModel.GameProfilesViewModel);
+        Assert.NotNull(mainViewModel.DownloadsViewModel);
+        Assert.NotNull(mainViewModel.ToolsViewModel);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Windows/Infrastructure/DependencyInjection/ApplicationCompositionCollection.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Windows/Infrastructure/DependencyInjection/ApplicationCompositionCollection.cs
@@ -1,0 +1,13 @@
+namespace GenHub.Tests.Windows.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// Prevents temporary process environment changes from overlapping other tests.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class ApplicationCompositionCollection
+{
+    /// <summary>
+    /// The xUnit collection name.
+    /// </summary>
+    public const string Name = "Application composition";
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Windows/Infrastructure/DependencyInjection/WindowsApplicationCompositionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Windows/Infrastructure/DependencyInjection/WindowsApplicationCompositionTests.cs
@@ -10,6 +10,7 @@ using GenHub.Windows.Features.GitHub.Services;
 using GenHub.Windows.GameInstallations;
 using GenHub.Windows.Infrastructure.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 
 namespace GenHub.Tests.Windows.Infrastructure.DependencyInjection;
 
@@ -73,6 +74,17 @@ public class WindowsApplicationCompositionTests
         var services = new ServiceCollection();
         services.ConfigureApplicationServices(platformServices => platformServices.AddWindowsServices());
 
+        Assert.Contains(
+            services,
+            descriptor =>
+                descriptor.ServiceType == typeof(IGitHubTokenStorage)
+                && descriptor.ImplementationType == typeof(WindowsGitHubTokenStorage)
+                && descriptor.Lifetime == ServiceLifetime.Singleton);
+
+        var tokenStorageMock = new Mock<IGitHubTokenStorage>();
+        tokenStorageMock.Setup(storage => storage.HasToken()).Returns(true);
+        services.AddSingleton(tokenStorageMock.Object);
+
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.Equal(
@@ -81,10 +93,11 @@ public class WindowsApplicationCompositionTests
         Assert.IsType<WindowsInstallationDetector>(
             serviceProvider.GetRequiredService<IGameInstallationDetector>());
         Assert.NotNull(serviceProvider.GetRequiredService<IShortcutService>());
-        Assert.IsType<WindowsGitHubTokenStorage>(
-            serviceProvider.GetRequiredService<IGitHubTokenStorage>());
+        Assert.Same(tokenStorageMock.Object, serviceProvider.GetRequiredService<IGitHubTokenStorage>());
 
         var settingsViewModel = serviceProvider.GetRequiredService<SettingsViewModel>();
+        Assert.True(settingsViewModel.HasGitHubPat);
+        tokenStorageMock.Verify(storage => storage.HasToken(), Times.Once);
         Assert.NotNull(serviceProvider.GetRequiredService<GameProfileSettingsViewModel>());
 
         var mainViewModel = serviceProvider.GetRequiredService<MainViewModel>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Windows/Infrastructure/DependencyInjection/WindowsApplicationCompositionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Windows/Infrastructure/DependencyInjection/WindowsApplicationCompositionTests.cs
@@ -1,0 +1,96 @@
+using GenHub.Common.ViewModels;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GitHub;
+using GenHub.Core.Interfaces.Shortcuts;
+using GenHub.Features.GameProfiles.ViewModels;
+using GenHub.Features.Settings.ViewModels;
+using GenHub.Infrastructure.DependencyInjection;
+using GenHub.Windows.Features.GitHub.Services;
+using GenHub.Windows.GameInstallations;
+using GenHub.Windows.Infrastructure.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GenHub.Tests.Windows.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// Verifies the Windows application dependency injection composition.
+/// </summary>
+[Collection(ApplicationCompositionCollection.Name)]
+public class WindowsApplicationCompositionTests
+{
+    private sealed class TemporaryApplicationEnvironment : IDisposable
+    {
+        private readonly Dictionary<string, string?> _originalValues = [];
+
+        internal TemporaryApplicationEnvironment()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), $"GenHub.Tests.{Guid.NewGuid():N}");
+            AppDataPath = Path.Combine(RootPath, "AppData");
+            Directory.CreateDirectory(AppDataPath);
+
+            SetEnvironmentVariable("GENHUB_GenHub__AppDataPath", AppDataPath);
+            SetEnvironmentVariable("APPDATA", Path.Combine(RootPath, "RoamingAppData"));
+            SetEnvironmentVariable("LOCALAPPDATA", Path.Combine(RootPath, "LocalAppData"));
+            SetEnvironmentVariable("USERPROFILE", RootPath);
+            SetEnvironmentVariable("HOME", RootPath);
+            SetEnvironmentVariable("XDG_CONFIG_HOME", Path.Combine(RootPath, "Config"));
+            SetEnvironmentVariable("XDG_DATA_HOME", Path.Combine(RootPath, "Data"));
+        }
+
+        internal string AppDataPath { get; }
+
+        private string RootPath { get; }
+
+        void IDisposable.Dispose()
+        {
+            foreach (var pair in _originalValues)
+            {
+                Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+            }
+
+            Directory.Delete(RootPath, recursive: true);
+        }
+
+        private void SetEnvironmentVariable(string name, string value)
+        {
+            _originalValues[name] = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the real shared and Windows registrations resolve the startup view model graph.
+    /// </summary>
+    /// <remarks>
+    /// This is dependency injection composition coverage. It does not launch Avalonia or a packaged
+    /// Windows application.
+    /// </remarks>
+    [Fact]
+    public void ConfigureApplicationServices_ResolvesStartupViewModels()
+    {
+        using var testEnvironment = new TemporaryApplicationEnvironment();
+        var services = new ServiceCollection();
+        services.ConfigureApplicationServices(platformServices => platformServices.AddWindowsServices());
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.Equal(
+            testEnvironment.AppDataPath,
+            serviceProvider.GetRequiredService<IConfigurationProviderService>().GetRootAppDataPath());
+        Assert.IsType<WindowsInstallationDetector>(
+            serviceProvider.GetRequiredService<IGameInstallationDetector>());
+        Assert.NotNull(serviceProvider.GetRequiredService<IShortcutService>());
+        Assert.IsType<WindowsGitHubTokenStorage>(
+            serviceProvider.GetRequiredService<IGitHubTokenStorage>());
+
+        var settingsViewModel = serviceProvider.GetRequiredService<SettingsViewModel>();
+        Assert.NotNull(serviceProvider.GetRequiredService<GameProfileSettingsViewModel>());
+
+        var mainViewModel = serviceProvider.GetRequiredService<MainViewModel>();
+        Assert.Same(settingsViewModel, mainViewModel.SettingsViewModel);
+        Assert.NotNull(mainViewModel.GameProfilesViewModel);
+        Assert.NotNull(mainViewModel.DownloadsViewModel);
+        Assert.NotNull(mainViewModel.ToolsViewModel);
+    }
+}

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
@@ -52,7 +52,7 @@ public static class SharedViewModelModule
             sp.GetRequiredService<IGameInstallationService>(),
             sp.GetRequiredService<IStorageLocationService>(),
             sp.GetRequiredService<IUserDataTracker>(),
-            sp.GetRequiredService<IGitHubTokenStorage>()));
+            sp.GetService<IGitHubTokenStorage>()));
         services.AddSingleton<GameProfileSettingsViewModel>();
 
         // Register PublisherCardViewModel as transient


### PR DESCRIPTION
## Summary

Fix Linux startup composition when GitHub token storage is unavailable.

## Changes

- Resolve `IGitHubTokenStorage` optionally.
- Preserve Windows token storage.
- Add Linux and Windows composition-root tests with isolated temporary paths.

## Testing

- Release solution build passed.
- All 1,224 tests passed.

These tests validate DI composition, not packaged GUI startup.

## Risks and rollback

Low risk; revert this change to restore previous behavior.

## Related issues

Fixes #299

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes cross-platform startup composition by:
- Resolving GitHub token storage as an optional dependency for the settings view model.
- Adding Linux composition coverage without token storage.
- Adding Windows composition coverage that verifies token storage remains registered and usable.
- Isolating process-wide environment changes in nonparallel test collections.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs | Makes token storage optional during settings view-model resolution, matching the existing nullable constructor and null-safe behavior. |
| GenHub/GenHub.Tests/GenHub.Tests.Linux/Infrastructure/DependencyInjection/LinuxApplicationCompositionTests.cs | Verifies the Linux startup view-model graph resolves when no token-storage implementation is registered. |
| GenHub/GenHub.Tests/GenHub.Tests.Windows/Infrastructure/DependencyInjection/WindowsApplicationCompositionTests.cs | Verifies Windows retains its token-storage registration and injects it into the startup settings view model. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(windows): verify token storage inje..."](https://github.com/community-outpost/genhub/commit/16f72a588635d7aca1281c04a144830ad98afcfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47620601)</sub>

**Context used:**

- Knowledge Base — [App Shell and Dependency Injection](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/app-shell-and-di.md)

<!-- /greptile_comment -->