### PR TITLE
fix(macos): register the platform services the merged state requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,18 @@ jobs:
           dotnet build "${{ env.UI_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} $BUILD_PROPS
           dotnet build "${{ env.MACOS_PROJECT }}" -c ${{ env.BUILD_CONFIGURATION }} $BUILD_PROPS
 
+      # Runs the macOS composition root before publish. "Run Tests" at the end of this job
+      # already covered this project, but it sits after Publish and Smoke Test App Launch —
+      # so an unresolvable service killed the job at the smoke test, as a status-134 crash
+      # after packaging, and the assertion that names the service never executed. Running it
+      # here fails in seconds with the service name. A missing platform registration is
+      # invisible to per-branch CI, appearing only once both halves are merged, so this is
+      # the earliest point it can surface.
+      - name: Run macOS Tests
+        run: |
+          dotnet test GenHub/GenHub.Tests/GenHub.Tests.MacOS/GenHub.Tests.MacOS.csproj \
+            -c ${{ env.BUILD_CONFIGURATION }} --verbosity normal
+
       - name: Publish macOS App
         run: |
           BUILD_PROPS="-p:Version=${{ steps.buildinfo.outputs.VERSION }} -p:GitShortHash=${{ steps.buildinfo.outputs.SHORT_HASH }} -p:PullRequestNumber=${{ steps.buildinfo.outputs.PR_NUMBER }} -p:BuildChannel=${{ steps.buildinfo.outputs.CHANNEL }}"
@@ -484,7 +496,9 @@ jobs:
         shell: bash
         run: |
           while IFS= read -r test_project; do
-            [[ "$test_project" == *Windows* || "$test_project" == *Linux* ]] && continue
+            # MacOS is covered by "Run macOS Tests" before publish, so it is skipped
+            # here rather than run a second time.
+            [[ "$test_project" == *Windows* || "$test_project" == *Linux* || "$test_project" == *MacOS* ]] && continue
             echo "Testing $test_project"
             dotnet test "$test_project" -c ${{ env.BUILD_CONFIGURATION }} --verbosity normal
           done < <(find GenHub/GenHub.Tests -type f -name '*.csproj' | sort)

--- a/GenHub/GenHub.MacOS/Infrastructure/DependencyInjection/MacOSServicesModule.cs
+++ b/GenHub/GenHub.MacOS/Infrastructure/DependencyInjection/MacOSServicesModule.cs
@@ -1,11 +1,17 @@
-using System.Runtime.Versioning;
 using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Shortcuts;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Interfaces.Workspace;
 using GenHub.Features.AppUpdate.Interfaces;
 using GenHub.Features.AppUpdate.Services;
+using GenHub.Features.GameSettings;
+using GenHub.Features.Workspace;
 using GenHub.MacOS.Features.Shortcuts;
 using GenHub.MacOS.GameInstallations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Runtime.Versioning;
 
 namespace GenHub.MacOS.Infrastructure.DependencyInjection;
 
