### PR TITLE
fix(manifest): continue past unavailable directories

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
@@ -144,6 +144,57 @@ public class ManifestDiscoveryServiceTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that unavailable descendants do not prevent discovery in accessible sibling directories.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DiscoverManifestsAsync_WithUnavailableDescendants_ContinuesDiscoveringAccessibleManifests()
+    {
+        // Arrange
+        const string accessibleManifestId = "1.0.genhub.mod.accessible";
+        var accessibleDirectory = Directory.CreateDirectory(
+            Path.Combine(_tempDirectory, "accessible")).FullName;
+        var inaccessibleDirectory = Directory.CreateDirectory(
+            Path.Combine(_tempDirectory, "inaccessible")).FullName;
+        var removedDirectory = Directory.CreateDirectory(
+            Path.Combine(_tempDirectory, "removed")).FullName;
+        await File.WriteAllTextAsync(
+            Path.Combine(accessibleDirectory, "accessible.json"),
+            SerializeManifest(accessibleManifestId));
+
+        IEnumerable<string> EnumerateFiles(string directory, string pattern)
+        {
+            if (directory == inaccessibleDirectory)
+            {
+                throw new UnauthorizedAccessException("Injected inaccessible directory.");
+            }
+
+            if (directory == removedDirectory)
+            {
+                throw new DirectoryNotFoundException("Injected concurrently removed directory.");
+            }
+
+            return Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly);
+        }
+
+        var discoveryService = new ManifestDiscoveryService(
+            _loggerMock.Object,
+            _cacheMock.Object,
+            EnumerateFiles,
+            directory => Directory.EnumerateDirectories(
+                directory,
+                "*",
+                SearchOption.TopDirectoryOnly));
+
+        // Act
+        var manifests = await discoveryService.DiscoverManifestsAsync([_tempDirectory]);
+
+        // Assert
+        var manifest = Assert.Single(manifests);
+        Assert.Equal(accessibleManifestId, manifest.Key);
+    }
+
+    /// <summary>
     /// Tests that ValidateDependencies returns false when a required dependency is missing.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
@@ -158,9 +158,16 @@ public class ManifestDiscoveryServiceTests : IDisposable
             Path.Combine(_tempDirectory, "inaccessible")).FullName;
         var removedDirectory = Directory.CreateDirectory(
             Path.Combine(_tempDirectory, "removed")).FullName;
+        var unlistableDirectory = Directory.CreateDirectory(
+            Path.Combine(_tempDirectory, "unlistable")).FullName;
+        var unreachableDirectory = Directory.CreateDirectory(
+            Path.Combine(unlistableDirectory, "unreachable")).FullName;
         await File.WriteAllTextAsync(
             Path.Combine(accessibleDirectory, "accessible.json"),
             SerializeManifest(accessibleManifestId));
+        await File.WriteAllTextAsync(
+            Path.Combine(unreachableDirectory, "unreachable.json"),
+            SerializeManifest("1.0.genhub.mod.unreachable"));
 
         IEnumerable<string> EnumerateFiles(string directory, string pattern)
         {
@@ -177,14 +184,21 @@ public class ManifestDiscoveryServiceTests : IDisposable
             return Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly);
         }
 
+        IEnumerable<string> EnumerateDirectories(string directory)
+        {
+            if (directory == unlistableDirectory)
+            {
+                throw new UnauthorizedAccessException("Injected unlistable directory.");
+            }
+
+            return Directory.EnumerateDirectories(directory, "*", SearchOption.TopDirectoryOnly);
+        }
+
         var discoveryService = new ManifestDiscoveryService(
             _loggerMock.Object,
             _cacheMock.Object,
             EnumerateFiles,
-            directory => Directory.EnumerateDirectories(
-                directory,
-                "*",
-                SearchOption.TopDirectoryOnly));
+            EnumerateDirectories);
 
         // Act
         var manifests = await discoveryService.DiscoverManifestsAsync([_tempDirectory]);

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -24,7 +24,7 @@ public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, 
         (directory, pattern) => Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly);
 
     private readonly Func<string, IEnumerable<string>> _enumerateDirectories =
-        directory => Directory.EnumerateDirectories(directory, "*", SearchOption.TopDirectoryOnly);
+        directory => Directory.EnumerateDirectories(directory);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ManifestDiscoveryService"/> class with filesystem test seams.

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -20,6 +20,29 @@ namespace GenHub.Features.Manifest;
 public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, IManifestCache manifestCache)
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private readonly Func<string, string, IEnumerable<string>> _enumerateFiles =
+        (directory, pattern) => Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly);
+
+    private readonly Func<string, IEnumerable<string>> _enumerateDirectories =
+        directory => Directory.EnumerateDirectories(directory, "*", SearchOption.TopDirectoryOnly);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManifestDiscoveryService"/> class with filesystem test seams.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="manifestCache">The manifest cache.</param>
+    /// <param name="enumerateFiles">The top-level file enumerator.</param>
+    /// <param name="enumerateDirectories">The top-level directory enumerator.</param>
+    internal ManifestDiscoveryService(
+        ILogger<ManifestDiscoveryService> logger,
+        IManifestCache manifestCache,
+        Func<string, string, IEnumerable<string>> enumerateFiles,
+        Func<string, IEnumerable<string>> enumerateDirectories)
+        : this(logger, manifestCache)
+    {
+        _enumerateFiles = enumerateFiles;
+        _enumerateDirectories = enumerateDirectories;
+    }
 
     /// <summary>
     /// Gets manifests by content type.
