### PR TITLE
fix: disable unsafe CAS garbage collection

### DIFF
--- a/GenHub/GenHub.Core/Constants/CasDefaults.cs
+++ b/GenHub/GenHub.Core/Constants/CasDefaults.cs
@@ -24,4 +24,10 @@ public static class CasDefaults
     /// Default garbage collection grace period in days.
     /// </summary>
     public const int GcGracePeriodDays = 7;
+
+    /// <summary>
+    /// Explains why destructive CAS garbage collection is currently unavailable.
+    /// </summary>
+    public const string GarbageCollectionDisabledMessage =
+        "CAS garbage collection is disabled until complete reachability tracking is proven safe. No CAS blobs were deleted.";
 }

--- a/GenHub/GenHub.Core/Interfaces/Storage/ICasLifecycleManager.cs
+++ b/GenHub/GenHub.Core/Interfaces/Storage/ICasLifecycleManager.cs
@@ -37,13 +37,13 @@ public interface ICasLifecycleManager
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Runs garbage collection immediately.
-    /// Should only be called AFTER all untrack operations are complete.
+    /// Requests garbage collection.
+    /// Destructive collection is currently disabled until reachability tracking is proven complete.
     /// </summary>
     /// <param name="force">Whether to force collection regardless of grace period.</param>
     /// <param name="lockTimeout">Optional timeout to wait for the GC lock. Defaults to 5 seconds if not specified.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Result with GC statistics.</returns>