@@ -23,7 +29,20 @@ public static class MacOSServicesModule
     public static IServiceCollection AddMacOSServices(this IServiceCollection services)
     {
         services.AddSingleton<IGameInstallationDetector, MacOSInstallationDetector>();
+        services.AddSingleton<IGamePathProvider, MacOSGamePathProvider>();
+        services.AddSingleton<ISymlinkCapabilityProvider, UnixSymlinkCapabilityProvider>();
         services.AddSingleton<IShortcutService, MacOSShortcutService>();
+
+        // Real hard links via link(2). Without this the base implementation throws, which
+        // is deliberate: silently copying made a missing registration invisible while
+        // every workspace consumed a full copy of the game.
+        services.AddScoped<IFileOperationsService>(serviceProvider =>
+        {
+            var baseService = serviceProvider.GetRequiredService<FileOperationsService>();
+            var casService = serviceProvider.GetRequiredService<ICasService>();
+            var logger = serviceProvider.GetRequiredService<ILogger<UnixFileOperationsService>>();
+            return new UnixFileOperationsService(baseService, casService, logger);
+        });
 
         // Disables self-update on macOS, which publishes no update artifacts.
         // AppServices.ConfigureApplicationServices invokes the platform module after

--- a/GenHub/GenHub.Tests/Shared/CompositionRootAssertions.cs
+++ b/GenHub/GenHub.Tests/Shared/CompositionRootAssertions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GenHub.Common.ViewModels;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.Shortcuts;
 using GenHub.Core.Interfaces.Workspace;
 using GenHub.Features.AppUpdate.Interfaces;
@@ -43,7 +44,9 @@ public static class CompositionRootAssertions
     [
         typeof(IConfigurationProviderService),
         typeof(IFileOperationsService),
+        typeof(IGamePathProvider),
         typeof(IShortcutService),
+        typeof(ISymlinkCapabilityProvider),
         typeof(IVelopackUpdateManager),
     ];
 


### PR DESCRIPTION
## Summary

`development` is currently broken on macOS. `GenHub.app` aborts at container build:

```
GenHub.app exited during startup (status 134)
System.InvalidOperationException: Unable to resolve service for type
'IGamePathProvider' while attempting to activate 'GameSettingsService'
```

This cascades across roughly twenty service descriptors, including `MainViewModel`, `IGameLauncher` and `IGameProfileManager`. The `Build macOS` job on `development` is red.

## Why neither #328 nor #329 could have caught it

#328 made `IGamePathProvider` a **required** constructor dependency — deliberately, so an unregistered provider fails at container build instead of silently resolving to the Windows implementation. #329 added the macOS host and its DI module.

The macOS registrations reference types introduced by #328 and a module introduced by #329, so they compile only once **both** are merged. Neither PR could carry them, and both were genuinely green in isolation. The failure exists only in the merged state, which per-branch CI cannot reach.

## Changes

- Register `IGamePathProvider`, `ISymlinkCapabilityProvider` and `IFileOperationsService` for macOS.

  Only `IGamePathProvider` breaks startup. Without the other two, macOS silently copies instead of hard-linking and cannot reach symlink strategies — the exact behaviours #328 set out to fix — so all three land together.

- Add the missing `typeof` entries to the shared composition-root assertions.

- **Move the macOS test run before publish.** `GenHub.Tests.MacOS` was already covered by the job's final `Run Tests` step, but that step sits *after* `Publish macOS App` and `Smoke Test App Launch`. The startup crash killed the job at the smoke test, so the assertion that names the unresolvable service never executed — the breakage surfaced only as a status-134 crash after packaging. `MacOSHost_ResolvesEveryRequiredService` already asserted exactly this; it was simply reached too late to be useful. Running it before publish fails in seconds and names the service. The project is now skipped in the later sweep so it runs once rather than twice.

  *Corrected from the original description of this PR, which claimed the project ran nowhere in CI. It did run — just too late to matter.*

## Testing

- `MacOSCompositionRootTests`: 3 passed. Fails on `development` without this change.
- `GenHub.Tests.Core`: 1408 passed.
- `GenHub.MacOS` builds with 0 warnings.
- `Build macOS` passes on this branch, against red on `development`.

## Risks and rollback

Registration-only, scoped to the macOS module; no behaviour change on Windows or Linux. Revert-safe, though reverting restores the startup crash.

## Related

Unblocks the native-launch PR, which is where these registrations were originally staged. Alpha 4 cannot ship until this lands — #229's promote gate requires a green CI run for the exact release SHA.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Registers the macOS implementations required by shared game-settings and workspace services.
- Adds macOS game-path, symlink-capability, and Unix file-operations registrations.
- Expands composition-root assertions to cover the newly required platform services.
- Runs the macOS test project before publishing and avoids rerunning it in the generic test sweep.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new macOS registrations and CI coverage consistent with existing platform patterns.

The macOS composition root now supplies each required service with available dependencies, all platform modules satisfy the expanded assertions, and the only current macOS test project remains executed exactly once in its native CI job.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Runs the sole macOS-specific test project before publish and excludes it from the later sweep to prevent duplicate execution. |
| GenHub/GenHub.MacOS/Infrastructure/DependencyInjection/MacOSServicesModule.cs | Registers constructible macOS and Unix service implementations using the established platform-wrapper pattern and correct registration order. |
| GenHub/GenHub.Tests/Shared/CompositionRootAssertions.cs | Adds required platform interfaces that are registered and resolved by all current platform composition roots. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(macos): register the platform servic..."](https://github.com/community-outpost/genhub/commit/e82b75a35e9de9f396e52b051181e2b001e0e76a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48558288)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [App Shell and Dependency Injection](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/app-shell-and-di.md)
- Knowledge Base — [Workspace Assembly](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/workspace-assembly.md)
- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)
</details>

<!-- /greptile_comment -->