@@ -61,7 +84,10 @@ public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, 
         foreach (var directory in searchDirectories.Where(Directory.Exists))
         {
             logger.LogInformation("Scanning directory for manifests: {Directory}", directory);
-            var manifestFiles = Directory.EnumerateFiles(directory, FileTypes.JsonFilePattern, SearchOption.AllDirectories);
+            var manifestFiles = EnumerateFilesSafely(
+                directory,
+                FileTypes.JsonFilePattern,
+                cancellationToken);
             foreach (var manifestFile in manifestFiles)
             {
                 try
@@ -157,6 +183,11 @@ public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, 
         return true;
     }
 
+    private static bool IsSkippableEnumerationException(Exception exception)
+    {
+        return exception is UnauthorizedAccessException or IOException;
+    }
+
     private static bool IsVersionCompatible(string actualVersion, string minVersion, string maxVersion)
     {
         if (!string.IsNullOrEmpty(minVersion) && string.Compare(actualVersion, minVersion, StringComparison.OrdinalIgnoreCase) < 0)
@@ -184,16 +215,71 @@ public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, 
         return null;
     }
 
+    private IEnumerable<string> EnumerateFilesSafely(
+        string rootDirectory,
+        string searchPattern,
+        CancellationToken cancellationToken)
+    {
+        var pendingDirectories = new Stack<string>();
+        pendingDirectories.Push(rootDirectory);
+
+        while (pendingDirectories.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var currentDirectory = pendingDirectories.Pop();
+
+            string[] files;
+            try
+            {
+                files = _enumerateFiles(currentDirectory, searchPattern).ToArray();
+            }
+            catch (Exception ex) when (IsSkippableEnumerationException(ex))
+            {
+                logger.LogWarning(
+                    ex,
+                    "Skipping files in inaccessible or unavailable manifest directory: {Directory}",
+                    currentDirectory);
+                files = [];
+            }
+
+            foreach (var file in files)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return file;
+            }
+
+            string[] childDirectories;
+            try
+            {
+                childDirectories = _enumerateDirectories(currentDirectory).ToArray();
+            }
+            catch (Exception ex) when (IsSkippableEnumerationException(ex))
+            {
+                logger.LogWarning(
+                    ex,
+                    "Skipping inaccessible or unavailable manifest directory: {Directory}",
+                    currentDirectory);
+                childDirectories = [];
+            }
+
+            for (var index = childDirectories.Length - 1; index >= 0; index--)
+            {
+                pendingDirectories.Push(childDirectories[index]);
+            }
+        }
+    }
+
     private async Task DiscoverFileSystemManifestsAsync(IEnumerable<string> searchDirectories, CancellationToken cancellationToken)
     {
         foreach (var directory in searchDirectories.Where(Directory.Exists))
         {
             logger.LogInformation("Scanning directory for manifests: {Directory}", directory);
 
-            // Look for both .json and .manifest.json files to avoid conflicts with stored manifests
-            var manifestFiles = Directory.EnumerateFiles(directory, FileTypes.ManifestFilePattern, SearchOption.AllDirectories)
-                .Concat(Directory.EnumerateFiles(directory, "*.json", SearchOption.AllDirectories)
-                    .Where(f => !f.EndsWith(FileTypes.ManifestFileExtension)));
+            // The JSON pattern includes both .json and .manifest.json files.
+            var manifestFiles = EnumerateFilesSafely(
+                directory,
+                FileTypes.JsonFilePattern,
+                cancellationToken);
 
             foreach (var manifestFile in manifestFiles)
             {


### PR DESCRIPTION
## Summary

Prevent recursive manifest discovery from aborting when a nested directory is inaccessible or removed during enumeration.

Traverse directories individually, preserve cancellation, log skipped paths, and continue discovering manifests in accessible siblings.

Add deterministic coverage for inaccessible and concurrently removed directories.

## Testing

- Focused manifest tests: 8 passed.
- Core Release suite: 1,211 passed.

## Dependency

Stacked on #305. Retarget to `development` after #305 merges.

Closes #308

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates manifest discovery to continue scanning accessible sibling directories when nested paths become unavailable.
- Replaces all-directory enumeration with cancellation-aware, directory-by-directory traversal.
- Logs and skips filesystem enumeration failures caused by unavailable paths.
- Adds deterministic tests for inaccessible and concurrently removed directories.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs | Introduces resilient, cancellation-aware recursive traversal that skips unavailable directories while preserving discovery in accessible siblings. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs | Adds deterministic coverage for file and child-directory enumeration failures during recursive discovery. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push manifest root] --> B{Pending directories?}
    B -->|No| Z[Discovery complete]
    B -->|Yes| C[Pop next directory]
    C --> D[Check cancellation]
    D --> E[Enumerate matching files]
    E -->|Unavailable| F[Log warning and skip files]
    E -->|Success| G[Process discovered manifests]
    F --> H[Enumerate child directories]
    G --> H
    H -->|Unavailable| I[Log warning and skip descendants]
    H -->|Success| J[Push child directories]
    I --> B
    J --> B
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(manifest): cover directory enumerat..."](https://github.com/community-outpost/genhub/commit/ace7451f9892bdd1a85ffba3ebefda84a4c1ad66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47898426)</sub>

<!-- /greptile_comment -->