### PR TITLE
fix(steam): roll back failed proxy preparation

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameProfiles;
@@ -485,10 +486,44 @@ public class GameLauncherTests
     public async Task LaunchProfileAsync_ConcurrentSteamProfilesSharingInstallation_SerializesSetup()
     {
         // Arrange
+        var testRoot = Path.Combine(
+            Path.GetTempPath(),
+            "GenHub-GameLauncherAliasTests",
+            Guid.NewGuid().ToString("N"));
+        var physicalInstallationPath = Path.Combine(testRoot, "physical-installation");
+        var installationAliasPath = Path.Combine(testRoot, "installation-alias");
+        Directory.CreateDirectory(physicalInstallationPath);
+        CreateDirectoryAlias(installationAliasPath, physicalInstallationPath);
+        Assert.Equal(
+            InstallationPathLockKey.Create(physicalInstallationPath),
+            InstallationPathLockKey.Create(installationAliasPath),
+            InstallationPathLockKey.Comparer);
+
         var firstProfile = CreateTestProfile();
         firstProfile.UseSteamLaunch = true;
+        firstProfile.GameInstallationId = "physical-installation";
         var secondProfile = CreateTestProfile();
         secondProfile.UseSteamLaunch = true;
+        secondProfile.GameInstallationId = "installation-alias";
+
+        var physicalInstallation = new GameInstallation(
+            physicalInstallationPath,
+            GameInstallationType.Steam);
+        physicalInstallation.SetPaths(physicalInstallationPath, null);
+        var aliasInstallation = new GameInstallation(
+            installationAliasPath,
+            GameInstallationType.Steam);
+        aliasInstallation.SetPaths(installationAliasPath, null);
+
+        _gameInstallationServiceMock.Setup(x => x.GetInstallationAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string installationId, CancellationToken _) =>
+                OperationResult<GameInstallation>.CreateSuccess(
+                    installationId == firstProfile.GameInstallationId
+                        ? physicalInstallation
+                        : aliasInstallation));
+
         var cleanupStarted = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseCleanup = new TaskCompletionSource<bool>(
@@ -507,25 +542,42 @@ public class GameLauncherTests
                 return OperationResult<bool>.CreateFailure("Injected cleanup stop.");
             });
 
-        // Act
-        var firstLaunch = _gameLauncher.LaunchProfileAsync(firstProfile);
-        await cleanupStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        var secondLaunch = _gameLauncher.LaunchProfileAsync(secondProfile);
-
         try
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(250));
-            Assert.Equal(1, Volatile.Read(ref cleanupCalls));
+            // Act
+            var firstLaunch = _gameLauncher.LaunchProfileAsync(firstProfile);
+            await cleanupStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var secondLaunch = _gameLauncher.LaunchProfileAsync(secondProfile);
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+                Assert.Equal(1, Volatile.Read(ref cleanupCalls));
+            }
+            finally
+            {
+                releaseCleanup.TrySetResult(true);
+            }
+
+            // Assert
+            var results = await Task.WhenAll(firstLaunch, secondLaunch);
+            Assert.All(results, result => Assert.False(result.Success));
+            Assert.Equal(2, Volatile.Read(ref cleanupCalls));
         }
         finally
         {
             releaseCleanup.TrySetResult(true);
-        }
 
-        // Assert
-        var results = await Task.WhenAll(firstLaunch, secondLaunch);
-        Assert.All(results, result => Assert.False(result.Success));
-        Assert.Equal(2, Volatile.Read(ref cleanupCalls));
+            if (Directory.Exists(installationAliasPath))
+            {
+                Directory.Delete(installationAliasPath);
+            }
+
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
     }
 
     /// <summary>
@@ -863,5 +915,31 @@ public class GameLauncherTests
             GameClient = new GameClient { Id = "version-1", ExecutablePath = @"C:\Games\generals.exe", GameType = GameType.Generals },
             EnabledContentIds = ["1.0.genhub.mod.test"],
         };
+    }
+
+    private static void CreateDirectoryAlias(string aliasPath, string targetPath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Directory.CreateSymbolicLink(aliasPath, targetPath);
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "cmd.exe",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("/c");
+        startInfo.ArgumentList.Add("mklink");
+        startInfo.ArgumentList.Add("/J");
+        startInfo.ArgumentList.Add(aliasPath);
+        startInfo.ArgumentList.Add(targetPath);
+
+        using var process = Process.Start(startInfo) ??
+            throw new InvalidOperationException("Failed to start junction creation process.");
+        process.WaitForExit();
+        Assert.Equal(0, process.ExitCode);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -478,6 +478,57 @@ public class GameLauncherTests
     }
 
     /// <summary>
+    /// Verifies Steam launch setup is serialized across profiles that share an installation.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_ConcurrentSteamProfilesSharingInstallation_SerializesSetup()
+    {
+        // Arrange
+        var firstProfile = CreateTestProfile();
+        firstProfile.UseSteamLaunch = true;
+        var secondProfile = CreateTestProfile();
+        secondProfile.UseSteamLaunch = true;
+        var cleanupStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCleanup = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cleanupCalls = 0;
+
+        _steamLauncherMock.Setup(x => x.CleanupGameDirectoryAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                Interlocked.Increment(ref cleanupCalls);
+                cleanupStarted.TrySetResult(true);
+                await releaseCleanup.Task;
+                return OperationResult<bool>.CreateFailure("Injected cleanup stop.");
+            });
+
+        // Act
+        var firstLaunch = _gameLauncher.LaunchProfileAsync(firstProfile);
+        await cleanupStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var secondLaunch = _gameLauncher.LaunchProfileAsync(secondProfile);
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+            Assert.Equal(1, Volatile.Read(ref cleanupCalls));
+        }
+        finally
+        {
+            releaseCleanup.TrySetResult(true);
+        }
+
+        // Assert
+        var results = await Task.WhenAll(firstLaunch, secondLaunch);
+        Assert.All(results, result => Assert.False(result.Success));
+        Assert.Equal(2, Volatile.Read(ref cleanupCalls));
+    }
+
+    /// <summary>
     /// Launches a profile with empty enabled content and asserts success.
     /// </summary>
     /// <returns>The async task.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/SteamLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/SteamLauncherTests.cs
