### PR TITLE
feat(platform): make paths, manifests, and Unix workspaces platform-aware

### DIFF
--- a/GenHub/GenHub.Core/Constants/ManifestConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ManifestConstants.cs
@@ -16,6 +16,17 @@ public static class ManifestConstants
     public const string DefaultManifestVersion = "1";
 
     /// <summary>
+    /// Manifest format version that introduces artifact variants.
+    /// </summary>
+    /// <remarks>
+    /// Bumped from <see cref="DefaultManifestFormatVersion"/> so that a manifest using
+    /// variants is identifiable as such rather than presenting as a version 1 manifest
+    /// with an unexpected field. Ingestion rejects this version for now — see
+    /// <see cref="Models.Manifest.ManifestIngestionGate"/>.
+    /// </remarks>
+    public const int VariantsManifestFormatVersion = 2;
+
+    /// <summary>
     /// Prefix for publisher content IDs.
     /// </summary>
     public const string PublisherContentIdPrefix = "publisher";

--- a/GenHub/GenHub.Core/Interfaces/Workspace/ISymlinkCapabilityProvider.cs
+++ b/GenHub/GenHub.Core/Interfaces/Workspace/ISymlinkCapabilityProvider.cs
@@ -1,0 +1,25 @@
+namespace GenHub.Core.Interfaces.Workspace;
+
+/// <summary>
+/// Reports whether this process can create symbolic links.
+/// <para>
+/// Previously the launcher asked "is this process an administrator", computed it only on
+/// Windows, and left it <c>false</c> everywhere else. It then downgraded the
+/// <c>SymlinkOnly</c> and <c>HybridCopySymlink</c> strategies to <c>HardLink</c> whenever
+/// the answer was false, which made both strategies permanently unreachable on Linux and
+/// macOS — where <c>symlink(2)</c> needs no privilege at all. Users could select a
+/// strategy in Settings that silently never applied.
+/// </para>
+/// <para>
+/// Naming the capability rather than the privilege makes the platform answer obvious:
+/// Windows genuinely gates symlink creation behind <c>SeCreateSymbolicLinkPrivilege</c>
+/// (or Developer Mode); Unix does not gate it at all.
+/// </para>
+/// </summary>
+public interface ISymlinkCapabilityProvider
+{
+    /// <summary>
+    /// Gets a value indicating whether this process can create symbolic links.
+    /// </summary>
+    bool CanCreateSymlinks { get; }
+}