+    /// <returns>A disabled result with zero deletion statistics.</returns>
     Task<OperationResult<GarbageCollectionStats>> RunGarbageCollectionAsync(
         bool force = false,
         TimeSpan? lockTimeout = null,

--- a/GenHub/GenHub.Core/Interfaces/Storage/ICasService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Storage/ICasService.cs
@@ -53,11 +53,12 @@ public interface ICasService
     Task<OperationResult<Stream>> OpenContentStreamAsync(string hash, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Runs garbage collection to remove unreferenced content.
+    /// Requests garbage collection of unreferenced content.
+    /// Destructive collection is currently disabled until reachability tracking is proven complete.
     /// </summary>
     /// <param name="force">If true, ignores the grace period and deletes all unreferenced objects immediately.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result of the garbage collection operation.</returns>
+    /// <returns>A clear disabled result; no CAS blobs are deleted.</returns>
     Task<CasGarbageCollectionResult> RunGarbageCollectionAsync(bool force = false, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/GenHub/GenHub.Core/Models/Content/ContentRemovalResult.cs
+++ b/GenHub/GenHub.Core/Models/Content/ContentRemovalResult.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace GenHub.Core.Models.Content;
 
@@ -36,4 +37,9 @@ public record ContentRemovalResult
     /// Gets the duration of the operation.
     /// </summary>
     public TimeSpan Duration { get; init; }
+
+    /// <summary>
+    /// Gets non-fatal warnings reported during removal.
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
 }

--- a/GenHub/GenHub.Core/Models/Results/CAS/CasGarbageCollectionResult.cs
+++ b/GenHub/GenHub.Core/Models/Results/CAS/CasGarbageCollectionResult.cs
@@ -1,3 +1,5 @@
+using GenHub.Core.Constants;
+
 namespace GenHub.Core.Models.Results.CAS;
 
 /// <summary>
@@ -5,6 +7,20 @@ namespace GenHub.Core.Models.Results.CAS;
 /// </summary>
 public class CasGarbageCollectionResult : ResultBase
 {
+    /// <summary>
+    /// Creates the fail-closed result returned while destructive garbage collection is disabled.
+    /// </summary>
+    /// <returns>A disabled result that reports zero deletion.</returns>
+    public static CasGarbageCollectionResult CreateDisabled()
+    {
+        return new CasGarbageCollectionResult(
+            false,
+            CasDefaults.GarbageCollectionDisabledMessage)
+        {
+            Disabled = true,
+        };
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CasGarbageCollectionResult"/> class.
     /// </summary>
@@ -38,6 +54,11 @@ public class CasGarbageCollectionResult : ResultBase
 
     /// <summary>Gets or sets the number of objects that were referenced and kept.</summary>
     public int ObjectsReferenced { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether destructive garbage collection is disabled.
+    /// </summary>
+    public bool Disabled { get; init; }
 
     /// <summary>Gets the percentage of storage freed.</summary>
     public double PercentageFreed

--- a/GenHub/GenHub.Core/Models/Storage/GarbageCollectionStats.cs
+++ b/GenHub/GenHub.Core/Models/Storage/GarbageCollectionStats.cs
@@ -43,6 +43,11 @@ public record GarbageCollectionStats
     public bool InProgress { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether collection was blocked because destructive GC is disabled.
+    /// </summary>
+    public bool Disabled { get; init; }
+
+    /// <summary>
     /// Gets a static instance representing a skipped GC operation.
     /// </summary>
     public static GarbageCollectionStats SkippedResult { get; } = new()
@@ -68,5 +73,20 @@ public record GarbageCollectionStats
         Duration = TimeSpan.Zero,
         Skipped = true,
         InProgress = true,
+    };
+
+    /// <summary>
+    /// Gets a static instance representing fail-closed disabled garbage collection.
+    /// </summary>
+    public static GarbageCollectionStats DisabledResult { get; } = new()
+    {
+        ObjectsScanned = 0,
+        ObjectsReferenced = 0,
+        ObjectsDeleted = 0,
+        BytesFreed = 0,
+        Duration = TimeSpan.Zero,
+        Skipped = true,
+        InProgress = false,
+        Disabled = true,
     };
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -12,6 +12,7 @@ using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameProfile;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
+using GenHub.Core.Models.Results.CAS;
 using GenHub.Core.Models.Storage;
 using GenHub.Core.Models.Workspace;
 using GenHub.Features.AppUpdate.Interfaces;
@@ -338,7 +339,7 @@ public class SettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DeleteCasStorageCommand_CallsService()
+    public async Task DeleteCasStorageCommand_ReportsGarbageCollectionIsDisabled()
     {
         // Arrange
         // Setup stats to return valid data so update method works
@@ -350,6 +351,9 @@ public class SettingsViewModelTests
             .ReturnsAsync(OperationResult<IEnumerable<WorkspaceInfo>>.CreateSuccess([]));
         _mockProfileManager.Setup(x => x.GetAllProfilesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(ProfileOperationResult<IReadOnlyList<GameProfile>>.CreateSuccess([]));
+        _mockCasService
+            .Setup(x => x.RunGarbageCollectionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CasGarbageCollectionResult.CreateDisabled());
 
         var viewModel = new SettingsViewModel(
             _mockConfigService.Object,
@@ -370,6 +374,20 @@ public class SettingsViewModelTests
 
         // Assert
         _mockCasService.Verify(x => x.RunGarbageCollectionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockNotificationService.Verify(
+            service => service.ShowInfo(
+                "CAS Cleanup Disabled",
+                CasDefaults.GarbageCollectionDisabledMessage,
+                It.IsAny<int?>(),
+                It.IsAny<bool>()),
+            Times.Once);
+        _mockNotificationService.Verify(
+            service => service.ShowSuccess(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>()),
+            Times.Never);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -378,7 +378,7 @@ public class SettingsViewModelTests
             service => service.ShowInfo(
                 "CAS Cleanup Disabled",
                 CasDefaults.GarbageCollectionDisabledMessage,
-                It.IsAny<int?>(),
+                (int)TimeIntervals.NotificationHideDelay.TotalMilliseconds,
                 It.IsAny<bool>()),
             Times.Once);
         _mockNotificationService.Verify(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ContentReconciliationOrchestratorGarbageCollectionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ContentReconciliationOrchestratorGarbageCollectionTests.cs
@@ -1,0 +1,117 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Results;
+using GenHub.Core.Models.Storage;
+using GenHub.Features.Content.Services.Reconciliation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace GenHub.Tests.Core.Features.Reconciliation;
+
+/// <summary>
+/// Verifies that reconciliation reports disabled garbage collection without failing
+/// otherwise-successful manifest operations.
+/// </summary>
+public class ContentReconciliationOrchestratorGarbageCollectionTests
+{
+    /// <summary>
+    /// Verifies that replacement results expose the disabled-GC warning.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ExecuteContentReplacementAsync_WhenGcDisabled_ReturnsWarning()
+    {
+        var reconciliationService = new Mock<IContentReconciliationService>();
+        reconciliationService
+            .Setup(service => service.OrchestrateBulkUpdateAsync(
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ReconciliationResult>.CreateSuccess(
+                ReconciliationResult.Empty));
+
+        var orchestrator = CreateOrchestrator(
+            reconciliationService,
+            CreateDisabledLifecycleManager());
+        var request = new ContentReplacementRequest
+        {
+            ManifestMapping = new Dictionary<string, string>
+            {
+                ["1.0.publisher.mod.old"] = "2.0.publisher.mod.new",
+            },
+            RemoveOldManifests = false,
+        };
+
+        var result = await orchestrator.ExecuteContentReplacementAsync(request);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains(CasDefaults.GarbageCollectionDisabledMessage, result.Data.Warnings);
+        Assert.Equal(0, result.Data.CasObjectsCollected);
+        Assert.Equal(0, result.Data.BytesFreed);
+    }
+
+    /// <summary>
+    /// Verifies that removal results expose the disabled-GC warning.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ExecuteContentRemovalAsync_WhenGcDisabled_ReturnsWarning()
+    {
+        var reconciliationService = new Mock<IContentReconciliationService>();
+        var lifecycleManager = CreateDisabledLifecycleManager();
+        lifecycleManager
+            .Setup(manager => manager.UntrackManifestsAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<BulkUntrackResult>.CreateSuccess(
+                new BulkUntrackResult(0, 0, [])));
+
+        var orchestrator = CreateOrchestrator(reconciliationService, lifecycleManager);
+
+        var result = await orchestrator.ExecuteContentRemovalAsync([]);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains(CasDefaults.GarbageCollectionDisabledMessage, result.Data.Warnings);
+        Assert.Equal(0, result.Data.CasObjectsCollected);
+        Assert.Equal(0, result.Data.BytesFreed);
+    }
+
+    private static Mock<ICasLifecycleManager> CreateDisabledLifecycleManager()
+    {
+        var lifecycleManager = new Mock<ICasLifecycleManager>();
+        lifecycleManager
+            .Setup(manager => manager.RunGarbageCollectionAsync(
+                It.IsAny<bool>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GarbageCollectionStats>.CreateFailure(
+                CasDefaults.GarbageCollectionDisabledMessage,
+                GarbageCollectionStats.DisabledResult,
+                TimeSpan.Zero));
+        return lifecycleManager;
+    }
+
+    private static ContentReconciliationOrchestrator CreateOrchestrator(
+        Mock<IContentReconciliationService> reconciliationService,
+        Mock<ICasLifecycleManager> lifecycleManager)
+    {
+        var auditLog = new Mock<IReconciliationAuditLog>();
+        auditLog
+            .Setup(log => log.LogOperationAsync(
+                It.IsAny<ReconciliationAuditEntry>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        return new ContentReconciliationOrchestrator(
+            reconciliationService.Object,
+            Mock.Of<IContentManifestPool>(),
+            lifecycleManager.Object,
+            auditLog.Object,
+            NullLogger<ContentReconciliationOrchestrator>.Instance);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ContentReconciliationOrchestratorGarbageCollectionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ContentReconciliationOrchestratorGarbageCollectionTests.cs
@@ -33,9 +33,11 @@ public class ContentReconciliationOrchestratorGarbageCollectionTests
             .ReturnsAsync(OperationResult<ReconciliationResult>.CreateSuccess(
                 ReconciliationResult.Empty));
 
+        var auditEntries = new List<ReconciliationAuditEntry>();
         var orchestrator = CreateOrchestrator(
             reconciliationService,
-            CreateDisabledLifecycleManager());
+            CreateDisabledLifecycleManager(),
+            auditEntries);
         var request = new ContentReplacementRequest
         {
             ManifestMapping = new Dictionary<string, string>
@@ -52,6 +54,9 @@ public class ContentReconciliationOrchestratorGarbageCollectionTests
         Assert.Contains(CasDefaults.GarbageCollectionDisabledMessage, result.Data.Warnings);
         Assert.Equal(0, result.Data.CasObjectsCollected);
         Assert.Equal(0, result.Data.BytesFreed);
+        var auditEntry = Assert.Single(auditEntries);
+        Assert.NotNull(auditEntry.Metadata);
+        Assert.Contains(CasDefaults.GarbageCollectionDisabledMessage, auditEntry.Metadata["warnings"]);
     }
 
     /// <summary>
@@ -70,7 +75,8 @@ public class ContentReconciliationOrchestratorGarbageCollectionTests
             .ReturnsAsync(OperationResult<BulkUntrackResult>.CreateSuccess(
                 new BulkUntrackResult(0, 0, [])));
 
-        var orchestrator = CreateOrchestrator(reconciliationService, lifecycleManager);
+        var auditEntries = new List<ReconciliationAuditEntry>();
+        var orchestrator = CreateOrchestrator(reconciliationService, lifecycleManager, auditEntries);
 
         var result = await orchestrator.ExecuteContentRemovalAsync([]);
 
@@ -79,6 +85,9 @@ public class ContentReconciliationOrchestratorGarbageCollectionTests
         Assert.Contains(CasDefaults.GarbageCollectionDisabledMessage, result.Data.Warnings);
         Assert.Equal(0, result.Data.CasObjectsCollected);
         Assert.Equal(0, result.Data.BytesFreed);
+        var auditEntry = Assert.Single(auditEntries);
+        Assert.NotNull(auditEntry.Metadata);
+        Assert.Contains(CasDefaults.GarbageCollectionDisabledMessage, auditEntry.Metadata["warnings"]);
     }
 
     private static Mock<ICasLifecycleManager> CreateDisabledLifecycleManager()
@@ -98,13 +107,15 @@ public class ContentReconciliationOrchestratorGarbageCollectionTests
 
     private static ContentReconciliationOrchestrator CreateOrchestrator(
         Mock<IContentReconciliationService> reconciliationService,
-        Mock<ICasLifecycleManager> lifecycleManager)
+        Mock<ICasLifecycleManager> lifecycleManager,
+        List<ReconciliationAuditEntry>? auditEntries = null)
     {
         var auditLog = new Mock<IReconciliationAuditLog>();
         auditLog
             .Setup(log => log.LogOperationAsync(
                 It.IsAny<ReconciliationAuditEntry>(),
                 It.IsAny<CancellationToken>()))
+            .Callback<ReconciliationAuditEntry, CancellationToken>((entry, _) => auditEntries?.Add(entry))
             .Returns(Task.CompletedTask);
 
         return new ContentReconciliationOrchestrator(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasGarbageCollectionDisabledTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasGarbageCollectionDisabledTests.cs
@@ -1,0 +1,77 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Models.Results.CAS;
+using GenHub.Core.Models.Storage;
+using GenHub.Features.Storage.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace GenHub.Tests.Core.Features.Storage;
+
+/// <summary>
+/// Verifies that every programmatic CAS garbage-collection layer fails closed.
+/// </summary>
+public class CasGarbageCollectionDisabledTests
+{
+    /// <summary>
+    /// Verifies that direct service calls cannot scan or delete CAS blobs, including forced calls.
+    /// </summary>
+    /// <param name="force">Whether the caller requests forced collection.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CasService_RunGarbageCollectionAsync_IsDisabledWithoutStorageAccess(bool force)
+    {
+        var storage = new Mock<ICasStorage>(MockBehavior.Strict);
+        var referenceTracker = new Mock<ICasReferenceTracker>(MockBehavior.Strict);
+        var service = new CasService(
+            storage.Object,
+            referenceTracker.Object,
+            NullLogger<CasService>.Instance,
+            Options.Create(new CasConfiguration()),
+            Mock.Of<IFileHashProvider>(),
+            Mock.Of<IStreamHashProvider>());
+
+        var result = await service.RunGarbageCollectionAsync(force);
+
+        Assert.False(result.Success);
+        Assert.True(result.Disabled);
+        Assert.Equal(CasDefaults.GarbageCollectionDisabledMessage, result.FirstError);
+        Assert.Equal(0, result.ObjectsDeleted);
+        Assert.Equal(0, result.BytesFreed);
+        storage.VerifyNoOtherCalls();
+        referenceTracker.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// Verifies that the lifecycle API preserves the disabled result and reports no deletion.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CasLifecycleManager_RunGarbageCollectionAsync_ReportsDisabled()
+    {
+        var casService = new Mock<ICasService>();
+        casService
+            .Setup(service => service.RunGarbageCollectionAsync(true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CasGarbageCollectionResult.CreateDisabled());
+
+        using var lifecycleManager = new CasLifecycleManager(
+            Mock.Of<ICasReferenceTracker>(),
+            casService.Object,
+            Mock.Of<ICasStorage>(),
+            Options.Create(new CasConfiguration()),
+            NullLogger<CasLifecycleManager>.Instance);
+
+        var result = await lifecycleManager.RunGarbageCollectionAsync(force: true);
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.True(result.Data.Disabled);
+        Assert.Equal(CasDefaults.GarbageCollectionDisabledMessage, result.FirstError);
+        Assert.Equal(0, result.Data.ObjectsDeleted);
+        Assert.Equal(0, result.Data.BytesFreed);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasGarbageCollectionResultTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasGarbageCollectionResultTests.cs
@@ -1,3 +1,4 @@
+using GenHub.Core.Constants;
 using GenHub.Core.Models.Results.CAS;
 
 namespace GenHub.Tests.Core.Features.Storage;
@@ -142,5 +143,20 @@ public class CasGarbageCollectionResultTests
         Assert.Equal(50, result.ObjectsScanned);
         Assert.Equal(40, result.ObjectsReferenced);
         Assert.Equal(20.0, result.PercentageFreed);
+    }
+
+    /// <summary>
+    /// Verifies that the disabled factory returns a clear fail-closed result.
+    /// </summary>
+    [Fact]
+    public void CreateDisabled_ReturnsClearDisabledResult()
+    {
+        var result = CasGarbageCollectionResult.CreateDisabled();
+
+        Assert.False(result.Success);
+        Assert.True(result.Disabled);
+        Assert.Equal(CasDefaults.GarbageCollectionDisabledMessage, result.FirstError);
+        Assert.Equal(0, result.ObjectsDeleted);
+        Assert.Equal(0, result.BytesFreed);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
@@ -256,4 +256,28 @@ public class ContentReconciliationServiceTests
                 It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    /// <summary>
+    /// Verifies that scheduled garbage collection reports the fail-closed disabled result.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ScheduleGarbageCollectionAsync_WhenDisabled_ReturnsFailure()
+    {
+        _casServiceMock
+            .Setup(service => service.RunGarbageCollectionAsync(
+                It.IsAny<bool>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GarbageCollectionStats>.CreateFailure(
+                GenHub.Core.Constants.CasDefaults.GarbageCollectionDisabledMessage,
+                GarbageCollectionStats.DisabledResult,
+                TimeSpan.Zero));
+
+        var result = await _service.ScheduleGarbageCollectionAsync(force: true);
+
+        result.Success.Should().BeFalse();
+        result.FirstError.Should().Be(
+            GenHub.Core.Constants.CasDefaults.GarbageCollectionDisabledMessage);
+    }
 }

--- a/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentReconciliationService.cs
@@ -354,9 +354,14 @@ public class ContentReconciliationService(
                 try
                 {
                     var gcResult = await casLifecycleManager.RunGarbageCollectionAsync(force, lockTimeout: null, cancellationToken);
-                    return gcResult.Success
-                        ? OperationResult.CreateSuccess()
-                        : OperationResult.CreateFailure(gcResult.FirstError ?? "GC failed");
+                    if (gcResult.Success)
+                    {
+                        return OperationResult.CreateSuccess();
+                    }
+
+                    var error = gcResult.FirstError ?? "GC failed";
+                    logger.LogWarning("Scheduled garbage collection did not run: {Error}", error);
+                    return OperationResult.CreateFailure(error);
                 }
                 catch (OperationCanceledException)
                 {

--- a/GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs
@@ -177,6 +177,19 @@ public class ContentReconciliationOrchestrator(
                 Warnings = warnings,
             };
 
+            var auditMetadata = new Dictionary<string, string>
+            {
+                ["profilesUpdated"] = profilesUpdated.ToString(),
+                ["workspacesInvalidated"] = workspacesInvalidated.ToString(),
+                ["manifestsRemoved"] = manifestsRemoved.ToString(),
+                ["casObjectsCollected"] = casObjectsCollected.ToString(),
+                ["bytesFreed"] = bytesFreed.ToString(),
+            };
+            if (warnings.Count > 0)
+            {
+                auditMetadata["warnings"] = string.Join("; ", warnings);
+            }
+
             await auditLog.LogOperationAsync(
                 new ReconciliationAuditEntry
                 {
@@ -189,14 +202,7 @@ public class ContentReconciliationOrchestrator(
                     Success = !criticalFailureOccurred,
                     ErrorMessage = criticalFailureOccurred ? string.Join("; ", warnings) : null,
                     Duration = stopwatch.Elapsed,
-                    Metadata = new Dictionary<string, string>
-                    {
-                        ["profilesUpdated"] = profilesUpdated.ToString(),
-                        ["workspacesInvalidated"] = workspacesInvalidated.ToString(),
-                        ["manifestsRemoved"] = manifestsRemoved.ToString(),
-                        ["casObjectsCollected"] = casObjectsCollected.ToString(),
-                        ["bytesFreed"] = bytesFreed.ToString(),
-                    },
+                    Metadata = auditMetadata,
                 },
                 cancellationToken);
 
@@ -394,6 +400,19 @@ public class ContentReconciliationOrchestrator(
                 Warnings = warnings,
             };
 
+            var auditMetadata = new Dictionary<string, string>
+            {
+                ["profilesUpdated"] = profilesUpdated.ToString(),
+                ["workspacesInvalidated"] = invalidatedWorkspacesCount.ToString(),
+                ["manifestsRemoved"] = manifestsRemoved.ToString(),
+                ["casObjectsCollected"] = casObjectsCollected.ToString(),
+                ["bytesFreed"] = bytesFreed.ToString(),
+            };
+            if (warnings.Count > 0)
+            {
+                auditMetadata["warnings"] = string.Join("; ", warnings);
+            }
+
             await auditLog.LogOperationAsync(
                 new ReconciliationAuditEntry
                 {
@@ -403,14 +422,7 @@ public class ContentReconciliationOrchestrator(
                     AffectedManifestIds = ids,
                     Success = !criticalFailureOccurred,
                     ErrorMessage = criticalFailureOccurred ? "One or more manifests failed to untrack or be removed from the pool." : null,
-                    Metadata = new Dictionary<string, string>
-                    {
-                        ["profilesUpdated"] = profilesUpdated.ToString(),
-                        ["workspacesInvalidated"] = invalidatedWorkspacesCount.ToString(),
-                        ["manifestsRemoved"] = manifestsRemoved.ToString(),
-                        ["casObjectsCollected"] = casObjectsCollected.ToString(),
-                        ["bytesFreed"] = bytesFreed.ToString(),
-                    },
+                    Metadata = auditMetadata,
                     Duration = stopwatch.Elapsed,
                 },
                 cancellationToken);

--- a/GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs
@@ -155,6 +155,12 @@ public class ContentReconciliationOrchestrator(
                         casObjectsCollected = gcResult.Data.ObjectsDeleted;
                         bytesFreed = gcResult.Data.BytesFreed;
                     }
+                    else
+                    {
+                        var warning = gcResult.FirstError ?? "Garbage collection did not run";
+                        warnings.Add(warning);
+                        logger.LogWarning("[Orchestrator:{OpId}] {Warning}", operationId, warning);
+                    }
                 }
             }
 
@@ -267,6 +273,7 @@ public class ContentReconciliationOrchestrator(
         var stopwatch = Stopwatch.StartNew();
         var operationId = Guid.NewGuid().ToString("N")[..ReconciliationConstants.OperationIdLength];
         var ids = manifestIds.ToList();
+        var warnings = new List<string>();
 
         logger.LogInformation(
             "[Orchestrator:{OpId}] Starting content removal for {Count} manifests",
@@ -366,6 +373,12 @@ public class ContentReconciliationOrchestrator(
                     casObjectsCollected = gcResult.Data.ObjectsDeleted;
                     bytesFreed = gcResult.Data.BytesFreed;
                 }
+                else
+                {
+                    var warning = gcResult.FirstError ?? "Garbage collection did not run";
+                    warnings.Add(warning);
+                    logger.LogWarning("[Orchestrator:{OpId}] {Warning}", operationId, warning);
+                }
             }
 
             stopwatch.Stop();
@@ -378,6 +391,7 @@ public class ContentReconciliationOrchestrator(
                 CasObjectsCollected = casObjectsCollected,
                 BytesFreed = bytesFreed,
                 Duration = stopwatch.Elapsed,
+                Warnings = warnings,
             };
 
             await auditLog.LogOperationAsync(

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1088,7 +1088,10 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _installationService.InvalidateCache();
 
         await UpdateDangerZoneDataAsync();
-        _notificationService.ShowSuccess("Data Deleted", "All application data has been deleted successfully.", 5000);
+        _notificationService.ShowSuccess(
+            "Data Deleted",
+            $"Profiles, workspaces, manifests, and user data were deleted. {CasDefaults.GarbageCollectionDisabledMessage}",
+            5000);
     }
 
     [RelayCommand]
@@ -1112,7 +1115,14 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         {
             _logger.LogWarning("Deleting CAS storage (forced)");
             var result = await _casService.RunGarbageCollectionAsync(force: true, CancellationToken.None);
-            if (result.ObjectsDeleted == 0)
+            if (result.Disabled)
+            {
+                _notificationService.ShowInfo(
+                    "CAS Cleanup Disabled",
+                    result.FirstError ?? CasDefaults.GarbageCollectionDisabledMessage,
+                    TimeIntervals.NotificationHideDelay.Milliseconds);
+            }
+            else if (result.ObjectsDeleted == 0)
             {
                 if (result.ObjectsReferenced > 0)
                 {

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1120,17 +1120,17 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
                 _notificationService.ShowInfo(
                     "CAS Cleanup Disabled",
                     result.FirstError ?? CasDefaults.GarbageCollectionDisabledMessage,
-                    TimeIntervals.NotificationHideDelay.Milliseconds);
+                    (int)TimeIntervals.NotificationHideDelay.TotalMilliseconds);
             }
             else if (result.ObjectsDeleted == 0)
             {
                 if (result.ObjectsReferenced > 0)
                 {
-                    _notificationService.ShowInfo("CAS Clean", "All items in CAS are currently in use and cannot be deleted.", TimeIntervals.NotificationHideDelay.Milliseconds);
+                    _notificationService.ShowInfo("CAS Clean", "All items in CAS are currently in use and cannot be deleted.", (int)TimeIntervals.NotificationHideDelay.TotalMilliseconds);
                 }
                 else
                 {
-                    _notificationService.ShowInfo("CAS Empty", "CAS storage is already empty.", TimeIntervals.NotificationHideDelay.Milliseconds);
+                    _notificationService.ShowInfo("CAS Empty", "CAS storage is already empty.", (int)TimeIntervals.NotificationHideDelay.TotalMilliseconds);
                 }
             }
             else
@@ -1162,7 +1162,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
                     await _manifestPool.RemoveManifestAsync(manifest.Id);
                 }
 
-                _notificationService.ShowSuccess("Manifests Deleted", $"Deleted {count} manifest(s) successfully.", TimeIntervals.NotificationHideDelay.Milliseconds);
+                _notificationService.ShowSuccess("Manifests Deleted", $"Deleted {count} manifest(s) successfully.", (int)TimeIntervals.NotificationHideDelay.TotalMilliseconds);
             }
 
             await UpdateDangerZoneDataAsync();

--- a/GenHub/GenHub/Features/Storage/Services/CasLifecycleManager.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasLifecycleManager.cs
@@ -181,8 +181,19 @@ public class CasLifecycleManager(
                 ObjectsDeleted = gcResult.ObjectsDeleted,
                 BytesFreed = gcResult.BytesFreed,
                 Duration = stopwatch.Elapsed,
-                Skipped = false,
+                Skipped = gcResult.Disabled,
+                Disabled = gcResult.Disabled,
             };
+
+            if (!gcResult.Success)
+            {
+                var error = gcResult.FirstError ?? "CAS garbage collection failed";
+                logger.LogWarning("Garbage collection did not run: {Error}", error);
+                return OperationResult<GarbageCollectionStats>.CreateFailure(
+                    error,
+                    stats,
+                    stopwatch.Elapsed);
+            }
 
             logger.LogInformation(
                 "GC completed: scanned={Scanned}, referenced={Referenced}, deleted={Deleted}, freed={Bytes} bytes",

--- a/GenHub/GenHub/Features/Storage/Services/CasMaintenanceService.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasMaintenanceService.cs
@@ -76,7 +76,13 @@ public class CasMaintenanceService(
         // Run garbage collection
         var gcResult = await casService.RunGarbageCollectionAsync(cancellationToken: cancellationToken);
 
-        if (gcResult.Success)
+        if (gcResult.Disabled)
+        {
+            logger.LogWarning(
+                "CAS garbage collection did not run: {Reason}",
+                gcResult.FirstError);
+        }
+        else if (gcResult.Success)
         {
             logger.LogInformation("CAS garbage collection completed: {ObjectsDeleted} objects deleted, {BytesFreed:N0} bytes freed in {Elapsed}", gcResult.ObjectsDeleted, gcResult.BytesFreed, gcResult.Elapsed);
         }

--- a/GenHub/GenHub/Features/Storage/Services/CasService.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasService.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Enums;
@@ -25,8 +26,6 @@ public class CasService(
     IStreamHashProvider streamHashProvider,
     ICasPoolManager? poolManager = null) : ICasService
 {
-    private readonly CasConfiguration _config = config.Value;
-
     /// <inheritdoc/>
     public async Task<OperationResult<string>> StoreContentAsync(string sourcePath, string? expectedHash = null, CancellationToken cancellationToken = default)
     {
@@ -257,68 +256,21 @@ public class CasService(
     }
 
     /// <inheritdoc/>
-    public async Task<CasGarbageCollectionResult> RunGarbageCollectionAsync(bool force = false, CancellationToken cancellationToken = default)
+    public Task<CasGarbageCollectionResult> RunGarbageCollectionAsync(
+        bool force = false,
+        CancellationToken cancellationToken = default)
     {
-        var startTime = DateTime.UtcNow;
-        var result = new CasGarbageCollectionResult(true, (string?)null);
+        _ = referenceTracker;
+        _ = config;
 
-        try
-        {
-            logger.LogInformation("Starting CAS garbage collection (force={Force})", force);
-
-            // Get all objects in CAS
-            var allHashes = await storage.GetAllObjectHashesAsync(cancellationToken);
-            result.ObjectsScanned = allHashes.Length;
-
-            // Get all referenced hashes
-            var referencedHashes = await referenceTracker.GetAllReferencedHashesAsync(cancellationToken);
-            result.ObjectsReferenced = referencedHashes.Count;
-
-            // Find unreferenced objects
-            var unreferencedHashes = System.Linq.Enumerable.Except(allHashes, referencedHashes);
-
-            // Use configurable grace period unless forced
-            var gracePeriod = force ? TimeSpan.Zero : _config.GcGracePeriod;
-            long bytesFreed = 0;
-            int objectsDeleted = 0;
-
-            foreach (var hash in unreferencedHashes)
-            {
-                try
-                {
-                    var creationTime = await storage.GetObjectCreationTimeAsync(hash, cancellationToken);
-                    if (force || creationTime == null || DateTime.UtcNow - creationTime.Value > gracePeriod)
-                    {
-                        // Get size before deletion
-                        var objectPath = storage.GetObjectPath(hash);
-                        if (File.Exists(objectPath))
-                        {
-                            var fileInfo = new FileInfo(objectPath);
-                            bytesFreed += fileInfo.Length;
-                        }
-
-                        await storage.DeleteObjectAsync(hash, cancellationToken);
-                        objectsDeleted++;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "Failed to delete unreferenced object {Hash}", hash);
-                }
-            }
-
-            result.ObjectsDeleted = objectsDeleted;
-            result.BytesFreed = bytesFreed;
-
-            logger.LogInformation("CAS garbage collection completed: {ObjectsDeleted} objects deleted, {BytesFreed} bytes freed", objectsDeleted, bytesFreed);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "CAS garbage collection failed");
-            result = new CasGarbageCollectionResult(false, ex.Message, DateTime.UtcNow - startTime);
-        }
-
-        return result;
+        // Re-enable only after references cover every persisted manifest, workspace, user-data
+        // link, and CAS pool; startup can rebuild and audit that graph; and crash/concurrency
+        // tests prove that no live blob can be classified as unreachable.
+        logger.LogWarning(
+            "{Message} Requested force={Force}",
+            CasDefaults.GarbageCollectionDisabledMessage,
+            force);
+        return Task.FromResult(CasGarbageCollectionResult.CreateDisabled());
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary

Disables the destructive CAS garbage collection path fail-closed until reference tracking is provably complete.

## Changes

- `CasService.RunGarbageCollectionAsync` no longer deletes objects; it returns an explicit `CasGarbageCollectionResult.CreateDisabled()` and logs why.
- `CasLifecycleManager` propagates the disabled/failed state instead of reporting a successful run.
- Settings surfaces the disabled state; collection statistics types gain a `Disabled` flag.
- Tests assert no deletion occurs (`CasGarbageCollectionDisabledTests`, orchestrator GC tests).

## Why

The reference tracker does not cover every live reference source (persisted manifests, existing workspaces, user-data links, CAS pools), so live blobs can be classified unreachable and permanently deleted — surfacing later as failed or silently incomplete workspace preparation. Re-enable criteria are listed in #310.

## Testing

- 62 affected tests pass locally (GarbageCollection, SettingsViewModel, ContentReconciliation filters).
- Note: local verification required cherry-picking a one-line `Split` overload disambiguation in `GitHubTopicsDiscoverer.cs` (not included here) because `development` does not compile on .NET SDK 8.0.129; CI SDKs are unaffected.

## Risks and rollback

Low risk: no behavior removed except deletion itself; revert restores previous GC.

Fixes #310

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables destructive CAS garbage collection until reachability tracking is complete.
- Direct and lifecycle GC APIs now return explicit disabled results with zero deletion statistics.
- Reconciliation and settings flows surface disabled collection as a warning rather than successful cleanup.
- Audit metadata and result models retain the disabled state, with focused tests confirming that storage is not accessed or deleted.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The destructive collection path appears safely disabled, but completion-event reporting remains incomplete and should be reconciled with the existing operation-status contract.

Audit records now preserve disabled-GC warnings, while successful replacement events still omit them and successful removal operations publish no completion event; no current recipient of these events was found, limiting the present impact.

**Files Needing Attention:** GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs; GenHub/GenHub.Core/Models/Content/ReconciliationCompletedEvent.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Storage/Services/CasService.cs | Replaces destructive garbage collection with an explicit fail-closed disabled result. |
| GenHub/GenHub/Features/Storage/Services/CasLifecycleManager.cs | Maps the service-level disabled result into lifecycle statistics without reporting deletion. |
| GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs | Propagates disabled collection through reconciliation results and audit metadata. |
| GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs | Displays an informational disabled-cleanup notification instead of a success notification. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasGarbageCollectionDisabledTests.cs | Verifies direct and lifecycle collection remain disabled without accessing CAS storage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Caller["Settings, maintenance, or reconciliation flow"] --> Lifecycle["CasLifecycleManager"]
    Lifecycle --> Service["CasService.RunGarbageCollectionAsync"]
    Service --> Disabled["CreateDisabled result"]
    Disabled --> NoAccess["No CAS scan or deletion"]
    Disabled --> Propagate["Disabled stats and warning propagated"]
    Propagate --> UI["Settings notification"]
    Propagate --> Result["Reconciliation result and audit metadata"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: record reconciliation warnings in a..."](https://github.com/community-outpost/genhub/commit/f87fa5e2fe8b42a9928cf3bec7e3afc21904e4a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48284302)</sub>

**Context used:**

- Knowledge Base — [Content Manifest System](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-manifest-system.md)

<!-- /greptile_comment -->