@@ -1,0 +1,277 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Models.Launching;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Features.Launching;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GenHub.Tests.Core.Features.Launching;
+
+/// <summary>
+/// Filesystem tests for <see cref="SteamLauncher"/>.
+/// </summary>
+public sealed class SteamLauncherTests : IDisposable
+{
+    private const string ExecutableName = "genhub-test-game.exe";
+    private readonly string _tempDirectory;
+    private readonly string _gameInstallPath;
+    private readonly string _workspacePath;
+    private readonly string _originalExecutablePath;
+    private readonly string _workspaceExecutablePath;
+    private readonly string _proxySourcePath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SteamLauncherTests"/> class.
+    /// </summary>
+    public SteamLauncherTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "GenHub-SteamLauncherTests",
+            Guid.NewGuid().ToString("N"));
+        _gameInstallPath = Path.Combine(_tempDirectory, "game");
+        _workspacePath = Path.Combine(_tempDirectory, "workspace");
+        _originalExecutablePath = Path.Combine(_gameInstallPath, ExecutableName);
+        _workspaceExecutablePath = Path.Combine(_workspacePath, "workspace-game.exe");
+        _proxySourcePath = Path.Combine(_tempDirectory, SteamConstants.ProxyLauncherFileName);
+
+        Directory.CreateDirectory(_gameInstallPath);
+        Directory.CreateDirectory(_workspacePath);
+        File.WriteAllText(_originalExecutablePath, "original executable");
+        File.WriteAllText(_workspaceExecutablePath, "workspace executable");
+        File.WriteAllText(_proxySourcePath, "proxy executable");
+    }
+
+    /// <summary>
+    /// Verifies a successful preparation deploys the proxy and preserves existing files.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_ValidPaths_DeploysProxyAndPreservesExistingDependencies()
+    {
+        // Arrange
+        var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
+        var workspaceDependencyPath = Path.Combine(_workspacePath, "binkw32.dll");
+        File.WriteAllText(Path.Combine(_gameInstallPath, "steam_api.dll"), "steam api");
+        File.WriteAllText(Path.Combine(_gameInstallPath, "binkw32.dll"), "installation dependency");
+        File.WriteAllText(workspaceDependencyPath, "pre-existing workspace dependency");
+
+        // Act
+        var result = await PrepareAsync(CreateLauncher(), steamAppId: "12345");
+
+        // Assert
+        Assert.True(result.Success, result.AllErrors);
+        Assert.Equal("proxy executable", File.ReadAllText(_originalExecutablePath));
+        Assert.Equal("original executable", File.ReadAllText(backupPath));
+        Assert.True(File.Exists(Path.Combine(_gameInstallPath, "proxy_config.json")));
+        Assert.Equal("12345", File.ReadAllText(Path.Combine(_gameInstallPath, "steam_appid.txt")));
+        Assert.Equal("12345", File.ReadAllText(Path.Combine(_workspacePath, "steam_appid.txt")));
+        Assert.Equal("steam api", File.ReadAllText(Path.Combine(_workspacePath, "steam_api.dll")));
+        Assert.Equal("pre-existing workspace dependency", File.ReadAllText(workspaceDependencyPath));
+        Assert.Empty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
+    /// Verifies invalid workspace input is rejected before the game executable is changed.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_MissingWorkspaceExecutable_DoesNotMutateInstallation()
+    {
+        // Arrange
+        var missingExecutable = Path.Combine(_workspacePath, "missing.exe");
+
+        // Act
+        var result = await PrepareAsync(
+            CreateLauncher(),
+            targetExecutablePath: missingExecutable);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("original executable", File.ReadAllText(_originalExecutablePath));
+        Assert.False(File.Exists(_originalExecutablePath + SteamConstants.BackupExtension));
+        Assert.False(File.Exists(Path.Combine(_gameInstallPath, "proxy_config.json")));
+        Assert.Empty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
+    /// Verifies a late write failure restores files changed by the current attempt.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_LateWriteFailure_RestoresOriginalAndPreExistingFiles()
+    {
+        // Arrange
+        var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
+        var configPath = Path.Combine(_gameInstallPath, "proxy_config.json");
+        var workspaceAppIdPath = Path.Combine(_workspacePath, "steam_appid.txt");
+        File.WriteAllText(_originalExecutablePath, "proxy executable");
+        File.WriteAllText(backupPath, "pre-existing original executable");
+        File.WriteAllText(configPath, "pre-existing config");
+        File.WriteAllText(workspaceAppIdPath, "pre-existing app id");
+
+        var writeCount = 0;
+        async Task FailingWriter(string path, string contents, CancellationToken cancellationToken)
+        {
+            writeCount++;
+            await File.WriteAllTextAsync(path, contents, cancellationToken);
+            if (writeCount == 3)
+            {
+                throw new IOException("Injected late write failure.");
+            }
+        }
+
+        // Act
+        var result = await PrepareAsync(CreateLauncher(FailingWriter), steamAppId: "12345");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Injected late write failure", result.AllErrors);
+        Assert.Equal("pre-existing original executable", File.ReadAllText(_originalExecutablePath));
+        Assert.Equal("pre-existing original executable", File.ReadAllText(backupPath));
+        Assert.Equal("pre-existing config", File.ReadAllText(configPath));
+        Assert.Equal("pre-existing app id", File.ReadAllText(workspaceAppIdPath));
+        Assert.Empty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
+    /// Verifies an uncertain pre-existing backup is preserved but not used to overwrite the current executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_UnrelatedPreExistingBackup_RestoresPreAttemptExecutable()
+    {
+        // Arrange
+        var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
+        File.WriteAllText(_originalExecutablePath, "current executable");
+        File.WriteAllText(backupPath, "stale pre-existing backup");
+
+        async Task FailingWriter(string path, string contents, CancellationToken cancellationToken)
+        {
+            await File.WriteAllTextAsync(path, contents, cancellationToken);
+            throw new IOException("Injected write failure.");
+        }
+
+        // Act
+        var result = await PrepareAsync(CreateLauncher(FailingWriter));
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("current executable", File.ReadAllText(_originalExecutablePath));
+        Assert.Equal("stale pre-existing backup", File.ReadAllText(backupPath));
+        Assert.Empty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
+    /// Verifies cancellation after executable replacement restores the original executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_CanceledAfterMutation_RollsBackCurrentAttempt()
+    {
+        // Arrange
+        using var cancellationSource = new CancellationTokenSource();
+        var writeCount = 0;
+
+        async Task CancelingWriter(string path, string contents, CancellationToken cancellationToken)
+        {
+            writeCount++;
+            await File.WriteAllTextAsync(path, contents, cancellationToken);
+            if (writeCount == 2)
+            {
+                cancellationSource.Cancel();
+            }
+        }
+
+        // Act
+        var result = await PrepareAsync(
+            CreateLauncher(CancelingWriter),
+            steamAppId: "12345",
+            cancellationToken: cancellationSource.Token);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("canceled", result.AllErrors, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("original executable", File.ReadAllText(_originalExecutablePath));
+        Assert.False(File.Exists(_originalExecutablePath + SteamConstants.BackupExtension));
+        Assert.False(File.Exists(Path.Combine(_gameInstallPath, "proxy_config.json")));
+        Assert.Empty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
+    /// Verifies rollback reports an unsafe executable conflict and retains recovery copies.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_ExecutableChangesDuringFailure_ReportsRollbackConflict()
+    {
+        // Arrange
+        async Task ConflictingWriter(string path, string contents, CancellationToken cancellationToken)
+        {
+            await File.WriteAllTextAsync(path, contents, cancellationToken);
+            File.WriteAllText(_originalExecutablePath, "external executable change");
+            throw new IOException("Injected write failure.");
+        }
+
+        // Act
+        var result = await PrepareAsync(CreateLauncher(ConflictingWriter));
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("did not overwrite unexpectedly changed executable", result.AllErrors);
+        Assert.Equal("external executable change", File.ReadAllText(_originalExecutablePath));
+        Assert.Equal(
+            "original executable",
+            File.ReadAllText(_originalExecutablePath + SteamConstants.BackupExtension));
+        Assert.NotEmpty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
+    /// Deletes the temporary test directory.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private SteamLauncher CreateLauncher(
+        Func<string, string, CancellationToken, Task>? writer = null)
+    {
+        var logger = new Mock<ILogger<SteamLauncher>>();
+        return new SteamLauncher(
+            logger.Object,
+            _proxySourcePath,
+            writer ?? File.WriteAllTextAsync);
+    }
+
+    private Task<OperationResult<SteamLaunchPrepResult>> PrepareAsync(
+        SteamLauncher launcher,
+        string? targetExecutablePath = null,
+        string? steamAppId = null,
+        CancellationToken cancellationToken = default)
+    {
+        return launcher.PrepareForProfileAsync(
+            _gameInstallPath,
+            "test-profile",
+            Array.Empty<ContentManifest>(),
+            ExecutableName,
+            targetExecutablePath ?? _workspaceExecutablePath,
+            _workspacePath,
+            steamAppId: steamAppId,
+            cancellationToken: cancellationToken);
+    }
+
+    private string[] GetRollbackArtifacts()
+    {
+        return Directory.GetFiles(
+            _tempDirectory,
+            "*.genhub-rollback-*",
+            SearchOption.AllDirectories);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/SteamLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/SteamLauncherTests.cs
@@ -96,6 +96,27 @@ public sealed class SteamLauncherTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies preparation can recover when a prior crash left only the executable backup.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_MissingTargetWithBackup_DeploysProxyFromRecoveryState()
+    {
+        // Arrange
+        var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
+        File.Move(_originalExecutablePath, backupPath);
+
+        // Act
+        var result = await PrepareAsync(CreateLauncher());
+
+        // Assert
+        Assert.True(result.Success, result.AllErrors);
+        Assert.Equal("proxy executable", File.ReadAllText(_originalExecutablePath));
+        Assert.Equal("original executable", File.ReadAllText(backupPath));
+        Assert.Empty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
     /// Verifies a late write failure restores files changed by the current attempt.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
@@ -136,31 +157,156 @@ public sealed class SteamLauncherTests : IDisposable
     }
 
     /// <summary>
-    /// Verifies an uncertain pre-existing backup is preserved but not used to overwrite the current executable.
+    /// Verifies an uncertain pre-existing backup prevents preparation without changing either executable.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_UnrelatedPreExistingBackup_RestoresPreAttemptExecutable()
+    public async Task PrepareForProfileAsync_UnrelatedPreExistingBackup_FailsWithoutMutation()
     {
         // Arrange
         var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
         File.WriteAllText(_originalExecutablePath, "current executable");
         File.WriteAllText(backupPath, "stale pre-existing backup");
 
-        async Task FailingWriter(string path, string contents, CancellationToken cancellationToken)
-        {
-            await File.WriteAllTextAsync(path, contents, cancellationToken);
-            throw new IOException("Injected write failure.");
-        }
-
         // Act
-        var result = await PrepareAsync(CreateLauncher(FailingWriter));
+        var result = await PrepareAsync(CreateLauncher());
 
         // Assert
         Assert.False(result.Success);
+        Assert.Contains("unverified pre-existing backup", result.AllErrors);
         Assert.Equal("current executable", File.ReadAllText(_originalExecutablePath));
         Assert.Equal("stale pre-existing backup", File.ReadAllText(backupPath));
+        Assert.False(File.Exists(Path.Combine(_gameInstallPath, "proxy_config.json")));
         Assert.Empty(GetRollbackArtifacts());
+    }
+
+    /// <summary>
+    /// Verifies cleanup preserves an unrelated backup instead of overwriting a valid executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CleanupGameDirectoryAsync_UnrelatedBackup_PreservesExecutableAndArtifacts()
+    {
+        // Arrange
+        var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
+        var configPath = Path.Combine(_gameInstallPath, "proxy_config.json");
+        File.WriteAllText(backupPath, "stale pre-existing backup");
+        File.WriteAllText(configPath, "pre-existing config");
+
+        // Act
+        var result = await CreateLauncher().CleanupGameDirectoryAsync(
+            _gameInstallPath,
+            ExecutableName);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("original executable", File.ReadAllText(_originalExecutablePath));
+        Assert.Equal("stale pre-existing backup", File.ReadAllText(backupPath));
+        Assert.Equal("pre-existing config", File.ReadAllText(configPath));
+    }
+
+    /// <summary>
+    /// Verifies cleanup restores a backup only when the installed executable is the known proxy.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CleanupGameDirectoryAsync_DeployedProxy_RestoresVerifiedBackup()
+    {
+        // Arrange
+        var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
+        var configPath = Path.Combine(_gameInstallPath, "proxy_config.json");
+        File.WriteAllText(_originalExecutablePath, "proxy executable");
+        File.WriteAllText(backupPath, "original executable");
+        File.WriteAllText(configPath, "prepared config");
+
+        // Act
+        var result = await CreateLauncher().CleanupGameDirectoryAsync(
+            _gameInstallPath,
+            ExecutableName);
+
+        // Assert
+        Assert.True(result.Success, result.AllErrors);
+        Assert.Equal("original executable", File.ReadAllText(_originalExecutablePath));
+        Assert.False(File.Exists(backupPath));
+        Assert.False(File.Exists(configPath));
+    }
+
+    /// <summary>
+    /// Verifies cleanup fails without deleting proxy artifacts when the original backup is missing.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CleanupGameDirectoryAsync_DeployedProxyWithoutBackup_FailsClosed()
+    {
+        // Arrange
+        var configPath = Path.Combine(_gameInstallPath, "proxy_config.json");
+        File.WriteAllText(_originalExecutablePath, "proxy executable");
+        File.WriteAllText(configPath, "prepared config");
+
+        // Act
+        var result = await CreateLauncher().CleanupGameDirectoryAsync(
+            _gameInstallPath,
+            ExecutableName);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("proxy executable", File.ReadAllText(_originalExecutablePath));
+        Assert.Equal("prepared config", File.ReadAllText(configPath));
+    }
+
+    /// <summary>
+    /// Verifies concurrent preparations for one installation cannot overlap their mutations.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task PrepareForProfileAsync_ConcurrentProfilesSharingInstallation_SerializesMutations()
+    {
+        // Arrange
+        var firstWriteStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstWrite = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondWriteStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task BlockingWriter(string path, string contents, CancellationToken cancellationToken)
+        {
+            firstWriteStarted.TrySetResult(true);
+            await releaseFirstWrite.Task.WaitAsync(cancellationToken);
+            await File.WriteAllTextAsync(path, contents, cancellationToken);
+        }
+
+        async Task ObservedWriter(string path, string contents, CancellationToken cancellationToken)
+        {
+            secondWriteStarted.TrySetResult(true);
+            await File.WriteAllTextAsync(path, contents, cancellationToken);
+        }
+
+        var firstPreparation = PrepareAsync(
+            CreateLauncher(BlockingWriter),
+            profileId: "first-profile");
+        await firstWriteStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var secondPreparation = PrepareAsync(
+            CreateLauncher(ObservedWriter),
+            profileId: "second-profile");
+
+        try
+        {
+            var prematureSecondWrite = await Task.WhenAny(
+                secondWriteStarted.Task,
+                Task.Delay(TimeSpan.FromMilliseconds(250)));
+            Assert.NotSame(secondWriteStarted.Task, prematureSecondWrite);
+        }
+        finally
+        {
+            releaseFirstWrite.TrySetResult(true);
+        }
+
+        // Assert
+        var results = await Task.WhenAll(firstPreparation, secondPreparation);
+        Assert.All(results, result => Assert.True(result.Success, result.AllErrors));
+        Assert.True(secondWriteStarted.Task.IsCompleted);
     }
 
     /// <summary>
@@ -254,11 +400,12 @@ public sealed class SteamLauncherTests : IDisposable
         SteamLauncher launcher,
         string? targetExecutablePath = null,
         string? steamAppId = null,
+        string profileId = "test-profile",
         CancellationToken cancellationToken = default)
     {
         return launcher.PrepareForProfileAsync(
             _gameInstallPath,
-            "test-profile",
+            profileId,
             Array.Empty<ContentManifest>(),
             ExecutableName,
             targetExecutablePath ?? _workspaceExecutablePath,

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -51,6 +51,9 @@ public class GameLauncher(
     IConfigurationProviderService configurationProvider) : IGameLauncher
 {
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _profileLaunchLocks = new();
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _steamInstallationLaunchLocks =
+        new(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
     private static readonly SearchValues<char> InvalidArgChars = SearchValues.Create(";|&\n\r`$%");
 
     /// <inheritdoc/>
@@ -58,6 +61,18 @@ public class GameLauncher(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(profileId);
         var semaphore = _profileLaunchLocks.GetOrAdd(profileId, _ => new SemaphoreSlim(1, 1));
+        await semaphore.WaitAsync(cancellationToken);
+        return new SemaphoreReleaser(semaphore);
+    }
+
+    private static async Task<IDisposable> AcquireSteamInstallationLockAsync(
+        string installationPath,
+        CancellationToken cancellationToken)
+    {
+        var normalizedPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(installationPath));
+        var semaphore = _steamInstallationLaunchLocks.GetOrAdd(
+            normalizedPath,
+            _ => new SemaphoreSlim(1, 1));
         await semaphore.WaitAsync(cancellationToken);
         return new SemaphoreReleaser(semaphore);
     }
@@ -454,6 +469,8 @@ public class GameLauncher(
 
     private async Task<LaunchOperationResult<GameLaunchInfo>> LaunchProfileAsync(GameProfile profile, bool skipUserDataCleanup, IProgress<LaunchProgress>? progress, string launchId, CancellationToken cancellationToken)
     {
+        IDisposable? steamInstallationLock = null;
+
         try
         {
             logger.LogInformation("[GameLauncher] === Starting launch for profile '{ProfileName}' (ID: {ProfileId}) ===", profile.Name, profile.Id);
@@ -607,6 +624,9 @@ public class GameLauncher(
 
             if (isSteamLaunch)
             {
+                steamInstallationLock = await AcquireSteamInstallationLockAsync(
+                    actualInstallationPath,
+                    cancellationToken);
                 logger.LogInformation("[GameLauncher] Steam launch detected - workspace will be adjacent to installation in .genhub-workspace directory");
 
                 // Workspace should be adjacent to the installation directory, not inside it
@@ -649,7 +669,20 @@ public class GameLauncher(
 
                     // Always use generals.exe for Steam cleanup (the actual Steam executable)
                     var steamExecutableName = GameClientConstants.GeneralsExecutable;
-                    await steamLauncher.CleanupGameDirectoryAsync(actualInstallationPath, steamExecutableName, cancellationToken);
+                    var cleanupResult = await steamLauncher.CleanupGameDirectoryAsync(
+                        actualInstallationPath,
+                        steamExecutableName,
+                        cancellationToken);
+                    if (!cleanupResult.Success)
+                    {
+                        logger.LogError(
+                            "[GameLauncher] Pre-launch Steam cleanup failed: {Error}",
+                            cleanupResult.FirstError);
+                        return LaunchOperationResult<GameLaunchInfo>.CreateFailure(
+                            $"Failed to restore the Steam installation before launch: {cleanupResult.FirstError}",
+                            launchId,
+                            profile.Id);
+                    }
                 }
             }
 
@@ -1047,6 +1080,10 @@ public class GameLauncher(
             logger.LogError(ex, "Failed to launch profile {ProfileId}, cleaning up placeholder entry", profile.Id);
             await launchRegistry.UnregisterLaunchAsync(launchId);
             return LaunchOperationResult<GameLaunchInfo>.CreateFailure($"Launch failed: {ex.Message}", launchId, profile.Id);
+        }
+        finally
+        {
+            steamInstallationLock?.Dispose();
         }
     }
 

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -52,7 +52,7 @@ public class GameLauncher(
 {
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _profileLaunchLocks = new();
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _steamInstallationLaunchLocks =
-        new(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        new(InstallationPathLockKey.Comparer);
 
     private static readonly SearchValues<char> InvalidArgChars = SearchValues.Create(";|&\n\r`$%");
 
@@ -69,7 +69,7 @@ public class GameLauncher(
         string installationPath,
         CancellationToken cancellationToken)
     {
-        var normalizedPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(installationPath));
+        var normalizedPath = InstallationPathLockKey.Create(installationPath);
         var semaphore = _steamInstallationLaunchLocks.GetOrAdd(
             normalizedPath,
             _ => new SemaphoreSlim(1, 1));

--- a/GenHub/GenHub/Features/Launching/InstallationPathLockKey.cs
+++ b/GenHub/GenHub/Features/Launching/InstallationPathLockKey.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+
+namespace GenHub.Features.Launching;
+
+/// <summary>
+/// Creates stable lock keys for installation paths, including filesystem aliases.
+/// </summary>
+internal static class InstallationPathLockKey
+{
+    /// <summary>
+    /// Gets the platform-appropriate lock-key comparer.
+    /// </summary>
+    public static StringComparer Comparer { get; } = OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    /// <summary>
+    /// Creates a lock key with existing symbolic-link and junction components resolved.
+    /// </summary>
+    /// <param name="installationPath">The installation directory path.</param>
+    /// <returns>The canonical installation lock key.</returns>
+    public static string Create(string installationPath)
+    {
+        var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(installationPath));
+        return Path.TrimEndingDirectorySeparator(ResolvePathComponents(fullPath));
+    }
+
+    private static string ResolvePathComponents(string fullPath)
+    {
+        var root = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrEmpty(root))
+        {
+            return fullPath;
+        }
+
+        var currentPath = root;
+        var relativePath = fullPath[root.Length..];
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        foreach (var segment in relativePath.Split(separators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            currentPath = Path.Combine(currentPath, segment);
+            if (!Directory.Exists(currentPath))
+            {
+                continue;
+            }
+
+            var resolvedTarget = Directory.ResolveLinkTarget(currentPath, returnFinalTarget: true);
+            if (resolvedTarget is not null)
+            {
+                currentPath = ResolvePathComponents(Path.GetFullPath(resolvedTarget.FullName));
+            }
+        }
+
+        return currentPath;
+    }
+}

--- a/GenHub/GenHub/Features/Launching/SteamLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/SteamLauncher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -34,6 +35,9 @@ public class SteamLauncher : ISteamLauncher
     private static readonly StringComparer PathComparer = OperatingSystem.IsWindows()
         ? StringComparer.OrdinalIgnoreCase
         : StringComparer.Ordinal;
+
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _installationMutationLocks =
+        new(PathComparer);
 
     private readonly ILogger<SteamLauncher> _logger;
     private readonly string? _proxySourcePathOverride;
@@ -91,9 +95,14 @@ public class SteamLauncher : ISteamLauncher
         CancellationToken cancellationToken = default)
     {
         PreparationRollback? rollback = null;
+        IDisposable? installationMutationLock = null;
 
         try
         {
+            gameInstallPath = Path.GetFullPath(gameInstallPath);
+            installationMutationLock = await AcquireInstallationMutationLockAsync(
+                gameInstallPath,
+                cancellationToken);
             _logger.LogInformation(
                 "[SteamLauncher] Preparing game directory {Path} for profile {ProfileId} using Proxy Launcher",
                 gameInstallPath,
@@ -109,7 +118,6 @@ public class SteamLauncher : ISteamLauncher
                     $"Proxy Launcher binary not found at {proxySourcePath}. Please build GenHub.ProxyLauncher project.");
             }
 
-            gameInstallPath = Path.GetFullPath(gameInstallPath);
             if (!Directory.Exists(gameInstallPath))
             {
                 return OperationResult<SteamLaunchPrepResult>.CreateFailure(
@@ -278,63 +286,77 @@ public class SteamLauncher : ISteamLauncher
 
             return OperationResult<SteamLaunchPrepResult>.CreateFailure(errors);
         }
+        finally
+        {
+            installationMutationLock?.Dispose();
+        }
     }
 
     /// <inheritdoc/>
-    public Task<OperationResult<bool>> CleanupGameDirectoryAsync(
+    public async Task<OperationResult<bool>> CleanupGameDirectoryAsync(
         string gameInstallPath,
         string executableName,
         CancellationToken cancellationToken = default)
     {
+        IDisposable? installationMutationLock = null;
+
         try
         {
+            gameInstallPath = Path.GetFullPath(gameInstallPath);
+            installationMutationLock = await AcquireInstallationMutationLockAsync(
+                gameInstallPath,
+                cancellationToken);
             _logger.LogInformation("[SteamLauncher] Cleaning up game directory: {Path}", gameInstallPath);
 
-            // 1. Remove Proxy Config
-            var proxyConfigPath = Path.Combine(gameInstallPath, ProxyConfigFileName);
-            if (File.Exists(proxyConfigPath))
-            {
-                _logger.LogDebug("[SteamLauncher] Removing proxy config: {Path}", proxyConfigPath);
-                File.Delete(proxyConfigPath);
-            }
-
-            // 2. Restore original game executable from backup
             var targetExePath = Path.Combine(gameInstallPath, executableName);
             var backupPath = targetExePath + SteamConstants.BackupExtension;
 
             if (File.Exists(backupPath))
             {
+                if (File.Exists(targetExePath))
+                {
+                    var proxySourcePath = ResolveProxySourcePath();
+                    if (!File.Exists(proxySourcePath) ||
+                        !FilesAreEqual(targetExePath, proxySourcePath))
+                    {
+                        var error =
+                            $"Refusing to replace '{targetExePath}' from the unverified backup '{backupPath}'.";
+                        _logger.LogError("[SteamLauncher] {Error}", error);
+                        return OperationResult<bool>.CreateFailure(error);
+                    }
+                }
+
                 _logger.LogInformation(
                     "[SteamLauncher] Restoring original {Exe} from backup",
                     executableName);
-
-                try
-                {
-                    // Delete the proxy (current exe)
-                    if (File.Exists(targetExePath))
-                    {
-                        File.Delete(targetExePath);
-                    }
-
-                    // Restore original from backup
-                    File.Move(backupPath, targetExePath);
-                    _logger.LogInformation(
-                        "[SteamLauncher] Successfully restored original {Exe}",
-                        executableName);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(
-                        ex,
-                        "[SteamLauncher] Failed to restore original {Exe} from backup",
-                        executableName);
-                }
+                File.Move(backupPath, targetExePath, overwrite: true);
+                _logger.LogInformation(
+                    "[SteamLauncher] Successfully restored original {Exe}",
+                    executableName);
             }
             else
             {
+                var proxySourcePath = ResolveProxySourcePath();
+                if (File.Exists(targetExePath) &&
+                    File.Exists(proxySourcePath) &&
+                    FilesAreEqual(targetExePath, proxySourcePath))
+                {
+                    var error =
+                        $"Cannot restore '{targetExePath}' because its original backup is missing.";
+                    _logger.LogError("[SteamLauncher] {Error}", error);
+                    return OperationResult<bool>.CreateFailure(error);
+                }
+
                 _logger.LogDebug(
                     "[SteamLauncher] No backup found for {Exe}, skipping restoration",
                     executableName);
+            }
+
+            var proxyConfigPath = Path.Combine(gameInstallPath, ProxyConfigFileName);
+            if (File.Exists(proxyConfigPath))
+            {
+                _logger.LogDebug("[SteamLauncher] Removing proxy config: {Path}", proxyConfigPath);
+                File.Delete(proxyConfigPath);
             }
 
             // Cleanup any tracking file if it still exists from old version
@@ -347,13 +369,29 @@ public class SteamLauncher : ISteamLauncher
             // Note: .genhub-workspace-active junction cleanup removed - no longer using junctions
             // Each profile uses its own adjacent workspace directly
             _logger.LogInformation("[SteamLauncher] Cleaned up game directory artifacts: {Path}", gameInstallPath);
-            return Task.FromResult(OperationResult<bool>.CreateSuccess(true));
+            return OperationResult<bool>.CreateSuccess(true);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "[SteamLauncher] Failed to cleanup game directory: {Path}", gameInstallPath);
-            return Task.FromResult(OperationResult<bool>.CreateFailure($"Failed to cleanup: {ex.Message}"));
+            return OperationResult<bool>.CreateFailure($"Failed to cleanup: {ex.Message}");
         }
+        finally
+        {
+            installationMutationLock?.Dispose();
+        }
+    }
+
+    private static async Task<IDisposable> AcquireInstallationMutationLockAsync(
+        string installationPath,
+        CancellationToken cancellationToken)
+    {
+        var normalizedPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(installationPath));
+        var semaphore = _installationMutationLocks.GetOrAdd(
+            normalizedPath,
+            _ => new SemaphoreSlim(1, 1));
+        await semaphore.WaitAsync(cancellationToken);
+        return new SemaphoreReleaser(semaphore);
     }
 
     private async Task WriteSteamAppIdAsync(
@@ -484,6 +522,35 @@ public class SteamLauncher : ISteamLauncher
         return copies;
     }
 
+    private bool FilesAreEqual(string firstPath, string secondPath)
+    {
+        var firstInfo = new FileInfo(firstPath);
+        var secondInfo = new FileInfo(secondPath);
+        if (firstInfo.Length != secondInfo.Length)
+        {
+            return false;
+        }
+
+        using var firstStream = File.OpenRead(firstPath);
+        using var secondStream = File.OpenRead(secondPath);
+        return SHA256.HashData(firstStream).SequenceEqual(SHA256.HashData(secondStream));
+    }
+
+    private sealed class SemaphoreReleaser(SemaphoreSlim semaphore) : IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore = semaphore;
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _semaphore.Release();
+                _disposed = true;
+            }
+        }
+    }
+
     private sealed class PreparationRollback
     {
         private readonly string _targetExePath;
@@ -521,31 +588,42 @@ public class SteamLauncher : ISteamLauncher
         {
             _targetInitiallyExisted = File.Exists(_targetExePath);
 
-            if (_targetInitiallyExisted)
+            if (!_targetInitiallyExisted)
             {
-                _temporaryFiles.Add(_executableSnapshotPath);
-                File.Copy(_targetExePath, _executableSnapshotPath, overwrite: false);
+                if (!File.Exists(_backupPath))
+                {
+                    throw new FileNotFoundException(
+                        "Neither the target executable nor its recovery backup is available.",
+                        _targetExePath);
+                }
 
-                var targetIsCurrentProxy = File.Exists(_backupPath) &&
-                    FilesAreEqual(_targetExePath, _proxySourcePath);
-                _executableRestoreSource = targetIsCurrentProxy
-                    ? _backupPath
-                    : _executableSnapshotPath;
-            }
-            else
-            {
                 _executableRestoreSource = _backupPath;
+                return;
             }
 
-            if (!File.Exists(_backupPath))
+            _temporaryFiles.Add(_executableSnapshotPath);
+            File.Copy(_targetExePath, _executableSnapshotPath, overwrite: false);
+
+            if (File.Exists(_backupPath))
             {
-                var backupStagingPath = CreateTemporaryPath(_backupPath);
-                _temporaryFiles.Add(backupStagingPath);
-                File.Copy(_targetExePath, backupStagingPath, overwrite: false);
-                File.Move(backupStagingPath, _backupPath, overwrite: false);
-                _temporaryFiles.Remove(backupStagingPath);
-                _backupCreated = true;
+                if (!FilesAreEqual(_targetExePath, _proxySourcePath))
+                {
+                    throw new IOException(
+                        $"Refusing to use unverified pre-existing backup '{_backupPath}' while " +
+                        $"'{_targetExePath}' is not the GenHub proxy.");
+                }
+
+                _executableRestoreSource = _backupPath;
+                return;
             }
+
+            _executableRestoreSource = _executableSnapshotPath;
+            var backupStagingPath = CreateTemporaryPath(_backupPath);
+            _temporaryFiles.Add(backupStagingPath);
+            File.Copy(_targetExePath, backupStagingPath, overwrite: false);
+            File.Move(backupStagingPath, _backupPath, overwrite: false);
+            _temporaryFiles.Remove(backupStagingPath);
+            _backupCreated = true;
         }
 
         public void DeployProxy()

--- a/GenHub/GenHub/Features/Launching/SteamLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/SteamLauncher.cs
@@ -37,7 +37,7 @@ public class SteamLauncher : ISteamLauncher
         : StringComparer.Ordinal;
 
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _installationMutationLocks =
-        new(PathComparer);
+        new(InstallationPathLockKey.Comparer);
 
     private readonly ILogger<SteamLauncher> _logger;
     private readonly string? _proxySourcePathOverride;
@@ -386,7 +386,7 @@ public class SteamLauncher : ISteamLauncher
         string installationPath,
         CancellationToken cancellationToken)
     {
-        var normalizedPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(installationPath));
+        var normalizedPath = InstallationPathLockKey.Create(installationPath);
         var semaphore = _installationMutationLocks.GetOrAdd(
             normalizedPath,
             _ => new SemaphoreSlim(1, 1));

--- a/GenHub/GenHub/Features/Launching/SteamLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/SteamLauncher.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,19 +20,49 @@ namespace GenHub.Features.Launching;
 /// Service for preparing game directories for Steam-tracked profile launches.
 /// This approach uses a "Proxy Launcher" mechanism:
 /// 1. We start a Workspace as usual (isolated environment).
-/// 2. We drop a sidecar ProxyLauncher.exe next to the original game executables (we do NOT overwrite them).
+/// 2. We back up and replace the original game executable with the proxy.
 /// 3. We write a proxy_config.json telling the Proxy to launch the Workspace executable using direct paths.
-/// 4. Steam launch options can point at the sidecar proxy; the proxy then runs the Workspace game.
+/// 4. Steam launches the proxy under the original executable name; the proxy then runs the Workspace game.
 ///
 /// Each profile uses its own adjacent workspace: {installationRoot}\.genhub-workspace\{profileId}\
 /// The proxy_config.json is regenerated on each launch with the correct workspace paths for that profile.
-/// This keeps the game directory clean (no exe replacement) while maintaining Steam integration.
 /// </summary>
-public class SteamLauncher(
-    ILogger<SteamLauncher> logger) : ISteamLauncher
+public class SteamLauncher : ISteamLauncher
 {
     private const string ProxyConfigFileName = "proxy_config.json";
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private static readonly StringComparer PathComparer = OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    private readonly ILogger<SteamLauncher> _logger;
+    private readonly string? _proxySourcePathOverride;
+    private readonly Func<string, string, CancellationToken, Task> _writeAllTextAsync;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SteamLauncher"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    public SteamLauncher(ILogger<SteamLauncher> logger)
+        : this(logger, null, File.WriteAllTextAsync)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SteamLauncher"/> class with test seams.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="proxySourcePathOverride">An optional proxy source path override.</param>
+    /// <param name="writeAllTextAsync">The text file writer.</param>
+    internal SteamLauncher(
+        ILogger<SteamLauncher> logger,
+        string? proxySourcePathOverride,
+        Func<string, string, CancellationToken, Task> writeAllTextAsync)
+    {
+        _logger = logger;
+        _proxySourcePathOverride = proxySourcePathOverride;
+        _writeAllTextAsync = writeAllTextAsync;
+    }
 
     /// <summary>
     /// Configuration for the proxy launcher.
@@ -58,151 +90,76 @@ public class SteamLauncher(
         string? steamAppId = null,
         CancellationToken cancellationToken = default)
     {
+        PreparationRollback? rollback = null;
+
         try
         {
-            logger.LogInformation(
+            _logger.LogInformation(
                 "[SteamLauncher] Preparing game directory {Path} for profile {ProfileId} using Proxy Launcher",
                 gameInstallPath,
                 profileId);
 
-            var proxyConfigPath = Path.Combine(gameInstallPath, ProxyConfigFileName);
-            var proxyDeployPath = Path.Combine(gameInstallPath, SteamConstants.ProxyLauncherFileName);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            // 1. Ensure we have the ProxyLauncher binary available
-            var currentBaseDir = AppDomain.CurrentDomain.BaseDirectory;
-            var proxySourcePath = Path.Combine(currentBaseDir, SteamConstants.ProxyLauncherFileName);
-
+            // Validate every prerequisite that can be checked without changing the installation.
+            var proxySourcePath = ResolveProxySourcePath();
             if (!File.Exists(proxySourcePath))
             {
-                logger.LogDebug("[SteamLauncher] Proxy Launcher not found in base directory: {Path}. Checking fallbacks...", proxySourcePath);
-
-                // Fallback 1: Development path relative to typical bin output structure
-                var devPaths = new[]
-                {
-                    Path.GetFullPath(Path.Combine(currentBaseDir, "..", "..", "..", "..", "GenHub.ProxyLauncher", "bin", "Debug", "net8.0-windows", "win-x64", "GenHub.ProxyLauncher.exe")),
-                    Path.GetFullPath(Path.Combine(currentBaseDir, "..", "..", "..", "..", "GenHub.ProxyLauncher", "bin", "Release", "net8.0-windows", "win-x64", "GenHub.ProxyLauncher.exe")),
-                    Path.GetFullPath(Path.Combine(currentBaseDir, "net8.0-windows", "GenHub.ProxyLauncher.exe")), // In case it's in a subfolder
-                };
-
-                foreach (var devPath in devPaths)
-                {
-                    if (File.Exists(devPath))
-                    {
-                        proxySourcePath = devPath;
-                        break;
-                    }
-                }
-
-                if (!File.Exists(proxySourcePath))
-                {
-                    return OperationResult<SteamLaunchPrepResult>.CreateFailure(
-                        $"Proxy Launcher binary not found at {proxySourcePath}. Please build GenHub.ProxyLauncher project.");
-                }
-            }
-
-            // 2. Deploy Proxy Launcher as the game executable
-            // Steam launches the game executable (e.g., generals.exe), so we replace it with our proxy.
-            // The proxy then launches the actual workspace executable.
-            // Original game exe is backed up to .ghbak for restoration and version detection.
-            var targetExeName = executableName; // e.g., "generals.exe" or "game.exe" (Zero Hour)
-            var targetExePath = Path.Combine(gameInstallPath, targetExeName);
-            var backupPath = targetExePath + SteamConstants.BackupExtension;
-
-            // Backup original executable if not already backed up
-            if (!File.Exists(backupPath) && File.Exists(targetExePath))
-            {
-                logger.LogInformation(
-                    "[SteamLauncher] Backing up original {Exe} to {Backup}",
-                    targetExeName,
-                    Path.GetFileName(backupPath));
-
-                try
-                {
-                    File.Copy(targetExePath, backupPath, overwrite: false);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "[SteamLauncher] Failed to create backup of {Exe}", targetExeName);
-                    return OperationResult<SteamLaunchPrepResult>.CreateFailure(
-                        $"Failed to backup original executable: {ex.Message}");
-                }
-            }
-
-            // Deploy proxy (always overwrite - if backup exists, target is our old proxy)
-            logger.LogInformation("[SteamLauncher] Deploying proxy launcher as {Exe}", targetExeName);
-
-            try
-            {
-                // Try to kill any running instances of the target executable to release file lock
-                var processName = Path.GetFileNameWithoutExtension(targetExePath);
-                var runningProcesses = Process.GetProcessesByName(processName);
-                foreach (var process in runningProcesses)
-                {
-                    try
-                    {
-                        if (process.MainModule?.FileName?.Equals(targetExePath, StringComparison.OrdinalIgnoreCase) == true)
-                        {
-                            logger.LogWarning(
-                                "[SteamLauncher] Killing running process {ProcessName} ({Pid}) to update proxy",
-                                process.ProcessName,
-                                process.Id);
-                            process.Kill();
-                            process.WaitForExit(1000);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogWarning(ex, "[SteamLauncher] Failed to kill process {Pid}", process.Id);
-                    }
-                }
-
-                // Wait briefly for file lock to release
-                if (runningProcesses.Length > 0)
-                {
-                    Thread.Sleep(500);
-                }
-
-                File.Copy(proxySourcePath, targetExePath, overwrite: true);
-                logger.LogInformation("[SteamLauncher] Successfully deployed proxy as {Exe}", targetExeName);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "[SteamLauncher] Failed to deploy proxy as {Exe}", targetExeName);
                 return OperationResult<SteamLaunchPrepResult>.CreateFailure(
-                    $"Failed to deploy proxy launcher: {ex.Message}");
+                    $"Proxy Launcher binary not found at {proxySourcePath}. Please build GenHub.ProxyLauncher project.");
             }
 
-            var primaryDeployedPath = targetExePath;
+            gameInstallPath = Path.GetFullPath(gameInstallPath);
+            if (!Directory.Exists(gameInstallPath))
+            {
+                return OperationResult<SteamLaunchPrepResult>.CreateFailure(
+                    $"Game installation directory not found: {gameInstallPath}");
+            }
 
-            // 3. Create Proxy Config (always points to the workspace executable)
-            var effectiveTargetExecutable = targetExecutablePath;
+            var targetExePath = Path.Combine(gameInstallPath, executableName);
+            var backupPath = targetExePath + SteamConstants.BackupExtension;
+            var proxyConfigPath = Path.Combine(gameInstallPath, ProxyConfigFileName);
 
-            // Validate that the target executable exists
+            if (Directory.Exists(targetExePath))
+            {
+                return OperationResult<SteamLaunchPrepResult>.CreateFailure(
+                    $"Game executable path is a directory: {targetExePath}");
+            }
+
+            if (!File.Exists(targetExePath) && !File.Exists(backupPath))
+            {
+                return OperationResult<SteamLaunchPrepResult>.CreateFailure(
+                    $"Original game executable not found: {targetExePath}");
+            }
+
+            if (Directory.Exists(backupPath))
+            {
+                return OperationResult<SteamLaunchPrepResult>.CreateFailure(
+                    $"Backup executable path is a directory: {backupPath}");
+            }
+
+            var effectiveTargetExecutable = Path.GetFullPath(targetExecutablePath);
             if (!File.Exists(effectiveTargetExecutable))
             {
                 return OperationResult<SteamLaunchPrepResult>.CreateFailure(
                     $"Target executable not found: {effectiveTargetExecutable}. Workspace may not be properly prepared.");
             }
 
-            // Ensure paths are absolute
-            effectiveTargetExecutable = Path.GetFullPath(effectiveTargetExecutable);
             var effectiveWorkingDirectory = string.IsNullOrEmpty(targetWorkingDirectory)
                 ? Path.GetDirectoryName(effectiveTargetExecutable) ?? string.Empty
                 : Path.GetFullPath(targetWorkingDirectory);
 
-            // Use direct workspace paths - proxy_config.json is regenerated on each launch with correct paths
-            // Each profile uses its own adjacent workspace: {installationRoot}\.genhub-workspace\{profileId}\
-            // This removes the .genhub-workspace-active junction indirection layer
-            logger.LogInformation(
-                "[SteamLauncher] Using direct workspace paths - Target: {Target}, WorkDir: {WorkDir}",
-                effectiveTargetExecutable,
-                effectiveWorkingDirectory);
-
-            // Validate working directory exists
             if (!Directory.Exists(effectiveWorkingDirectory))
             {
                 return OperationResult<SteamLaunchPrepResult>.CreateFailure(
                     $"Working directory not found: {effectiveWorkingDirectory}");
+            }
+
+            var targetDirectory = Path.GetDirectoryName(effectiveTargetExecutable);
+            if (string.IsNullOrEmpty(targetDirectory) || !Directory.Exists(targetDirectory))
+            {
+                return OperationResult<SteamLaunchPrepResult>.CreateFailure(
+                    $"Target executable directory not found: {targetDirectory}");
             }
 
             var config = new ProxyConfig
@@ -214,52 +171,84 @@ public class SteamLauncher(
             };
 
             var configJson = JsonSerializer.Serialize(config, JsonOptions);
-            await File.WriteAllTextAsync(proxyConfigPath, configJson, cancellationToken);
-            logger.LogInformation("[SteamLauncher] Wrote proxy config to {Path}", proxyConfigPath);
-            logger.LogInformation(
+            var appIdDirectories = string.IsNullOrEmpty(steamAppId)
+                ? []
+                : new[] { effectiveWorkingDirectory, targetDirectory, gameInstallPath }
+                    .Distinct(PathComparer)
+                    .ToArray();
+            var filesToCapture = new List<string> { proxyConfigPath };
+
+            foreach (var directory in appIdDirectories)
+            {
+                filesToCapture.Add(Path.Combine(directory, "steam_appid.txt"));
+            }
+
+            foreach (var path in filesToCapture.Distinct(PathComparer))
+            {
+                if (Directory.Exists(path))
+                {
+                    return OperationResult<SteamLaunchPrepResult>.CreateFailure(
+                        $"Required file path is a directory: {path}");
+                }
+            }
+
+            var dependencyCopies = GetRequiredDependencyCopies(
+                gameInstallPath,
+                [effectiveWorkingDirectory, targetDirectory]);
+            foreach (var (_, destinationPath) in dependencyCopies)
+            {
+                if (Directory.Exists(destinationPath))
+                {
+                    return OperationResult<SteamLaunchPrepResult>.CreateFailure(
+                        $"Runtime dependency path is a directory: {destinationPath}");
+                }
+            }
+
+            rollback = new PreparationRollback(
+                targetExePath,
+                backupPath,
+                proxySourcePath,
+                filesToCapture);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await StopRunningTargetProcessesAsync(targetExePath, cancellationToken);
+
+            rollback.PrepareExecutableBackup();
+            rollback.DeployProxy();
+
+            _logger.LogInformation("[SteamLauncher] Successfully deployed proxy as {Exe}", executableName);
+            _logger.LogInformation(
+                "[SteamLauncher] Using direct workspace paths - Target: {Target}, WorkDir: {WorkDir}",
+                effectiveTargetExecutable,
+                effectiveWorkingDirectory);
+
+            await rollback.WriteTextAsync(proxyConfigPath, configJson, _writeAllTextAsync, cancellationToken);
+            _logger.LogInformation("[SteamLauncher] Wrote proxy config to {Path}", proxyConfigPath);
+            _logger.LogInformation(
                 "[SteamLauncher] Proxy config - Target: {Target}, WorkDir: {WorkDir}, Args: {ArgCount}",
                 config.TargetExecutable,
                 config.WorkingDirectory,
                 config.Arguments.Length);
 
-            // 5. CRITICAL: Always write steam_appid.txt next to BOTH the working directory and the target executable.
-            // Steam overlays/readiness logic checks the executable directory first. Many modded game clients call SteamAPI_Init
-            // and immediately look for steam_appid.txt adjacent to their EXE. If we only write it to the install dir, the
-            // workspace executable will trigger SteamAPI_RestartAppIfNecessary and surface the "invalid license" error.
-            if (!string.IsNullOrEmpty(steamAppId))
+            foreach (var directory in appIdDirectories)
             {
-                await WriteSteamAppIdAsync(steamAppId, effectiveWorkingDirectory, cancellationToken);
-
-                var targetDirectory = Path.GetDirectoryName(effectiveTargetExecutable);
-                if (!string.IsNullOrEmpty(targetDirectory) &&
-                    !string.Equals(targetDirectory, effectiveWorkingDirectory, StringComparison.OrdinalIgnoreCase))
-                {
-                    await WriteSteamAppIdAsync(steamAppId, targetDirectory, cancellationToken);
-                }
+                await WriteSteamAppIdAsync(steamAppId!, directory, rollback, cancellationToken);
             }
 
-            // 6. Ensure steam_appid.txt also exists alongside the proxy (Steam sometimes checks the launch dir)
-            if (!string.IsNullOrEmpty(steamAppId))
+            foreach (var (sourcePath, destinationPath) in dependencyCopies)
             {
-                await WriteSteamAppIdAsync(steamAppId, gameInstallPath, cancellationToken);
+                await rollback.CopyNewFileAsync(sourcePath, destinationPath, cancellationToken);
+                _logger.LogInformation(
+                    "[SteamLauncher] Copied missing critical file {File} to {Destination}",
+                    Path.GetFileName(sourcePath),
+                    Path.GetDirectoryName(destinationPath));
             }
 
-            // 7. Critical: Ensure steam_api.dll and other runtime dependencies exist where the target exe loads from.
-            // Some modded clients are distributed without these files in their manifests (to keep manifests minimal).
-            // Missing steam_api.dll is the primary cause of "invalid license" when the workspace executable calls SteamAPI_Init.
-            await EnsureRuntimeDependenciesAsync(gameInstallPath, effectiveWorkingDirectory, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            var targetDirForDeps = Path.GetDirectoryName(effectiveTargetExecutable);
-            if (!string.IsNullOrEmpty(targetDirForDeps) &&
-                !string.Equals(targetDirForDeps, effectiveWorkingDirectory, StringComparison.OrdinalIgnoreCase))
-            {
-                await EnsureRuntimeDependenciesAsync(gameInstallPath, targetDirForDeps, cancellationToken);
-            }
-
-            // Return result
             var result = new SteamLaunchPrepResult
             {
-                ExecutablePath = primaryDeployedPath, // Sidecar proxy path (leave originals untouched)
+                ExecutablePath = targetExePath,
                 WorkingDirectory = gameInstallPath,
                 ProfileId = profileId,
                 FilesLinked = 0,
@@ -268,12 +257,26 @@ public class SteamLauncher(
                 SteamAppId = steamAppId,
             };
 
+            rollback.Commit();
             return OperationResult<SteamLaunchPrepResult>.CreateSuccess(result);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "[SteamLauncher] Failed to prepare proxy for profile {ProfileId}", profileId);
-            return OperationResult<SteamLaunchPrepResult>.CreateFailure($"Failed to prepare proxy: {ex.Message}");
+            _logger.LogError(ex, "[SteamLauncher] Failed to prepare proxy for profile {ProfileId}", profileId);
+
+            var errors = new List<string>
+            {
+                ex is OperationCanceledException
+                    ? "Steam proxy preparation was canceled."
+                    : $"Failed to prepare proxy: {ex.Message}",
+            };
+
+            if (rollback is not null)
+            {
+                errors.AddRange(rollback.Rollback());
+            }
+
+            return OperationResult<SteamLaunchPrepResult>.CreateFailure(errors);
         }
     }
 
@@ -285,13 +288,13 @@ public class SteamLauncher(
     {
         try
         {
-            logger.LogInformation("[SteamLauncher] Cleaning up game directory: {Path}", gameInstallPath);
+            _logger.LogInformation("[SteamLauncher] Cleaning up game directory: {Path}", gameInstallPath);
 
             // 1. Remove Proxy Config
             var proxyConfigPath = Path.Combine(gameInstallPath, ProxyConfigFileName);
             if (File.Exists(proxyConfigPath))
             {
-                logger.LogDebug("[SteamLauncher] Removing proxy config: {Path}", proxyConfigPath);
+                _logger.LogDebug("[SteamLauncher] Removing proxy config: {Path}", proxyConfigPath);
                 File.Delete(proxyConfigPath);
             }
 
@@ -301,7 +304,7 @@ public class SteamLauncher(
 
             if (File.Exists(backupPath))
             {
-                logger.LogInformation(
+                _logger.LogInformation(
                     "[SteamLauncher] Restoring original {Exe} from backup",
                     executableName);
 
@@ -315,13 +318,13 @@ public class SteamLauncher(
 
                     // Restore original from backup
                     File.Move(backupPath, targetExePath);
-                    logger.LogInformation(
+                    _logger.LogInformation(
                         "[SteamLauncher] Successfully restored original {Exe}",
                         executableName);
                 }
                 catch (Exception ex)
                 {
-                    logger.LogWarning(
+                    _logger.LogWarning(
                         ex,
                         "[SteamLauncher] Failed to restore original {Exe} from backup",
                         executableName);
@@ -329,7 +332,7 @@ public class SteamLauncher(
             }
             else
             {
-                logger.LogDebug(
+                _logger.LogDebug(
                     "[SteamLauncher] No backup found for {Exe}, skipping restoration",
                     executableName);
             }
@@ -343,23 +346,22 @@ public class SteamLauncher(
 
             // Note: .genhub-workspace-active junction cleanup removed - no longer using junctions
             // Each profile uses its own adjacent workspace directly
-            logger.LogInformation("[SteamLauncher] Cleaned up game directory artifacts: {Path}", gameInstallPath);
+            _logger.LogInformation("[SteamLauncher] Cleaned up game directory artifacts: {Path}", gameInstallPath);
             return Task.FromResult(OperationResult<bool>.CreateSuccess(true));
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "[SteamLauncher] Failed to cleanup game directory: {Path}", gameInstallPath);
+            _logger.LogError(ex, "[SteamLauncher] Failed to cleanup game directory: {Path}", gameInstallPath);
             return Task.FromResult(OperationResult<bool>.CreateFailure($"Failed to cleanup: {ex.Message}"));
         }
     }
 
-    private async Task WriteSteamAppIdAsync(string steamAppId, string directory, CancellationToken cancellationToken)
+    private async Task WriteSteamAppIdAsync(
+        string steamAppId,
+        string directory,
+        PreparationRollback rollback,
+        CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(directory))
-        {
-            return;
-        }
-
         var appIdPath = Path.Combine(directory, "steam_appid.txt");
 
         // Check current content - only rewrite if different (avoid breaking hardlinks unnecessarily)
@@ -370,47 +372,496 @@ public class SteamLauncher(
             needsWrite = currentContent.Trim() != steamAppId;
             if (needsWrite)
             {
-                logger.LogWarning(
+                _logger.LogWarning(
                     "[SteamLauncher] steam_appid.txt has wrong ID ({WrongId}), overwriting with correct ID ({CorrectId})",
                     currentContent.Trim(),
                     steamAppId);
-
-                // Delete the hardlink to avoid modifying original
-                File.Delete(appIdPath);
             }
         }
 
         if (needsWrite)
         {
-            await File.WriteAllTextAsync(appIdPath, steamAppId, cancellationToken);
-            logger.LogInformation(
+            await rollback.WriteTextAsync(appIdPath, steamAppId, _writeAllTextAsync, cancellationToken);
+            _logger.LogInformation(
                 "[SteamLauncher] Wrote steam_appid.txt ({AppId}) to {Path}",
                 steamAppId,
                 directory);
         }
     }
 
-    private async Task EnsureRuntimeDependenciesAsync(string sourceDirectory, string destinationDirectory, CancellationToken cancellationToken)
+    private string ResolveProxySourcePath()
     {
-        if (string.IsNullOrWhiteSpace(destinationDirectory))
+        if (!string.IsNullOrEmpty(_proxySourcePathOverride))
         {
-            return;
+            return Path.GetFullPath(_proxySourcePathOverride);
         }
 
-        var filesToEnsure = new[] { "steam_api.dll", "binkw32.dll", "mss32.dll" };
-        foreach (var file in filesToEnsure)
+        var currentBaseDir = AppDomain.CurrentDomain.BaseDirectory;
+        var defaultPath = Path.Combine(currentBaseDir, SteamConstants.ProxyLauncherFileName);
+        if (File.Exists(defaultPath))
         {
-            var sourcePath = Path.Combine(sourceDirectory, file);
-            var destPath = Path.Combine(destinationDirectory, file);
-            if (File.Exists(sourcePath) && !File.Exists(destPath))
+            return defaultPath;
+        }
+
+        _logger.LogDebug(
+            "[SteamLauncher] Proxy Launcher not found in base directory: {Path}. Checking fallbacks...",
+            defaultPath);
+
+        var developmentPaths = new[]
+        {
+            Path.GetFullPath(Path.Combine(currentBaseDir, "..", "..", "..", "..", "GenHub.ProxyLauncher", "bin", "Debug", "net8.0-windows", "win-x64", "GenHub.ProxyLauncher.exe")),
+            Path.GetFullPath(Path.Combine(currentBaseDir, "..", "..", "..", "..", "GenHub.ProxyLauncher", "bin", "Release", "net8.0-windows", "win-x64", "GenHub.ProxyLauncher.exe")),
+            Path.GetFullPath(Path.Combine(currentBaseDir, "net8.0-windows", "GenHub.ProxyLauncher.exe")),
+        };
+
+        return developmentPaths.FirstOrDefault(File.Exists) ?? defaultPath;
+    }
+
+    private async Task StopRunningTargetProcessesAsync(
+        string targetExePath,
+        CancellationToken cancellationToken)
+    {
+        var processName = Path.GetFileNameWithoutExtension(targetExePath);
+        var runningProcesses = Process.GetProcessesByName(processName);
+
+        try
+        {
+            foreach (var process in runningProcesses)
             {
-                File.Copy(sourcePath, destPath);
-                logger.LogInformation("[SteamLauncher] Copied missing critical file {File} to {Destination}", file, destinationDirectory);
+                try
+                {
+                    if (process.MainModule?.FileName is string processPath &&
+                        PathComparer.Equals(Path.GetFullPath(processPath), targetExePath))
+                    {
+                        _logger.LogWarning(
+                            "[SteamLauncher] Killing running process {ProcessName} ({Pid}) to update proxy",
+                            process.ProcessName,
+                            process.Id);
+                        process.Kill();
+                        process.WaitForExit(1000);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "[SteamLauncher] Failed to kill process {Pid}", process.Id);
+                }
+            }
+
+            if (runningProcesses.Length > 0)
+            {
+                await Task.Delay(500, cancellationToken);
+            }
+        }
+        finally
+        {
+            foreach (var process in runningProcesses)
+            {
+                process.Dispose();
+            }
+        }
+    }
+
+    private List<(string SourcePath, string DestinationPath)> GetRequiredDependencyCopies(
+        string sourceDirectory,
+        IEnumerable<string> destinationDirectories)
+    {
+        var filesToEnsure = new[] { "steam_api.dll", "binkw32.dll", "mss32.dll" };
+        var copies = new List<(string SourcePath, string DestinationPath)>();
+
+        foreach (var destinationDirectory in destinationDirectories.Distinct(PathComparer))
+        {
+            foreach (var file in filesToEnsure)
+            {
+                var sourcePath = Path.Combine(sourceDirectory, file);
+                var destinationPath = Path.Combine(destinationDirectory, file);
+                if (File.Exists(sourcePath) && !File.Exists(destinationPath))
+                {
+                    copies.Add((sourcePath, destinationPath));
+                }
             }
         }
 
-        // Yield control occasionally to respect cancellation
-        await Task.Yield();
-        cancellationToken.ThrowIfCancellationRequested();
+        return copies;
+    }
+
+    private sealed class PreparationRollback
+    {
+        private readonly string _targetExePath;
+        private readonly string _backupPath;
+        private readonly string _proxySourcePath;
+        private readonly string _executableSnapshotPath;
+        private readonly Dictionary<string, byte[]?> _originalFiles = new(PathComparer);
+        private readonly Dictionary<string, byte[]> _preparedFiles = new(PathComparer);
+        private readonly List<string> _mutatedFiles = [];
+        private readonly HashSet<string> _temporaryFiles = new(PathComparer);
+        private bool _backupCreated;
+        private bool _executableMutationStarted;
+        private bool _targetInitiallyExisted;
+        private string? _executableRestoreSource;
+        private bool _completed;
+
+        public PreparationRollback(
+            string targetExePath,
+            string backupPath,
+            string proxySourcePath,
+            IEnumerable<string> filesToCapture)
+        {
+            _targetExePath = targetExePath;
+            _backupPath = backupPath;
+            _proxySourcePath = proxySourcePath;
+            _executableSnapshotPath = CreateTemporaryPath(targetExePath);
+
+            foreach (var path in filesToCapture.Distinct(PathComparer))
+            {
+                _originalFiles[path] = File.Exists(path) ? File.ReadAllBytes(path) : null;
+            }
+        }
+
+        public void PrepareExecutableBackup()
+        {
+            _targetInitiallyExisted = File.Exists(_targetExePath);
+
+            if (_targetInitiallyExisted)
+            {
+                _temporaryFiles.Add(_executableSnapshotPath);
+                File.Copy(_targetExePath, _executableSnapshotPath, overwrite: false);
+
+                var targetIsCurrentProxy = File.Exists(_backupPath) &&
+                    FilesAreEqual(_targetExePath, _proxySourcePath);
+                _executableRestoreSource = targetIsCurrentProxy
+                    ? _backupPath
+                    : _executableSnapshotPath;
+            }
+            else
+            {
+                _executableRestoreSource = _backupPath;
+            }
+
+            if (!File.Exists(_backupPath))
+            {
+                var backupStagingPath = CreateTemporaryPath(_backupPath);
+                _temporaryFiles.Add(backupStagingPath);
+                File.Copy(_targetExePath, backupStagingPath, overwrite: false);
+                File.Move(backupStagingPath, _backupPath, overwrite: false);
+                _temporaryFiles.Remove(backupStagingPath);
+                _backupCreated = true;
+            }
+        }
+
+        public void DeployProxy()
+        {
+            var stagingPath = CreateTemporaryPath(_targetExePath);
+            _temporaryFiles.Add(stagingPath);
+            File.Copy(_proxySourcePath, stagingPath, overwrite: false);
+
+            if (_targetInitiallyExisted)
+            {
+                if (!File.Exists(_targetExePath) ||
+                    !FilesAreEqual(_targetExePath, _executableSnapshotPath))
+                {
+                    throw new IOException(
+                        $"Game executable changed before proxy deployment: {_targetExePath}");
+                }
+            }
+            else if (File.Exists(_targetExePath))
+            {
+                throw new IOException(
+                    $"Game executable appeared before proxy deployment: {_targetExePath}");
+            }
+
+            _executableMutationStarted = true;
+            File.Move(stagingPath, _targetExePath, overwrite: true);
+            _temporaryFiles.Remove(stagingPath);
+        }
+
+        public async Task WriteTextAsync(
+            string path,
+            string contents,
+            Func<string, string, CancellationToken, Task> writer,
+            CancellationToken cancellationToken)
+        {
+            var stagingPath = CreateTemporaryPath(path);
+            _temporaryFiles.Add(stagingPath);
+
+            await writer(stagingPath, contents, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureCapturedFileIsUnchanged(path);
+            var preparedContents = File.ReadAllBytes(stagingPath);
+            File.Move(stagingPath, path, overwrite: true);
+            _preparedFiles[path] = preparedContents;
+            TrackMutation(path);
+            _temporaryFiles.Remove(stagingPath);
+        }
+
+        public async Task CopyNewFileAsync(
+            string sourcePath,
+            string destinationPath,
+            CancellationToken cancellationToken)
+        {
+            await using var source = new FileStream(
+                sourcePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                81920,
+                useAsync: true);
+            await using var destination = new FileStream(
+                destinationPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                81920,
+                useAsync: true);
+
+            _originalFiles[destinationPath] = null;
+            TrackMutation(destinationPath);
+            await source.CopyToAsync(destination, cancellationToken);
+        }
+
+        public void Commit()
+        {
+            var errors = new List<string>();
+            CleanupTemporaryFiles(errors);
+            if (errors.Count > 0)
+            {
+                throw new IOException(string.Join(" ", errors));
+            }
+
+            _completed = true;
+        }
+
+        public IReadOnlyList<string> Rollback()
+        {
+            if (_completed)
+            {
+                return [];
+            }
+
+            var errors = new List<string>();
+
+            for (var index = _mutatedFiles.Count - 1; index >= 0; index--)
+            {
+                var path = _mutatedFiles[index];
+
+                try
+                {
+                    if (!CanRestoreCapturedFile(path))
+                    {
+                        errors.Add($"Rollback did not overwrite unexpectedly changed file '{path}'.");
+                        continue;
+                    }
+
+                    RestoreCapturedFile(path, _originalFiles[path]);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Rollback failed for '{path}': {ex.Message}");
+                }
+            }
+
+            var executableRestored = TryRestoreExecutable(errors);
+            if (executableRestored && _backupCreated)
+            {
+                try
+                {
+                    File.Delete(_backupPath);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Rollback failed to remove new backup '{_backupPath}': {ex.Message}");
+                }
+            }
+
+            if (executableRestored)
+            {
+                CleanupTemporaryFiles(errors);
+            }
+            else
+            {
+                foreach (var path in _temporaryFiles.Where(File.Exists))
+                {
+                    errors.Add($"Recovery file retained at '{path}'.");
+                }
+
+                if (_backupCreated && File.Exists(_backupPath))
+                {
+                    errors.Add($"Recovery backup retained at '{_backupPath}'.");
+                }
+            }
+
+            _completed = true;
+            return errors;
+        }
+
+        private void TrackMutation(string path)
+        {
+            if (!_mutatedFiles.Contains(path, PathComparer))
+            {
+                _mutatedFiles.Add(path);
+            }
+        }
+
+        private bool CanRestoreCapturedFile(string path)
+        {
+            if (!_preparedFiles.TryGetValue(path, out var preparedContents))
+            {
+                return true;
+            }
+
+            if (!File.Exists(path))
+            {
+                return _originalFiles[path] is null;
+            }
+
+            return File.ReadAllBytes(path).SequenceEqual(preparedContents);
+        }
+
+        private void EnsureCapturedFileIsUnchanged(string path)
+        {
+            var originalContents = _originalFiles[path];
+            if (originalContents is null)
+            {
+                if (File.Exists(path) || Directory.Exists(path))
+                {
+                    throw new IOException($"File appeared before preparation could update it: {path}");
+                }
+
+                return;
+            }
+
+            if (!File.Exists(path) ||
+                !File.ReadAllBytes(path).SequenceEqual(originalContents))
+            {
+                throw new IOException($"File changed before preparation could update it: {path}");
+            }
+        }
+
+        private bool TryRestoreExecutable(List<string> errors)
+        {
+            if (!_executableMutationStarted)
+            {
+                return true;
+            }
+
+            try
+            {
+                var restoreSource = GetExecutableRestoreSource();
+                if (_targetInitiallyExisted &&
+                    File.Exists(_targetExePath) &&
+                    FilesAreEqual(_targetExePath, restoreSource))
+                {
+                    return true;
+                }
+
+                if (File.Exists(_targetExePath) &&
+                    !FilesAreEqual(_targetExePath, _proxySourcePath))
+                {
+                    errors.Add(
+                        $"Rollback did not overwrite unexpectedly changed executable '{_targetExePath}'.");
+                    return false;
+                }
+
+                AtomicCopy(restoreSource, _targetExePath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Rollback failed to restore executable '{_targetExePath}': {ex.Message}");
+                return false;
+            }
+        }
+
+        private string GetExecutableRestoreSource()
+        {
+            if (!string.IsNullOrEmpty(_executableRestoreSource) &&
+                File.Exists(_executableRestoreSource))
+            {
+                return _executableRestoreSource;
+            }
+
+            if (File.Exists(_backupPath))
+            {
+                return _backupPath;
+            }
+
+            throw new FileNotFoundException(
+                "No recovery copy of the original executable is available.",
+                _executableRestoreSource);
+        }
+
+        private void CleanupTemporaryFiles(List<string> errors)
+        {
+            foreach (var path in _temporaryFiles.ToArray())
+            {
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+
+                    _temporaryFiles.Remove(path);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Failed to remove preparation artifact '{path}': {ex.Message}");
+                }
+            }
+        }
+
+        private void RestoreCapturedFile(string path, byte[]? originalContents)
+        {
+            if (originalContents is null)
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+
+                return;
+            }
+
+            var stagingPath = CreateTemporaryPath(path);
+            try
+            {
+                File.WriteAllBytes(stagingPath, originalContents);
+                File.Move(stagingPath, path, overwrite: true);
+            }
+            finally
+            {
+                if (File.Exists(stagingPath))
+                {
+                    File.Delete(stagingPath);
+                }
+            }
+        }
+
+        private void AtomicCopy(string sourcePath, string destinationPath)
+        {
+            var stagingPath = CreateTemporaryPath(destinationPath);
+            _temporaryFiles.Add(stagingPath);
+            File.Copy(sourcePath, stagingPath, overwrite: false);
+            File.Move(stagingPath, destinationPath, overwrite: true);
+            _temporaryFiles.Remove(stagingPath);
+        }
+
+        private bool FilesAreEqual(string firstPath, string secondPath)
+        {
+            var firstInfo = new FileInfo(firstPath);
+            var secondInfo = new FileInfo(secondPath);
+            if (firstInfo.Length != secondInfo.Length)
+            {
+                return false;
+            }
+
+            using var firstStream = File.OpenRead(firstPath);
+            using var secondStream = File.OpenRead(secondPath);
+            return SHA256.HashData(firstStream).SequenceEqual(SHA256.HashData(secondStream));
+        }
+
+        private string CreateTemporaryPath(string path)
+        {
+            return $"{path}.genhub-rollback-{Guid.NewGuid():N}";
+        }
     }
 }


### PR DESCRIPTION
## Summary

Prevent failed Steam proxy preparation from leaving the proxy installed.

## Changes

- Validate filesystem prerequisites before replacing the executable.
- Roll back mutations after failures or cancellation.
- Preserve pre-existing backups and artifacts.
- Retain recovery files when rollback cannot safely proceed.
- Add focused filesystem regression tests.

## Testing

- Release solution build passed.
- All 1,228 tests passed.

## Risks and rollback

Process termination can bypass managed rollback. File locks or concurrent changes may prevent restoration; recovery files are retained and reported.

## Related issues

Fixes #303

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Prevents failed Steam proxy preparation from leaving installation mutations behind.
- Serializes Steam launch setup by canonical installation path, including symbolic-link and junction aliases.
- Validates filesystem prerequisites before replacing the game executable.
- Restores captured files after preparation failures or cancellation and retains recovery artifacts when restoration is unsafe.
- Rejects unverified backups instead of treating stale backup contents as authoritative.
- Adds focused regression tests for cleanup, rollback, cancellation, backup handling, and concurrent launches.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported installation serialization, filesystem-alias, and stale-backup issues are addressed by the current locking and verification paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Launching/GameLauncher.cs | Serializes the complete Steam setup window by canonical installation path and now aborts when pre-launch cleanup cannot safely restore the installation. |
| GenHub/GenHub/Features/Launching/InstallationPathLockKey.cs | Canonicalizes existing symbolic-link and junction components so aliases of one physical installation share the same lock key. |
| GenHub/GenHub/Features/Launching/SteamLauncher.cs | Adds mutation serialization, prerequisite validation, verified backup handling, transactional rollback, and conflict-preserving recovery behavior. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs | Adds coverage proving that concurrent launches through physical and aliased installation paths serialize their Steam setup. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/SteamLauncherTests.cs | Adds filesystem regression coverage for preparation, cleanup, rollback, cancellation, stale backups, recovery states, and concurrent mutation attempts. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Steam profile launch] --> B[Canonicalize installation path]
    B --> C[Acquire installation launch lock]
    C --> D[Verify and clean prior proxy state]
    D --> E[Validate workspace and filesystem prerequisites]
    E --> F[Capture original files and executable]
    F --> G[Deploy proxy and write configuration]
    G --> H{Preparation succeeds?}
    H -->|Yes| I[Commit prepared state]
    H -->|No or canceled| J[Roll back current mutations]
    J --> K{Safe restoration possible?}
    K -->|Yes| L[Restore original state]
    K -->|No| M[Retain recovery files and report conflict]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(steam): canonicalize installation lo..."](https://github.com/community-outpost/genhub/commit/a4565f64eb9085638d43365c0c53839b17446290) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47617122)</sub>

**Context used:**

- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)

<!-- /greptile_comment -->