--- a/GenHub/GenHub.Core/Models/Manifest/ArtifactVariant.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ArtifactVariant.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GenHub.Core.Models.Manifest;
+
+/// <summary>
+/// A platform-specific build within a single content release.
+/// <para>
+/// One release of a game client can produce several builds — win-x64, linux-x64 and
+/// osx-arm64 — that share a version and a name but not a file list or an entry point.
+/// A single flat file list cannot describe that: the same manifest would advertise a
+/// Windows executable to a macOS host, which installs cleanly and then cannot run.
+/// </para>
+/// <para>
+/// Variants are optional. A manifest with no variants is a single unconstrained build
+/// described by <see cref="ContentManifest.Files"/>, which is what every manifest
+/// written before this type existed looks like.
+/// </para>
+/// </summary>
+public class ArtifactVariant
+{
+    /// <summary>
+    /// Gets or sets the runtime identifiers this variant can run on, for example
+    /// <c>osx-arm64</c> or <c>win-x64</c>.
+    /// <para>
+    /// Architecture matters, not just the operating system: an x64 build is not
+    /// interchangeable with an arm64 one, and a macOS user on Apple Silicon offered an
+    /// <c>osx-x64</c> build gets a launch that fails in the loader.
+    /// </para>
+    /// <para>
+    /// An empty list means the variant is platform-neutral, which is correct for map
+    /// packs, INI tweaks and <c>.big</c> content that contains no native code.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("runtimeIdentifiers")]
+    public List<string> RuntimeIdentifiers { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the relative path of the file to launch for this variant.
+    /// <para>
+    /// Declared rather than inferred. Inferring it from file extensions is ambiguous
+    /// the moment a variant ships more than one runnable file, and the result then
+    /// depends on file enumeration order.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("entryPoint")]
+    public string? EntryPoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the files belonging to this variant.
+    /// </summary>
+    [JsonPropertyName("files")]
+    public List<ManifestFile> Files { get; set; } = [];
+
+    /// <summary>
+    /// Determines whether this variant can run on the given runtime identifier.
+    /// </summary>
+    /// <param name="runtimeIdentifier">The host runtime identifier, for example <c>osx-arm64</c>.</param>
+    /// <returns><c>true</c> when the variant is platform-neutral or explicitly targets the runtime.</returns>
+    public bool SupportsRuntime(string runtimeIdentifier)
+    {
+        if (RuntimeIdentifiers.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (var candidate in RuntimeIdentifiers)
+        {
+            if (string.Equals(candidate, runtimeIdentifier, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/GenHub/GenHub.Core/Models/Manifest/ContentManifest.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ContentManifest.cs
@@ -1,6 +1,7 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using GenHub.Core.Constants;
 using GenHub.Core.Models.Enums;
-using System.Text.Json.Serialization;
 
 namespace GenHub.Core.Models.Manifest;
 
@@ -10,6 +11,8 @@ namespace GenHub.Core.Models.Manifest;
 /// </summary>
 public class ContentManifest
 {
+    private List<ArtifactVariant> _variants = [];
+
     /// <summary>Gets or sets the manifest format version.</summary>
     public string ManifestVersion { get; set; } = ManifestConstants.DefaultManifestVersion;
 
@@ -61,8 +64,45 @@ public class ContentManifest
     /// <summary>Gets or sets the list of known addons for this game (manifest-driven, not hardcoded).</summary>
     public List<string> KnownAddons { get; set; } = [];
 
-    /// <summary>Gets or sets all files included in this content package.</summary>
+    /// <summary>
+    /// Gets or sets all files included in this content package.
+    /// <para>
+    /// This describes the single, unconstrained build. When <see cref="Variants"/> is
+    /// non-empty this list is ignored in favour of the matching variant. Consumers
+    /// should resolve through <c>ManifestVariantResolver</c> rather than reading this
+    /// directly, so that multi-platform manifests behave correctly.
+    /// </para>
+    /// </summary>
     public List<ManifestFile> Files { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets platform-specific builds of this content.
+    /// <para>
+    /// Optional and empty by default, so every manifest written before variants existed
+    /// keeps working unchanged: an empty list means "<see cref="Files"/> is the only
+    /// build". Populate it when one release ships several platform builds that share a
+    /// version but differ in file list or entry point.
+    /// </para>
+    /// </summary>
+    public List<ArtifactVariant> Variants
+    {
+        get => _variants;
+        set => _variants = value ?? [];
+    }
+
+    /// <summary>
+    /// Gets or sets the relative path of the file to launch, for single-variant content.
+    /// <para>
+    /// Declared rather than inferred from file extensions. Without it, resolution falls
+    /// back to guessing from the file list, which is ambiguous as soon as more than one
+    /// file qualifies and then depends on enumeration order.
+    /// </para>
+    /// <para>
+    /// When <see cref="Variants"/> is populated, each variant carries its own entry
+    /// point and this is ignored.
+    /// </para>
+    /// </summary>
+    public string? EntryPoint { get; set; }
 
     /// <summary>Gets or sets the required directory structure.</summary>
     public List<string> RequiredDirectories { get; set; } = [];

--- a/GenHub/GenHub.Core/Models/Manifest/EntryPointResolution.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/EntryPointResolution.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GenHub.Core.Models.Manifest;
+
+/// <summary>
+/// The outcome of resolving which file a manifest launches.
+/// <para>
+/// Failure carries the candidates that were considered. Resolution failing silently, or
+/// failing with only "no executable found", leaves whoever hits it guessing at what the
+/// manifest actually contained.
+/// </para>
+/// </summary>
+public sealed class EntryPointResolution
+{
+    private EntryPointResolution(string? relativePath, string reason, IReadOnlyList<string> candidates)
+    {
+        RelativePath = relativePath;
+        Reason = reason;
+        Candidates = candidates;
+    }
+
+    /// <summary>Gets a value indicating whether an entry point was determined.</summary>
+    public bool Success => RelativePath is not null;
+
+    /// <summary>Gets the resolved relative path, or <c>null</c> when resolution failed.</summary>
+    public string? RelativePath { get; }
+
+    /// <summary>
+    /// Gets a human-readable explanation: on success, how the entry point was chosen; on
+    /// failure, why it could not be.
+    /// </summary>
+    public string Reason { get; }
+
+    /// <summary>Gets the file paths considered, for diagnosing a failure.</summary>
+    public IReadOnlyList<string> Candidates { get; }
+
+    /// <summary>
+    /// Creates a successful resolution.
+    /// </summary>
+    /// <param name="relativePath">The resolved entry point.</param>
+    /// <param name="reason">How it was chosen.</param>
+    /// <returns>A successful resolution.</returns>
+    public static EntryPointResolution Resolved(string relativePath, string reason) =>
+        new(relativePath, reason, []);
+
+    /// <summary>
+    /// Creates a failed resolution.
+    /// </summary>
+    /// <param name="reason">Why resolution failed.</param>
+    /// <param name="candidates">The files that were considered.</param>
+    /// <returns>A failed resolution.</returns>
+    public static EntryPointResolution Failed(string reason, IEnumerable<ManifestFile> candidates) =>
+        new(null, reason, candidates.Select(f => f.RelativePath).ToList());
+
+    /// <summary>
+    /// Builds a log-ready description including the candidates considered.
+    /// </summary>
+    /// <returns>A diagnostic string.</returns>
+    public override string ToString() =>
+        Success
+            ? $"{RelativePath} ({Reason})"
+            : Candidates.Count == 0
+                ? Reason
+                : $"{Reason} Candidates: {string.Join(", ", Candidates)}";
+}

--- a/GenHub/GenHub.Core/Models/Manifest/ManifestIngestionGate.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ManifestIngestionGate.cs
@@ -1,0 +1,73 @@
+using System.Globalization;
+using GenHub.Core.Constants;
+
+namespace GenHub.Core.Models.Manifest;
+
+/// <summary>
+/// Fail-closed gate for manifests that declare artifact variants.
+/// </summary>
+/// <remarks>
+/// Variants are expressed by <see cref="ContentManifest.Variants"/> and resolved by
+/// <see cref="ManifestVariantResolver"/>, but the consumers that act on a manifest —
+/// deliverers, validators, CAS reference counting and garbage collection — still read
+/// <see cref="ContentManifest.Files"/> directly. A manifest declaring variants would be
+/// accepted and then mishandled by every one of them: <c>Files</c> is empty for a
+/// variant manifest, so content would appear to install successfully while delivering
+/// nothing, and reference counting would record the wrong set of blobs.
+/// <para>
+/// Rejecting at ingestion is therefore deliberate and temporary. It is the only
+/// protection until the consumers are migrated to the resolved-variant model, and it
+/// should be removed as part of that migration rather than relaxed piecemeal.
+/// </para>
+/// </remarks>
+public static class ManifestIngestionGate
+{
+    /// <summary>
+    /// Determines whether a manifest may be ingested.
+    /// </summary>
+    /// <param name="manifest">The manifest to check.</param>
+    /// <param name="rejectionReason">
+    /// When the manifest is rejected, a message naming the manifest and the reason;
+    /// otherwise <c>null</c>.
+    /// </param>
+    /// <returns><c>true</c> when the manifest may be ingested; otherwise <c>false</c>.</returns>
+    public static bool TryAccept(ContentManifest? manifest, out string? rejectionReason)
+    {
+        rejectionReason = null;
+
+        if (manifest is null)
+        {
+            return true;
+        }
+
+        // Checked independently rather than as one condition. Declared version alone is
+        // not trustworthy — a manifest can carry variants while still claiming version 1 —
+        // and variants alone are not the only signal, since a format-2 manifest may use
+        // other version-2 features this pipeline equally cannot handle.
+        var declaresVariants = manifest.Variants.Count > 0;
+        var declaresVariantFormat =
+            int.TryParse(
+                manifest.ManifestVersion,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var declaredFormat)
+            && declaredFormat >= ManifestConstants.VariantsManifestFormatVersion;
+
+        if (!declaresVariants && !declaresVariantFormat)
+        {
+            return true;
+        }
+
+        var cause = declaresVariants
+            ? $"declares {manifest.Variants.Count} artifact variant(s)"
+            : $"declares manifest format version {manifest.ManifestVersion}";
+
+        rejectionReason =
+            $"Manifest '{manifest.Id.Value}' {cause}, which requires manifest format version " +
+            $"{ManifestConstants.VariantsManifestFormatVersion} and is not yet accepted. " +
+            "Variant manifests are rejected until the content pipeline is migrated to the " +
+            "resolved-variant model; publish a manifest without variants in the meantime.";
+
+        return false;
+    }
+}

--- a/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using GenHub.Core.Utilities;
+
+namespace GenHub.Core.Models.Manifest;
+
+/// <summary>
+/// Resolves which files a manifest contributes on the current host, and which one to
+/// launch.
+/// <para>
+/// Entry-point resolution used to be <c>Files.FirstOrDefault(f =&gt; f.IsExecutable)</c>,
+/// which is order-dependent whenever more than one file qualifies, and silently picked
+/// whichever the enumeration happened to yield first.
+/// </para>
+/// </summary>
+public static class ManifestVariantResolver
+{
+    /// <summary>
+    /// Gets the runtime identifier of the current host, for example <c>osx-arm64</c>.
+    /// </summary>
+    public static string CurrentRuntimeIdentifier => RuntimeInformation.RuntimeIdentifier;
+
+    /// <summary>
+    /// Selects the files a manifest contributes on the given runtime.
+    /// </summary>
+    /// <param name="manifest">The manifest to resolve.</param>
+    /// <param name="runtimeIdentifier">Host runtime identifier; defaults to the current host.</param>
+    /// <returns>
+    /// The matching variant's files, or the flat <see cref="ContentManifest.Files"/> list
+    /// when the manifest declares no variants. Empty when variants are declared but none
+    /// matches, which means the content genuinely cannot run here.
+    /// </returns>
+    public static IReadOnlyList<ManifestFile> ResolveFiles(
+        ContentManifest manifest,
+        string? runtimeIdentifier = null)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        var variant = ResolveVariant(manifest, runtimeIdentifier);
+
+        if (variant is not null)
+        {
+            return variant.Files;
+        }
+
+        return manifest.Variants.Count == 0 ? manifest.Files : [];
+    }
+
+    /// <summary>
+    /// Selects the variant that applies on the given runtime.
+    /// </summary>
+    /// <param name="manifest">The manifest to resolve.</param>
+    /// <param name="runtimeIdentifier">Host runtime identifier; defaults to the current host.</param>
+    /// <returns>The matching variant, or <c>null</c> when the manifest declares none or none matches.</returns>
+    public static ArtifactVariant? ResolveVariant(
+        ContentManifest manifest,
+        string? runtimeIdentifier = null)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        if (manifest.Variants.Count == 0)
+        {
+            return null;
+        }
+
+        var rid = runtimeIdentifier ?? CurrentRuntimeIdentifier;
+
+        // Prefer an explicit match over a platform-neutral one, so a manifest carrying
+        // both a native build and a neutral asset bundle resolves to the native build.
+        return manifest.Variants.FirstOrDefault(v => v.RuntimeIdentifiers.Count > 0 && v.SupportsRuntime(rid))
+            ?? manifest.Variants.FirstOrDefault(v => v.RuntimeIdentifiers.Count == 0);
+    }
+
+    /// <summary>
+    /// Determines whether a manifest has anything runnable or installable on the runtime.
+    /// <para>
+    /// Used to keep content that cannot run on this host out of the catalogue, rather
+    /// than letting a user install it successfully and then find it does nothing.
+    /// </para>
+    /// </summary>
+    /// <param name="manifest">The manifest to test.</param>
+    /// <param name="runtimeIdentifier">Host runtime identifier; defaults to the current host.</param>
+    /// <returns><c>true</c> when the manifest applies to the runtime.</returns>
+    public static bool SupportsRuntime(ContentManifest manifest, string? runtimeIdentifier = null)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        return manifest.Variants.Count == 0
+            || ResolveVariant(manifest, runtimeIdentifier) is not null;
+    }
+
+    /// <summary>
+    /// Resolves the relative path of the file to launch.
+    /// <para>
+    /// The chain is deliberately explicit, and refuses to guess at the end:
+    /// </para>
+    /// <list type="number">
+    ///   <item><description>the declared entry point, on the variant or the manifest;</description></item>
+    ///   <item><description>the only file marked as needing the execute bit, if there is exactly one;</description></item>
+    ///   <item><description>the only legacy launch candidate by extension, if there is exactly one;</description></item>
+    ///   <item><description>otherwise fail, and report every candidate considered.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="manifest">The manifest to resolve.</param>
+    /// <param name="runtimeIdentifier">Host runtime identifier; defaults to the current host.</param>
+    /// <returns>A result carrying either the entry point or a diagnosable failure.</returns>
+    public static EntryPointResolution ResolveEntryPoint(
+        ContentManifest manifest,
+        string? runtimeIdentifier = null)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        var variant = ResolveVariant(manifest, runtimeIdentifier);
+        var files = ResolveFiles(manifest, runtimeIdentifier);
+        var declared = manifest.Variants.Count == 0
+            ? manifest.EntryPoint
+            : variant?.EntryPoint;
+
+        if (!string.IsNullOrWhiteSpace(declared))
+        {
+            // A declared entry point that is not in the file list is a manifest defect.
+            // Failing here is far more diagnosable than failing at Process.Start.
+            var matchedFile = files.FirstOrDefault(f => PathsMatch(f.RelativePath, declared));
+
+            return matchedFile is not null
+                ? EntryPointResolution.Resolved(matchedFile.RelativePath, "declared entry point")
+                : EntryPointResolution.Failed(
+                    $"Manifest '{manifest.Id}' declares entry point '{declared}', which is not among its "
+                    + $"{files.Count} file(s).",
+                    files);
+        }
+
+        var executable = files
+            .Where(f =>
+                f.IsExecutable
+                && ExecutableFileClassifier.IsLegacyLaunchCandidate(f.RelativePath))
+            .ToList();
+        if (executable.Count == 1)
+        {
+            return EntryPointResolution.Resolved(executable[0].RelativePath, "only file requiring execute permission");
+        }
+
+        if (executable.Count == 0)
+        {
+            var legacy = files
+                .Where(f => ExecutableFileClassifier.IsLegacyLaunchCandidate(f.RelativePath))
+                .ToList();
+
+            if (legacy.Count == 1)
+            {
+                return EntryPointResolution.Resolved(legacy[0].RelativePath, "only launch candidate by extension");
+            }
+
+            return EntryPointResolution.Failed(
+                legacy.Count == 0
+                    ? $"Manifest '{manifest.Id}' contains no launchable file."
+                    : $"Manifest '{manifest.Id}' contains {legacy.Count} possible launch targets and declares no entry point.",
+                files);
+        }
+
+        return EntryPointResolution.Failed(
+            $"Manifest '{manifest.Id}' marks {executable.Count} files as requiring execute permission and "
+            + "declares no entry point, so the launch target is ambiguous.",
+            files);
+    }
+
+    private static bool PathsMatch(string left, string right) =>
+        string.Equals(
+            left.Replace('\\', '/').TrimStart('/'),
+            right.Replace('\\', '/').TrimStart('/'),
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
+++ b/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+
+namespace GenHub.Core.Utilities;
+
+/// <summary>
+/// Single source of truth for what "executable" means when building a manifest.
+/// <para>
+/// Five call sites previously answered this independently and disagreed. Extensionless
+/// files were classified executable by one and not by the other four, which matters
+/// because a native Mach-O or ELF game binary has no extension:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>ContentManifestBuilder</c>: .exe, .dll, .so, extensionless</description></item>
+///   <item><description><c>GitHubInferenceHelper</c>: .exe, .dll, .sh, .bat, .so</description></item>
+///   <item><description><c>ManifestGenerationService</c>: .exe, .dat</description></item>
+///   <item><description><c>CommunityOutpostDeliverer</c>: .exe</description></item>
+///   <item><description><c>FileTreeItem</c>: .exe</description></item>
+/// </list>
+/// <para>
+/// It also conflated three separate questions: is this the launch target, is this
+/// executable code, and does this file need the Unix execute bit. They have different
+/// answers. A <c>.dylib</c> is executable code, is never a launch target, and is mapped
+/// by dyld with read permission only — giving it +x is meaningless. A <c>.dat</c> is
+/// data that the Steam layout happens to launch through, and is not code at all.
+/// </para>
+/// <para>
+/// So this class answers exactly two questions, and the launch target is answered
+/// elsewhere by an explicit declaration rather than inferred from a filename.
+/// </para>
+/// </summary>
+public static class ExecutableFileClassifier
+{
+    /// <summary>
+    /// Extensions for loadable code that is never itself launched and never needs the
+    /// execute bit. Dynamic libraries are mapped by the loader, which requires read
+    /// access only.
+    /// </summary>
+    private static readonly string[] LibraryExtensions = [".dll", ".so", ".dylib"];
+
+    /// <summary>
+    /// Extensions that are directly runnable and therefore need the execute bit on Unix.
+    /// </summary>
+    private static readonly string[] RunnableExtensions = [".exe", ".sh", ".command"];
+
+    /// <summary>
+    /// Determines whether a file needs the Unix execute bit to be runnable.
+    /// <para>
+    /// This is what <c>ManifestFile.IsExecutable</c> means. It is a permission fact, not
+    /// a statement about which file the profile launches.
+    /// </para>
+    /// <para>
+    /// Extensionless files count: that is the shape of a native Mach-O or ELF binary,
+    /// and it is the case the previous inconsistency got wrong.
+    /// </para>
+    /// </summary>
+    /// <param name="path">A file name or relative path. Not required to exist on disk.</param>
+    /// <returns><c>true</c> when the file should be marked executable.</returns>
+    public static bool RequiresExecutePermission(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(path);
+
+        // Extensionless: a native binary. Directories and dotfiles are excluded by the
+        // caller, which only ever passes real file entries.
+        if (string.IsNullOrEmpty(extension))
+        {
+            return true;
+        }
+
+        if (MatchesAny(extension, LibraryExtensions))
+        {
+            return false;
+        }
+
+        return MatchesAny(extension, RunnableExtensions);
+    }
+
+    /// <summary>
+    /// Determines whether a file could be the launch target when a manifest declares no
+    /// explicit entry point.
+    /// <para>
+    /// This exists only to keep manifests written before entry points were declarable
+    /// working. New content should declare its entry point rather than rely on this.
+    /// </para>
+    /// </summary>
+    /// <param name="path">A file name or relative path.</param>
+    /// <returns><c>true</c> when the file is a plausible legacy launch target.</returns>
+    public static bool IsLegacyLaunchCandidate(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(path);
+
+        // Extensionless native binaries and Windows executables only. Notably not .dat:
+        // the Steam layout launches game.dat through a proxy, but that is a launch
+        // *strategy* chosen by the Steam integration, not a property of the file.
+        return string.IsNullOrEmpty(extension)
+            || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool MatchesAny(string extension, string[] candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (extension.Equals(candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
+++ b/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
@@ -6,6 +6,10 @@ using GenHub.Core.Interfaces.Shortcuts;
 using GenHub.Linux.Features.Shortcuts;
 using GenHub.Linux.GameInstallations;
 using GenHub.Features.GameSettings;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Interfaces.Workspace;
+using GenHub.Features.Workspace;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GenHub.Linux.Infrastructure.DependencyInjection;
@@ -26,6 +30,18 @@ public static class LinuxServicesModule
         services.AddSingleton<IGameInstallationDetector, LinuxInstallationDetector>();
         services.AddSingleton<IGamePathProvider, LinuxGamePathProvider>();
         services.AddSingleton<IShortcutService, LinuxShortcutService>();
+
+        // Real hard links via link(2). Without this the base implementation throws, which
+        // is deliberate: silently copying made a missing registration invisible while
+        // every workspace consumed a full copy of the game.
+        services.AddScoped<IFileOperationsService>(serviceProvider =>
+        {
+            var baseService = serviceProvider.GetRequiredService<FileOperationsService>();
+            var casService = serviceProvider.GetRequiredService<ICasService>();
+            var logger = serviceProvider.GetRequiredService<ILogger<UnixFileOperationsService>>();
+            return new UnixFileOperationsService(baseService, casService, logger);
+        });
+
 
         return services;
     }

--- a/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
+++ b/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
@@ -29,6 +29,7 @@ public static class LinuxServicesModule
     {
         services.AddSingleton<IGameInstallationDetector, LinuxInstallationDetector>();
         services.AddSingleton<IGamePathProvider, LinuxGamePathProvider>();
+        services.AddSingleton<ISymlinkCapabilityProvider, UnixSymlinkCapabilityProvider>();
         services.AddSingleton<IShortcutService, LinuxShortcutService>();
 
         // Real hard links via link(2). Without this the base implementation throws, which

--- a/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
+++ b/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
@@ -3,14 +3,14 @@ using System.Runtime.Versioning;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Shortcuts;
-using GenHub.Linux.Features.Shortcuts;
-using GenHub.Linux.GameInstallations;
-using GenHub.Features.GameSettings;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Interfaces.Workspace;
+using GenHub.Features.GameSettings;
 using GenHub.Features.Workspace;
-using Microsoft.Extensions.Logging;
+using GenHub.Linux.Features.Shortcuts;
+using GenHub.Linux.GameInstallations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace GenHub.Linux.Infrastructure.DependencyInjection;
 
@@ -42,7 +42,6 @@ public static class LinuxServicesModule
             var logger = serviceProvider.GetRequiredService<ILogger<UnixFileOperationsService>>();
             return new UnixFileOperationsService(baseService, casService, logger);
         });
-
 
         return services;
     }

--- a/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
+++ b/GenHub/GenHub.Linux/Infrastructure/DependencyInjection/LinuxServicesModule.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Runtime.Versioning;
 using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Shortcuts;
 using GenHub.Linux.Features.Shortcuts;
 using GenHub.Linux.GameInstallations;
+using GenHub.Features.GameSettings;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GenHub.Linux.Infrastructure.DependencyInjection;
@@ -22,6 +24,7 @@ public static class LinuxServicesModule
     public static IServiceCollection AddLinuxServices(this IServiceCollection services)
     {
         services.AddSingleton<IGameInstallationDetector, LinuxInstallationDetector>();
+        services.AddSingleton<IGamePathProvider, LinuxGamePathProvider>();
         services.AddSingleton<IShortcutService, LinuxShortcutService>();
 
         return services;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubInferenceHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubInferenceHelperTests.cs
@@ -85,10 +85,12 @@ public class GitHubInferenceHelperTests
     [Theory]
     [InlineData("program.exe", true)]
     [InlineData("script.sh", true)]
+
     // A native game binary has no extension. This previously returned false here while
     // returning true in ContentManifestBuilder, so the same file was classified
     // differently depending on which factory built the manifest.
     [InlineData("generalszh", true)]
+
     // Changed deliberately: a dynamic library is loadable code, not a runnable file.
     // dyld and ld.so map libraries with read access, so the execute bit is meaningless,
     // and under a hard-link workspace setting it would mutate a shared CAS blob.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubInferenceHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubInferenceHelperTests.cs
@@ -84,8 +84,16 @@ public class GitHubInferenceHelperTests
     /// <param name="expected">Expected boolean result.</param>
     [Theory]
     [InlineData("program.exe", true)]
-    [InlineData("library.dll", true)]
     [InlineData("script.sh", true)]
+    // A native game binary has no extension. This previously returned false here while
+    // returning true in ContentManifestBuilder, so the same file was classified
+    // differently depending on which factory built the manifest.
+    [InlineData("generalszh", true)]
+    // Changed deliberately: a dynamic library is loadable code, not a runnable file.
+    // dyld and ld.so map libraries with read access, so the execute bit is meaningless,
+    // and under a hard-link workspace setting it would mutate a shared CAS blob.
+    [InlineData("library.dll", false)]
+    [InlineData("libSDL3.dylib", false)]
     [InlineData("readme.txt", false)]
     public void IsExecutableFile_ReturnsExpectedResult(string fileName, bool expected)
     {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GamePathProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GamePathProviderTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using GenHub.Core.Models.Enums;
+using GenHub.Features.GameSettings;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameSettings;
+
+/// <summary>
+/// Pins the Options.ini directory each platform provider produces.
+/// <para>
+/// These paths are dictated by the game engine, not chosen by GenHub. They mirror
+/// <c>GlobalData::BuildUserDataPathFromRegistry</c> in the GeneralsGameCode tree. If
+/// GenHub writes Options.ini anywhere else, the engine simply never reads it: the
+/// launch still succeeds and every profile setting is silently discarded, with no
+/// error anywhere. That failure is invisible in manual testing, so it is pinned here.
+/// </para>
+/// </summary>
+public class GamePathProviderTests
+{
+    /// <summary>
+    /// macOS resolves under Application Support with no vendor subdirectory. Notably
+    /// this is NOT the SDL_GetPrefPath convention of
+    /// <c>~/Library/Application Support/&lt;org&gt;/&lt;app&gt;/</c>, which an
+    /// SDL3-based port would otherwise be expected to use.
+    /// </summary>
+    /// <param name="gameType">The game being resolved.</param>
+    /// <param name="expectedLeaf">The directory name the engine expects.</param>
+    [Theory]
+    [InlineData(GameType.ZeroHour, "Command and Conquer Generals Zero Hour Data")]
+    [InlineData(GameType.Generals, "Command and Conquer Generals Data")]
+    public void MacOSProvider_ResolvesUnderApplicationSupport(GameType gameType, string expectedLeaf)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var expected = Path.Combine(home, "Library", "Application Support", expectedLeaf);
+
+        var actual = new MacOSGamePathProvider().GetOptionsDirectory(gameType);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Linux honours XDG_DATA_HOME when it is set.
+    /// </summary>
+    [Fact]
+    public void LinuxProvider_HonoursXdgDataHome()
+    {
+        var original = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        try
+        {
+            var custom = Path.Combine(Path.GetTempPath(), "genhub-xdg-probe");
+            Environment.SetEnvironmentVariable("XDG_DATA_HOME", custom);
+
+            var actual = new LinuxGamePathProvider().GetOptionsDirectory(GameType.ZeroHour);
+
+            Assert.Equal(
+                Path.Combine(custom, "Command and Conquer Generals Zero Hour Data"),
+                actual);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("XDG_DATA_HOME", original);
+        }
+    }
+
+    /// <summary>
+    /// With XDG_DATA_HOME unset, Linux falls back to ~/.local/share, matching the
+    /// engine rather than defaulting to the home directory root.
+    /// </summary>
+    [Fact]
+    public void LinuxProvider_FallsBackToLocalShare()
+    {
+        var original = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        try
+        {
+            Environment.SetEnvironmentVariable("XDG_DATA_HOME", null);
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            var actual = new LinuxGamePathProvider().GetOptionsDirectory(GameType.ZeroHour);
+
+            Assert.Equal(
+                Path.Combine(home, ".local", "share", "Command and Conquer Generals Zero Hour Data"),
+                actual);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("XDG_DATA_HOME", original);
+        }
+    }
+
+    /// <summary>
+    /// The Unix providers must not resolve to the home directory root. That is what
+    /// <c>SpecialFolder.MyDocuments</c> returns on Unix, and it is what every platform
+    /// silently used before <c>IGamePathProvider</c> was registered anywhere.
+    /// </summary>
+    [Fact]
+    public void UnixProviders_DoNotResolveDirectlyUnderHome()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var badPath = Path.Combine(home, "Command and Conquer Generals Zero Hour Data");
+
+        Assert.NotEqual(badPath, new MacOSGamePathProvider().GetOptionsDirectory(GameType.ZeroHour));
+        Assert.NotEqual(badPath, new LinuxGamePathProvider().GetOptionsDirectory(GameType.ZeroHour));
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
@@ -138,6 +138,31 @@ public class ContentManifestPoolTests : IDisposable
     }
 
     /// <summary>
+    /// An explicit JSON null must not replace the manifest's non-null variants
+    /// collection and crash the ingestion gate.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetManifestAsync_WithNullVariants_PreservesEmptyCollection()
+    {
+        var manifestId = ManifestId.Create("1.0.genhub.mod.nullvariants");
+        var manifestPath = Path.Combine(_tempDirectory, "null-variants.json");
+        await File.WriteAllTextAsync(
+            manifestPath,
+            """{"Id":"1.0.genhub.mod.nullvariants","Variants":null}""");
+
+        _storageServiceMock.Setup(service => service.GetManifestStoragePath(manifestId))
+            .Returns(manifestPath);
+
+        var result = await _manifestPool.GetManifestAsync(manifestId);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Empty(result.Data.Variants);
+        Assert.True(ManifestIngestionGate.TryAccept(result.Data, out _));
+    }
+
+    /// <summary>
     /// Should return null when manifest does not exist.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
@@ -495,4 +495,79 @@ public class ContentManifestPoolTests : IDisposable
         _storageServiceMock.Setup(x => x.GetContentStorageRoot())
             .Returns(_tempDirectory);
     }
+    /// <summary>
+    /// A variant manifest must be rejected before any content is written.
+    /// </summary>
+    /// <remarks>
+    /// The pool is the chokepoint every deliverer, resolver and detector reaches, so this
+    /// is where the gate has to hold. Returning a failure is not sufficient on its own:
+    /// what matters is that nothing was stored and no CAS references were tracked, because
+    /// mis-tracked references are what corrupts reference counting and garbage collection.
+    /// </remarks>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AddManifestAsync_WithVariants_RejectsBeforeStoringContent()
+    {
+        var manifest = CreateTestManifest();
+        manifest.Variants.Add(new ArtifactVariant());
+
+        var result = await _manifestPool.AddManifestAsync(manifest);
+
+        Assert.False(result.Success);
+        Assert.Contains("variant", result.FirstError, StringComparison.OrdinalIgnoreCase);
+
+        _storageServiceMock.Verify(
+            x => x.IsContentStoredAsync(It.IsAny<ManifestId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _referenceTrackerMock.Verify(
+            x => x.TrackManifestReferencesAsync(It.IsAny<string>(), It.IsAny<ContentManifest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// The source-directory overload must reject a variant manifest without storing content.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AddManifestAsync_WithSourceDirectory_WithVariants_RejectsBeforeStoringContent()
+    {
+        var manifest = CreateTestManifest();
+        manifest.Variants.Add(new ArtifactVariant());
+
+        var result = await _manifestPool.AddManifestAsync(manifest, _tempDirectory);
+
+        Assert.False(result.Success);
+        Assert.Contains("variant", result.FirstError, StringComparison.OrdinalIgnoreCase);
+
+        _storageServiceMock.Verify(
+            x => x.StoreContentAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _referenceTrackerMock.Verify(
+            x => x.TrackManifestReferencesAsync(It.IsAny<string>(), It.IsAny<ContentManifest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A manifest without variants must not be rejected by the gate; every manifest
+    /// published today is this shape.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AddManifestAsync_WithoutVariants_IsNotRejectedByTheGate()
+    {
+        var manifest = CreateTestManifest();
+        _storageServiceMock.Setup(x => x.IsContentStoredAsync(manifest.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+        _storageServiceMock.Setup(x => x.GetManifestStoragePath(manifest.Id))
+            .Returns(Path.Combine(_tempDirectory, $"{manifest.Id}.manifest.json"));
+
+        var result = await _manifestPool.AddManifestAsync(manifest);
+
+        Assert.True(result.Success, $"Expected success but got: {result.FirstError}");
+    }
+
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
@@ -1,9 +1,11 @@
+using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using GenHub.Features.Manifest;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.IO;
 using System.Text.Json;
 using ContentType = GenHub.Core.Models.Enums.ContentType;
 
@@ -35,14 +37,24 @@ public class ManifestDiscoveryServiceTests : IDisposable
     private readonly string _tempDirectory;
 
     /// <summary>
+    /// Mock configuration provider supplying the application data path.
+    /// </summary>
+    private readonly Mock<IConfigurationProviderService> _configProviderMock;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ManifestDiscoveryServiceTests"/> class.
     /// </summary>
     public ManifestDiscoveryServiceTests()
     {
         _loggerMock = new Mock<ILogger<ManifestDiscoveryService>>();
         _cacheMock = new Mock<IManifestCache>();
-        _discoveryService = new ManifestDiscoveryService(_loggerMock.Object, _cacheMock.Object);
         _tempDirectory = Directory.CreateTempSubdirectory("GenHub.ManifestDiscoveryTests.").FullName;
+        _configProviderMock = new Mock<IConfigurationProviderService>();
+        _configProviderMock.Setup(x => x.GetApplicationDataPath()).Returns(_tempDirectory);
+        _discoveryService = new ManifestDiscoveryService(
+            _loggerMock.Object,
+            _cacheMock.Object,
+            _configProviderMock.Object);
     }
 
     /// <summary>
@@ -197,6 +209,7 @@ public class ManifestDiscoveryServiceTests : IDisposable
         var discoveryService = new ManifestDiscoveryService(
             _loggerMock.Object,
             _cacheMock.Object,
+            _configProviderMock.Object,
             EnumerateFiles,
             EnumerateDirectories);
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestProviderTests.cs
@@ -86,6 +86,29 @@ public class ManifestProviderTests
     }
 
     /// <summary>
+    /// Cached variant manifests must pass the same fail-closed ingestion gate as newly
+    /// discovered manifests.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetManifestAsync_WithCachedVariantManifest_ThrowsValidationException()
+    {
+        var gameClient = new GameClient { Id = "1.0.genhub.mod.variant" };
+        var manifest = new ContentManifest
+        {
+            Id = gameClient.Id,
+            Variants = [new ArtifactVariant()],
+        };
+
+        _poolMock
+            .Setup(pool => pool.GetManifestAsync(manifest.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest?>.CreateSuccess(manifest));
+
+        await Assert.ThrowsAsync<ManifestValidationException>(
+            () => _manifestProvider.GetManifestAsync(gameClient));
+    }
+
+    /// <summary>
     /// Tests that GetManifestAsync builds correct manifest ID for game installation.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -117,6 +140,33 @@ public class ManifestProviderTests
         Assert.NotNull(result);
         Assert.Equal("1.108.eaapp.gameinstallation.generals", result.Id);
         _poolMock.Verify(x => x.GetManifestAsync(ManifestId.Create("1.108.eaapp.gameinstallation.generals"), default), Times.Once);
+    }
+
+    /// <summary>
+    /// The installation overload must not bypass the fail-closed variant gate.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetManifestAsync_WithInstallationCachedVariantManifest_ThrowsValidationException()
+    {
+        var installation = new GameInstallation(
+            installationPath: @"C:\TestPath",
+            installationType: GameInstallationType.EaApp,
+            logger: null);
+        installation.SetPaths(@"C:\TestPath\Command and Conquer Generals", null);
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.108.eaapp.gameinstallation.generals"),
+            Variants = [new ArtifactVariant()],
+        };
+
+        _poolMock
+            .Setup(pool => pool.GetManifestAsync(manifest.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest?>.CreateSuccess(manifest));
+
+        await Assert.ThrowsAsync<ManifestValidationException>(
+            () => _manifestProvider.GetManifestAsync(installation));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Features.Workspace;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.Workspace;
+
+/// <summary>
+/// Demonstrates why marking a workspace file executable must not be done in place when
+/// the workspace is built from hard links.
+/// <para>
+/// The content store keys objects purely on content hash. Unix file mode lives in the
+/// inode, which a hard link shares with its target, so the store cannot represent two
+/// files with identical bytes and different modes. Setting the execute bit on a linked
+/// workspace file therefore changes the stored blob for every profile referencing that
+/// hash.
+/// </para>
+/// </summary>
+public class ExecutablePermissionIsolationTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(
+        Path.GetTempPath(),
+        $"genhub-execisolation-{Guid.NewGuid():N}");
+
+    private readonly UnixFileOperationsService _service;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutablePermissionIsolationTests"/> class.
+    /// </summary>
+    public ExecutablePermissionIsolationTests()
+    {
+        Directory.CreateDirectory(_tempDir);
+
+        var baseService = new FileOperationsService(
+            NullLogger<FileOperationsService>.Instance,
+            new Mock<IDownloadService>().Object,
+            new Mock<ICasService>().Object);
+
+        _service = new UnixFileOperationsService(
+            baseService,
+            new Mock<ICasService>().Object,
+            NullLogger<UnixFileOperationsService>.Instance);
+    }
+
+    private static bool OnUnix => !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    /// <summary>
+    /// Establishes the hazard: chmod through a hard link changes the target too.
+    /// <para>
+    /// If this ever stops being true, the workspace copy this behaviour forces could be
+    /// dropped. It is asserted rather than assumed, because the whole design of
+    /// <c>EnsureExecutableAsync</c> rests on it.
+    /// </para>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ChmodThroughHardLink_AlsoChangesTheTarget()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var casBlob = Path.Combine(_tempDir, "cas-blob");
+        var workspaceFile = Path.Combine(_tempDir, "workspace-file");
+        await File.WriteAllTextAsync(casBlob, "engine binary");
+        File.SetUnixFileMode(casBlob, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        await _service.CreateHardLinkAsync(workspaceFile, casBlob);
+
+        File.SetUnixFileMode(
+            workspaceFile,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        Assert.True(
+            File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
+            "Expected chmod through a hard link to affect the shared inode. If this now "
+            + "fails, the copy-before-chmod behaviour in WorkspaceStrategyBase can be revisited.");
+    }
+
+    /// <summary>
+    /// The mitigation: copying first gives the workspace its own inode, so the execute
+    /// bit stops at the workspace and the stored blob keeps the mode it was ingested with.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyBeforeChmod_LeavesTheStoredBlobUntouched()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var casBlob = Path.Combine(_tempDir, "cas-blob");
+        var workspaceFile = Path.Combine(_tempDir, "workspace-file");
+        await File.WriteAllTextAsync(casBlob, "engine binary");
+        File.SetUnixFileMode(casBlob, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        await _service.CreateHardLinkAsync(workspaceFile, casBlob);
+
+        // What WorkspaceStrategyBase.EnsureExecutableAsync does: break the link first.
+        var temporaryPath = workspaceFile + ".genhub-exec-tmp";
+        File.Copy(workspaceFile, temporaryPath, overwrite: true);
+        File.Delete(workspaceFile);
+        File.Move(temporaryPath, workspaceFile);
+        File.SetUnixFileMode(
+            workspaceFile,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        Assert.True(File.GetUnixFileMode(workspaceFile).HasFlag(UnixFileMode.UserExecute));
+        Assert.False(
+            File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
+            "The stored blob was modified, so every other profile using this hash is affected.");
+
+        // Content must survive the round trip; a broken link is only acceptable if the
+        // bytes are identical.
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(workspaceFile));
+    }
+
+    /// <summary>
+    /// Releases the temporary directory.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test over.
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
@@ -1,9 +1,9 @@
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Models.Manifest;
 using GenHub.Features.Workspace;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -29,6 +29,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
         $"genhub-execisolation-{Guid.NewGuid():N}");
 
     private readonly UnixFileOperationsService _service;
+    private readonly WorkspaceStrategyBaseTests.TestWorkspaceStrategy _strategy;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExecutablePermissionIsolationTests"/> class.
@@ -46,9 +47,8 @@ public class ExecutablePermissionIsolationTests : IDisposable
             baseService,
             new Mock<ICasService>().Object,
             NullLogger<UnixFileOperationsService>.Instance);
+        _strategy = new WorkspaceStrategyBaseTests.TestWorkspaceStrategy(_service);
     }
-
-    private static bool OnUnix => !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     /// <summary>
     /// Establishes the hazard: chmod through a hard link changes the target too.
@@ -62,7 +62,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
     [Fact]
     public async Task ChmodThroughHardLink_AlsoChangesTheTarget()
     {
-        if (!OnUnix)
+        if (OperatingSystem.IsWindows())
         {
             return;
         }
@@ -92,7 +92,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
     [Fact]
     public async Task CopyBeforeChmod_LeavesTheStoredBlobUntouched()
     {
-        if (!OnUnix)
+        if (OperatingSystem.IsWindows())
         {
             return;
         }
@@ -104,22 +104,53 @@ public class ExecutablePermissionIsolationTests : IDisposable
 
         await _service.CreateHardLinkAsync(workspaceFile, casBlob);
 
-        // What WorkspaceStrategyBase.EnsureExecutableAsync does: break the link first.
         var temporaryPath = workspaceFile + ".genhub-exec-tmp";
-        File.Copy(workspaceFile, temporaryPath, overwrite: true);
-        File.Delete(workspaceFile);
-        File.Move(temporaryPath, workspaceFile);
-        File.SetUnixFileMode(
-            workspaceFile,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        await _strategy.TestEnsureExecutableAsync(
+            new ManifestFile { RelativePath = "workspace-file", IsExecutable = true },
+            workspaceFile);
 
         Assert.True(File.GetUnixFileMode(workspaceFile).HasFlag(UnixFileMode.UserExecute));
         Assert.False(
             File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
             "The stored blob was modified, so every other profile using this hash is affected.");
 
+        Assert.False(
+            File.Exists(temporaryPath),
+            "The temporary copy must not survive; workspace validation would report it.");
+
         // Content must survive the round trip; a broken link is only acceptable if the
         // bytes are identical.
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(workspaceFile));
+    }
+
+    /// <summary>
+    /// The destination must never be observable as missing or non-executable. Verification
+    /// never mutates, so a workspace left with a non-executable entry point stays broken
+    /// for every later launch — the failure this sequence exists to prevent.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExecutableMaterialization_ReplacesDestinationAtomically()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var workspaceFile = Path.Combine(_tempDir, "atomic-entry-point");
+        await File.WriteAllTextAsync(workspaceFile, "engine binary");
+        File.SetUnixFileMode(workspaceFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var temporaryPath = workspaceFile + ".genhub-exec-tmp";
+        await _strategy.TestEnsureExecutableAsync(
+            new ManifestFile { RelativePath = "atomic-entry-point", IsExecutable = true },
+            workspaceFile);
+
+        Assert.True(File.Exists(workspaceFile));
+        Assert.True(
+            File.GetUnixFileMode(workspaceFile).HasFlag(UnixFileMode.UserExecute),
+            "The replacement was already executable before it became the destination.");
+        Assert.False(File.Exists(temporaryPath));
         Assert.Equal("engine binary", await File.ReadAllTextAsync(workspaceFile));
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
@@ -78,10 +78,13 @@ public class ExecutablePermissionIsolationTests : IDisposable
             workspaceFile,
             UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
 
+        const string message =
+            "Expected chmod through a hard link to affect the shared inode. If this now "
+            + "fails, the copy-before-chmod behaviour in WorkspaceStrategyBase can be revisited.";
+
         Assert.True(
             File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
-            "Expected chmod through a hard link to affect the shared inode. If this now "
-            + "fails, the copy-before-chmod behaviour in WorkspaceStrategyBase can be revisited.");
+            message);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -95,42 +95,34 @@ public class FileOperationsServiceTests : IDisposable
     }
 
     /// <summary>
-    /// Tests that CreateHardLinkAsync creates a hard link or falls back to copy on unsupported platforms.
+    /// The base service must refuse to create a hard link, because it cannot.
+    /// <para>
+    /// This replaces a test that swallowed five exception types and then asserted only
+    /// <c>File.Exists</c> and matching content — assertions a plain <c>File.Copy</c>
+    /// satisfies. The base implementation did exactly that on Unix, so the test passed
+    /// while every Linux workspace silently full-copied the game instead of linking it.
+    /// A test that cannot distinguish the bug from the fix is worse than no test.
+    /// </para>
+    /// <para>
+    /// Real link behaviour is covered per platform, where it can actually be asserted:
+    /// see <c>UnixFileOperationsServiceTests</c> and <c>WindowsFileOperationsServiceTests</c>.
+    /// </para>
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CreateHardLinkAsync_CreatesHardLinkOrCopies()
+    public async Task CreateHardLinkAsync_OnBaseService_RefusesInsteadOfCopying()
     {
         var src = Path.Combine(_tempDir, "source.txt");
         var link = Path.Combine(_tempDir, "hardlink.txt");
 
         await File.WriteAllTextAsync(src, "test content");
 
-        // Try to create hard link; on unsupported platforms or not implemented, skip test
-        try
-        {
-            await _service.CreateHardLinkAsync(link, src);
-        }
-        catch (NotImplementedException)
-        {
-            // Not implemented in base service, skip test
-            return;
-        }
-        catch (PlatformNotSupportedException)
-        {
-            return;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return;
-        }
-        catch (NotSupportedException)
-        {
-            return;
-        }
+        var thrown = await Record.ExceptionAsync(() => _service.CreateHardLinkAsync(link, src));
 
-        Assert.True(File.Exists(link));
-        Assert.Equal("test content", await File.ReadAllTextAsync(link));
+        Assert.IsType<NotSupportedException>(thrown);
+        Assert.False(
+            File.Exists(link),
+            "The base service produced a file, which means it silently copied rather than refusing.");
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
@@ -13,12 +13,12 @@ using GenHub.Core.Models.Results;
 using GenHub.Core.Models.Storage;
 using GenHub.Core.Models.Workspace;
 using GenHub.Features.Storage.Services;
+using GenHub.Features.Workspace;
 using GenHub.Infrastructure.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Runtime.InteropServices;
-using GenHub.Features.Workspace;
 
 namespace GenHub.Tests.Core.Features.Workspace;
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
@@ -17,6 +17,8 @@ using GenHub.Infrastructure.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Runtime.InteropServices;
+using GenHub.Features.Workspace;
 
 namespace GenHub.Tests.Core.Features.Workspace;
 
@@ -81,6 +83,19 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
         services.AddSingleton<ICasService>(mockCasService.Object);
 
         services.AddWorkspaceServices();
+
+        // AddWorkspaceServices registers the base FileOperationsService, which cannot
+        // create hard links on any platform by design — each host registers a decorator
+        // that can. Do the same here on Unix so the HardLink strategy is genuinely
+        // exercised rather than skipped.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            services.AddScoped<IFileOperationsService>(sp => new UnixFileOperationsService(
+                sp.GetRequiredService<FileOperationsService>(),
+                sp.GetRequiredService<ICasService>(),
+                sp.GetRequiredService<ILogger<UnixFileOperationsService>>()));
+            services.AddScoped<FileOperationsService>();
+        }
 
         _serviceProvider = services.BuildServiceProvider();
         _workspaceManager = _serviceProvider.GetRequiredService<IWorkspaceManager>();
@@ -326,8 +341,9 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
             return;
         }
 
-        // Skip HardLink strategy on Windows in Core tests - the base FileOperationsService
-        // doesn't support hard links on Windows, use WindowsFileOperationsService instead
+        // Skip HardLink on Windows: the decorator that implements it there lives in
+        // GenHub.Windows and is covered by WindowsFileOperationsServiceTests. On Unix the
+        // real UnixFileOperationsService is registered above, so HardLink runs for real.
         if (strategy == WorkspaceStrategy.HardLink && isWindows)
         {
             return;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/UnixFileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/UnixFileOperationsServiceTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Models.Results;
+using GenHub.Features.Workspace;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.Workspace;
+
+/// <summary>
+/// Tests for <see cref="UnixFileOperationsService"/>.
+/// <para>
+/// These assert that a hard link is a hard link. The previous test asserted only
+/// <c>File.Exists</c> and matching content, which a plain copy satisfies — which is
+/// exactly why nobody noticed that Unix had been copying instead of linking.
+/// </para>
+/// </summary>
+public class UnixFileOperationsServiceTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(
+        Path.GetTempPath(),
+        $"genhub-unixfileops-{Guid.NewGuid():N}");
+
+    private readonly Mock<ICasService> _casServiceMock = new();
+    private readonly UnixFileOperationsService _service;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnixFileOperationsServiceTests"/> class.
+    /// </summary>
+    public UnixFileOperationsServiceTests()
+    {
+        Directory.CreateDirectory(_tempDir);
+
+        var baseService = new FileOperationsService(
+            NullLogger<FileOperationsService>.Instance,
+            new Mock<IDownloadService>().Object,
+            new Mock<ICasService>().Object);
+
+        _service = new UnixFileOperationsService(
+            baseService,
+            _casServiceMock.Object,
+            NullLogger<UnixFileOperationsService>.Instance);
+    }
+
+    private static bool OnUnix => !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    /// <summary>
+    /// The link and its target must be the same inode with a link count of two. Content
+    /// equality is not sufficient evidence: a copy has identical content and a distinct
+    /// inode, and that is the failure mode this test exists to detect.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateHardLinkAsync_ProducesRealLinkNotCopy()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var source = Path.Combine(_tempDir, "source.dat");
+        var link = Path.Combine(_tempDir, "link.dat");
+        await File.WriteAllTextAsync(source, "payload");
+
+        await _service.CreateHardLinkAsync(link, source);
+
+        Assert.True(File.Exists(link));
+
+        var sourceInfo = new FileInfo(source);
+        var linkInfo = new FileInfo(link);
+
+        // UnixFileMode alone would not distinguish a copy; the identity check is the point.
+        Assert.Equal(sourceInfo.Length, linkInfo.Length);
+
+        // Mutating through one path must be visible through the other. That is only true
+        // for a shared inode, so it distinguishes a link from a copy without needing stat.
+        await File.WriteAllTextAsync(source, "mutated through the source path");
+        Assert.Equal("mutated through the source path", await File.ReadAllTextAsync(link));
+
+        // And the reverse direction, to rule out a coincidence of ordering.
+        await File.WriteAllTextAsync(link, "mutated through the link path");
+        Assert.Equal("mutated through the link path", await File.ReadAllTextAsync(source));
+    }
+
+    /// <summary>
+    /// A missing target must raise a diagnosable error naming the file, rather than the
+    /// bare "errno 2" that an uninterpreted P/Invoke failure would produce.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateHardLinkAsync_MissingTarget_ThrowsFileNotFound()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var missing = Path.Combine(_tempDir, "does-not-exist.dat");
+        var link = Path.Combine(_tempDir, "link.dat");
+
+        var thrown = await Record.ExceptionAsync(() => _service.CreateHardLinkAsync(link, missing));
+
+        Assert.IsType<FileNotFoundException>(thrown);
+        Assert.Contains("does-not-exist.dat", thrown.Message);
+    }
+
+    /// <summary>
+    /// Linking over an existing file replaces it, matching the Windows implementation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateHardLinkAsync_ExistingDestination_IsReplaced()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var source = Path.Combine(_tempDir, "source.dat");
+        var link = Path.Combine(_tempDir, "link.dat");
+        await File.WriteAllTextAsync(source, "new content");
+        await File.WriteAllTextAsync(link, "stale content");
+
+        await _service.CreateHardLinkAsync(link, source);
+
+        Assert.Equal("new content", await File.ReadAllTextAsync(link));
+    }
+
+    /// <summary>
+    /// Copying from CAS must create an independent inode. Full-copy and hybrid callers
+    /// are allowed to modify their destination without changing the shared CAS blob.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyFromCasAsync_ProducesIndependentCopy()
+    {
+        var casBlob = Path.Combine(_tempDir, "cas-copy-source.dat");
+        var copy = Path.Combine(_tempDir, "cas-copy-destination.dat");
+        await File.WriteAllTextAsync(casBlob, "shared content");
+
+        _casServiceMock
+            .Setup(service => service.GetContentPathAsync("hash", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<string>.CreateSuccess(casBlob));
+
+        Assert.True(await _service.CopyFromCasAsync("hash", copy));
+
+        await File.WriteAllTextAsync(copy, "workspace content");
+
+        Assert.Equal("shared content", await File.ReadAllTextAsync(casBlob));
+        Assert.Equal("workspace content", await File.ReadAllTextAsync(copy));
+    }
+
+    /// <summary>
+    /// The base implementation must refuse rather than quietly copy. Silently copying is
+    /// what hid the missing Unix registration for as long as it existed.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task BaseService_CreateHardLinkAsync_ThrowsRatherThanCopying()
+    {
+        var baseService = new FileOperationsService(
+            NullLogger<FileOperationsService>.Instance,
+            new Mock<IDownloadService>().Object,
+            new Mock<ICasService>().Object);
+
+        var source = Path.Combine(_tempDir, "base-source.dat");
+        var link = Path.Combine(_tempDir, "base-link.dat");
+        await File.WriteAllTextAsync(source, "payload");
+
+        var thrown = await Record.ExceptionAsync(() => baseService.CreateHardLinkAsync(link, source));
+
+        Assert.IsType<NotSupportedException>(thrown);
+        Assert.False(File.Exists(link), "The base service copied the file instead of refusing.");
+    }
+
+    /// <summary>
+    /// Releases the temporary directory.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test over.
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceStrategyBaseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceStrategyBaseTests.cs
@@ -284,6 +284,19 @@ public class WorkspaceStrategyBaseTests : IDisposable
         /// <returns>The total size in bytes.</returns>
         public long TestCalculateActualTotalSize(WorkspaceConfiguration configuration) => CalculateActualTotalSize(configuration);
 
+        /// <summary>
+        /// Exposes executable materialization for production-path regression tests.
+        /// </summary>
+        /// <param name="file">The manifest file.</param>
+        /// <param name="targetPath">The materialized workspace path.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task representing the operation.</returns>
+        public Task TestEnsureExecutableAsync(
+            ManifestFile file,
+            string targetPath,
+            CancellationToken cancellationToken = default) =>
+            EnsureExecutableAsync(file, targetPath, cancellationToken);
+
         /// <inheritdoc/>
         protected override Task CreateCasLinkAsync(string hash, string targetPath, GenHub.Core.Models.Enums.ContentType? contentType, CancellationToken cancellationToken)
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using GenHub.Core.Interfaces.Workspace;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameClients;
@@ -14,7 +15,7 @@ namespace GenHub.Tests.Core.Features.Workspace;
 /// <summary>
 /// Tests for the WorkspaceValidator class.
 /// </summary>
-public class WorkspaceValidatorTests : IDisposable
+public partial class WorkspaceValidatorTests : IDisposable
 {
     private readonly Mock<ILogger<WorkspaceValidator>> _mockLogger;
     private readonly WorkspaceValidator _validator;
@@ -259,7 +260,11 @@ public class WorkspaceValidatorTests : IDisposable
     [Fact]
     public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_ReturnsAccessWarning()
     {
-        if (OperatingSystem.IsWindows())
+        // Root bypasses the permission bits entirely: faccessat reports execute access for
+        // an other-only bit, so the behaviour under test does not exist for uid 0. Checked
+        // via geteuid rather than the user name, which is wrong under `sudo -E` and for any
+        // uid-0 account named otherwise.
+        if (OperatingSystem.IsWindows() || GetEffectiveUserId() == 0)
         {
             return;
         }
@@ -360,4 +365,12 @@ public class WorkspaceValidatorTests : IDisposable
             Strategy = WorkspaceStrategy.FullCopy,
         };
     }
+
+    /// <summary>
+    /// Effective user ID, POSIX <c>geteuid(2)</c>. Declared here because the production
+    /// equivalent is internal to the GenHub assembly.
+    /// </summary>
+    /// <returns>The effective user ID; 0 is root.</returns>
+    [LibraryImport("libc", EntryPoint = "geteuid")]
+    private static partial uint GetEffectiveUserId();
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -252,6 +252,76 @@ public class WorkspaceValidatorTests : IDisposable
     }
 
     /// <summary>
+    /// An execute bit for an identity other than the effective process identity must not
+    /// make a workspace entry point appear executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_ReturnsAccessWarning()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(
+            executablePath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.OtherExecute);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.ValidateWorkspaceAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains(
+            result.Data.Issues,
+            issue => issue.IssueType == ValidationIssueType.AccessDenied
+                && issue.Severity == ValidationSeverity.Warning);
+    }
+
+    /// <summary>
+    /// A workspace entry point executable by the current identity remains valid.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ValidateWorkspaceAsync_ExecutableEntryPoint_HasNoAccessError()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(
+            executablePath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.ValidateWorkspaceAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.DoesNotContain(
+            result.Data.Issues,
+            issue => issue.IssueType == ValidationIssueType.AccessDenied);
+    }
+
+    /// <summary>
     /// Disposes of test resources.
     /// </summary>
     public void Dispose()

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
@@ -35,8 +35,10 @@ public class ApplicationDataPathConventionTests
         // The implementation of the convention itself has to start somewhere.
         ["ConfigurationProviderService.cs"] = "Defines the canonical path.",
         ["UserSettingsService.cs"] = "Loads the settings file that stores the override; cannot depend on it.",
+
         // Displays the built-in default next to the user's override in the UI.
         ["SettingsViewModel.cs"] = "Computes the factory-default path to show on reset.",
+
         // Core-layer fallback, overridden at the composition root by ContentPipelineModule.
         ["ProviderDefinitionLoader.cs"] = "Default only; the DI registration supplies an override.",
     };

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Infrastructure;
+
+/// <summary>
+/// Guards the convention that application data paths are resolved through
+/// <c>IConfigurationProviderService</c> rather than read directly from the OS.
+/// <para>
+/// <c>ConfigurationProviderService.GetApplicationDataPath()</c> honours a user-configured
+/// <c>UserSettings.ApplicationDataPath</c>. Five separate runtime call sites bypassed it
+/// with a raw <c>Environment.GetFolderPath(SpecialFolder.ApplicationData)</c>, so
+/// relocating the data directory moved profiles, workspaces and CAS but silently left
+/// manifest discovery, provider loading, the Steam patcher and tool workspaces behind in
+/// the default tree.
+/// </para>
+/// <para>
+/// The pattern recurred five times independently, which is evidence that code review does
+/// not catch it. This test does. If a new legitimate use appears, add it to the allowlist
+/// with a comment explaining why it is not a bypass.
+/// </para>
+/// </summary>
+public class ApplicationDataPathConventionTests
+{
+    private const string ForbiddenPattern = "GetFolderPath(Environment.SpecialFolder.ApplicationData)";
+
+    /// <summary>
+    /// Files permitted to read the OS application-data folder directly, with the reason.
+    /// </summary>
+    private static readonly Dictionary<string, string> Allowed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // The implementation of the convention itself has to start somewhere.
+        ["ConfigurationProviderService.cs"] = "Defines the canonical path.",
+        ["UserSettingsService.cs"] = "Loads the settings file that stores the override; cannot depend on it.",
+        // Displays the built-in default next to the user's override in the UI.
+        ["SettingsViewModel.cs"] = "Computes the factory-default path to show on reset.",
+        // Core-layer fallback, overridden at the composition root by ContentPipelineModule.
+        ["ProviderDefinitionLoader.cs"] = "Default only; the DI registration supplies an override.",
+    };
+
+    /// <summary>
+    /// Scans the shared and core projects for direct application-data lookups.
+    /// </summary>
+    [Fact]
+    public void NoUnapprovedDirectApplicationDataLookups()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var searchRoots = new[]
+        {
+            Path.Combine(repoRoot, "GenHub", "GenHub"),
+            Path.Combine(repoRoot, "GenHub", "GenHub.Core"),
+        };
+
+        var offenders = searchRoots
+            .Where(Directory.Exists)
+            .SelectMany(root => Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                        && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+            .Where(path => !Allowed.ContainsKey(Path.GetFileName(path)))
+            .Where(path => File.ReadAllText(path).Contains(ForbiddenPattern, StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(repoRoot, path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        var message =
+            $"These files read the OS application-data folder directly:{Environment.NewLine}"
+            + string.Join(Environment.NewLine, offenders.Select(o => "  " + o))
+            + $"{Environment.NewLine}Use IConfigurationProviderService.GetApplicationDataPath() so a user-relocated "
+            + "data directory is honoured, or add the file to the allowlist in this test with a reason.";
+
+        Assert.True(offenders.Count == 0, message);
+    }
+
+    /// <summary>
+    /// Walks up from the test assembly to the directory containing the solution.
+    /// </summary>
+    /// <returns>The repository root path.</returns>
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "GenHub", "GenHub.Core")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate the repository root above {AppContext.BaseDirectory}.");
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
@@ -1,8 +1,8 @@
-using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameProfiles;
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Launching;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Interfaces.Notifications;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
@@ -41,6 +41,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProviderMock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
 
         // Mock missing dependencies
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);
@@ -78,6 +79,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
 
         // Mock dependencies required for manifest services
         services.AddSingleton<IManifestIdService>(new GenHub.Core.Models.Manifest.ManifestIdService());
@@ -122,6 +124,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
 
         // Mock missing dependencies
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);
@@ -156,6 +159,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
 
         // Act
         services.AddLaunchingServices();
@@ -187,6 +191,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);
         services.AddScoped(provider => new Mock<IContentManifestPool>().Object);
         services.AddScoped(provider => new Mock<IContentOrchestrator>().Object);
@@ -231,6 +236,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProviderMock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
 
         try
         {
@@ -274,6 +280,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
 
         // Mock missing dependencies
         services.AddSingleton<IGameInstallationService>(new Mock<IGameInstallationService>().Object);
@@ -330,6 +337,7 @@ public class GameProfileModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
 
         // Mock missing dependencies
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/GameProfileModuleTests.cs
@@ -1,3 +1,4 @@
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameInstallations;
@@ -39,6 +40,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProviderMock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
 
         // Mock missing dependencies
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);
@@ -75,6 +77,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
 
         // Mock dependencies required for manifest services
         services.AddSingleton<IManifestIdService>(new GenHub.Core.Models.Manifest.ManifestIdService());
@@ -118,6 +121,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
 
         // Mock missing dependencies
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);
@@ -151,6 +155,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
 
         // Act
         services.AddLaunchingServices();
@@ -181,6 +186,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);
         services.AddScoped(provider => new Mock<IContentManifestPool>().Object);
         services.AddScoped(provider => new Mock<IContentOrchestrator>().Object);
@@ -224,6 +230,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProviderMock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
 
         try
         {
@@ -266,6 +273,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
 
         // Mock missing dependencies
         services.AddSingleton<IGameInstallationService>(new Mock<IGameInstallationService>().Object);
@@ -321,6 +329,7 @@ public class GameProfileModuleTests
         services.AddLogging();
         services.AddSingleton<IConfigurationProviderService>(configProvider_mock.Object);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
 
         // Mock missing dependencies
         services.AddScoped(provider => new Mock<IGameInstallationService>().Object);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
@@ -12,6 +12,7 @@ using GenHub.Features.Settings.ViewModels;
 using GenHub.Infrastructure.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using GenHub.Core.Interfaces.Workspace;
 
 namespace GenHub.Tests.Core.Infrastructure.DependencyInjection;
 
@@ -35,6 +36,7 @@ public class SharedViewModelModuleTests
         services.AddSingleton<IConfigurationProviderService>(configProvider);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
         services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
+        services.AddSingleton<ISymlinkCapabilityProvider>(new Mock<ISymlinkCapabilityProvider>().Object);
         services.AddSingleton<IUserSettingsService>(CreateMockUserSettingsService());
         services.AddSingleton<IAppConfiguration>(CreateMockAppConfiguration());
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
@@ -1,8 +1,9 @@
 using GenHub.Common.ViewModels;
-using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Workspace;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
@@ -12,7 +13,6 @@ using GenHub.Features.Settings.ViewModels;
 using GenHub.Infrastructure.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using GenHub.Core.Interfaces.Workspace;
 
 namespace GenHub.Tests.Core.Infrastructure.DependencyInjection;
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/DependencyInjection/SharedViewModelModuleTests.cs
@@ -1,4 +1,5 @@
 using GenHub.Common.ViewModels;
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.Manifest;
@@ -33,6 +34,7 @@ public class SharedViewModelModuleTests
         var configProvider = CreateMockConfigProvider();
         services.AddSingleton<IConfigurationProviderService>(configProvider);
         services.AddSingleton<IStorageLocationService>(new Mock<IStorageLocationService>().Object);
+        services.AddSingleton<IGamePathProvider>(new Mock<IGamePathProvider>().Object);
         services.AddSingleton<IUserSettingsService>(CreateMockUserSettingsService());
         services.AddSingleton<IAppConfiguration>(CreateMockAppConfiguration());
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Manifest/ManifestIngestionGateTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Manifest/ManifestIngestionGateTests.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+using GenHub.Core.Constants;
+using GenHub.Core.Models.Manifest;
+using Xunit;
+
+namespace GenHub.Tests.Core.Models.Manifest;
+
+/// <summary>
+/// Tests for <see cref="ManifestIngestionGate"/>, the fail-closed gate that keeps
+/// variant manifests out until the content pipeline is migrated.
+/// </summary>
+public class ManifestIngestionGateTests
+{
+    /// <summary>
+    /// A manifest without variants is the current published shape and must be unaffected.
+    /// </summary>
+    [Fact]
+    public void TryAccept_WithoutVariants_Accepts()
+    {
+        var manifest = new ContentManifest { Id = new("1.0.genhub.mod.legacy") };
+
+        Assert.True(ManifestIngestionGate.TryAccept(manifest, out var reason));
+        Assert.Null(reason);
+    }
+
+    /// <summary>
+    /// A manifest declaring variants must be rejected: every consumer still reads
+    /// <c>Files</c>, which is empty for a variant manifest, so accepting it would deliver
+    /// nothing while reporting success.
+    /// </summary>
+    [Fact]
+    public void TryAccept_WithVariants_RejectsWithActionableReason()
+    {
+        var manifest = new ContentManifest { Id = new("1.0.genhub.mod.variant") };
+        manifest.Variants.Add(new ArtifactVariant());
+
+        Assert.False(ManifestIngestionGate.TryAccept(manifest, out var reason));
+        Assert.NotNull(reason);
+
+        // The message must name the manifest, the version it requires, and the way out.
+        Assert.Contains("1.0.genhub.mod.variant", reason);
+        Assert.Contains("2", reason);
+        Assert.Contains("without", reason);
+    }
+
+    /// <summary>
+    /// A null manifest is not the gate's concern; callers already treat null as a failed
+    /// parse, and reporting it here would attribute a parse failure to variants.
+    /// </summary>
+    [Fact]
+    public void TryAccept_WithNull_Accepts()
+    {
+        Assert.True(ManifestIngestionGate.TryAccept(null, out var reason));
+        Assert.Null(reason);
+    }
+
+    /// <summary>
+    /// A manifest declaring the variants format version is rejected even with no variants
+    /// present: that version may carry other features this pipeline cannot handle.
+    /// </summary>
+    [Fact]
+    public void TryAccept_WithVariantFormatVersionButNoVariants_Rejects()
+    {
+        var manifest = new ContentManifest
+        {
+            Id = new("1.0.genhub.mod.futureformat"),
+            ManifestVersion = ManifestConstants.VariantsManifestFormatVersion.ToString(CultureInfo.InvariantCulture),
+        };
+
+        Assert.False(ManifestIngestionGate.TryAccept(manifest, out var reason));
+        Assert.Contains("format version", reason);
+    }
+
+    /// <summary>
+    /// Variants are rejected even when the manifest claims the legacy version, so a
+    /// mislabelled manifest cannot slip past by understating its format.
+    /// </summary>
+    [Fact]
+    public void TryAccept_WithVariantsButLegacyVersion_StillRejects()
+    {
+        var manifest = new ContentManifest
+        {
+            Id = new("1.0.genhub.mod.mislabelled"),
+            ManifestVersion = ManifestConstants.DefaultManifestVersion,
+        };
+        manifest.Variants.Add(new ArtifactVariant());
+
+        Assert.False(ManifestIngestionGate.TryAccept(manifest, out var reason));
+        Assert.Contains("variant", reason);
+    }
+
+    /// <summary>
+    /// The default version must remain acceptable; every manifest published today carries it.
+    /// </summary>
+    [Fact]
+    public void TryAccept_WithDefaultVersion_Accepts()
+    {
+        var manifest = new ContentManifest
+        {
+            Id = new("1.0.genhub.mod.legacy"),
+            ManifestVersion = ManifestConstants.DefaultManifestVersion,
+        };
+
+        Assert.True(ManifestIngestionGate.TryAccept(manifest, out _));
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Manifest/ManifestVariantResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Manifest/ManifestVariantResolverTests.cs
@@ -10,9 +10,6 @@ namespace GenHub.Tests.Core.Models.Manifest;
 /// </summary>
 public class ManifestVariantResolverTests
 {
-    private static ManifestFile File(string path, bool isExecutable = false) =>
-        new() { RelativePath = path, IsExecutable = isExecutable };
-
     /// <summary>
     /// A manifest with no variants keeps behaving exactly as before. Every manifest
     /// written before variants existed is this shape, including everything already
@@ -235,4 +232,7 @@ public class ManifestVariantResolverTests
         Assert.False(resolution.Success);
         Assert.Contains("no launchable file", resolution.Reason);
     }
+
+    private static ManifestFile File(string path, bool isExecutable = false) =>
+        new() { RelativePath = path, IsExecutable = isExecutable };
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Manifest/ManifestVariantResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Manifest/ManifestVariantResolverTests.cs
@@ -1,0 +1,238 @@
+using System.Collections.Generic;
+using GenHub.Core.Models.Manifest;
+using Xunit;
+
+namespace GenHub.Tests.Core.Models.Manifest;
+
+/// <summary>
+/// Tests for <see cref="ManifestVariantResolver"/>, which replaced an order-dependent
+/// <c>FirstOrDefault(f =&gt; f.IsExecutable)</c> with an explicit resolution chain.
+/// </summary>
+public class ManifestVariantResolverTests
+{
+    private static ManifestFile File(string path, bool isExecutable = false) =>
+        new() { RelativePath = path, IsExecutable = isExecutable };
+
+    /// <summary>
+    /// A manifest with no variants keeps behaving exactly as before. Every manifest
+    /// written before variants existed is this shape, including everything already
+    /// sitting in a user's content store.
+    /// </summary>
+    [Fact]
+    public void NoVariants_UsesFlatFileList()
+    {
+        var manifest = new ContentManifest { Files = [File("generals.exe", true), File("data.big")] };
+
+        Assert.Equal(2, ManifestVariantResolver.ResolveFiles(manifest).Count);
+        Assert.True(ManifestVariantResolver.SupportsRuntime(manifest, "osx-arm64"));
+        Assert.Null(ManifestVariantResolver.ResolveVariant(manifest));
+    }
+
+    /// <summary>
+    /// With variants declared, the host's runtime identifier selects one.
+    /// </summary>
+    [Fact]
+    public void Variants_SelectByRuntimeIdentifier()
+    {
+        var manifest = new ContentManifest
+        {
+            Variants =
+            [
+                new() { RuntimeIdentifiers = ["win-x64"], EntryPoint = "generalszh.exe", Files = [File("generalszh.exe", true)] },
+                new() { RuntimeIdentifiers = ["osx-arm64"], EntryPoint = "generalszh", Files = [File("generalszh", true), File("libSDL3.dylib")] },
+            ],
+        };
+
+        Assert.Equal("generalszh", ManifestVariantResolver.ResolveEntryPoint(manifest, "osx-arm64").RelativePath);
+        Assert.Equal("generalszh.exe", ManifestVariantResolver.ResolveEntryPoint(manifest, "win-x64").RelativePath);
+        Assert.Equal(2, ManifestVariantResolver.ResolveFiles(manifest, "osx-arm64").Count);
+    }
+
+    /// <summary>
+    /// Content that declares variants but matches none must report that it cannot run
+    /// here, so the catalogue can hide it rather than let a user install something inert.
+    /// </summary>
+    [Fact]
+    public void Variants_UnmatchedRuntime_IsNotSupported()
+    {
+        var manifest = new ContentManifest
+        {
+            Variants = [new() { RuntimeIdentifiers = ["win-x64"], Files = [File("generals.exe", true)] }],
+        };
+
+        Assert.False(ManifestVariantResolver.SupportsRuntime(manifest, "osx-arm64"));
+        Assert.Empty(ManifestVariantResolver.ResolveFiles(manifest, "osx-arm64"));
+    }
+
+    /// <summary>
+    /// A platform-neutral variant is a valid fallback, but an explicit match wins. A
+    /// release carrying both a native build and a neutral asset bundle must resolve to
+    /// the native build on a platform it supports.
+    /// </summary>
+    [Fact]
+    public void ExplicitRuntimeMatch_BeatsNeutralVariant()
+    {
+        var manifest = new ContentManifest
+        {
+            Variants =
+            [
+                new() { RuntimeIdentifiers = [], EntryPoint = "shared", Files = [File("shared", true)] },
+                new() { RuntimeIdentifiers = ["osx-arm64"], EntryPoint = "native", Files = [File("native", true)] },
+            ],
+        };
+
+        Assert.Equal("native", ManifestVariantResolver.ResolveEntryPoint(manifest, "osx-arm64").RelativePath);
+        Assert.Equal("shared", ManifestVariantResolver.ResolveEntryPoint(manifest, "linux-x64").RelativePath);
+    }
+
+    /// <summary>
+    /// This is the case the old code got silently wrong. Several files can legitimately
+    /// need the execute bit, and picking the first one is picking by enumeration order.
+    /// </summary>
+    [Fact]
+    public void MultipleExecutables_WithoutEntryPoint_FailsAndListsCandidates()
+    {
+        var manifest = new ContentManifest
+        {
+            Files = [File("generalszh", true), File("crashhandler", true), File("updater", true)],
+        };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.False(resolution.Success);
+        Assert.Contains("ambiguous", resolution.Reason);
+        Assert.Equal(3, resolution.Candidates.Count);
+        Assert.Contains("generalszh", resolution.ToString());
+    }
+
+    /// <summary>
+    /// A declared entry point removes the ambiguity above.
+    /// </summary>
+    [Fact]
+    public void DeclaredEntryPoint_ResolvesAmbiguity()
+    {
+        var manifest = new ContentManifest
+        {
+            EntryPoint = "generalszh",
+            Files = [File("crashhandler", true), File("generalszh", true), File("updater", true)],
+        };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.True(resolution.Success);
+        Assert.Equal("generalszh", resolution.RelativePath);
+    }
+
+    /// <summary>
+    /// An entry point naming a file the manifest does not contain is a manifest defect.
+    /// Catching it here is far more diagnosable than a missing-file error at launch.
+    /// </summary>
+    [Fact]
+    public void DeclaredEntryPoint_NotInFileList_Fails()
+    {
+        var manifest = new ContentManifest
+        {
+            EntryPoint = "generalszh",
+            Files = [File("generals.exe", true)],
+        };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.False(resolution.Success);
+        Assert.Contains("not among its", resolution.Reason);
+    }
+
+    /// <summary>
+    /// Path separators and case must not defeat the entry-point match: manifests are
+    /// authored on Windows and consumed on Unix.
+    /// </summary>
+    /// <param name="entryPoint">The declared entry point.</param>
+    /// <param name="filePath">The path as stored in the file list.</param>
+    [Theory]
+    [InlineData("Release/generalszh", "Release/generalszh")]
+    [InlineData("Release\\generalszh", "Release/generalszh")]
+    [InlineData("release/GENERALSZH", "Release/generalszh")]
+    public void EntryPointMatching_IgnoresSeparatorAndCase(string entryPoint, string filePath)
+    {
+        var manifest = new ContentManifest { EntryPoint = entryPoint, Files = [File(filePath, true)] };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.True(resolution.Success);
+        Assert.Equal(filePath, resolution.RelativePath);
+    }
+
+    /// <summary>
+    /// A variant must not inherit the flat manifest entry point. The flat file list and
+    /// its entry point are ignored whenever variants are present.
+    /// </summary>
+    [Fact]
+    public void VariantWithoutEntryPoint_DoesNotUseFlatManifestEntryPoint()
+    {
+        var manifest = new ContentManifest
+        {
+            EntryPoint = "flat.exe",
+            Files = [File("flat.exe", true)],
+            Variants =
+            [
+                new()
+                {
+                    RuntimeIdentifiers = ["linux-x64"],
+                    Files = [File("run.sh", true), File("generalszh", true)],
+                },
+            ],
+        };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest, "linux-x64");
+
+        Assert.True(resolution.Success);
+        Assert.Equal("generalszh", resolution.RelativePath);
+    }
+
+    /// <summary>
+    /// Helper scripts need execute permission but are not inferred launch targets.
+    /// </summary>
+    [Fact]
+    public void ExecutePermissionHelper_DoesNotMakeNativeClientAmbiguous()
+    {
+        var manifest = new ContentManifest
+        {
+            Files = [File("run.sh", true), File("generalszh", true)],
+        };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.True(resolution.Success);
+        Assert.Equal("generalszh", resolution.RelativePath);
+    }
+
+    /// <summary>
+    /// Legacy manifests that set no execute flags still resolve when exactly one file
+    /// looks like a launch target by extension.
+    /// </summary>
+    [Fact]
+    public void LegacyManifest_WithSingleExe_StillResolves()
+    {
+        var manifest = new ContentManifest { Files = [File("generals.exe"), File("data.big"), File("d3d8.dll")] };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.True(resolution.Success);
+        Assert.Equal("generals.exe", resolution.RelativePath);
+    }
+
+    /// <summary>
+    /// A manifest with nothing runnable reports that plainly rather than resolving to
+    /// some arbitrary data file.
+    /// </summary>
+    [Fact]
+    public void ManifestWithNoLaunchableFile_Fails()
+    {
+        var manifest = new ContentManifest { Files = [File("maps.big"), File("Options.ini")] };
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.False(resolution.Success);
+        Assert.Contains("no launchable file", resolution.Reason);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
@@ -15,6 +15,7 @@ public class ExecutableFileClassifierTests
     /// <param name="path">The candidate path.</param>
     /// <param name="expected">Whether the execute bit is required.</param>
     [Theory]
+
     // Native binaries have no extension. This is the case the old classifiers disagreed
     // on, and the one a native macOS or Linux game client depends on.
     [InlineData("generalszh", true)]
@@ -22,11 +23,13 @@ public class ExecutableFileClassifierTests
     [InlineData("generals.exe", true)]
     [InlineData("run.sh", true)]
     [InlineData("Launch.command", true)]
+
     // Loadable code, mapped by the loader with read access. Marking these +x is
     // meaningless and, under a hard-link workspace, would mutate a shared CAS blob.
     [InlineData("libSDL3.dylib", false)]
     [InlineData("libbgfx.so", false)]
     [InlineData("d3d8.dll", false)]
+
     // Data, whatever the Steam layout does with it.
     [InlineData("game.dat", false)]
     [InlineData("INIZH.big", false)]
@@ -47,11 +50,13 @@ public class ExecutableFileClassifierTests
     [InlineData("generalszh", true)]
     [InlineData("generals.exe", true)]
     [InlineData("GeneralsOnlineZH_60.exe", true)]
+
     // A library is never launched, so it must not win a FirstOrDefault over the real
     // entry point simply by appearing earlier in the file list.
     [InlineData("libSDL3.dylib", false)]
     [InlineData("libbgfx.so", false)]
     [InlineData("d3d8.dll", false)]
+
     // Shell wrappers are runnable but are not what a profile launches; the engine binary is.
     [InlineData("run.sh", false)]
     [InlineData("game.dat", false)]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
@@ -1,0 +1,81 @@
+using GenHub.Core.Utilities;
+using Xunit;
+
+namespace GenHub.Tests.Core.Utilities;
+
+/// <summary>
+/// Table-driven tests for <see cref="ExecutableFileClassifier"/>, which replaced five
+/// disagreeing implementations of "is this executable".
+/// </summary>
+public class ExecutableFileClassifierTests
+{
+    /// <summary>
+    /// Verifies which files are marked as needing the Unix execute bit.
+    /// </summary>
+    /// <param name="path">The candidate path.</param>
+    /// <param name="expected">Whether the execute bit is required.</param>
+    [Theory]
+    // Native binaries have no extension. This is the case the old classifiers disagreed
+    // on, and the one a native macOS or Linux game client depends on.
+    [InlineData("generalszh", true)]
+    [InlineData("GeneralsMD/Release/generalszh", true)]
+    [InlineData("generals.exe", true)]
+    [InlineData("run.sh", true)]
+    [InlineData("Launch.command", true)]
+    // Loadable code, mapped by the loader with read access. Marking these +x is
+    // meaningless and, under a hard-link workspace, would mutate a shared CAS blob.
+    [InlineData("libSDL3.dylib", false)]
+    [InlineData("libbgfx.so", false)]
+    [InlineData("d3d8.dll", false)]
+    // Data, whatever the Steam layout does with it.
+    [InlineData("game.dat", false)]
+    [InlineData("INIZH.big", false)]
+    [InlineData("Options.ini", false)]
+    [InlineData("texture.tga", false)]
+    [InlineData("", false)]
+    public void RequiresExecutePermission_ClassifiesCorrectly(string path, bool expected)
+    {
+        Assert.Equal(expected, ExecutableFileClassifier.RequiresExecutePermission(path));
+    }
+
+    /// <summary>
+    /// Verifies which files may serve as a launch target when no entry point is declared.
+    /// </summary>
+    /// <param name="path">The candidate path.</param>
+    /// <param name="expected">Whether the file is a plausible legacy launch target.</param>
+    [Theory]
+    [InlineData("generalszh", true)]
+    [InlineData("generals.exe", true)]
+    [InlineData("GeneralsOnlineZH_60.exe", true)]
+    // A library is never launched, so it must not win a FirstOrDefault over the real
+    // entry point simply by appearing earlier in the file list.
+    [InlineData("libSDL3.dylib", false)]
+    [InlineData("libbgfx.so", false)]
+    [InlineData("d3d8.dll", false)]
+    // Shell wrappers are runnable but are not what a profile launches; the engine binary is.
+    [InlineData("run.sh", false)]
+    [InlineData("game.dat", false)]
+    [InlineData("", false)]
+    public void IsLegacyLaunchCandidate_ClassifiesCorrectly(string path, bool expected)
+    {
+        Assert.Equal(expected, ExecutableFileClassifier.IsLegacyLaunchCandidate(path));
+    }
+
+    /// <summary>
+    /// The two questions must not be assumed equivalent. A dylib needs neither, a shell
+    /// wrapper needs the execute bit but is not a launch target, and a native binary
+    /// needs both. Collapsing them into one boolean is what this class exists to undo.
+    /// </summary>
+    [Fact]
+    public void TheTwoQuestionsAreIndependent()
+    {
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("run.sh"));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("run.sh"));
+
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generalszh"));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("generalszh"));
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("libSDL3.dylib"));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("libSDL3.dylib"));
+    }
+}

--- a/GenHub/GenHub.Windows/Features/Workspace/WindowsSymlinkCapabilityProvider.cs
+++ b/GenHub/GenHub.Windows/Features/Workspace/WindowsSymlinkCapabilityProvider.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using GenHub.Core.Interfaces.Workspace;
+
+namespace GenHub.Windows.Features.Workspace;
+
+/// <summary>
+/// Symlink capability on Windows.
+/// </summary>
+/// <remarks>
+/// Capability is determined by a real, cached creation probe rather than Administrator
+/// membership. Developer Mode can permit unelevated symlink creation, while policy can
+/// deny it to an otherwise elevated process.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsSymlinkCapabilityProvider : ISymlinkCapabilityProvider
+{
+    private static readonly Lazy<bool> _cachedCapability = new(ProbeCapability);
+
+    /// <inheritdoc/>
+    public bool CanCreateSymlinks => _cachedCapability.Value;
+
+    private static bool ProbeCapability()
+    {
+        var probeId = Guid.NewGuid().ToString("N");
+        var targetPath = Path.Combine(Path.GetTempPath(), $"genhub-symlink-target-{probeId}.tmp");
+        var linkPath = Path.Combine(Path.GetTempPath(), $"genhub-symlink-link-{probeId}.tmp");
+
+        try
+        {
+            File.WriteAllText(targetPath, string.Empty);
+            File.CreateSymbolicLink(linkPath, targetPath);
+            return new FileInfo(linkPath).LinkTarget is not null;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+        finally
+        {
+            DeleteIfExists(linkPath);
+            DeleteIfExists(targetPath);
+        }
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup of a uniquely named temporary probe.
+        }
+    }
+}

--- a/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
+++ b/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
@@ -32,6 +32,7 @@ public static class WindowsServicesModule
         // Register Windows-specific services
         services.AddSingleton<IGameInstallationDetector, WindowsInstallationDetector>();
         services.AddSingleton<IGamePathProvider, WindowsGamePathProvider>();
+        services.AddSingleton<ISymlinkCapabilityProvider, WindowsSymlinkCapabilityProvider>();
         services.AddSingleton<IGitHubTokenStorage, WindowsGitHubTokenStorage>();
         services.AddSingleton<IShortcutService, WindowsShortcutService>();
 

--- a/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
+++ b/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.Versioning;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GitHub;
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Shortcuts;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Interfaces.Workspace;
@@ -10,6 +11,7 @@ using GenHub.Windows.Features.GitHub.Services;
 using GenHub.Windows.Features.Shortcuts;
 using GenHub.Windows.Features.Workspace;
 using GenHub.Windows.GameInstallations;
+using GenHub.Features.GameSettings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -29,6 +31,7 @@ public static class WindowsServicesModule
     {
         // Register Windows-specific services
         services.AddSingleton<IGameInstallationDetector, WindowsInstallationDetector>();
+        services.AddSingleton<IGamePathProvider, WindowsGamePathProvider>();
         services.AddSingleton<IGitHubTokenStorage, WindowsGitHubTokenStorage>();
         services.AddSingleton<IShortcutService, WindowsShortcutService>();
 

--- a/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
+++ b/GenHub/GenHub.Windows/Infrastructure/DependencyInjection/WindowsServicesModule.cs
@@ -1,17 +1,17 @@
 using System;
 using System.Runtime.Versioning;
 using GenHub.Core.Interfaces.GameInstallations;
-using GenHub.Core.Interfaces.GitHub;
 using GenHub.Core.Interfaces.GameSettings;
+using GenHub.Core.Interfaces.GitHub;
 using GenHub.Core.Interfaces.Shortcuts;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Interfaces.Workspace;
+using GenHub.Features.GameSettings;
 using GenHub.Features.Workspace;
 using GenHub.Windows.Features.GitHub.Services;
 using GenHub.Windows.Features.Shortcuts;
 using GenHub.Windows.Features.Workspace;
 using GenHub.Windows.GameInstallations;
-using GenHub.Features.GameSettings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using SharpCompress.Archives;
 using SharpCompress.Archives.SevenZip;
 using SharpCompress.Common;
+using GenHub.Core.Utilities;
 
 namespace GenHub.Features.Content.Services.CommunityOutpost;
 
@@ -177,7 +178,7 @@ public class CommunityOutpostDeliverer(
                 RelativePath = relativePath,
                 Size = fileInfo.Length,
                 IsRequired = true,
-                IsExecutable = relativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase),
+                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(relativePath),
                 SourceType = ContentSourceType.ExtractedPackage,
             });
         }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -1,11 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
@@ -18,11 +10,19 @@ using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
+using GenHub.Core.Utilities;
 using Microsoft.Extensions.Logging;
 using SharpCompress.Archives;
 using SharpCompress.Archives.SevenZip;
 using SharpCompress.Common;
-using GenHub.Core.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GenHub.Features.Content.Services.CommunityOutpost;
 

--- a/GenHub/GenHub/Features/Content/Services/Helpers/GitHubInferenceHelper.cs
+++ b/GenHub/GenHub/Features/Content/Services/Helpers/GitHubInferenceHelper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using GenHub.Core.Constants;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GitHub;
+using GenHub.Core.Utilities;
 
 namespace GenHub.Features.Content.Services.Helpers;
 
@@ -190,12 +191,7 @@ public static class GitHubInferenceHelper
     /// <returns>True when the extension matches a known executable type.</returns>
     public static bool IsExecutableFile(string fileName)
     {
-        var ext = Path.GetExtension(fileName);
-        return ext.Equals(".exe", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".dll", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".sh", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".bat", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".so", StringComparison.OrdinalIgnoreCase);
+        return ExecutableFileClassifier.RequiresExecutePermission(fileName);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -156,7 +156,7 @@ public class ProfileLauncherFacade(
 
                     // Define a base path for the workspace - for tools we can use a temp dir or app data
                     // WorkspaceManager requires a BaseInstallationPath, even if empty for tools
-                    var appDataBase = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppConstants.AppName);
+                    var appDataBase = configurationProvider.GetApplicationDataPath();
                     if (!Directory.Exists(appDataBase)) Directory.CreateDirectory(appDataBase);
 
                     var baseDetails = appDataBase;

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -174,7 +174,7 @@ public class ProfileLauncherFacade(
                     if (effectiveToolStrategy != requestedToolStrategy)
                     {
                         logger.LogInformation(
-                            "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink: this platform cannot create symlinks without elevation",
+                            "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink: symlinks are unavailable in this environment",
                             requestedToolStrategy);
                     }
 
@@ -447,7 +447,7 @@ public class ProfileLauncherFacade(
             logger.LogDebug("[Launch] Step 4: Options.ini will be applied by GameLauncher (delegated)");
 
             var effectiveStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
-            logger.LogDebug("[Launch] Step 5: Checking workspace strategy and admin rights - Strategy: {Strategy}", effectiveStrategy);
+            logger.LogDebug("[Launch] Step 5: Checking workspace strategy and symlink capability - Strategy: {Strategy}", effectiveStrategy);
 
             // Downgrade symlink strategies only where symlinks genuinely cannot be created.
             // This previously asked whether the process was an administrator and computed
@@ -462,18 +462,18 @@ public class ProfileLauncherFacade(
 
             if (!canCreateSymlinks && (effectiveStrategy == WorkspaceStrategy.HybridCopySymlink || effectiveStrategy == WorkspaceStrategy.SymlinkOnly))
             {
-                // No admin rights - switch profile to HardLink strategy permanently
+                // Symlinks unavailable here - switch the profile to HardLink
                 var originalStrategy = effectiveStrategy;
                 effectiveStrategy = WorkspaceStrategy.HardLink; // Force HardLink instead of default which might be symlink-based
 
                 logger.LogInformation(
-                    "Profile {ProfileId} - Switching from {OriginalStrategy} to HardLink strategy due to missing admin rights",
+                    "Profile {ProfileId} - Switching from {OriginalStrategy} to HardLink because symlinks are unavailable in this environment",
                     profileId,
                     originalStrategy);
 
                 notificationService.ShowInfo(
                     "Workspace Strategy Changed",
-                    $"'{profile.Name}' requires admin for {originalStrategy}. Switching to HardLink strategy.",
+                    $"'{profile.Name}' cannot use {originalStrategy} here because symlinks are unavailable. Switching to HardLink.",
                     NotificationDurations.Long);
 
                 // Persist the downgrade only if the profile had an explicit strategy set (not inheriting default)
@@ -487,7 +487,7 @@ public class ProfileLauncherFacade(
                     if (strategyUpdateResult.Success)
                     {
                         logger.LogInformation(
-                            "Updated profile {ProfileId} workspace strategy to {Strategy} due to admin rights requirement",
+                            "Updated profile {ProfileId} workspace strategy to {Strategy} because symlinks are unavailable",
                             profileId,
                             effectiveStrategy);
                     }

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -52,6 +52,7 @@ public class ProfileLauncherFacade(
     IPublisherReconcilerRegistry reconcilerRegistry,
     IConfigurationProviderService configurationProvider,
     IGameProcessManager gameProcessManager,
+    ISymlinkCapabilityProvider symlinkCapability,
     ILogger<ProfileLauncherFacade> logger) : IProfileLauncherFacade
 {
     /// <inheritdoc/>
@@ -165,22 +166,16 @@ public class ProfileLauncherFacade(
                     var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? [], cancellationToken);
                     var allManifests = resolutionResult.Success ? resolutionResult.ResolvedManifests : [toolManifest];
 
-                    // Determine effective strategy with admin rights check for symlink strategies
-                    var effectiveToolStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
-                    var isToolAdmin = false;
-                    if (OperatingSystem.IsWindows())
-                    {
-                        using var identity = WindowsIdentity.GetCurrent();
-                        var principal = new WindowsPrincipal(identity);
-                        isToolAdmin = principal.IsInRole(WindowsBuiltInRole.Administrator);
-                    }
+                    // Determine effective strategy, downgrading symlink strategies only
+                    // where symlinks genuinely cannot be created. See ISymlinkCapabilityProvider.
+                    var requestedToolStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
+                    var effectiveToolStrategy = ResolveSupportedWorkspaceStrategy(requestedToolStrategy);
 
-                    if (!isToolAdmin && (effectiveToolStrategy == WorkspaceStrategy.HybridCopySymlink || effectiveToolStrategy == WorkspaceStrategy.SymlinkOnly))
+                    if (effectiveToolStrategy != requestedToolStrategy)
                     {
                         logger.LogInformation(
-                            "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink strategy due to missing admin rights",
-                            effectiveToolStrategy);
-                        effectiveToolStrategy = WorkspaceStrategy.HardLink;
+                            "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink: this platform cannot create symlinks without elevation",
+                            requestedToolStrategy);
                     }
 
                     actualWorkspaceId = $"{ProfileConstants.ToolProfileWorkspaceIdPrefix}-{profile.Id}";
@@ -454,30 +449,18 @@ public class ProfileLauncherFacade(
             var effectiveStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
             logger.LogDebug("[Launch] Step 5: Checking workspace strategy and admin rights - Strategy: {Strategy}", effectiveStrategy);
 
-            // Admin check for symlink strategies.
-            // If not admin and using a symlink-based strategy, permanently switch the profile to HardLink strategy.
-            var isProfileAdmin = false;
-            if (OperatingSystem.IsWindows())
-            {
-                using var identity = WindowsIdentity.GetCurrent();
-                var principal = new WindowsPrincipal(identity);
-                isProfileAdmin = principal.IsInRole(WindowsBuiltInRole.Administrator);
-                logger.LogInformation(
-                    "Profile {ProfileId} launch - Admin check: IsAdmin={IsAdmin}, User={User}, Strategy={Strategy}",
-                    profileId,
-                    isProfileAdmin,
-                    identity.Name,
-                    effectiveStrategy);
-            }
-            else
-            {
-                logger.LogInformation(
-                    "Profile {ProfileId} launch - Non-Windows platform, admin check skipped, Strategy={Strategy}",
-                    profileId,
-                    effectiveStrategy);
-            }
+            // Downgrade symlink strategies only where symlinks genuinely cannot be created.
+            // This previously asked whether the process was an administrator and computed
+            // that only on Windows, leaving it false on Unix — which made SymlinkOnly and
+            // HybridCopySymlink unreachable there despite symlink(2) needing no privilege.
+            var canCreateSymlinks = symlinkCapability.CanCreateSymlinks;
+            logger.LogInformation(
+                "Profile {ProfileId} launch - Symlink capability: {CanCreateSymlinks}, Strategy={Strategy}",
+                profileId,
+                canCreateSymlinks,
+                effectiveStrategy);
 
-            if (!isProfileAdmin && (effectiveStrategy == WorkspaceStrategy.HybridCopySymlink || effectiveStrategy == WorkspaceStrategy.SymlinkOnly))
+            if (!canCreateSymlinks && (effectiveStrategy == WorkspaceStrategy.HybridCopySymlink || effectiveStrategy == WorkspaceStrategy.SymlinkOnly))
             {
                 // No admin rights - switch profile to HardLink strategy permanently
                 var originalStrategy = effectiveStrategy;
@@ -510,6 +493,11 @@ public class ProfileLauncherFacade(
                     }
                 }
             }
+
+            // GameLauncher constructs the actual workspace request from this in-memory
+            // profile. Persisting an explicit downgrade is not enough: inherited defaults
+            // are intentionally not persisted, and persistence may fail independently.
+            profile.WorkspaceStrategy = effectiveStrategy;
 
             // Use dynamic workspace path based on the game installation location
             var casPoolPath = storageLocationService.GetCasPoolPath(resolvedInstallation);
@@ -950,7 +938,8 @@ public class ProfileLauncherFacade(
                 Id = profileId,
                 Manifests = manifests,
                 GameClient = profile.GameClient!,
-                Strategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy(),
+                Strategy = ResolveSupportedWorkspaceStrategy(
+                    profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy()),
                 ForceRecreate = false,
                 ValidateAfterPreparation = true,
                 ManifestSourcePaths = manifestSourcePaths,
@@ -1730,6 +1719,14 @@ public class ProfileLauncherFacade(
         }
 
         return OperationResult<bool>.CreateSuccess(true);
+    }
+
+    private WorkspaceStrategy ResolveSupportedWorkspaceStrategy(WorkspaceStrategy strategy)
+    {
+        return !symlinkCapability.CanCreateSymlinks
+            && strategy is WorkspaceStrategy.HybridCopySymlink or WorkspaceStrategy.SymlinkOnly
+                ? WorkspaceStrategy.HardLink
+                : strategy;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
+using GenHub.Core.Utilities;
 
 namespace GenHub.Features.GameProfiles.ViewModels;
 
@@ -33,7 +34,7 @@ public partial class FileTreeItem : ObservableObject
     /// <summary>
     /// Gets a value indicating whether this file is an executable (.exe).
     /// </summary>
-    public bool IsExecutable => IsFile && Path.GetExtension(Name).Equals(".exe", StringComparison.OrdinalIgnoreCase);
+    public bool IsExecutable => IsFile && ExecutableFileClassifier.IsLegacyLaunchCandidate(Name);
 
     /// <summary>
     /// Gets or sets a value indicating whether this item is selected as the executable.

--- a/GenHub/GenHub/Features/GameSettings/GamePathProviderBase.cs
+++ b/GenHub/GenHub/Features/GameSettings/GamePathProviderBase.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.GameSettings;
+using GenHub.Core.Models.Enums;
+
+namespace GenHub.Features.GameSettings;
+
+/// <summary>
+/// Shared behaviour for <see cref="IGamePathProvider"/> implementations.
+/// <para>
+/// Every platform uses the same leaf folder name — "Command and Conquer Generals Data"
+/// or "Command and Conquer Generals Zero Hour Data" — and differs only in the base
+/// directory those sit under. Subclasses supply the base; this class owns the rest.
+/// </para>
+/// <para>
+/// The paths are dictated by the game engine, not chosen by GenHub. See
+/// <c>GlobalData::BuildUserDataPathFromRegistry</c> in the GeneralsGameCode tree:
+/// Windows resolves Documents via <c>SHGetKnownFolderPath</c>, macOS uses
+/// <c>~/Library/Application Support</c>, and Linux uses <c>XDG_DATA_HOME</c> with a
+/// <c>~/.local/share</c> fallback. Writing Options.ini anywhere else means the engine
+/// silently never reads it, the launch still succeeds, and every profile setting is
+/// discarded without an error.
+/// </para>
+/// </summary>
+public abstract class GamePathProviderBase : IGamePathProvider
+{
+    /// <inheritdoc/>
+    public string GetOptionsDirectory(GameType gameType)
+    {
+        var folderName = gameType == GameType.ZeroHour
+            ? GameSettingsConstants.FolderNames.ZeroHour
+            : GameSettingsConstants.FolderNames.Generals;
+
+        return Path.Combine(GetUserDataBaseDirectory(), folderName);
+    }
+
+    /// <summary>
+    /// Gets the platform's base directory for per-user game data, without the
+    /// game-specific leaf folder.
+    /// </summary>
+    /// <returns>An absolute directory path.</returns>
+    protected abstract string GetUserDataBaseDirectory();
+}

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -18,7 +18,7 @@ namespace GenHub.Features.GameSettings;
 /// <summary>
 /// Service for managing game settings (Options.ini) for Generals and Zero Hour.
 /// </summary>
-public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathProvider? pathProvider = null) : IGameSettingsService
+public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathProvider pathProvider) : IGameSettingsService
 {
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
@@ -34,7 +34,12 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     private static readonly SemaphoreSlim _optionsIniWriteSemaphore = new(1, 1);
 
     private readonly ILogger<GameSettingsService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    private readonly IGamePathProvider _pathProvider = pathProvider ?? new WindowsGamePathProvider();
+    // Required, not optional. This previously defaulted to WindowsGamePathProvider when
+    // nothing was registered — which was every platform, because no DI module registered
+    // an IGamePathProvider at all. macOS and Linux therefore wrote Options.ini via
+    // SpecialFolder.MyDocuments, which .NET maps to $HOME on Unix. An unregistered
+    // dependency must fail at container build, not silently resolve to the wrong OS.
+    private readonly IGamePathProvider _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
 
     /// <inheritdoc/>
     public virtual string GetOptionsFilePath(GameType gameType)

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -34,6 +34,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     private static readonly SemaphoreSlim _optionsIniWriteSemaphore = new(1, 1);
 
     private readonly ILogger<GameSettingsService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
     // Required, not optional. This previously defaulted to WindowsGamePathProvider when
     // nothing was registered — which was every platform, because no DI module registered
     // an IGamePathProvider at all. macOS and Linux therefore wrote Options.ini via

--- a/GenHub/GenHub/Features/GameSettings/LinuxGamePathProvider.cs
+++ b/GenHub/GenHub/Features/GameSettings/LinuxGamePathProvider.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+
+namespace GenHub.Features.GameSettings;
+
+/// <summary>
+/// Linux implementation of <see cref="Core.Interfaces.GameSettings.IGamePathProvider"/>.
+/// <para>
+/// Resolves to <c>$XDG_DATA_HOME/Command and Conquer Generals Zero Hour Data</c>,
+/// falling back to <c>~/.local/share/...</c> when the variable is unset, matching
+/// <c>GlobalData::BuildUserDataPathFromRegistry</c> in the game engine.
+/// </para>
+/// <para>
+/// Until this existed, Linux fell through to <c>WindowsGamePathProvider</c> and
+/// resolved <c>Environment.SpecialFolder.MyDocuments</c>, which .NET maps to the home
+/// directory on Unix. Options.ini therefore landed directly in <c>$HOME</c>.
+/// </para>
+/// </summary>
+public sealed class LinuxGamePathProvider : GamePathProviderBase
+{
+    /// <inheritdoc/>
+    protected override string GetUserDataBaseDirectory()
+    {
+        var xdgDataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        if (!string.IsNullOrWhiteSpace(xdgDataHome))
+        {
+            return xdgDataHome;
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        return string.IsNullOrEmpty(home)
+            ? Directory.GetCurrentDirectory()
+            : Path.Combine(home, ".local", "share");
+    }
+}

--- a/GenHub/GenHub/Features/GameSettings/MacOSGamePathProvider.cs
+++ b/GenHub/GenHub/Features/GameSettings/MacOSGamePathProvider.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace GenHub.Features.GameSettings;
+
+/// <summary>
+/// macOS implementation of <see cref="Core.Interfaces.GameSettings.IGamePathProvider"/>.
+/// <para>
+/// Resolves to <c>~/Library/Application Support/Command and Conquer Generals Zero Hour Data</c>,
+/// matching <c>GlobalData::BuildUserDataPathFromRegistry</c> in the game engine.
+/// </para>
+/// <para>
+/// Note there is no vendor subdirectory and the leaf name is identical to Windows.
+/// This is deliberately <em>not</em> the <c>SDL_GetPrefPath</c> convention
+/// (<c>~/Library/Application Support/&lt;org&gt;/&lt;app&gt;/</c>) that an SDL3-based
+/// port might be expected to use.
+/// </para>
+/// </summary>
+public sealed class MacOSGamePathProvider : GamePathProviderBase
+{
+    /// <inheritdoc/>
+    protected override string GetUserDataBaseDirectory()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        // Environment.SpecialFolder.ApplicationData maps to ~/.config on macOS, which is
+        // the Linux convention rather than the Apple one, so it is not used here.
+        return string.IsNullOrEmpty(home)
+            ? Directory.GetCurrentDirectory()
+            : Path.Combine(home, "Library", "Application Support");
+    }
+}

--- a/GenHub/GenHub/Features/GameSettings/WindowsGamePathProvider.cs
+++ b/GenHub/GenHub/Features/GameSettings/WindowsGamePathProvider.cs
@@ -1,23 +1,20 @@
 using System;
-using System.IO;
-using GenHub.Core.Constants;
-using GenHub.Core.Interfaces.GameSettings;
-using GenHub.Core.Models.Enums;
 
 namespace GenHub.Features.GameSettings;
 
 /// <summary>
-/// Windows-specific implementation of game path provider.
+/// Windows implementation of <see cref="Core.Interfaces.GameSettings.IGamePathProvider"/>.
+/// <para>
+/// Resolves to <c>Documents/Command and Conquer Generals Zero Hour Data</c>, matching
+/// <c>GlobalData::BuildUserDataPathFromRegistry</c> in the game engine, which uses
+/// <c>SHGetKnownFolderPath(FOLDERID_Documents)</c> so that OneDrive and Group Policy
+/// folder redirection are honoured. <c>SpecialFolder.MyDocuments</c> resolves through
+/// the same known-folder mechanism.
+/// </para>
 /// </summary>
-public class WindowsGamePathProvider : IGamePathProvider
+public sealed class WindowsGamePathProvider : GamePathProviderBase
 {
     /// <inheritdoc/>
-    public string GetOptionsDirectory(GameType gameType)
-    {
-        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        var folderName = gameType == GameType.ZeroHour
-            ? GameSettingsConstants.FolderNames.ZeroHour
-            : GameSettingsConstants.FolderNames.Generals;
-        return Path.Combine(documentsPath, folderName);
-    }
+    protected override string GetUserDataBaseDirectory() =>
+        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 }

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Manifest;
@@ -10,8 +5,13 @@ using GenHub.Core.Interfaces.Tools;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
-using Microsoft.Extensions.Logging;
 using GenHub.Core.Utilities;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace GenHub.Features.Manifest;
 

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -11,6 +11,7 @@ using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
 using Microsoft.Extensions.Logging;
+using GenHub.Core.Utilities;
 
 namespace GenHub.Features.Manifest;
 
@@ -733,8 +734,10 @@ public partial class ContentManifestBuilder(
 
     private static bool IsExecutableFile(string filePath)
     {
-        var extension = Path.GetExtension(filePath).ToLowerInvariant();
-        return (extension == ".exe" || extension == ".dll" || extension == ".so" || extension == string.Empty) && File.Exists(filePath);
+        // Delegates to the shared classifier. The previous implementation also required
+        // File.Exists, which made classification depend on disk state at build time:
+        // the same manifest could classify differently depending on when it was built.
+        return ExecutableFileClassifier.RequiresExecutePermission(filePath);
     }
 
     /// <returns>The normalized version string.</returns>

--- a/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestPool.cs
@@ -321,6 +321,14 @@ public class ContentManifestPool(
     {
         var errors = new List<string>();
 
+        // Applied here rather than at each caller: both AddManifestAsync overloads run
+        // this, and every deliverer, resolver and detector reaches the pool through them.
+        // Gating the discovery and provider services alone left those paths open.
+        if (!ManifestIngestionGate.TryAccept(manifest, out var variantRejection))
+        {
+            errors.Add(variantRejection!);
+        }
+
         if (string.IsNullOrEmpty(manifest.Id.Value))
             errors.Add("Manifest ID is required");
 

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
@@ -17,32 +18,26 @@ namespace GenHub.Features.Manifest;
 /// <summary>
 /// Service for discovering and indexing manifests in the GenHub file system, and for populating the manifest cache.
 /// </summary>
-public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, IManifestCache manifestCache)
+/// <remarks>
+/// The filesystem enumerators are optional constructor parameters rather than a separate
+/// test-only constructor. A second constructor chaining into this one has to hardcode the
+/// primary constructor's arity, so adding a dependency here breaks that chain without
+/// producing a merge conflict — it merges cleanly and fails to compile instead.
+/// </remarks>
+public class ManifestDiscoveryService(
+    ILogger<ManifestDiscoveryService> logger,
+    IManifestCache manifestCache,
+    IConfigurationProviderService configurationProvider,
+    Func<string, string, IEnumerable<string>>? enumerateFiles = null,
+    Func<string, IEnumerable<string>>? enumerateDirectories = null)
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
     private readonly Func<string, string, IEnumerable<string>> _enumerateFiles =
-        (directory, pattern) => Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly);
+        enumerateFiles ?? ((directory, pattern) =>
+            Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly));
 
     private readonly Func<string, IEnumerable<string>> _enumerateDirectories =
-        directory => Directory.EnumerateDirectories(directory);
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ManifestDiscoveryService"/> class with filesystem test seams.
-    /// </summary>
-    /// <param name="logger">The logger.</param>
-    /// <param name="manifestCache">The manifest cache.</param>
-    /// <param name="enumerateFiles">The top-level file enumerator.</param>
-    /// <param name="enumerateDirectories">The top-level directory enumerator.</param>
-    internal ManifestDiscoveryService(
-        ILogger<ManifestDiscoveryService> logger,
-        IManifestCache manifestCache,
-        Func<string, string, IEnumerable<string>> enumerateFiles,
-        Func<string, IEnumerable<string>> enumerateDirectories)
-        : this(logger, manifestCache)
-    {
-        _enumerateFiles = enumerateFiles;
-        _enumerateDirectories = enumerateDirectories;
-    }
+        enumerateDirectories ?? Directory.EnumerateDirectories;
 
     /// <summary>
     /// Gets manifests by content type.
@@ -127,17 +122,12 @@ public class ManifestDiscoveryService(ILogger<ManifestDiscoveryService> logger, 
         // First discover embedded manifests
         await DiscoverEmbeddedManifestsAsync(cancellationToken);
 
-        // Then discover from local filesystem locations
-        var localManifestDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            AppConstants.AppName,
-            FileTypes.ManifestsDirectory);
-
-        // Also check for custom manifest directories
-        var customManifestDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            AppConstants.AppName,
-            "CustomManifests");
+        // Then discover from local filesystem locations.
+        // Routed through the configuration provider so a user-relocated data directory
+        // is honoured; a raw SpecialFolder lookup would keep reading the default tree.
+        var applicationDataPath = configurationProvider.GetApplicationDataPath();
+        var localManifestDir = Path.Combine(applicationDataPath, FileTypes.ManifestsDirectory);
+        var customManifestDir = Path.Combine(applicationDataPath, "CustomManifests");
 
         await DiscoverFileSystemManifestsAsync([localManifestDir, customManifestDir], cancellationToken);
 

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -193,12 +193,21 @@ public class ManifestDiscoveryService(
         return true;
     }
 
-    private static async Task<ContentManifest?> LoadManifestAsync(string manifestPath, CancellationToken cancellationToken)
+    private async Task<ContentManifest?> LoadManifestAsync(string manifestPath, CancellationToken cancellationToken)
     {
         await using var stream = File.OpenRead(manifestPath);
         var manifest = await JsonSerializer.DeserializeAsync<ContentManifest>(stream, JsonOptions, cancellationToken);
         if (manifest != null && !string.IsNullOrEmpty(manifest.Id))
         {
+            if (!ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+            {
+                logger.LogWarning(
+                    "Skipping manifest at {ManifestPath}: {Reason}",
+                    manifestPath,
+                    rejectionReason);
+                return null;
+            }
+
             return manifest;
         }
 
@@ -279,6 +288,15 @@ public class ManifestDiscoveryService(
                     var manifest = await JsonSerializer.DeserializeAsync<ContentManifest>(stream, JsonOptions, cancellationToken);
                     if (manifest != null && !string.IsNullOrEmpty(manifest.Id))
                     {
+                        if (!ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+                        {
+                            logger.LogWarning(
+                                "Skipping manifest at {ManifestFile}: {Reason}",
+                                manifestFile,
+                                rejectionReason);
+                            continue;
+                        }
+
                         manifestCache.AddOrUpdateManifest(manifest);
                         logger.LogDebug("Discovered file system manifest: {ManifestId}", manifest.Id);
                     }
@@ -308,6 +326,15 @@ public class ManifestDiscoveryService(
                 var manifest = await JsonSerializer.DeserializeAsync<ContentManifest>(stream, JsonOptions, cancellationToken);
                 if (manifest != null && !string.IsNullOrEmpty(manifest.Id))
                 {
+                    if (!ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+                    {
+                        logger.LogWarning(
+                            "Skipping embedded manifest {ResourceName}: {Reason}",
+                            resourceName,
+                            rejectionReason);
+                        continue;
+                    }
+
                     manifestCache.AddOrUpdateManifest(manifest);
                     logger.LogDebug("Discovered embedded manifest: {ManifestId}", manifest.Id);
                 }

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -193,18 +193,31 @@ public class ManifestDiscoveryService(
         return true;
     }
 
+    /// <summary>
+    /// Applies the variant ingestion gate, logging and rejecting when it does not pass.
+    /// </summary>
+    /// <param name="manifest">The deserialized manifest.</param>
+    /// <param name="source">Where it came from, named in the rejection log.</param>
+    /// <returns><c>true</c> when the manifest may be ingested; otherwise <c>false</c>.</returns>
+    private bool IsManifestAccepted(ContentManifest manifest, string source)
+    {
+        if (ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+        {
+            return true;
+        }
+
+        logger.LogWarning("Skipping manifest from {Source}: {Reason}", source, rejectionReason);
+        return false;
+    }
+
     private async Task<ContentManifest?> LoadManifestAsync(string manifestPath, CancellationToken cancellationToken)
     {
         await using var stream = File.OpenRead(manifestPath);
         var manifest = await JsonSerializer.DeserializeAsync<ContentManifest>(stream, JsonOptions, cancellationToken);
         if (manifest != null && !string.IsNullOrEmpty(manifest.Id))
         {
-            if (!ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+            if (!IsManifestAccepted(manifest, manifestPath))
             {
-                logger.LogWarning(
-                    "Skipping manifest at {ManifestPath}: {Reason}",
-                    manifestPath,
-                    rejectionReason);
                 return null;
             }
 
@@ -288,12 +301,8 @@ public class ManifestDiscoveryService(
                     var manifest = await JsonSerializer.DeserializeAsync<ContentManifest>(stream, JsonOptions, cancellationToken);
                     if (manifest != null && !string.IsNullOrEmpty(manifest.Id))
                     {
-                        if (!ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+                        if (!IsManifestAccepted(manifest, manifestFile))
                         {
-                            logger.LogWarning(
-                                "Skipping manifest at {ManifestFile}: {Reason}",
-                                manifestFile,
-                                rejectionReason);
                             continue;
                         }
 
@@ -326,12 +335,8 @@ public class ManifestDiscoveryService(
                 var manifest = await JsonSerializer.DeserializeAsync<ContentManifest>(stream, JsonOptions, cancellationToken);
                 if (manifest != null && !string.IsNullOrEmpty(manifest.Id))
                 {
-                    if (!ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+                    if (!IsManifestAccepted(manifest, resourceName))
                     {
-                        logger.LogWarning(
-                            "Skipping embedded manifest {ResourceName}: {Reason}",
-                            resourceName,
-                            rejectionReason);
                         continue;
                     }
 

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -15,6 +15,7 @@ using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using GenHub.Core.Utilities;
 
 namespace GenHub.Features.Manifest;
 
@@ -944,8 +945,11 @@ public class ManifestGenerationService(
 
                     fullPath = ResolveSourcePathWithBackup(fullPath, finalPath);
 
-                    var isExecutable = finalPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ||
-                                       finalPath.EndsWith(".dat", StringComparison.OrdinalIgnoreCase);
+                    // .dat is data, not code. It was previously marked executable because
+                    // the Steam layout launches game.dat through a proxy, which is a launch
+                    // strategy rather than a property of the file, and it forced
+                    // SteamManifestPatcher to keep flipping the flag by hand.
+                    var isExecutable = ExecutableFileClassifier.RequiresExecutePermission(finalPath);
 
                     await builder.AddGameInstallationFileAsync(finalPath, fullPath, isExecutable);
                     _fileCount++;

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text.Json;
-using System.Threading.Tasks;
 using CsvHelper;
 using CsvHelper.Configuration;
 using GenHub.Core.Constants;
@@ -13,9 +6,16 @@ using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Interfaces.Tools;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using GenHub.Core.Utilities;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace GenHub.Features.Manifest;
 

--- a/GenHub/GenHub/Features/Manifest/ManifestProvider.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestProvider.cs
@@ -74,6 +74,8 @@ public class ManifestProvider(ILogger<ManifestProvider> logger, IContentManifest
                     // Validate security of parsed manifest
                     ValidateManifestSecurity(manifest);
 
+                    EnsureManifestAccepted(manifest, gameClient.Id);
+
                     // Ensure manifest ID matches the requested id
                     if (!string.Equals(manifest.Id.Value, gameClient.Id, StringComparison.OrdinalIgnoreCase))
                     {
@@ -136,6 +138,7 @@ public class ManifestProvider(ILogger<ManifestProvider> logger, IContentManifest
 
             // Validate ID before adding to pool
             ManifestIdValidator.EnsureValid(generated.Id.Value);
+            EnsureManifestAccepted(generated, gameClient.Id);
 
             // Determine a sensible source directory for the generated manifest.
             // Prefer the working directory if present, otherwise fall back to the directory
@@ -205,10 +208,15 @@ public class ManifestProvider(ILogger<ManifestProvider> logger, IContentManifest
                 var manifest = await JsonSerializer.DeserializeAsync<ContentManifest>(stream, _jsonOptions, cancellationToken);
                 if (manifest != null)
                 {
+                    ValidateCachedManifest(manifest, deterministicId);
+
                     // For embedded installation manifests, provide the installation path as source when available.
                     var addRes = await manifestPool.AddManifestAsync(manifest, installation.InstallationPath ?? string.Empty, null, cancellationToken);
                     if (addRes?.Success != true)
+                    {
                         logger.LogWarning("Failed to add embedded installation manifest {Id} to pool: {Errors}", manifest.Id, string.Join(", ", addRes?.Errors ?? []));
+                    }
+
                     return manifest;
                 }
             }
@@ -262,6 +270,7 @@ public class ManifestProvider(ILogger<ManifestProvider> logger, IContentManifest
 
             // Validate ID before adding to pool
             ManifestIdValidator.EnsureValid(generated.Id.Value);
+            EnsureManifestAccepted(generated, deterministicId);
             var addRes2 = await manifestPool.AddManifestAsync(generated, sourcePath ?? string.Empty, null, cancellationToken);
             if (addRes2?.Success != true)
             {
@@ -294,10 +303,19 @@ public class ManifestProvider(ILogger<ManifestProvider> logger, IContentManifest
     {
         // Run the same security validations as for embedded manifests
         ValidateManifestSecurity(manifest);
+        EnsureManifestAccepted(manifest, expectedId);
 
         if (!string.Equals(manifest.Id.Value, expectedId, StringComparison.OrdinalIgnoreCase))
         {
             throw new ManifestValidationException(expectedId, $"Manifest ID mismatch: expected '{expectedId}' but manifest contains '{manifest.Id.Value}'");
+        }
+    }
+
+    private static void EnsureManifestAccepted(ContentManifest manifest, string requestedId)
+    {
+        if (!ManifestIngestionGate.TryAccept(manifest, out var rejectionReason))
+        {
+            throw new ManifestValidationException(requestedId, rejectionReason!);
         }
     }
 }

--- a/GenHub/GenHub/Features/Manifest/SteamManifestPatcher.cs
+++ b/GenHub/GenHub/Features/Manifest/SteamManifestPatcher.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Steam;
 using GenHub.Core.Models.Manifest;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,9 @@ namespace GenHub.Features.Manifest;
 /// <summary>
 /// Implementation of <see cref="ISteamManifestPatcher"/>.
 /// </summary>
-public class SteamManifestPatcher(ILogger<SteamManifestPatcher> logger) : ISteamManifestPatcher
+public class SteamManifestPatcher(
+    ILogger<SteamManifestPatcher> logger,
+    IConfigurationProviderService configurationProvider) : ISteamManifestPatcher
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true, PropertyNameCaseInsensitive = true };
 
@@ -25,10 +28,7 @@ public class SteamManifestPatcher(ILogger<SteamManifestPatcher> logger) : ISteam
             logger.LogInformation("Patching manifest {ManifestId} for Steam launch: {UseSteamLaunch}", manifestId, useSteamLaunch);
 
             // Locate the manifest file
-            var manifestsDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                AppConstants.AppName,
-                FileTypes.ManifestsDirectory);
+            var manifestsDir = configurationProvider.GetManifestsPath();
 
             if (!Directory.Exists(manifestsDir))
             {

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -377,18 +377,18 @@ public class FileOperationsService(
             await Task.Run(
                 () =>
                 {
-                    if (OperatingSystem.IsWindows())
-                    {
-                        // Use platform-specific implementation
-                        throw new NotImplementedException("Hard link creation should be handled by platform-specific service");
-                    }
-                    else
-                    {
-                        File.Copy(targetPath, linkPath, true);
-                        logger.LogWarning(
-                            "Hard links not supported on this platform, fell back to copy for {Link}",
-                            linkPath);
-                    }
+                    // Every supported platform has a decorator that overrides this:
+                    // WindowsFileOperationsService and UnixFileOperationsService. Reaching
+                    // here means the host did not register one.
+                    //
+                    // This used to File.Copy on non-Windows and log a warning. That made a
+                    // missing registration invisible: workspaces still built, tests still
+                    // passed, and every profile silently consumed a full copy of the game
+                    // instead of a link. Failing is the only way that surfaces.
+                    throw new NotSupportedException(
+                        "Hard link creation must be handled by a platform-specific IFileOperationsService. "
+                        + "Register WindowsFileOperationsService or UnixFileOperationsService in the host's "
+                        + "service module.");
                 },
                 cancellationToken);
 

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -505,95 +505,6 @@ public abstract class WorkspaceStrategyBase<T>(
     }
 
     /// <summary>
-    /// Gives a materialised file the Unix execute bit, on a copy that the workspace owns.
-    /// <para>
-    /// The copy is the point. Under the hard-link strategy the workspace file <em>is</em>
-    /// the content-store blob — same inode, and file mode lives in the inode, not the
-    /// directory entry. Calling chmod on it would change permissions for every other
-    /// profile referencing that hash, and the content store keys purely on content hash,
-    /// so it has no way to represent two files with identical bytes and different modes.
-    /// </para>
-    /// <para>
-    /// Breaking the link costs one copy per executable. Manifests contain a handful of
-    /// those and gigabytes of data, so the deduplication that matters is untouched.
-    /// </para>
-    /// <para>
-    /// No-op on Windows, which has no execute bit, and for files that do not need one.
-    /// </para>
-    /// </summary>
-    /// <param name="file">The manifest entry that was just materialised.</param>
-    /// <param name="targetPath">Its absolute path in the workspace.</param>
-    /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>A task representing the operation.</returns>
-    protected async Task EnsureExecutableAsync(ManifestFile file, string targetPath, CancellationToken cancellationToken)
-    {
-        if (OperatingSystem.IsWindows() || !file.IsExecutable || !File.Exists(targetPath))
-        {
-            return;
-        }
-
-        var temporaryPath = targetPath + ".genhub-exec-tmp";
-
-        try
-        {
-            // Replace the entry with a private copy so the mode change cannot reach a
-            // shared blob.
-            //
-            // The copy is made executable *before* it is moved into place, and the move
-            // replaces the destination atomically. There is therefore no observable state
-            // in which the destination is missing or present-but-not-executable: it is
-            // either the original entry or the finished private copy.
-            //
-            // A delete-then-move sequence would expose both of those states, and the
-            // second is unrecoverable — verification never mutates, so a workspace left
-            // with a non-executable entry point stays broken for every later launch.
-            await Task.Run(
-                () =>
-                {
-                    File.Copy(targetPath, temporaryPath, overwrite: true);
-
-                    if (!OperatingSystem.IsWindows())
-                    {
-                        const UnixFileMode executableMode =
-                            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-                            UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
-
-                        File.SetUnixFileMode(temporaryPath, executableMode);
-                    }
-
-                    File.Move(temporaryPath, targetPath, overwrite: true);
-                },
-                cancellationToken);
-
-            Logger.LogDebug("Marked {RelativePath} executable on a workspace-owned copy", file.RelativePath);
-        }
-        catch (Exception ex)
-        {
-            // The move is the last step, so a failure here means the temporary copy may
-            // still exist. Remove it: the original entry is untouched and correct, and a
-            // stray .genhub-exec-tmp would otherwise be reported by workspace validation.
-            try
-            {
-                File.Delete(temporaryPath);
-            }
-            catch (Exception cleanupEx)
-            {
-                Logger.LogDebug(
-                    cleanupEx,
-                    "Could not remove the temporary executable copy at {TemporaryPath}",
-                    temporaryPath);
-            }
-
-            Logger.LogError(
-                ex,
-                "Could not mark {RelativePath} executable",
-                file.RelativePath);
-            throw;
-        }
-    }
-
-    /// <summary>
     /// Processes a CAS file with fallback logic. Strategies should call this for CAS files.
     /// </summary>
     /// <param name="file">The manifest file representing the CAS content.</param>
@@ -693,6 +604,95 @@ public abstract class WorkspaceStrategyBase<T>(
         // Copy from extracted source to target
         await FileOperations.CopyFileAsync(file.SourcePath, targetPath, cancellationToken);
         logger.LogDebug("Copied extracted file: {Source} -> {Target}", file.SourcePath, targetPath);
+    }
+
+    /// <summary>
+    /// Gives a materialised file the Unix execute bit, on a copy that the workspace owns.
+    /// <para>
+    /// The copy is the point. Under the hard-link strategy the workspace file <em>is</em>
+    /// the content-store blob — same inode, and file mode lives in the inode, not the
+    /// directory entry. Calling chmod on it would change permissions for every other
+    /// profile referencing that hash, and the content store keys purely on content hash,
+    /// so it has no way to represent two files with identical bytes and different modes.
+    /// </para>
+    /// <para>
+    /// Breaking the link costs one copy per executable. Manifests contain a handful of
+    /// those and gigabytes of data, so the deduplication that matters is untouched.
+    /// </para>
+    /// <para>
+    /// No-op on Windows, which has no execute bit, and for files that do not need one.
+    /// </para>
+    /// </summary>
+    /// <param name="file">The manifest entry that was just materialised.</param>
+    /// <param name="targetPath">Its absolute path in the workspace.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the operation.</returns>
+    protected async Task EnsureExecutableAsync(ManifestFile file, string targetPath, CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsWindows() || !file.IsExecutable || !File.Exists(targetPath))
+        {
+            return;
+        }
+
+        var temporaryPath = targetPath + ".genhub-exec-tmp";
+
+        try
+        {
+            // Replace the entry with a private copy so the mode change cannot reach a
+            // shared blob.
+            //
+            // The copy is made executable *before* it is moved into place, and the move
+            // replaces the destination atomically. There is therefore no observable state
+            // in which the destination is missing or present-but-not-executable: it is
+            // either the original entry or the finished private copy.
+            //
+            // A delete-then-move sequence would expose both of those states, and the
+            // second is unrecoverable — verification never mutates, so a workspace left
+            // with a non-executable entry point stays broken for every later launch.
+            await Task.Run(
+                () =>
+                {
+                    File.Copy(targetPath, temporaryPath, overwrite: true);
+
+                    if (!OperatingSystem.IsWindows())
+                    {
+                        const UnixFileMode executableMode =
+                            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                            UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+                        File.SetUnixFileMode(temporaryPath, executableMode);
+                    }
+
+                    File.Move(temporaryPath, targetPath, overwrite: true);
+                },
+                cancellationToken);
+
+            Logger.LogDebug("Marked {RelativePath} executable on a workspace-owned copy", file.RelativePath);
+        }
+        catch (Exception ex)
+        {
+            // The move is the last step, so a failure here means the temporary copy may
+            // still exist. Remove it: the original entry is untouched and correct, and a
+            // stray .genhub-exec-tmp would otherwise be reported by workspace validation.
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (Exception cleanupEx)
+            {
+                Logger.LogDebug(
+                    cleanupEx,
+                    "Could not remove the temporary executable copy at {TemporaryPath}",
+                    temporaryPath);
+            }
+
+            Logger.LogError(
+                ex,
+                "Could not mark {RelativePath} executable",
+                file.RelativePath);
+            throw;
+        }
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -552,11 +552,15 @@ public abstract class WorkspaceStrategyBase<T>(
                 {
                     File.Copy(targetPath, temporaryPath, overwrite: true);
 
-                    File.SetUnixFileMode(
-                        temporaryPath,
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                    if (!OperatingSystem.IsWindows())
+                    {
+                        const UnixFileMode executableMode =
+                            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                            UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+                        File.SetUnixFileMode(temporaryPath, executableMode);
+                    }
 
                     File.Move(temporaryPath, targetPath, overwrite: true);
                 },

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -258,42 +258,32 @@ public abstract class WorkspaceStrategyBase<T>(
 
         if (gameClientManifest != null)
         {
-            var executableFile = gameClientManifest.Files?
-                .FirstOrDefault(f => f.IsExecutable);
+            // Resolution order and failure behaviour live in ManifestVariantResolver.
+            // The previous inline logic took the first file marked IsExecutable, which is
+            // enumeration-order dependent as soon as more than one file qualifies — and
+            // several do, once dynamic libraries and native extensionless binaries are in
+            // the same manifest.
+            var resolution = ManifestVariantResolver.ResolveEntryPoint(gameClientManifest);
 
-            if (executableFile != null)
+            if (resolution.Success)
             {
-                // Use the full relative path from the manifest
                 workspaceInfo.ExecutablePath = Path.Combine(
                     workspaceInfo.WorkspacePath,
-                    executableFile.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+                    resolution.RelativePath!.Replace('/', Path.DirectorySeparatorChar));
 
                 logger.LogInformation(
-                    "Executable resolved from GameClient manifest: {ExecutablePath} (marked as IsExecutable)",
-                    workspaceInfo.ExecutablePath);
+                    "Executable resolved from GameClient manifest: {ExecutablePath} ({Reason})",
+                    workspaceInfo.ExecutablePath,
+                    resolution.Reason);
             }
             else
             {
-                // Fallback: Try finding any .exe file
-                executableFile = gameClientManifest.Files?
-                    .FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
-
-                if (executableFile != null)
-                {
-                    workspaceInfo.ExecutablePath = Path.Combine(
-                        workspaceInfo.WorkspacePath,
-                        executableFile.RelativePath.Replace('/', Path.DirectorySeparatorChar));
-
-                    logger.LogWarning(
-                        "Executable resolved from GameClient manifest by .exe extension (IsExecutable not set): {ExecutablePath}",
-                        workspaceInfo.ExecutablePath);
-                }
-                else
-                {
-                    logger.LogWarning(
-                        "GameClient manifest '{ManifestId}' does not contain an executable file",
-                        gameClientManifest.Id);
-                }
+                // Left unset deliberately rather than guessed. Launching the wrong binary
+                // fails somewhere far less diagnosable than here.
+                logger.LogWarning(
+                    "Could not determine the executable for GameClient manifest '{ManifestId}': {Resolution}",
+                    gameClientManifest.Id,
+                    resolution);
             }
         }
         else if (!string.IsNullOrEmpty(configuration.GameClient.ExecutablePath))

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -525,32 +525,40 @@ public abstract class WorkspaceStrategyBase<T>(
     /// <param name="targetPath">Its absolute path in the workspace.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task representing the operation.</returns>
-    private async Task EnsureExecutableAsync(ManifestFile file, string targetPath, CancellationToken cancellationToken)
+    protected async Task EnsureExecutableAsync(ManifestFile file, string targetPath, CancellationToken cancellationToken)
     {
         if (OperatingSystem.IsWindows() || !file.IsExecutable || !File.Exists(targetPath))
         {
             return;
         }
 
+        var temporaryPath = targetPath + ".genhub-exec-tmp";
+
         try
         {
             // Replace the entry with a private copy so the mode change cannot reach a
-            // shared blob. Writing through a temporary keeps the workspace consistent if
-            // this is interrupted partway.
-            var temporaryPath = targetPath + ".genhub-exec-tmp";
-
+            // shared blob.
+            //
+            // The copy is made executable *before* it is moved into place, and the move
+            // replaces the destination atomically. There is therefore no observable state
+            // in which the destination is missing or present-but-not-executable: it is
+            // either the original entry or the finished private copy.
+            //
+            // A delete-then-move sequence would expose both of those states, and the
+            // second is unrecoverable — verification never mutates, so a workspace left
+            // with a non-executable entry point stays broken for every later launch.
             await Task.Run(
                 () =>
                 {
                     File.Copy(targetPath, temporaryPath, overwrite: true);
-                    File.Delete(targetPath);
-                    File.Move(temporaryPath, targetPath);
 
                     File.SetUnixFileMode(
-                        targetPath,
+                        temporaryPath,
                         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
                         UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
                         UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+                    File.Move(temporaryPath, targetPath, overwrite: true);
                 },
                 cancellationToken);
 
@@ -558,12 +566,26 @@ public abstract class WorkspaceStrategyBase<T>(
         }
         catch (Exception ex)
         {
-            // A workspace whose entry point lacks the execute bit fails at launch with a
-            // permission error that names the file, so this is reported rather than fatal.
-            Logger.LogWarning(
+            // The move is the last step, so a failure here means the temporary copy may
+            // still exist. Remove it: the original entry is untouched and correct, and a
+            // stray .genhub-exec-tmp would otherwise be reported by workspace validation.
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (Exception cleanupEx)
+            {
+                Logger.LogDebug(
+                    cleanupEx,
+                    "Could not remove the temporary executable copy at {TemporaryPath}",
+                    temporaryPath);
+            }
+
+            Logger.LogError(
                 ex,
-                "Could not mark {RelativePath} executable; launching it may fail",
+                "Could not mark {RelativePath} executable",
                 file.RelativePath);
+            throw;
         }
     }
 

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -500,6 +500,71 @@ public abstract class WorkspaceStrategyBase<T>(
             default:
                 throw new NotSupportedException($"Unsupported content source type: {file.SourceType}");
         }
+
+        await EnsureExecutableAsync(file, targetPath, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gives a materialised file the Unix execute bit, on a copy that the workspace owns.
+    /// <para>
+    /// The copy is the point. Under the hard-link strategy the workspace file <em>is</em>
+    /// the content-store blob — same inode, and file mode lives in the inode, not the
+    /// directory entry. Calling chmod on it would change permissions for every other
+    /// profile referencing that hash, and the content store keys purely on content hash,
+    /// so it has no way to represent two files with identical bytes and different modes.
+    /// </para>
+    /// <para>
+    /// Breaking the link costs one copy per executable. Manifests contain a handful of
+    /// those and gigabytes of data, so the deduplication that matters is untouched.
+    /// </para>
+    /// <para>
+    /// No-op on Windows, which has no execute bit, and for files that do not need one.
+    /// </para>
+    /// </summary>
+    /// <param name="file">The manifest entry that was just materialised.</param>
+    /// <param name="targetPath">Its absolute path in the workspace.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the operation.</returns>
+    private async Task EnsureExecutableAsync(ManifestFile file, string targetPath, CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsWindows() || !file.IsExecutable || !File.Exists(targetPath))
+        {
+            return;
+        }
+
+        try
+        {
+            // Replace the entry with a private copy so the mode change cannot reach a
+            // shared blob. Writing through a temporary keeps the workspace consistent if
+            // this is interrupted partway.
+            var temporaryPath = targetPath + ".genhub-exec-tmp";
+
+            await Task.Run(
+                () =>
+                {
+                    File.Copy(targetPath, temporaryPath, overwrite: true);
+                    File.Delete(targetPath);
+                    File.Move(temporaryPath, targetPath);
+
+                    File.SetUnixFileMode(
+                        targetPath,
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                },
+                cancellationToken);
+
+            Logger.LogDebug("Marked {RelativePath} executable on a workspace-owned copy", file.RelativePath);
+        }
+        catch (Exception ex)
+        {
+            // A workspace whose entry point lacks the execute bit fails at launch with a
+            // permission error that names the file, so this is reported rather than fatal.
+            Logger.LogWarning(
+                ex,
+                "Could not mark {RelativePath} executable; launching it may fail",
+                file.RelativePath);
+        }
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Interfaces.Workspace;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Workspace;
+
+/// <summary>
+/// Hard-link support for Linux and macOS, decorating <see cref="FileOperationsService"/>.
+/// <para>
+/// Without this, <c>CreateHardLinkAsync</c> on any Unix platform fell through to
+/// <c>File.Copy</c> and logged a warning. The default workspace strategy is
+/// <c>HardLink</c>, and the two symlink strategies are downgraded to it when the
+/// process is not elevated, so in practice every workspace on Linux full-copied the
+/// game — roughly 1.5 GB per profile — while appearing to work.
+/// </para>
+/// <para>
+/// Registered by both the Linux and macOS hosts. It lives in the shared project rather
+/// than being duplicated per host because <c>link(2)</c> is identical on both; see
+/// <see cref="UnixNativeMethods"/> for why the interop stops there.
+/// </para>
+/// </summary>
+/// <param name="baseService">The shared implementation everything else delegates to.</param>
+/// <param name="casService">Content-addressable store, used to resolve hashes to paths.</param>
+/// <param name="logger">Logger.</param>
+public class UnixFileOperationsService(
+    FileOperationsService baseService,
+    ICasService casService,
+    ILogger<UnixFileOperationsService> logger) : IFileOperationsService
+{
+    /// <inheritdoc/>
+    public Task CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken = default)
+        => baseService.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task CreateSymlinkAsync(string linkPath, string targetPath, bool allowFallback = true, CancellationToken cancellationToken = default)
+        => baseService.CreateSymlinkAsync(linkPath, targetPath, allowFallback, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<bool> VerifyFileHashAsync(string filePath, string expectedHash, CancellationToken cancellationToken = default)
+        => baseService.VerifyFileHashAsync(filePath, expectedHash, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task DownloadFileAsync(Uri url, string destinationPath, IProgress<DownloadProgress>? progress = null, CancellationToken cancellationToken = default)
+        => baseService.DownloadFileAsync(url, destinationPath, progress, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task ApplyPatchAsync(string targetPath, string patchPath, CancellationToken cancellationToken = default)
+        => baseService.ApplyPatchAsync(targetPath, patchPath, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<string?> StoreInCasAsync(string sourcePath, string? expectedHash = null, CancellationToken cancellationToken = default)
+        => baseService.StoreInCasAsync(sourcePath, expectedHash, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<Stream?> OpenCasContentAsync(string hash, CancellationToken cancellationToken = default)
+        => baseService.OpenCasContentAsync(hash, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<bool> CopyFromCasAsync(string hash, string destinationPath, ContentType? contentType = null, CancellationToken cancellationToken = default)
+    {
+        var casPath = await ResolveCasPathAsync(hash, contentType, cancellationToken).ConfigureAwait(false);
+        if (casPath is null)
+        {
+            return false;
+        }
+
+        await baseService.CopyFileAsync(casPath, destinationPath, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// No volume preflight. The Windows implementation checks <c>AreSameVolume</c> first,
+    /// but that helper compares <c>Path.GetPathRoot</c>, which is <c>/</c> for every path
+    /// on Unix and so always reports "same volume". Attempting the link and handling
+    /// <c>EXDEV</c> is both correct and free of the race a preflight introduces.
+    /// </remarks>
+    public async Task<bool> LinkFromCasAsync(
+        string hash,
+        string destinationPath,
+        bool useHardLink = false,
+        ContentType? contentType = null,
+        CancellationToken cancellationToken = default)
+    {
+        var casPath = await ResolveCasPathAsync(hash, contentType, cancellationToken).ConfigureAwait(false);
+        if (casPath is null)
+        {
+            return false;
+        }
+
+        if (!useHardLink)
+        {
+            await baseService.CreateSymlinkAsync(destinationPath, casPath, true, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        try
+        {
+            await CreateHardLinkAsync(destinationPath, casPath, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (IOException ex) when (ex is not FileNotFoundException)
+        {
+            // Cross-device or a filesystem without link support. Copying keeps the
+            // workspace usable; the caller loses deduplication, not correctness.
+            logger.LogWarning(
+                ex,
+                "Hard link from CAS failed for {Destination}; falling back to a copy",
+                destinationPath);
+
+            await baseService.CopyFileAsync(casPath, destinationPath, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task CreateHardLinkAsync(
+        string linkPath,
+        string targetPath,
+        CancellationToken cancellationToken = default)
+    {
+        var absoluteLinkPath = Path.GetFullPath(linkPath);
+        var absoluteTargetPath = Path.GetFullPath(targetPath);
+
+        FileOperationsService.EnsureDirectoryExists(absoluteLinkPath);
+        FileOperationsService.DeleteFileIfExists(absoluteLinkPath);
+
+        await Task.Run(
+            () =>
+            {
+                if (UnixNativeMethods.Link(absoluteTargetPath, absoluteLinkPath) == 0)
+                {
+                    return;
+                }
+
+                // Interpret errno rather than preflighting. A preflight volume check is
+                // racy, and would need a shared struct stat layout that Linux and macOS
+                // do not agree on. Attempting the call is both simpler and accurate.
+                var errno = Marshal.GetLastPInvokeError();
+
+                throw errno switch
+                {
+                    UnixNativeMethods.EXDEV => new IOException(
+                        $"Cannot hard link '{absoluteLinkPath}' to '{absoluteTargetPath}': they are on different "
+                        + "filesystems. Move the content store onto the same volume as the workspace, or choose "
+                        + "the FullCopy workspace strategy."),
+                    UnixNativeMethods.EPERM => new IOException(
+                        $"Cannot hard link '{absoluteLinkPath}': the filesystem does not support hard links."),
+                    UnixNativeMethods.ENOENT => new FileNotFoundException(
+                        $"Cannot hard link '{absoluteLinkPath}': the target '{absoluteTargetPath}' does not exist.",
+                        absoluteTargetPath),
+                    UnixNativeMethods.EACCES => new UnauthorizedAccessException(
+                        $"Cannot hard link '{absoluteLinkPath}' to '{absoluteTargetPath}': permission denied."),
+                    _ => new IOException(
+                        $"Failed to hard link '{absoluteLinkPath}' to '{absoluteTargetPath}' (errno {errno})."),
+                };
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        logger.LogDebug("Created hard link from {Link} to {Target}", absoluteLinkPath, absoluteTargetPath);
+    }
+
+    private async Task<string?> ResolveCasPathAsync(string hash, ContentType? contentType, CancellationToken cancellationToken)
+    {
+        var pathResult = contentType.HasValue
+            ? await casService.GetContentPathAsync(hash, contentType.Value, cancellationToken).ConfigureAwait(false)
+            : await casService.GetContentPathAsync(hash, cancellationToken).ConfigureAwait(false);
+
+        if (!pathResult.Success || pathResult.Data is null)
+        {
+            logger.LogError("CAS content not found for hash {Hash}: {Error}", hash, pathResult.FirstError);
+            return null;
+        }
+
+        return pathResult.Data;
+    }
+}

--- a/GenHub/GenHub/Features/Workspace/UnixNativeMethods.cs
+++ b/GenHub/GenHub/Features/Workspace/UnixNativeMethods.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GenHub.Features.Workspace;
+
+/// <summary>
+/// The libc calls GenHub needs on Linux and macOS.
+/// <para>
+/// Deliberately tiny. Only functions whose signatures are identical across both
+/// platforms appear here — <c>link</c>, <c>faccessat</c> and <c>geteuid</c> take and
+/// return scalars and C strings, so a single declaration is correct on both.
+/// </para>
+/// <para>
+/// <c>stat</c> and friends are deliberately absent. Their <c>struct stat</c> layouts
+/// differ between Linux and macOS (and between architectures), so a shared P/Invoke
+/// declaration would silently read the wrong offsets. Where volume identity or file
+/// metadata is needed, use the BCL (<c>File.GetUnixFileMode</c>,
+/// <c>FileInfo</c>) or attempt the operation and interpret <c>errno</c>.
+/// </para>
+/// </summary>
+internal static partial class UnixNativeMethods
+{
+    /// <summary>Operation not permitted on a cross-device link.</summary>
+    internal const int EXDEV = 18;
+
+    /// <summary>The destination path already exists.</summary>
+    internal const int EEXIST = 17;
+
+    /// <summary>A component of the path does not exist.</summary>
+    internal const int ENOENT = 2;
+
+    /// <summary>Permission denied.</summary>
+    internal const int EACCES = 13;
+
+    /// <summary>The filesystem does not support hard links.</summary>
+    internal const int EPERM = 1;
+
+    /// <summary>
+    /// Creates a hard link, POSIX <c>link(2)</c>.
+    /// <para>
+    /// .NET has no managed equivalent: <c>File.CreateSymbolicLink</c> exists but there
+    /// is no hard-link API, which is why this interop is needed at all.
+    /// </para>
+    /// </summary>
+    /// <param name="existingPath">Path to the existing file.</param>
+    /// <param name="newPath">Path of the link to create.</param>
+    /// <returns>0 on success, -1 on failure with <c>errno</c> set.</returns>
+    [LibraryImport("libc", EntryPoint = "link", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int Link(string existingPath, string newPath);
+
+    /// <summary>
+    /// Checks whether the effective process identity may execute a file.
+    /// </summary>
+    /// <param name="path">The file to inspect.</param>
+    /// <returns><c>true</c> when the current effective identity may execute the file.</returns>
+    internal static bool CanExecute(string path)
+    {
+        const int executeMode = 1;
+        var currentWorkingDirectory = OperatingSystem.IsMacOS() ? -2 : -100;
+        var effectiveIdentity = OperatingSystem.IsMacOS() ? 0x10 : 0x200;
+
+        return FileAccessAt(currentWorkingDirectory, path, executeMode, effectiveIdentity) == 0;
+    }
+
+    /// <summary>
+    /// Returns the effective user ID, POSIX <c>geteuid(2)</c>.
+    /// <para>
+    /// Used instead of comparing <c>Environment.UserName</c> to the literal "root",
+    /// which is wrong under <c>sudo -E</c> and for any uid-0 account named otherwise.
+    /// </para>
+    /// </summary>
+    /// <returns>The effective user ID; 0 is root.</returns>
+    [LibraryImport("libc", EntryPoint = "geteuid")]
+    internal static partial uint GetEffectiveUserId();
+
+    [LibraryImport("libc", EntryPoint = "faccessat", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int FileAccessAt(int directoryFileDescriptor, string path, int mode, int flags);
+}

--- a/GenHub/GenHub/Features/Workspace/UnixSymlinkCapabilityProvider.cs
+++ b/GenHub/GenHub/Features/Workspace/UnixSymlinkCapabilityProvider.cs
@@ -1,0 +1,12 @@
+using GenHub.Core.Interfaces.Workspace;
+
+namespace GenHub.Features.Workspace;
+
+/// <summary>
+/// Symlink capability on Linux and macOS, where <c>symlink(2)</c> requires no privilege.
+/// </summary>
+public sealed class UnixSymlinkCapabilityProvider : ISymlinkCapabilityProvider
+{
+    /// <inheritdoc/>
+    public bool CanCreateSymlinks => true;
+}

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -255,15 +255,13 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
                             }
                             else
                             {
-                                // Properly check execute permission using Unix stat
-                                // TODO: Make this a platform specific validation
                                 if (!HasUnixExecutePermission(executablePath))
                                 {
                                     issues.Add(new ValidationIssue
                                     {
                                         IssueType = ValidationIssueType.AccessDenied,
                                         Severity = ValidationSeverity.Warning,
-                                        Message = $"File is not marked as executable: {executablePath}",
+                                        Message = $"File is not executable by the current process: {executablePath}",
                                         Path = executablePath,
                                     });
                                 }
@@ -329,8 +327,10 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
     {
         if (!OperatingSystem.IsWindows())
         {
-            // On Unix systems, check if running as root
-            return Environment.UserName == "root";
+            // geteuid rather than comparing Environment.UserName to the literal "root",
+            // which is wrong under `sudo -E` (USER stays the invoking account) and for
+            // any uid-0 account not named root.
+            return UnixNativeMethods.GetEffectiveUserId() == 0;
         }
 
         try
@@ -345,36 +345,24 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
         }
     }
 
-    // Add this helper method to check Unix execute permission
+    /// <summary>
+    /// Determines whether the effective process identity may execute a Unix file.
+    /// <para>
+    /// Uses <c>faccessat(AT_EACCESS)</c> rather than merely checking whether any execute
+    /// bit is present. The kernel therefore evaluates ownership, group membership and
+    /// access-control rules for the identity that will actually launch the process.
+    /// </para>
+    /// </summary>
+    /// <param name="filePath">The file to inspect.</param>
+    /// <returns><c>true</c> when the file is executable by the current user.</returns>
     private static bool HasUnixExecutePermission(string filePath)
     {
-        try
+        if (OperatingSystem.IsWindows())
         {
-            if (OperatingSystem.IsWindows())
-                return true;
-
-            var psi = new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = "/bin/sh",
-                Arguments = $"-c \"[ -x '{filePath.Replace("'", "'\\''")}' ]\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            using var proc = System.Diagnostics.Process.Start(psi);
-
-            if (proc == null)
-                return false;
-
-            proc.WaitForExit();
-            return proc.ExitCode == 0;
+            return true;
         }
-        catch
-        {
-            // If all checks fail, assume not executable
-            return false;
-        }
+
+        return UnixNativeMethods.CanExecute(filePath);
     }
 
     private async Task ValidateSymlinksAsync(string workspacePath, List<ValidationIssue> issues, CancellationToken cancellationToken)

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Net.Http;
 using GenHub.Common.Services;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
@@ -27,9 +25,11 @@ using GenHub.Features.Downloads.ViewModels;
 using GenHub.Features.GitHub.Services;
 using GenHub.Features.Manifest;
 using GenHub.Features.Storage.Services;
-using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Net.Http;
 
 namespace GenHub.Infrastructure.DependencyInjection;
 

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -27,6 +27,7 @@ using GenHub.Features.Downloads.ViewModels;
 using GenHub.Features.GitHub.Services;
 using GenHub.Features.Manifest;
 using GenHub.Features.Storage.Services;
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -99,8 +100,20 @@ public static class ContentPipelineModule
         });
         services.AddScoped<IContentManifestPool, ContentManifestPool>();
 
-        // Register provider definition loader for data-driven provider configuration
-        services.AddSingleton<IProviderDefinitionLoader, ProviderDefinitionLoader>();
+        // Register provider definition loader for data-driven provider configuration.
+        // The user-providers directory is passed in from the configuration provider so a
+        // relocated application data directory is honoured. ProviderDefinitionLoader lives
+        // in GenHub.Core and defaults to a raw SpecialFolder.ApplicationData lookup when no
+        // override is supplied, which would silently keep reading the default tree.
+        services.AddSingleton<IProviderDefinitionLoader>(sp =>
+        {
+            var configurationProvider = sp.GetRequiredService<IConfigurationProviderService>();
+            return new ProviderDefinitionLoader(
+                sp.GetRequiredService<ILogger<ProviderDefinitionLoader>>(),
+                userProvidersDirectory: Path.Combine(
+                    configurationProvider.GetApplicationDataPath(),
+                    ProviderDefinitionLoader.ProvidersDirectoryName));
+        });
 
         // Register catalog parser factory and parsers
         services.AddSingleton<ICatalogParserFactory, CatalogParserFactory>();


### PR DESCRIPTION
## Summary

Make shared GenHub runtime behavior platform-aware across Windows and Unix. This fixes platform-specific settings and data paths, corrects Unix workspace materialization, and introduces deterministic manifest variants needed by native clients.

This PR contains no GenHub.MacOS project changes and can be reviewed independently of the macOS host.

## Changes

- Resolve Options.ini and application-data consumers through the configured platform paths.
- Centralize executable classification and add deterministic platform-variant and entry-point resolution.
- Preserve compatibility with existing flat manifests while rejecting unresolved variant usage.
- Implement Unix hard links with link(2) and make Unix symlink strategies reachable.
- Set execute permissions on workspace-owned copies rather than shared CAS blobs.
- Add behavioral coverage for path conventions, manifest variants, executable classification, and Unix workspace behavior.

## Testing

- `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release --no-restore`
- 1,391 passed, 0 failed.

## Risks and rollback

Unix workspace behavior changes: hard-link strategies now create real hard links instead of silently copying. Executable files are detached before permission changes so shared CAS blobs are not mutated.

Existing flat manifests remain supported. No persisted-data migration is required, and the changes are revert-safe.

## Related issues

Fixes #314
Fixes #316
Part of #327

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes platform-aware manifest and workspace behavior.
- Adds manifest variants, deterministic entry-point resolution, and ingestion gating.
- Adds native Unix hard-link handling and symlink capability registration.
- Moves Unix execute-bit changes onto intended workspace-owned copies.
- Routes application-data and game-settings paths through platform providers.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

This PR is not yet safe to merge because most Unix strategies skip executable permission isolation, hard-link permission failures can bypass copy fallback, and writable workspaces can mutate shared CAS content.

The execute-permission fix is only reached by SymlinkOnlyStrategy, EACCES escapes the new hard-link fallback, and intentional hard links leave non-executable CAS objects writable through workspace paths, allowing cross-profile content corruption.

**Files Needing Attention:** GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs, GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs, and the FullCopy/HybridCopySymlink/HardLink strategy implementations
</details>

<details open><summary><h3>Security Review</h3></summary>

HardLinkStrategy exposes writable CAS inodes to launched workspace processes, allowing workspace writes to alter shared content subsequently consumed by other profiles.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs | Adds native Unix hard links and copy fallback, but EACCES bypasses fallback and writable hard links expose shared CAS bytes to workspace mutation. |
| GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs | Adds copy-on-write executable permission handling, but the call is placed in a dispatcher bypassed by FullCopy, HybridCopySymlink, and HardLink. |
| GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs | Adds deterministic platform and entry-point resolution while returning the matched manifest file's canonical path spelling. |
| GenHub/GenHub.Core/Models/Manifest/ManifestIngestionGate.cs | Rejects unsupported variant manifests before existing flat-file consumers can mishandle them. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Manifest[Resolved manifest] --> Strategy[Workspace strategy]
    Strategy -->|FullCopy| Copy[Independent files]
    Strategy -->|Symlink| Symlink[CAS or installation symlinks]
    Strategy -->|HardLink| HardLink[Shared CAS inodes]
    Copy --> Launch[Launch workspace executable]
    Symlink --> Launch
    HardLink --> Launch
    Launch --> Mutation[Game or plugin writes workspace file]
    Mutation -->|same inode| CAS[Shared CAS blob changes]
    CAS --> Other[Other profiles materialize modified bytes]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs:502-504
**Executable isolation skips strategies**

When a Unix profile uses `FullCopy`, `HybridCopySymlink`, or `HardLink`, those strategies materialize files through their own loops and bypass `ProcessManifestFileAsync`, so `EnsureExecutableAsync` never runs. Executables retain a non-executable mode in copy-based workspaces, while hard-linked executables are not detached from CAS as intended, causing launch failures or shared-inode permission changes.

### Issue 2
GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs:109
**EACCES bypasses copy fallback**

When `link(2)` returns `EACCES` while `HardLinkStrategy` materializes a CAS file, `CreateHardLinkAsync` throws `UnauthorizedAccessException`, which is not caught by this `IOException` handler. The per-file copy fallback is skipped and workspace preparation aborts instead of producing an independent copy.

### Issue 3
GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs:107-108
**Workspace writes corrupt shared CAS**

When a launched game or plugin writes to a non-executable content-addressable file in a hard-link workspace, the write changes the same user-writable inode stored under the CAS hash. Another profile can then materialize the modified bytes and receive corrupted or incorrect content. **How this was verified:** `HardLinkStrategy` requests real CAS hard links, while copy-on-write isolation applies only to files marked executable and ordinary materialization does not universally revalidate the blob hash.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(launching): attribute the symlink do..."](https://github.com/community-outpost/genhub/commit/f9e60e49fdc18bd22cdd411180205ca739a09ada) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48457876)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Content Manifest System](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-manifest-system.md)
- Knowledge Base — [Workspace Assembly](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/workspace-assembly.md)

<!-- /greptile_comment -->