### PR TITLE
fix(manifest): use JSON file pattern during discovery

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
@@ -221,8 +221,17 @@ public class ManifestDiscoveryServiceTests : IDisposable
     /// </summary>
     public void Dispose()
     {
-        Directory.Delete(_tempDirectory, true);
-        GC.SuppressFinalize(this);
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, true);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort cleanup should not fail an otherwise successful test.
+        }
     }
 
     private static string SerializeManifest(string id)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
@@ -4,6 +4,7 @@ using GenHub.Core.Models.Manifest;
 using GenHub.Features.Manifest;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Text.Json;
 using ContentType = GenHub.Core.Models.Enums.ContentType;
 
 namespace GenHub.Tests.Features.Manifest;
@@ -11,7 +12,7 @@ namespace GenHub.Tests.Features.Manifest;
 /// <summary>
 /// Unit tests for the <see cref="ManifestDiscoveryService"/> class.
 /// </summary>
-public class ManifestDiscoveryServiceTests
+public class ManifestDiscoveryServiceTests : IDisposable
 {
     /// <summary>
     /// Mock logger for the manifest discovery service.
@@ -29,6 +30,11 @@ public class ManifestDiscoveryServiceTests
     private readonly ManifestDiscoveryService _discoveryService;
 
     /// <summary>
+    /// Temporary directory used for filesystem discovery tests.
+    /// </summary>
+    private readonly string _tempDirectory;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ManifestDiscoveryServiceTests"/> class.
     /// </summary>
     public ManifestDiscoveryServiceTests()
@@ -36,6 +42,7 @@ public class ManifestDiscoveryServiceTests
         _loggerMock = new Mock<ILogger<ManifestDiscoveryService>>();
         _cacheMock = new Mock<IManifestCache>();
         _discoveryService = new ManifestDiscoveryService(_loggerMock.Object, _cacheMock.Object);
+        _tempDirectory = Directory.CreateTempSubdirectory("GenHub.ManifestDiscoveryTests.").FullName;
     }
 
     /// <summary>
@@ -82,6 +89,58 @@ public class ManifestDiscoveryServiceTests
         // Assert
         Assert.Equal(2, generalsCompatible.Count());
         Assert.Single(zeroHourCompatible);
+    }
+
+    /// <summary>
+    /// Tests that manifest discovery finds JSON manifests in nested directories and ignores non-JSON files.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverManifestsAsync_DiscoversNestedJsonManifest_AndIgnoresNonJsonFile()
+    {
+        // Arrange
+        const string nestedManifestId = "1.0.genhub.mod.nested";
+        const string ignoredManifestId = "1.0.genhub.mod.ignored";
+        var nestedDirectory = Path.Combine(_tempDirectory, "content", "manifests");
+        Directory.CreateDirectory(nestedDirectory);
+        await File.WriteAllTextAsync(
+            Path.Combine(nestedDirectory, "nested.json"),
+            SerializeManifest(nestedManifestId));
+        await File.WriteAllTextAsync(
+            Path.Combine(_tempDirectory, "ignored.txt"),
+            SerializeManifest(ignoredManifestId));
+
+        // Act
+        var manifests = await _discoveryService.DiscoverManifestsAsync([_tempDirectory]);
+
+        // Assert
+        Assert.Single(manifests);
+        Assert.Contains(nestedManifestId, manifests);
+        Assert.DoesNotContain(ignoredManifestId, manifests);
+    }
+
+    /// <summary>
+    /// Tests that a malformed JSON file does not prevent other nested manifests from being discovered.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverManifestsAsync_WithMalformedJson_ContinuesDiscoveringNestedManifest()
+    {
+        // Arrange
+        const string nestedManifestId = "1.0.genhub.mod.valid";
+        var nestedDirectory = Path.Combine(_tempDirectory, "content", "manifests");
+        Directory.CreateDirectory(nestedDirectory);
+        await File.WriteAllTextAsync(
+            Path.Combine(nestedDirectory, "valid.json"),
+            SerializeManifest(nestedManifestId));
+        await File.WriteAllTextAsync(Path.Combine(_tempDirectory, "malformed.json"), "{ invalid json");
+
+        // Act
+        var manifests = await _discoveryService.DiscoverManifestsAsync([_tempDirectory]);
+
+        // Assert
+        var manifest = Assert.Single(manifests);
+        Assert.Equal(nestedManifestId, manifest.Key);
     }
 
     /// <summary>
@@ -155,5 +214,19 @@ public class ManifestDiscoveryServiceTests
 
         // Assert
         Assert.True(result);
+    }
+
+    /// <summary>
+    /// Deletes temporary files created by filesystem discovery tests.
+    /// </summary>
+    public void Dispose()
+    {
+        Directory.Delete(_tempDirectory, true);
+        GC.SuppressFinalize(this);
+    }
+
+    private static string SerializeManifest(string id)
+    {
+        return JsonSerializer.Serialize(new ContentManifest { Id = ManifestId.Create(id) });
     }
 }

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -61,7 +61,7 @@ public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, 
         foreach (var directory in searchDirectories.Where(Directory.Exists))
         {
             logger.LogInformation("Scanning directory for manifests: {Directory}", directory);
-            var manifestFiles = Directory.EnumerateFiles(directory, "FileTypes.JsonFilePattern", SearchOption.AllDirectories);
+            var manifestFiles = Directory.EnumerateFiles(directory, FileTypes.JsonFilePattern, SearchOption.AllDirectories);
             foreach (var manifestFile in manifestFiles)
             {
                 try


### PR DESCRIPTION
## Summary

Fix manifest discovery to use the configured JSON filename pattern instead of a literal identifier, restoring recursive filesystem discovery.

Add coverage for nested manifests, non-JSON files, and malformed JSON.

## Testing

- Focused manifest tests: 7 passed.
- Core Release suite: 1,210 passed.

## Follow-up

Unavailable-directory resilience is tracked in #308 and implemented separately in #309.

Closes #302

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Corrects filesystem manifest discovery and adds focused coverage.
- Replaces the literal search-pattern identifier with `FileTypes.JsonFilePattern`.
- Adds tests for recursive JSON discovery, non-JSON exclusion, malformed JSON handling, and temporary-directory cleanup.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The manifest-pattern correction works as intended, but the outstanding recursive-enumeration failure should be fixed before merging.

Recursive enumeration remains outside the exception handler, so an inaccessible or concurrently removed descendant can still abort discovery instead of preserving manifests from accessible paths.

**Files Needing Attention:** GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs | Uses the centralized JSON glob during recursive discovery; the previously reported directory-enumeration failure remains outstanding. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs | Adds filesystem-backed tests for nested manifests, filtering, malformed JSON, and best-effort fixture cleanup. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test(manifest): harden temporary directo..."](https://github.com/community-outpost/genhub/commit/1079387c77b87d8b25e09a69e27b6ed6e160a8d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47618364)</sub>

<!-- /greptile_comment -->