### PR TITLE
feat(launching): launch the native BGFX client against retail archives

### DIFF
--- a/GenHub/GenHub.Core/Constants/RetailArchiveConstants.cs
+++ b/GenHub/GenHub.Core/Constants/RetailArchiveConstants.cs
@@ -1,0 +1,42 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// The contract between GenHub and a non-Windows engine build for locating retail archives.
+/// </summary>
+/// <remarks>
+/// A non-Windows engine reads <c>InstallPath</c> through <c>GetStringFromRegistry</c>, which
+/// on these platforms consults these variables before anything else, then mounts
+/// <c>*.big</c> from those roots in addition to the working directory. The names are
+/// therefore an external contract: changing one silently stops the engine finding content,
+/// with no error from either side.
+/// <para>
+/// Windows resolves install paths from the registry and does not read these, so nothing is
+/// set — and nothing should be validated against them — on that platform.
+/// </para>
+/// </remarks>
+public static class RetailArchiveConstants
+{
+    /// <summary>Environment variable naming the Zero Hour retail directory.</summary>
+    public const string ZeroHourInstallPathVariable = "CNC_ZH_INSTALLPATH";
+
+    /// <summary>Environment variable naming the Generals retail directory.</summary>
+    public const string GeneralsInstallPathVariable = "CNC_GENERALS_INSTALLPATH";
+
+    /// <summary>
+    /// Search pattern for the archives the engine mounts from a retail root.
+    /// </summary>
+    /// <remarks>
+    /// Used as an existence sentinel rather than matching a specific filename, which varies
+    /// by localisation and version.
+    /// </remarks>
+    public const string ArchiveSearchPattern = "*.big";
+
+    /// <summary>
+    /// Every retail archive root variable, Zero Hour first.
+    /// </summary>
+    public static readonly string[] InstallPathVariables =
+    [
+        ZeroHourInstallPathVariable,
+        GeneralsInstallPathVariable,
+    ];
+}

--- a/GenHub/GenHub.Core/Constants/RetailArchiveConstants.cs
+++ b/GenHub/GenHub.Core/Constants/RetailArchiveConstants.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace GenHub.Core.Constants;
 
 /// <summary>
@@ -30,6 +32,28 @@ public static class RetailArchiveConstants
     /// by localisation and version.
     /// </remarks>
     public const string ArchiveSearchPattern = "*.big";
+
+    /// <summary>
+    /// How <see cref="ArchiveSearchPattern"/> is matched within a retail root.
+    /// </summary>
+    /// <remarks>
+    /// Case-insensitive because retail data copied from a disc or a Windows machine is
+    /// frequently upper-cased, while the default glob is case-sensitive on Linux volumes and on
+    /// case-sensitive APFS. <c>INIZH.BIG</c> would otherwise read as no archives at all and
+    /// block a launch that would have worked — the opposite of what the check exists to do.
+    /// <para>
+    /// <see cref="EnumerationOptions.IgnoreInaccessible"/> is set back to <c>false</c> because
+    /// it defaults to <c>true</c> here, unlike the <see cref="SearchOption"/> overload. Left at
+    /// the default it turns an unreadable root into "no archives found", reporting a permission
+    /// problem as missing content.
+    /// </para>
+    /// </remarks>
+    public static readonly EnumerationOptions ArchiveSearch = new()
+    {
+        MatchCasing = MatchCasing.CaseInsensitive,
+        RecurseSubdirectories = false,
+        IgnoreInaccessible = false,
+    };
 
     /// <summary>
     /// Every retail archive root variable, Zero Hour first.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/BoundedErrorBufferTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/BoundedErrorBufferTests.cs
@@ -1,0 +1,104 @@
+using System.Reflection;
+using GenHub.Features.GameProfiles.Infrastructure;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Tests for the bounded stderr capture used to explain a failed launch.
+/// </summary>
+/// <remarks>
+/// The buffer is a private nested type; it is exercised through reflection rather than
+/// being made public, because it is an implementation detail of process management and
+/// its behaviour only matters through the diagnostics it produces.
+/// </remarks>
+public class BoundedErrorBufferTests
+{
+    private static readonly Type BufferType =
+        typeof(GameProcessManager).GetNestedType("BoundedErrorBuffer", BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// The startup context is where the cause usually is, so the first lines must survive
+    /// even when far more output follows than the buffer retains.
+    /// </summary>
+    [Fact]
+    public void Append_RetainsBothTheHeadAndTheTail()
+    {
+        var buffer = CreateBuffer();
+
+        Append(buffer, "dyld: library not loaded");
+        for (var i = 0; i < 200; i++)
+        {
+            Append(buffer, $"noise line {i}");
+        }
+
+        Append(buffer, "Abort trap: 6");
+
+        var text = buffer.ToString()!;
+
+        Assert.Contains("dyld: library not loaded", text);
+        Assert.Contains("Abort trap: 6", text);
+        Assert.Contains("omitted", text);
+    }
+
+    /// <summary>
+    /// A single pathological line must not be retained in full.
+    /// </summary>
+    [Fact]
+    public void Append_TruncatesAnOverlongLine()
+    {
+        var buffer = CreateBuffer();
+
+        Append(buffer, new string('x', 10_000));
+
+        var text = buffer.ToString()!;
+
+        Assert.Contains("line truncated", text);
+        Assert.True(text.Length < 10_000, "The overlong line was retained in full.");
+    }
+
+    /// <summary>
+    /// A null line is the framework's end-of-stream signal, not content.
+    /// </summary>
+    [Fact]
+    public void Append_TreatsNullAsEndOfStreamRatherThanContent()
+    {
+        var buffer = CreateBuffer();
+
+        Assert.False(EndOfStreamReached(buffer));
+
+        Append(buffer, "something failed");
+        Append(buffer, null);
+
+        Assert.True(EndOfStreamReached(buffer));
+        Assert.Equal("something failed", buffer.ToString());
+    }
+
+    /// <summary>
+    /// Total retained output stays bounded regardless of how much arrives.
+    /// </summary>
+    [Fact]
+    public void Append_BoundsTotalRetainedOutput()
+    {
+        var buffer = CreateBuffer();
+
+        for (var i = 0; i < 5_000; i++)
+        {
+            Append(buffer, new string('y', 500));
+        }
+
+        Assert.True(
+            buffer.ToString()!.Length < 128 * 1024,
+            "Retained output grew beyond the cap.");
+    }
+
+    private static object CreateBuffer() => Activator.CreateInstance(BufferType, nonPublic: true)!;
+
+    private static void Append(object buffer, string? line) =>
+        BufferType.GetMethod("Append", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(buffer, [line]);
+
+    private static bool EndOfStreamReached(object buffer) =>
+        (bool)BufferType.GetProperty("EndOfStreamReached", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(buffer)!;
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientFixture.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientFixture.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace GenHub.Tests.Core.Features.GameProfiles;
@@ -33,7 +34,10 @@ public static class NativeClientFixture
             var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
             if (!string.IsNullOrWhiteSpace(configured))
             {
-                return System.IO.Directory.Exists(configured) ? configured : null;
+                // Validated the same way as the discovered default below. A directory that
+                // exists but holds no engine binary is a misconfigured override, and these
+                // tests should skip rather than fail on it.
+                return File.Exists(Path.Combine(configured, BinaryName)) ? configured : null;
             }
 
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -41,5 +45,30 @@ public static class NativeClientFixture
 
             return File.Exists(Path.Combine(defaultDirectory, BinaryName)) ? defaultDirectory : null;
         }
+    }
+
+    /// <summary>
+    /// Determines whether a filename is one of the engine's dynamic libraries.
+    /// </summary>
+    /// <remarks>
+    /// Covers macOS <c>.dylib</c> and both Linux forms: unversioned <c>.so</c> and versioned
+    /// <c>.so.0</c> / <c>.so.0.1.0</c>, which are the common shape of a shipped Linux library
+    /// and which a plain <c>.so</c> suffix test misses.
+    /// </remarks>
+    /// <param name="fileName">The filename to test.</param>
+    /// <returns><c>true</c> when the file is a dynamic library.</returns>
+    public static bool IsDynamicLibrary(string fileName)
+    {
+        if (fileName.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(".so", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Matched on ".so." rather than ".so" so an earlier coincidental ".so" — inside
+        // ".sound", say — cannot shadow the real suffix and end the search early.
+        var versioned = fileName.IndexOf(".so.", StringComparison.OrdinalIgnoreCase);
+        return versioned >= 0
+            && fileName[(versioned + 4)..].All(c => char.IsDigit(c) || c == '.');
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientFixture.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientFixture.cs
@@ -1,0 +1,45 @@
+using System.Runtime.InteropServices;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Locates the local native client these integration tests launch.
+/// </summary>
+/// <remarks>
+/// Shared by every test that spawns the real engine, so discovery stays in one place: all
+/// of them skip unless a client is present, and diverging on how it is found would make
+/// some skip while others fail.
+/// </remarks>
+public static class NativeClientFixture
+{
+    /// <summary>Environment variable overriding the discovered directory.</summary>
+    public const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";
+
+    /// <summary>The engine executable's filename.</summary>
+    public const string BinaryName = "generalszh";
+
+    /// <summary>
+    /// Gets the native client directory, or <c>null</c> when these tests should skip.
+    /// </summary>
+    public static string? Directory
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
+
+            var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
+            if (!string.IsNullOrWhiteSpace(configured))
+            {
+                return System.IO.Directory.Exists(configured) ? configured : null;
+            }
+
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var defaultDirectory = Path.Combine(home, "TheSuperHackers", "GeneralsZH");
+
+            return File.Exists(Path.Combine(defaultDirectory, BinaryName)) ? defaultDirectory : null;
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientFixtureTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientFixtureTests.cs
@@ -1,0 +1,43 @@
+using GenHub.Tests.Core.Features.GameProfiles;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Tests for the shared native-client fixture helper.
+/// </summary>
+/// <remarks>
+/// The integration tests that use it all skip without a local engine install, so the
+/// library predicate would otherwise never be exercised on CI — including the versioned
+/// Linux forms, which a plain ".so" suffix test silently misses.
+/// </remarks>
+public class NativeClientFixtureTests
+{
+    /// <summary>
+    /// Recognises macOS and both Linux shapes, unversioned and versioned.
+    /// </summary>
+    /// <param name="fileName">The candidate filename.</param>
+    [Theory]
+    [InlineData("libSDL3.dylib")]
+    [InlineData("libSDL3.so")]
+    [InlineData("libSDL3.so.0")]
+    [InlineData("libSDL3.so.0.1.0")]
+    [InlineData("libstdc++.so.6")]
+    [InlineData("libavcodec.58.so.4")]
+    [InlineData("mylib.sound.so.1")]
+    public void IsDynamicLibrary_WithLibraryNames_ReturnsTrue(string fileName)
+        => Assert.True(NativeClientFixture.IsDynamicLibrary(fileName));
+
+    /// <summary>
+    /// Rejects the engine binary, data files, and names that merely contain ".so".
+    /// </summary>
+    /// <param name="fileName">The candidate filename.</param>
+    [Theory]
+    [InlineData("generalszh")]
+    [InlineData("INIZH.big")]
+    [InlineData("readme.txt")]
+    [InlineData("resources.sound")]
+    [InlineData("libfoo.sox")]
+    public void IsDynamicLibrary_WithNonLibraryNames_ReturnsFalse(string fileName)
+        => Assert.False(NativeClientFixture.IsDynamicLibrary(fileName));
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchCollection.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchCollection.cs
@@ -1,5 +1,7 @@
 using Xunit;
 
+using System.Runtime.InteropServices;
+
 namespace GenHub.Tests.Core.Features.GameProfiles;
 
 /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchCollection.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchCollection.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Serialises the tests that launch a real native game client.
+/// <para>
+/// The engine enforces a single running instance, so two of these in parallel produce a
+/// spurious failure: the second launch is refused by the first. That is engine behaviour
+/// rather than a test defect, and it has a product consequence — GenHub cannot run two
+/// native profiles simultaneously.
+/// </para>
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class NativeClientLaunchCollection
+{
+    /// <summary>The xUnit collection name.</summary>
+    public const string Name = "Native client launch";
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
@@ -17,7 +17,7 @@ namespace GenHub.Tests.Core.Features.GameProfiles;
 /// <para>
 /// Everything else in the native-client work is verified against synthetic binaries.
 /// This is the one test that answers the actual question: can GenHub start the real
-/// engine, against real retail data, and have it stay up?
+    /// engine, against real retail data, and have it remain running.
 /// </para>
 /// <para>
 /// Skipped unless a native install is present, so CI and other machines stay green.
@@ -36,9 +36,6 @@ public class NativeClientLaunchIntegrationTests
 
     private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
 
-    /// <summary>
-    /// Resolves the native install directory, or null when there is nothing to test.
-    /// </summary>
     private static string? NativeClientDirectory
     {
         get
@@ -98,11 +95,11 @@ public class NativeClientLaunchIntegrationTests
             await Task.Delay(LaunchSettleTime);
 
             var info = await _processManager.GetProcessInfoAsync(result.Data!.ProcessId);
-
-            Assert.True(
-                info.Success,
+            const string failureMessage =
                 "The engine started and then exited during initialisation. That is the failure "
-                + "mode this work exists to make visible; check the captured output.");
+                + "mode this work exists to make visible; check the captured output.";
+
+            Assert.True(info.Success, failureMessage);
         }
         finally
         {
@@ -151,12 +148,12 @@ public class NativeClientLaunchIntegrationTests
                 await Task.Delay(TimeSpan.FromSeconds(6));
                 var info = await _processManager.GetProcessInfoAsync(result.Data.ProcessId);
                 await _processManager.TerminateProcessAsync(result.Data.ProcessId);
-
-                Assert.False(
-                    info.Success,
+                const string failureMessage =
                     "The engine survived being launched from an unrelated working directory. If it "
                     + "no longer resolves archives relative to the current directory, the workspace "
-                    + "model can be relaxed.");
+                    + "model can be relaxed.";
+
+                Assert.False(info.Success, failureMessage);
                 return;
             }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using GenHub.Core.Models.Launching;
+using GenHub.Core.Models.Manifest;
+using GenHub.Features.GameProfiles.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// End-to-end launch of a real native Zero Hour client through GenHub's own process
+/// manager, rather than a stand-in script.
+/// <para>
+/// Everything else in the native-client work is verified against synthetic binaries.
+/// This is the one test that answers the actual question: can GenHub start the real
+/// engine, against real retail data, and have it stay up?
+/// </para>
+/// <para>
+/// Skipped unless a native install is present, so CI and other machines stay green.
+/// Point <c>GENHUB_NATIVE_CLIENT_DIR</c> at an install directory to run it; the default
+/// is the deploy script's own default location.
+/// </para>
+/// </summary>
+public class NativeClientLaunchIntegrationTests
+{
+    private const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";
+    private const string BinaryName = "generalszh";
+
+    /// <summary>How long the engine must stay up to count as a successful launch.</summary>
+    private static readonly TimeSpan LaunchSettleTime = TimeSpan.FromSeconds(12);
+
+    private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
+
+    /// <summary>
+    /// Resolves the native install directory, or null when there is nothing to test.
+    /// </summary>
+    private static string? NativeClientDirectory
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
+
+            var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
+            if (!string.IsNullOrWhiteSpace(configured))
+            {
+                return Directory.Exists(configured) ? configured : null;
+            }
+
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var defaultDirectory = Path.Combine(home, "TheSuperHackers", "GeneralsZH");
+
+            return File.Exists(Path.Combine(defaultDirectory, BinaryName)) ? defaultDirectory : null;
+        }
+    }
+
+    /// <summary>
+    /// Launches the engine with the install directory as the working directory, exactly
+    /// as a workspace launch would, and requires it to survive startup.
+    /// <para>
+    /// Windowed mode is requested so a test run cannot take over the display.
+    /// </para>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task RealNativeClient_LaunchesThroughGameProcessManager()
+    {
+        var installDirectory = NativeClientDirectory;
+        if (installDirectory is null)
+        {
+            return;
+        }
+
+        var configuration = new GameLaunchConfiguration
+        {
+            ExecutablePath = Path.Combine(installDirectory, BinaryName),
+            WorkingDirectory = installDirectory,
+            Arguments = new() { ["-win"] = string.Empty },
+        };
+
+        var result = await _processManager.StartProcessAsync(configuration);
+
+        Assert.True(result.Success, $"Launch failed: {string.Join(" ", result.Errors)}");
+        Assert.NotNull(result.Data);
+
+        try
+        {
+            // StartProcessAsync only waits out the launcher-detection delay. Give the
+            // engine long enough to fail the way it fails for real: mounting archives and
+            // initialising the renderer, both of which happen after the process exists.
+            await Task.Delay(LaunchSettleTime);
+
+            var info = await _processManager.GetProcessInfoAsync(result.Data!.ProcessId);
+
+            Assert.True(
+                info.Success,
+                "The engine started and then exited during initialisation. That is the failure "
+                + "mode this work exists to make visible; check the captured output.");
+        }
+        finally
+        {
+            await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
+        }
+    }
+
+    /// <summary>
+    /// The working directory is load-bearing, not cosmetic. The engine discovers its
+    /// <c>.big</c> archives relative to the current directory, so launching from anywhere
+    /// else fails within about a second — it finds no archives, or worse, mounts unrelated
+    /// ones it happens to encounter.
+    /// <para>
+    /// This is why <c>WorkspaceStrategyBase</c> sets <c>WorkingDirectory</c> to the
+    /// workspace root, and why a native client cannot simply be launched in place.
+    /// </para>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task RealNativeClient_RequiresItsInstallDirectoryAsWorkingDirectory()
+    {
+        var installDirectory = NativeClientDirectory;
+        if (installDirectory is null)
+        {
+            return;
+        }
+
+        var isolatedDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"genhub-wrong-cwd-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(isolatedDirectory);
+
+        try
+        {
+            var configuration = new GameLaunchConfiguration
+            {
+                ExecutablePath = Path.Combine(installDirectory, BinaryName),
+                WorkingDirectory = isolatedDirectory,
+                Arguments = new() { ["-win"] = string.Empty },
+            };
+
+            var result = await _processManager.StartProcessAsync(configuration);
+
+            if (result.Success && result.Data is not null)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(6));
+                var info = await _processManager.GetProcessInfoAsync(result.Data.ProcessId);
+                await _processManager.TerminateProcessAsync(result.Data.ProcessId);
+
+                Assert.False(
+                    info.Success,
+                    "The engine survived being launched from an unrelated working directory. If it "
+                    + "no longer resolves archives relative to the current directory, the workspace "
+                    + "model can be relaxed.");
+                return;
+            }
+
+            // The expected path: it dies during startup and the failure names the reason
+            // rather than reporting a bare exit code.
+            Assert.False(result.Success);
+            Assert.Contains("exited immediately", string.Join(" ", result.Errors), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(isolatedDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Cleanup failure is not a test failure.
+            }
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
@@ -28,35 +28,10 @@ namespace GenHub.Tests.Core.Features.GameProfiles;
 [Collection(NativeClientLaunchCollection.Name)]
 public class NativeClientLaunchIntegrationTests
 {
-    private const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";
-    private const string BinaryName = "generalszh";
-
     /// <summary>How long the engine must stay up to count as a successful launch.</summary>
     private static readonly TimeSpan LaunchSettleTime = TimeSpan.FromSeconds(12);
 
     private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
-
-    private static string? NativeClientDirectory
-    {
-        get
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return null;
-            }
-
-            var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
-            if (!string.IsNullOrWhiteSpace(configured))
-            {
-                return Directory.Exists(configured) ? configured : null;
-            }
-
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var defaultDirectory = Path.Combine(home, "TheSuperHackers", "GeneralsZH");
-
-            return File.Exists(Path.Combine(defaultDirectory, BinaryName)) ? defaultDirectory : null;
-        }
-    }
 
     /// <summary>
     /// Launches the engine with the install directory as the working directory, exactly
@@ -69,7 +44,7 @@ public class NativeClientLaunchIntegrationTests
     [Fact]
     public async Task RealNativeClient_LaunchesThroughGameProcessManager()
     {
-        var installDirectory = NativeClientDirectory;
+        var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
         {
             return;
@@ -77,7 +52,7 @@ public class NativeClientLaunchIntegrationTests
 
         var configuration = new GameLaunchConfiguration
         {
-            ExecutablePath = Path.Combine(installDirectory, BinaryName),
+            ExecutablePath = Path.Combine(installDirectory, NativeClientFixture.BinaryName),
             WorkingDirectory = installDirectory,
             Arguments = new() { ["-win"] = string.Empty },
         };
@@ -121,7 +96,7 @@ public class NativeClientLaunchIntegrationTests
     [Fact]
     public async Task RealNativeClient_RequiresItsInstallDirectoryAsWorkingDirectory()
     {
-        var installDirectory = NativeClientDirectory;
+        var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
         {
             return;
@@ -136,7 +111,7 @@ public class NativeClientLaunchIntegrationTests
         {
             var configuration = new GameLaunchConfiguration
             {
-                ExecutablePath = Path.Combine(installDirectory, BinaryName),
+                ExecutablePath = Path.Combine(installDirectory, NativeClientFixture.BinaryName),
                 WorkingDirectory = isolatedDirectory,
                 Arguments = new() { ["-win"] = string.Empty },
             };

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
@@ -25,6 +25,7 @@ namespace GenHub.Tests.Core.Features.GameProfiles;
 /// is the deploy script's own default location.
 /// </para>
 /// </summary>
+[Collection(NativeClientLaunchCollection.Name)]
 public class NativeClientLaunchIntegrationTests
 {
     private const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using GenHub.Core.Models.Launching;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Utilities;
+using GenHub.Features.GameProfiles.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Closes the loop between the manifest model and a real launch.
+/// <para>
+/// The variant and entry-point model is otherwise only exercised against hand-built
+/// manifests. This builds a manifest from an actual native install, resolves the entry
+/// point the way the workspace does, and launches whatever comes out — so a resolver
+/// that picks the wrong file fails here rather than in production.
+/// </para>
+/// <para>
+/// Skipped unless a native install is present. Set <c>GENHUB_NATIVE_CLIENT_DIR</c> to
+/// override the default location.
+/// </para>
+/// </summary>
+[Collection(NativeClientLaunchCollection.Name)]
+public class NativeClientManifestLaunchTests
+{
+    private const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";
+    private const string BinaryName = "generalszh";
+
+    private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
+
+    private static string? NativeClientDirectory
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
+
+            var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
+            if (!string.IsNullOrWhiteSpace(configured))
+            {
+                return Directory.Exists(configured) ? configured : null;
+            }
+
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var directory = Path.Combine(home, "TheSuperHackers", "GeneralsZH");
+
+            return File.Exists(Path.Combine(directory, BinaryName)) ? directory : null;
+        }
+    }
+
+    /// <summary>
+    /// Builds a manifest describing a real install and launches the entry point the
+    /// resolver selects.
+    /// <para>
+    /// The manifest deliberately includes the engine's dynamic libraries. That is the
+    /// shape that used to break resolution: several files qualify as executable, so
+    /// picking the first one was picking by enumeration order.
+    /// </para>
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ManifestResolvedEntryPoint_LaunchesTheRealEngine()
+    {
+        var installDirectory = NativeClientDirectory;
+        if (installDirectory is null)
+        {
+            return;
+        }
+
+        var manifest = BuildManifestFromInstall(installDirectory);
+
+        // Sanity-check the fixture actually reproduces the ambiguous case; otherwise this
+        // test would pass for the wrong reason.
+        Assert.True(
+            manifest.Variants.Single().Files.Count(f => f.IsExecutable) >= 1,
+            "Expected the install to contain at least one file requiring execute permission.");
+
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
+
+        Assert.True(resolution.Success, resolution.ToString());
+        Assert.Equal(BinaryName, resolution.RelativePath);
+
+        var configuration = new GameLaunchConfiguration
+        {
+            ExecutablePath = Path.Combine(installDirectory, resolution.RelativePath!),
+            WorkingDirectory = installDirectory,
+            Arguments = new() { ["-win"] = string.Empty },
+        };
+
+        var result = await _processManager.StartProcessAsync(configuration);
+        Assert.True(result.Success, $"Launch failed: {string.Join(" ", result.Errors)}");
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(12));
+            var info = await _processManager.GetProcessInfoAsync(result.Data!.ProcessId);
+            Assert.True(info.Success, "The engine exited during initialisation.");
+        }
+        finally
+        {
+            await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
+        }
+    }
+
+    /// <summary>
+    /// A manifest whose variant does not target this runtime must resolve to nothing,
+    /// so a Windows-only client is never offered on macOS.
+    /// </summary>
+    [Fact]
+    public void ManifestForAnotherRuntime_IsNotOfferedHere()
+    {
+        var installDirectory = NativeClientDirectory;
+        if (installDirectory is null)
+        {
+            return;
+        }
+
+        var manifest = BuildManifestFromInstall(installDirectory);
+        manifest.Variants.Single().RuntimeIdentifiers = ["win-x64"];
+
+        Assert.False(ManifestVariantResolver.SupportsRuntime(manifest));
+        Assert.Empty(ManifestVariantResolver.ResolveFiles(manifest));
+    }
+
+    /// <summary>
+    /// Builds a single-variant manifest describing the engine binary and its libraries,
+    /// classified by the shared rules rather than by hand.
+    /// </summary>
+    /// <param name="installDirectory">The native install directory.</param>
+    /// <returns>A manifest targeting the current runtime.</returns>
+    private static ContentManifest BuildManifestFromInstall(string installDirectory)
+    {
+        var engineFiles = new List<ManifestFile>();
+
+        foreach (var path in Directory.EnumerateFiles(installDirectory, "*", SearchOption.TopDirectoryOnly))
+        {
+            var name = Path.GetFileName(path);
+
+            // The engine and its bundled libraries; retail archives are the user's own
+            // content and belong to the installation, not the client manifest.
+            if (name != BinaryName && !name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            engineFiles.Add(new ManifestFile
+            {
+                RelativePath = name,
+                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(name),
+            });
+        }
+
+        return new ContentManifest
+        {
+            Name = "Native Zero Hour (BGFX)",
+            Variants =
+            [
+                new ArtifactVariant
+                {
+                    RuntimeIdentifiers = [ManifestVariantResolver.CurrentRuntimeIdentifier],
+                    EntryPoint = BinaryName,
+                    Files = engineFiles,
+                },
+            ],
+        };
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
@@ -58,6 +58,12 @@ public class NativeClientManifestLaunchTests
             manifest.Variants.Single().Files.Count(f => f.IsExecutable) >= 1,
             "Expected the install to contain at least one file requiring execute permission.");
 
+        // Without this the fixture could contain only the binary and still satisfy the
+        // assertions, leaving the library-handling path untested on either platform.
+        Assert.Contains(
+            manifest.Variants.Single().Files,
+            file => NativeClientFixture.IsDynamicLibrary(Path.GetFileName(file.RelativePath)));
+
         var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
 
         Assert.True(resolution.Success, resolution.ToString());
@@ -121,7 +127,7 @@ public class NativeClientManifestLaunchTests
 
             // The engine and its bundled libraries; retail archives are the user's own
             // content and belong to the installation, not the client manifest.
-            if (name != NativeClientFixture.BinaryName && !name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase))
+            if (name != NativeClientFixture.BinaryName && !NativeClientFixture.IsDynamicLibrary(name))
             {
                 continue;
             }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
@@ -29,32 +29,7 @@ namespace GenHub.Tests.Core.Features.GameProfiles;
 [Collection(NativeClientLaunchCollection.Name)]
 public class NativeClientManifestLaunchTests
 {
-    private const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";
-    private const string BinaryName = "generalszh";
-
     private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
-
-    private static string? NativeClientDirectory
-    {
-        get
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return null;
-            }
-
-            var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
-            if (!string.IsNullOrWhiteSpace(configured))
-            {
-                return Directory.Exists(configured) ? configured : null;
-            }
-
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var directory = Path.Combine(home, "TheSuperHackers", "GeneralsZH");
-
-            return File.Exists(Path.Combine(directory, BinaryName)) ? directory : null;
-        }
-    }
 
     /// <summary>
     /// Builds a manifest describing a real install and launches the entry point the
@@ -69,7 +44,7 @@ public class NativeClientManifestLaunchTests
     [Fact]
     public async Task ManifestResolvedEntryPoint_LaunchesTheRealEngine()
     {
-        var installDirectory = NativeClientDirectory;
+        var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
         {
             return;
@@ -86,7 +61,7 @@ public class NativeClientManifestLaunchTests
         var resolution = ManifestVariantResolver.ResolveEntryPoint(manifest);
 
         Assert.True(resolution.Success, resolution.ToString());
-        Assert.Equal(BinaryName, resolution.RelativePath);
+        Assert.Equal(NativeClientFixture.BinaryName, resolution.RelativePath);
 
         var configuration = new GameLaunchConfiguration
         {
@@ -117,7 +92,7 @@ public class NativeClientManifestLaunchTests
     [Fact]
     public void ManifestForAnotherRuntime_IsNotOfferedHere()
     {
-        var installDirectory = NativeClientDirectory;
+        var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
         {
             return;
@@ -146,7 +121,7 @@ public class NativeClientManifestLaunchTests
 
             // The engine and its bundled libraries; retail archives are the user's own
             // content and belong to the installation, not the client manifest.
-            if (name != BinaryName && !name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase))
+            if (name != NativeClientFixture.BinaryName && !name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
@@ -166,7 +141,7 @@ public class NativeClientManifestLaunchTests
                 new ArtifactVariant
                 {
                     RuntimeIdentifiers = [ManifestVariantResolver.CurrentRuntimeIdentifier],
-                    EntryPoint = BinaryName,
+                    EntryPoint = NativeClientFixture.BinaryName,
                     Files = engineFiles,
                 },
             ],

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
@@ -46,7 +46,7 @@ public class NativeLaunchDiagnosticsTests : IDisposable
             return;
         }
 
-        var binary = Path.Combine(_tempDir, "generalszh");
+        var binary = Path.Combine(_tempDir, NativeClientFixture.BinaryName);
         await File.WriteAllTextAsync(binary, "#!/bin/sh\nexit 0\n");
         if (!OperatingSystem.IsWindows())
         {
@@ -61,7 +61,7 @@ public class NativeLaunchDiagnosticsTests : IDisposable
 
         Assert.False(result.Success);
         Assert.Contains("execute permission", string.Join(" ", result.Errors), StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("generalszh", string.Join(" ", result.Errors));
+        Assert.Contains(NativeClientFixture.BinaryName, string.Join(" ", result.Errors));
     }
 
     /// <summary>
@@ -78,7 +78,7 @@ public class NativeLaunchDiagnosticsTests : IDisposable
             return;
         }
 
-        var binary = Path.Combine(_tempDir, "generalszh");
+        var binary = Path.Combine(_tempDir, NativeClientFixture.BinaryName);
         await File.WriteAllTextAsync(
             binary,
             "#!/bin/sh\necho \"dyld: Library not loaded: @rpath/libSDL3.dylib\" >&2\nexit 1\n");
@@ -116,7 +116,7 @@ public class NativeLaunchDiagnosticsTests : IDisposable
             return;
         }
 
-        var binary = Path.Combine(_tempDir, "generalszh");
+        var binary = Path.Combine(_tempDir, NativeClientFixture.BinaryName);
 
         // Writes far more than a pipe buffer holds, then keeps running.
         await File.WriteAllTextAsync(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using GenHub.Core.Models.Launching;
+using GenHub.Features.GameProfiles.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Verifies that a native client which fails to start says why.
+/// <para>
+/// The failure this guards against is silence. A binary missing its execute bit, or one
+/// that dies in the dynamic loader, previously produced no window and no error: the
+/// process started, exited, and the launcher reported an exit code with no context. On a
+/// native client whose libraries sit beside it in the workspace, that is the most likely
+/// first-run failure of all.
+/// </para>
+/// </summary>
+public class NativeLaunchDiagnosticsTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(
+        Path.GetTempPath(),
+        $"genhub-launchdiag-{Guid.NewGuid():N}");
+
+    private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NativeLaunchDiagnosticsTests"/> class.
+    /// </summary>
+    public NativeLaunchDiagnosticsTests() => Directory.CreateDirectory(_tempDir);
+
+    private static bool OnUnix => !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    /// <summary>
+    /// A file without the execute bit must be refused before launch, naming the file.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task NonExecutableFile_IsRefusedWithANamedError()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var binary = Path.Combine(_tempDir, "generalszh");
+        await File.WriteAllTextAsync(binary, "#!/bin/sh\nexit 0\n");
+        File.SetUnixFileMode(binary, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var result = await _processManager.StartProcessAsync(new GameLaunchConfiguration
+        {
+            ExecutablePath = binary,
+            WorkingDirectory = _tempDir,
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("execute permission", string.Join(" ", result.Errors), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("generalszh", string.Join(" ", result.Errors));
+    }
+
+    /// <summary>
+    /// A process that dies during startup must surface what it wrote to standard error,
+    /// not just its exit code. "dyld: library not loaded" identifies the problem; "exit
+    /// code 1" does not.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ProcessThatDiesAtStartup_SurfacesItsStderr()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var binary = Path.Combine(_tempDir, "generalszh");
+        await File.WriteAllTextAsync(
+            binary,
+            "#!/bin/sh\necho \"dyld: Library not loaded: @rpath/libSDL3.dylib\" >&2\nexit 1\n");
+        File.SetUnixFileMode(
+            binary,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var result = await _processManager.StartProcessAsync(new GameLaunchConfiguration
+        {
+            ExecutablePath = binary,
+            WorkingDirectory = _tempDir,
+        });
+
+        Assert.False(result.Success);
+
+        var message = string.Join(" ", result.Errors);
+        Assert.Contains("libSDL3.dylib", message);
+        Assert.Contains("Library not loaded", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A healthy process must still launch normally with stderr redirection enabled.
+    /// Redirecting a stream that is never drained is a classic way to deadlock a chatty
+    /// child process, so this confirms the drain works.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ChattyProcess_StillLaunchesWithoutDeadlocking()
+    {
+        if (!OnUnix)
+        {
+            return;
+        }
+
+        var binary = Path.Combine(_tempDir, "generalszh");
+
+        // Writes far more than a pipe buffer holds, then keeps running.
+        await File.WriteAllTextAsync(
+            binary,
+            "#!/bin/sh\ni=0\nwhile [ $i -lt 2000 ]; do echo \"log line $i padding padding padding\" >&2; i=$((i+1)); done\nsleep 30\n");
+        File.SetUnixFileMode(
+            binary,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var result = await _processManager.StartProcessAsync(new GameLaunchConfiguration
+        {
+            ExecutablePath = binary,
+            WorkingDirectory = _tempDir,
+        });
+
+        Assert.True(result.Success, $"Launch failed: {string.Join(" ", result.Errors)}");
+
+        if (result.Data is not null)
+        {
+            await _processManager.TerminateProcessAsync(result.Data.ProcessId);
+        }
+    }
+
+    /// <summary>
+    /// Releases the temporary directory.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test over.
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
@@ -48,7 +48,10 @@ public class NativeLaunchDiagnosticsTests : IDisposable
 
         var binary = Path.Combine(_tempDir, "generalszh");
         await File.WriteAllTextAsync(binary, "#!/bin/sh\nexit 0\n");
-        File.SetUnixFileMode(binary, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(binary, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
 
         var result = await _processManager.StartProcessAsync(new GameLaunchConfiguration
         {
@@ -79,9 +82,12 @@ public class NativeLaunchDiagnosticsTests : IDisposable
         await File.WriteAllTextAsync(
             binary,
             "#!/bin/sh\necho \"dyld: Library not loaded: @rpath/libSDL3.dylib\" >&2\nexit 1\n");
-        File.SetUnixFileMode(
-            binary,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                binary,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
 
         var result = await _processManager.StartProcessAsync(new GameLaunchConfiguration
         {
@@ -116,9 +122,12 @@ public class NativeLaunchDiagnosticsTests : IDisposable
         await File.WriteAllTextAsync(
             binary,
             "#!/bin/sh\ni=0\nwhile [ $i -lt 2000 ]; do echo \"log line $i padding padding padding\" >&2; i=$((i+1)); done\nsleep 30\n");
-        File.SetUnixFileMode(
-            binary,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                binary,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
 
         var result = await _processManager.StartProcessAsync(new GameLaunchConfiguration
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
@@ -167,8 +167,7 @@ public class RetailArchiveRootTests : IDisposable
                 // .so on Linux, and staging only one leaves the workspace incomplete there.
                 var name = Path.GetFileName(path);
                 return name == NativeClientFixture.BinaryName
-                    || name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase)
-                    || name.EndsWith(".so", StringComparison.OrdinalIgnoreCase);
+                    || NativeClientFixture.IsDynamicLibrary(name);
             });
 
         foreach (var source in engineFiles)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
@@ -97,11 +97,11 @@ public class RetailArchiveRootTests : IDisposable
         {
             await Task.Delay(TimeSpan.FromSeconds(14));
             var info = await _processManager.GetProcessInfoAsync(result.Data!.ProcessId);
-
-            Assert.True(
-                info.Success,
+            const string failureMessage =
                 "The engine exited despite the archive roots being supplied, so retail data "
-                + "was not reached through the environment.");
+                + "was not reached through the environment.";
+
+            Assert.True(info.Success, failureMessage);
         }
         finally
         {
@@ -143,16 +143,35 @@ public class RetailArchiveRootTests : IDisposable
         {
             await Task.Delay(TimeSpan.FromSeconds(14));
             var info = await _processManager.GetProcessInfoAsync(result.Data!.ProcessId);
-
-            Assert.False(
-                info.Success,
+            const string failureMessage =
                 "An engine-only workspace survived with no archive roots at all. If the engine "
                 + "now locates retail data by some other means, the environment plumbing in "
-                + "GameLauncher.AddRetailArchiveRoots may be unnecessary.");
+                + "GameLauncher.AddRetailArchiveRoots may be unnecessary.";
+
+            Assert.False(info.Success, failureMessage);
         }
         finally
         {
             await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
+        }
+    }
+
+    /// <summary>
+    /// Releases the staged workspace.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        try
+        {
+            if (Directory.Exists(_engineOnlyWorkspace))
+            {
+                Directory.Delete(_engineOnlyWorkspace, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test over.
         }
     }
 
@@ -179,29 +198,11 @@ public class RetailArchiveRootTests : IDisposable
             File.Copy(source, destination, overwrite: true);
         }
 
-        File.SetUnixFileMode(
-            Path.Combine(_engineOnlyWorkspace, BinaryName),
+        const UnixFileMode executableMode =
             UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
             UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
-    }
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
 
-    /// <summary>
-    /// Releases the staged workspace.
-    /// </summary>
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-        try
-        {
-            if (Directory.Exists(_engineOnlyWorkspace))
-            {
-                Directory.Delete(_engineOnlyWorkspace, recursive: true);
-            }
-        }
-        catch (IOException)
-        {
-            // A leftover temp directory is not worth failing a test over.
-        }
+        File.SetUnixFileMode(Path.Combine(_engineOnlyWorkspace, BinaryName), executableMode);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using GenHub.Core.Models.Launching;
+using GenHub.Features.GameProfiles.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Verifies that a workspace containing only the engine can reach the user's retail
+/// archives through the environment, instead of materialising ~3 GB per profile.
+/// <para>
+/// Zero Hour mounts <c>*.big</c> from the working directory plus any root named by
+/// <c>InstallPath</c>, which the non-Windows engine resolves from
+/// <c>$CNC_ZH_INSTALLPATH</c> and <c>$CNC_GENERALS_INSTALLPATH</c>. Zero Hour needs the
+/// base Generals archives as well as its own, so without this every profile workspace
+/// has to contain both games in full.
+/// </para>
+/// <para>
+/// Skipped unless a native install is present. Set <c>GENHUB_NATIVE_CLIENT_DIR</c> to
+/// override the default location.
+/// </para>
+/// </summary>
+[Collection(NativeClientLaunchCollection.Name)]
+public class RetailArchiveRootTests : IDisposable
+{
+    private const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";
+    private const string BinaryName = "generalszh";
+
+    private readonly string _engineOnlyWorkspace = Path.Combine(
+        Path.GetTempPath(),
+        $"genhub-engine-only-{Guid.NewGuid():N}");
+
+    private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
+
+    private static string? NativeClientDirectory
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
+
+            var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
+            if (!string.IsNullOrWhiteSpace(configured))
+            {
+                return Directory.Exists(configured) ? configured : null;
+            }
+
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var directory = Path.Combine(home, "TheSuperHackers", "GeneralsZH");
+
+            return File.Exists(Path.Combine(directory, BinaryName)) ? directory : null;
+        }
+    }
+
+    /// <summary>
+    /// An engine-only workspace plus environment-supplied archive roots must launch and
+    /// stay up, with no <c>.big</c> file anywhere in the workspace.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EngineOnlyWorkspace_ReachesRetailArchivesThroughEnvironment()
+    {
+        var installDirectory = NativeClientDirectory;
+        if (installDirectory is null)
+        {
+            return;
+        }
+
+        StageEngineOnly(installDirectory);
+
+        Assert.Empty(Directory.GetFiles(_engineOnlyWorkspace, "*.big"));
+
+        var configuration = new GameLaunchConfiguration
+        {
+            ExecutablePath = Path.Combine(_engineOnlyWorkspace, BinaryName),
+            WorkingDirectory = _engineOnlyWorkspace,
+            Arguments = new() { ["-win"] = string.Empty },
+            EnvironmentVariables = new()
+            {
+                // Trailing separator is required; see AddArchiveRoot in GameLauncher.
+                ["CNC_ZH_INSTALLPATH"] = installDirectory + Path.DirectorySeparatorChar,
+                ["CNC_GENERALS_INSTALLPATH"] = installDirectory + Path.DirectorySeparatorChar,
+            },
+        };
+
+        var result = await _processManager.StartProcessAsync(configuration);
+        Assert.True(result.Success, $"Launch failed: {string.Join(" ", result.Errors)}");
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(14));
+            var info = await _processManager.GetProcessInfoAsync(result.Data!.ProcessId);
+
+            Assert.True(
+                info.Success,
+                "The engine exited despite the archive roots being supplied, so retail data "
+                + "was not reached through the environment.");
+        }
+        finally
+        {
+            await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
+        }
+    }
+
+    /// <summary>
+    /// Without the archive roots the same workspace must fail, which is what makes the
+    /// test above meaningful rather than a coincidence.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EngineOnlyWorkspace_WithoutArchiveRoots_DoesNotSurvive()
+    {
+        var installDirectory = NativeClientDirectory;
+        if (installDirectory is null)
+        {
+            return;
+        }
+
+        StageEngineOnly(installDirectory);
+
+        var configuration = new GameLaunchConfiguration
+        {
+            ExecutablePath = Path.Combine(_engineOnlyWorkspace, BinaryName),
+            WorkingDirectory = _engineOnlyWorkspace,
+            Arguments = new() { ["-win"] = string.Empty },
+        };
+
+        var result = await _processManager.StartProcessAsync(configuration);
+
+        if (!result.Success)
+        {
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(14));
+            var info = await _processManager.GetProcessInfoAsync(result.Data!.ProcessId);
+
+            Assert.False(
+                info.Success,
+                "An engine-only workspace survived with no archive roots at all. If the engine "
+                + "now locates retail data by some other means, the environment plumbing in "
+                + "GameLauncher.AddRetailArchiveRoots may be unnecessary.");
+        }
+        finally
+        {
+            await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
+        }
+    }
+
+    /// <summary>
+    /// Copies just the engine and its dynamic libraries, deliberately leaving out every
+    /// archive and data directory.
+    /// </summary>
+    /// <param name="installDirectory">The source install.</param>
+    private void StageEngineOnly(string installDirectory)
+    {
+        Directory.CreateDirectory(_engineOnlyWorkspace);
+
+        var engineFiles = Directory
+            .EnumerateFiles(installDirectory, "*", SearchOption.TopDirectoryOnly)
+            .Where(path =>
+            {
+                var name = Path.GetFileName(path);
+                return name == BinaryName || name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase);
+            });
+
+        foreach (var source in engineFiles)
+        {
+            var destination = Path.Combine(_engineOnlyWorkspace, Path.GetFileName(source));
+            File.Copy(source, destination, overwrite: true);
+        }
+
+        File.SetUnixFileMode(
+            Path.Combine(_engineOnlyWorkspace, BinaryName),
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+    }
+
+    /// <summary>
+    /// Releases the staged workspace.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        try
+        {
+            if (Directory.Exists(_engineOnlyWorkspace))
+            {
+                Directory.Delete(_engineOnlyWorkspace, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test over.
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
@@ -28,36 +28,11 @@ namespace GenHub.Tests.Core.Features.GameProfiles;
 [Collection(NativeClientLaunchCollection.Name)]
 public class RetailArchiveRootTests : IDisposable
 {
-    private const string EnvironmentOverride = "GENHUB_NATIVE_CLIENT_DIR";
-    private const string BinaryName = "generalszh";
-
     private readonly string _engineOnlyWorkspace = Path.Combine(
         Path.GetTempPath(),
         $"genhub-engine-only-{Guid.NewGuid():N}");
 
     private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
-
-    private static string? NativeClientDirectory
-    {
-        get
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return null;
-            }
-
-            var configured = Environment.GetEnvironmentVariable(EnvironmentOverride);
-            if (!string.IsNullOrWhiteSpace(configured))
-            {
-                return Directory.Exists(configured) ? configured : null;
-            }
-
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var directory = Path.Combine(home, "TheSuperHackers", "GeneralsZH");
-
-            return File.Exists(Path.Combine(directory, BinaryName)) ? directory : null;
-        }
-    }
 
     /// <summary>
     /// An engine-only workspace plus environment-supplied archive roots must launch and
@@ -67,7 +42,7 @@ public class RetailArchiveRootTests : IDisposable
     [Fact]
     public async Task EngineOnlyWorkspace_ReachesRetailArchivesThroughEnvironment()
     {
-        var installDirectory = NativeClientDirectory;
+        var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
         {
             return;
@@ -79,7 +54,7 @@ public class RetailArchiveRootTests : IDisposable
 
         var configuration = new GameLaunchConfiguration
         {
-            ExecutablePath = Path.Combine(_engineOnlyWorkspace, BinaryName),
+            ExecutablePath = Path.Combine(_engineOnlyWorkspace, NativeClientFixture.BinaryName),
             WorkingDirectory = _engineOnlyWorkspace,
             Arguments = new() { ["-win"] = string.Empty },
             EnvironmentVariables = new()
@@ -117,7 +92,7 @@ public class RetailArchiveRootTests : IDisposable
     [Fact]
     public async Task EngineOnlyWorkspace_WithoutArchiveRoots_DoesNotSurvive()
     {
-        var installDirectory = NativeClientDirectory;
+        var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
         {
             return;
@@ -127,7 +102,7 @@ public class RetailArchiveRootTests : IDisposable
 
         var configuration = new GameLaunchConfiguration
         {
-            ExecutablePath = Path.Combine(_engineOnlyWorkspace, BinaryName),
+            ExecutablePath = Path.Combine(_engineOnlyWorkspace, NativeClientFixture.BinaryName),
             WorkingDirectory = _engineOnlyWorkspace,
             Arguments = new() { ["-win"] = string.Empty },
         };
@@ -188,8 +163,12 @@ public class RetailArchiveRootTests : IDisposable
             .EnumerateFiles(installDirectory, "*", SearchOption.TopDirectoryOnly)
             .Where(path =>
             {
+                // Both Unix shared-library extensions: the engine ships .dylib on macOS and
+                // .so on Linux, and staging only one leaves the workspace incomplete there.
                 var name = Path.GetFileName(path);
-                return name == BinaryName || name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase);
+                return name == NativeClientFixture.BinaryName
+                    || name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase)
+                    || name.EndsWith(".so", StringComparison.OrdinalIgnoreCase);
             });
 
         foreach (var source in engineFiles)
@@ -203,6 +182,11 @@ public class RetailArchiveRootTests : IDisposable
             UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
             UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
 
-        File.SetUnixFileMode(Path.Combine(_engineOnlyWorkspace, BinaryName), executableMode);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                Path.Combine(_engineOnlyWorkspace, NativeClientFixture.BinaryName),
+                executableMode);
+        }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Models.Launching;
 using GenHub.Features.GameProfiles.Infrastructure;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -60,8 +61,8 @@ public class RetailArchiveRootTests : IDisposable
             EnvironmentVariables = new()
             {
                 // Trailing separator is required; see AddArchiveRoot in GameLauncher.
-                ["CNC_ZH_INSTALLPATH"] = installDirectory + Path.DirectorySeparatorChar,
-                ["CNC_GENERALS_INSTALLPATH"] = installDirectory + Path.DirectorySeparatorChar,
+                [RetailArchiveConstants.ZeroHourInstallPathVariable] = installDirectory + Path.DirectorySeparatorChar,
+                [RetailArchiveConstants.GeneralsInstallPathVariable] = installDirectory + Path.DirectorySeparatorChar,
             },
         };
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
@@ -1,0 +1,74 @@
+using System.Runtime.InteropServices;
+using GenHub.Core.Models.Launching;
+using GenHub.Features.GameProfiles.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// End-to-end check that stderr from a process which dies immediately is still captured.
+/// </summary>
+/// <remarks>
+/// Covers the capture end to end: a real process fails, and both the first and last of
+/// its stderr survive into the reported error. The buffer's own tests exercise retention
+/// in isolation; this proves the wiring — handler, drain, buffer and error message —
+/// actually delivers them to the caller.
+/// <para>
+/// It does <b>not</b> deterministically pin the end-of-stream drain. Removing the
+/// <c>WaitForExit()</c> call leaves this test passing on macOS and .NET 8, because the
+/// handlers happen to complete before the capture is read even at twenty thousand lines.
+/// The drain is retained on the documented contract — the parameterless overload waits
+/// for redirected-output handlers, the timed ones do not — rather than on a failing test
+/// here. A platform with different scheduling may well expose it.
+/// </para>
+/// </remarks>
+public class StderrCaptureRaceTests
+{
+    private const string HeadLine = "GENHUB-HEAD-MARKER";
+    private const string TailLine = "GENHUB-TAIL-MARKER";
+
+    /// <summary>
+    /// A process that writes a head line, floods the buffer, writes a tail line and exits
+    /// non-zero must have both ends of its output reported in the failure.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StartProcessAsync_WithImmediateFailure_CapturesBothEndsOfStderr()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        // Arguments are key/value pairs; a leading '-' key is emitted as a flag followed
+        // by its value, which produces `/bin/sh -c <script>`.
+        var script =
+            $"echo {HeadLine} >&2; " +
+            "for i in $(seq 1 200); do echo noise-$i >&2; done; " +
+            $"echo {TailLine} >&2; " +
+            "exit 3";
+
+        var manager = new GameProcessManager(Mock.Of<ILogger<GameProcessManager>>());
+        try
+        {
+            var result = await manager.StartProcessAsync(new GameLaunchConfiguration
+            {
+                ExecutablePath = "/bin/sh",
+                Arguments = new Dictionary<string, string> { ["-c"] = script },
+                WorkingDirectory = Path.GetTempPath(),
+            });
+
+            var reported = string.Join(" ", result.Errors);
+
+            Assert.Contains("3", reported);
+            Assert.Contains(HeadLine, reported);
+            Assert.Contains(TailLine, reported);
+        }
+        finally
+        {
+            manager.Dispose();
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -27,7 +27,7 @@ namespace GenHub.Tests.Core.Features.Launching;
 /// <summary>
 /// Tests for <see cref="GameLauncher"/>.
 /// </summary>
-public class GameLauncherTests
+public class GameLauncherTests : IDisposable
 {
     private static readonly string[] TestContentIds = ["1.0.genhub.mod.test"];
     private readonly Mock<IGameProfileManager> _profileManagerMock = new();
@@ -47,6 +47,8 @@ public class GameLauncherTests
     private readonly Mock<ISteamLauncher> _steamLauncherMock = new();
     private readonly GameLauncher _gameLauncher;
 
+    private readonly string _retailRoot;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="GameLauncherTests"/> class.
     /// </summary>
@@ -57,11 +59,18 @@ public class GameLauncherTests
         _configurationProviderServiceMock.Setup(x => x.GetApplicationDataPath()).Returns(@"C:\Content");
         _configurationProviderServiceMock.Setup(x => x.GetDefaultWorkspaceStrategy()).Returns(WorkspaceStrategy.HardLink);
 
+        // A real directory holding a .big archive. The launcher validates retail archive
+        // roots before spawning, because the engine starts with no content and no error
+        // when they are wrong — so a fixture pointing at a path that does not exist would
+        // be rejected, exactly as a stale installation would be.
+        _retailRoot = Directory.CreateTempSubdirectory("GenHub.GameLauncherTests.").FullName;
+        File.WriteAllText(Path.Combine(_retailRoot, "Generals.big"), "archive");
+
         // Setup game installation service mock
-        var testInstallation = new GameInstallation(@"C:\Games\CommandAndConquer", GameInstallationType.Steam);
+        var testInstallation = new GameInstallation(_retailRoot, GameInstallationType.Steam);
 
         // Ensure Generals path is set so GameLauncher validation passes
-        testInstallation.SetPaths(@"C:\Games\CommandAndConquer", null);
+        testInstallation.SetPaths(_retailRoot, null);
 
         _gameInstallationServiceMock.Setup(x => x.GetInstallationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult<GameInstallation>.CreateSuccess(testInstallation));
@@ -941,5 +950,22 @@ public class GameLauncherTests
             throw new InvalidOperationException("Failed to start junction creation process.");
         process.WaitForExit();
         Assert.Equal(0, process.ExitCode);
+    }
+
+    /// <summary>
+    /// Removes the temporary retail root.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_retailRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best effort; a leftover temp directory is not worth failing the run over.
+        }
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -60,9 +60,9 @@ public class GameLauncherTests : IDisposable
         _configurationProviderServiceMock.Setup(x => x.GetDefaultWorkspaceStrategy()).Returns(WorkspaceStrategy.HardLink);
 
         // A real directory holding a .big archive. The launcher validates retail archive
-        // roots before spawning, because the engine starts with no content and no error
-        // when they are wrong — so a fixture pointing at a path that does not exist would
-        // be rejected, exactly as a stale installation would be.
+        // roots before spawning, because a wrong root only surfaces as a generic engine
+        // abort — so a fixture pointing at a path that does not exist would be rejected,
+        // exactly as a stale installation would be.
         _retailRoot = Directory.CreateTempSubdirectory("GenHub.GameLauncherTests.").FullName;
         File.WriteAllText(Path.Combine(_retailRoot, "Generals.big"), "archive");
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -911,6 +911,23 @@ public class GameLauncherTests : IDisposable
     }
 
     /// <summary>
+    /// Removes the temporary retail root.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_retailRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best effort; a leftover temp directory is not worth failing the run over.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
     /// Creates a test <see cref="GameProfile"/> with required members set.
     /// </summary>
     /// <returns>A valid <see cref="GameProfile"/>.</returns>
@@ -950,22 +967,5 @@ public class GameLauncherTests : IDisposable
             throw new InvalidOperationException("Failed to start junction creation process.");
         process.WaitForExit();
         Assert.Equal(0, process.ExitCode);
-    }
-
-    /// <summary>
-    /// Removes the temporary retail root.
-    /// </summary>
-    public void Dispose()
-    {
-        try
-        {
-            Directory.Delete(_retailRoot, recursive: true);
-        }
-        catch (IOException)
-        {
-            // Best effort; a leftover temp directory is not worth failing the run over.
-        }
-
-        GC.SuppressFinalize(this);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
@@ -49,6 +49,14 @@ public class RetailArchiveRootValidationTests : IDisposable
     [Fact]
     public void Validate_WithNonexistentRoot_RejectsRatherThanSkipping()
     {
+        // Rejection is non-Windows behaviour by design: Windows resolves install paths from
+        // the registry and never reads these variables, so validation skips there. The
+        // Windows side is asserted by Validate_OnWindows_SkipsEntirely.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
         var missing = Path.Combine(_tempDir, "gone");
 
         var error = Validate(InstallationWithZeroHour(missing));
@@ -63,6 +71,14 @@ public class RetailArchiveRootValidationTests : IDisposable
     [Fact]
     public void Validate_WithNoArchives_Rejects()
     {
+        // Rejection is non-Windows behaviour by design: Windows resolves install paths from
+        // the registry and never reads these variables, so validation skips there. The
+        // Windows side is asserted by Validate_OnWindows_SkipsEntirely.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
         var root = CreateRoot("empty", withArchive: false);
 
         var error = Validate(InstallationWithZeroHour(root));

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
@@ -14,9 +14,9 @@ namespace GenHub.Tests.Core.Features.Launching;
 /// Tests for the pre-spawn retail archive root check.
 /// </summary>
 /// <remarks>
-/// The engine reaches its main loop with zero content and no error when these roots are
-/// wrong, so a launch that "succeeded" cannot be distinguished from one that produced an
-/// empty game. Everything here is about refusing to spawn in that state.
+/// When these roots are wrong the engine aborts during initialisation with a generic
+/// crash that names nothing the user can act on. Everything here is about refusing to
+/// spawn and naming the offending root instead.
 /// </remarks>
 public class RetailArchiveRootValidationTests : IDisposable
 {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Features.Launching;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.Launching;
+
+/// <summary>
+/// Tests for the pre-spawn retail archive root check.
+/// </summary>
+/// <remarks>
+/// The engine reaches its main loop with zero content and no error when these roots are
+/// wrong, so a launch that "succeeded" cannot be distinguished from one that produced an
+/// empty game. Everything here is about refusing to spawn in that state.
+/// </remarks>
+public class RetailArchiveRootValidationTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetailArchiveRootValidationTests"/> class.
+    /// </summary>
+    public RetailArchiveRootValidationTests()
+    {
+        _tempDir = Directory.CreateTempSubdirectory("GenHub.ArchiveRootTests.").FullName;
+    }
+
+    /// <summary>
+    /// A root holding archives is accepted.
+    /// </summary>
+    [Fact]
+    public void Validate_WithArchivesPresent_Accepts()
+    {
+        var root = CreateRoot("valid", withArchive: true);
+
+        Assert.Null(Validate(InstallationWithZeroHour(root)));
+    }
+
+    /// <summary>
+    /// A stale installation path must be rejected. This is the case the earlier
+    /// implementation missed: the environment builder drops a nonexistent path, so
+    /// validating only the environment skipped it and the launch proceeded.
+    /// </summary>
+    [Fact]
+    public void Validate_WithNonexistentRoot_RejectsRatherThanSkipping()
+    {
+        var missing = Path.Combine(_tempDir, "gone");
+
+        var error = Validate(InstallationWithZeroHour(missing));
+
+        Assert.NotNull(error);
+        Assert.Contains(missing, error);
+    }
+
+    /// <summary>
+    /// A root that exists but holds no archives would produce an empty game.
+    /// </summary>
+    [Fact]
+    public void Validate_WithNoArchives_Rejects()
+    {
+        var root = CreateRoot("empty", withArchive: false);
+
+        var error = Validate(InstallationWithZeroHour(root));
+
+        Assert.NotNull(error);
+        Assert.Contains("no .big archives", error);
+    }
+
+    /// <summary>
+    /// An unreadable root is reported rather than treated as archive-free, so the message
+    /// points at the permission rather than at the content.
+    /// </summary>
+    [Fact]
+    public void Validate_WithUnreadableRoot_ReportsTheReadFailure()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || Environment.UserName == "root")
+        {
+            return;
+        }
+
+        var root = CreateRoot("unreadable", withArchive: true);
+        File.SetUnixFileMode(root, UnixFileMode.UserWrite);
+
+        try
+        {
+            var error = Validate(InstallationWithZeroHour(root));
+
+            Assert.NotNull(error);
+            Assert.Contains("could not be read", error);
+        }
+        finally
+        {
+            File.SetUnixFileMode(
+                root,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    /// <summary>
+    /// A game that is simply not installed declares no path and is not an error.
+    /// </summary>
+    [Fact]
+    public void Validate_WithNoDeclaredPath_Accepts()
+    {
+        Assert.Null(Validate(InstallationWithZeroHour(null)));
+    }
+
+    /// <summary>
+    /// Disposes the temporary directory.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A test left a directory unreadable; not worth failing the run over.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private static string? Validate(GameInstallation installation) =>
+        (string?)typeof(GameLauncher)
+            .GetMethod("ValidateRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, [new Dictionary<string, string>(), installation]);
+
+    private static GameInstallation InstallationWithZeroHour(string? zeroHourPath)
+    {
+        var installation = new GameInstallation(
+            Path.GetTempPath(),
+            GameInstallationType.Retail,
+            new Mock<ILogger<GameInstallation>>().Object);
+        installation.SetPaths(null, zeroHourPath);
+        return installation;
+    }
+
+    private string CreateRoot(string name, bool withArchive)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(_tempDir, name)).FullName;
+        if (withArchive)
+        {
+            File.WriteAllText(Path.Combine(root, "INIZH.big"), "archive");
+        }
+
+        return root;
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
@@ -188,6 +188,62 @@ public class RetailArchiveRootValidationTests : IDisposable
         Assert.StartsWith(root, environment[RetailArchiveConstants.ZeroHourInstallPathVariable]);
     }
 
+    /// <summary>
+    /// Zero Hour is an expansion and mounts the base Generals archives too, so a declared
+    /// Generals root that is broken must fail the launch — otherwise the game runs without
+    /// base content, the same silent failure one directory over.
+    /// </summary>
+    [Fact]
+    public void Validate_LaunchingZeroHour_AlsoRejectsABrokenGeneralsRoot()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var zeroHour = CreateRoot("zh-ok", withArchive: true);
+        var generals = CreateRoot("gen-empty", withArchive: false);
+
+        var error = ValidateFor(GameType.ZeroHour, generals, zeroHour);
+
+        Assert.NotNull(error);
+        Assert.Contains(generals, error);
+    }
+
+    /// <summary>
+    /// A Zero Hour installation carrying the base archives itself declares no separate
+    /// Generals root, and that is not an error.
+    /// </summary>
+    [Fact]
+    public void Validate_LaunchingZeroHour_WithNoGeneralsRootDeclared_Accepts()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var zeroHour = CreateRoot("zh-standalone", withArchive: true);
+
+        Assert.Null(ValidateFor(GameType.ZeroHour, null, zeroHour));
+    }
+
+    /// <summary>
+    /// Launching Generals must not fail over a stale Zero Hour root: it does not read it.
+    /// </summary>
+    [Fact]
+    public void Validate_LaunchingGenerals_IgnoresABrokenZeroHourRoot()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var generals = CreateRoot("gen-ok", withArchive: true);
+        var staleZeroHour = Path.Combine(_tempDir, "zh-gone");
+
+        Assert.Null(ValidateFor(GameType.Generals, generals, staleZeroHour));
+    }
+
     // Zero Hour throughout: these fixtures declare only a Zero Hour path, and validation is
     // scoped to the launching game so the sibling Generals root is deliberately untouched.
     private static string? Validate(GameInstallation installation) =>
@@ -209,6 +265,19 @@ public class RetailArchiveRootValidationTests : IDisposable
         typeof(GameLauncher)
             .GetMethod("AddRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
             .Invoke(null, [environment, installation]);
+
+    private static string? ValidateFor(GameType gameType, string? generalsPath, string? zeroHourPath)
+    {
+        var installation = new GameInstallation(
+            Path.GetTempPath(),
+            GameInstallationType.Retail,
+            new Mock<ILogger<GameInstallation>>().Object);
+        installation.SetPaths(generalsPath, zeroHourPath);
+
+        return (string?)typeof(GameLauncher)
+            .GetMethod("ValidateRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, [new Dictionary<string, string>(), installation, gameType]);
+    }
 
     private string CreateRoot(string name, bool withArchive)
     {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using GenHub.Core.Constants;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Features.Launching;
@@ -126,6 +127,51 @@ public class RetailArchiveRootValidationTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Windows never reads these variables — it resolves install paths from the registry —
+    /// so a layout without loose top-level archives must not fail the launch there.
+    /// </summary>
+    [Fact]
+    public void Validate_OnWindows_SkipsEntirely()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var root = CreateRoot("windows-no-archives", withArchive: false);
+
+        Assert.Null(Validate(InstallationWithZeroHour(root)));
+    }
+
+    /// <summary>
+    /// A profile that sets the root explicitly still gets the trailing separator. The engine
+    /// concatenates this value with the archive filename directly, so without one it builds
+    /// paths like "/path/toINIZH.big" and silently mounts nothing — the failure this whole
+    /// check exists to prevent.
+    /// </summary>
+    [Fact]
+    public void AddArchiveRoot_WithProfileOverrideMissingSeparator_StillNormalizes()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var root = CreateRoot("profile-override", withArchive: true).TrimEnd(Path.DirectorySeparatorChar);
+        var environment = new Dictionary<string, string>
+        {
+            [RetailArchiveConstants.ZeroHourInstallPathVariable] = root,
+        };
+
+        BuildEnvironment(environment, InstallationWithZeroHour(root));
+
+        Assert.EndsWith(
+            Path.DirectorySeparatorChar.ToString(),
+            environment[RetailArchiveConstants.ZeroHourInstallPathVariable]);
+        Assert.StartsWith(root, environment[RetailArchiveConstants.ZeroHourInstallPathVariable]);
+    }
+
     private static string? Validate(GameInstallation installation) =>
         (string?)typeof(GameLauncher)
             .GetMethod("ValidateRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
@@ -151,4 +197,9 @@ public class RetailArchiveRootValidationTests : IDisposable
 
         return root;
     }
+    private static void BuildEnvironment(Dictionary<string, string> environment, GameInstallation installation) =>
+        typeof(GameLauncher)
+            .GetMethod("AddRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, [environment, installation]);
+
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
@@ -127,6 +127,32 @@ public class RetailArchiveRootValidationTests : IDisposable
     }
 
     /// <summary>
+    /// Retail data copied from a disc or a Windows machine is frequently upper-cased. On a
+    /// case-sensitive volume a case-sensitive glob finds nothing, so a valid root is rejected
+    /// and the launch blocked — the opposite of what this check exists to do.
+    /// </summary>
+    /// <remarks>
+    /// Only exercises the regression on a case-sensitive volume, which in practice means Linux
+    /// CI. The <see cref="SearchOption"/> overload this replaced matches with
+    /// <see cref="MatchCasing.PlatformDefault"/>, and that is already case-insensitive on macOS
+    /// and Windows — so this passes there whether or not the fix is present. Verified by
+    /// reverting the fix locally and watching it still pass.
+    /// </remarks>
+    [Fact]
+    public void Validate_WithUpperCasedArchive_Accepts()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var root = Directory.CreateDirectory(Path.Combine(_tempDir, "uppercased")).FullName;
+        File.WriteAllText(Path.Combine(root, "INIZH.BIG"), "archive");
+
+        Assert.Null(Validate(InstallationWithZeroHour(root)));
+    }
+
+    /// <summary>
     /// Disposes the temporary directory.
     /// </summary>
     public void Dispose()

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
@@ -188,10 +188,12 @@ public class RetailArchiveRootValidationTests : IDisposable
         Assert.StartsWith(root, environment[RetailArchiveConstants.ZeroHourInstallPathVariable]);
     }
 
+    // Zero Hour throughout: these fixtures declare only a Zero Hour path, and validation is
+    // scoped to the launching game so the sibling Generals root is deliberately untouched.
     private static string? Validate(GameInstallation installation) =>
         (string?)typeof(GameLauncher)
             .GetMethod("ValidateRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
-            .Invoke(null, [new Dictionary<string, string>(), installation]);
+            .Invoke(null, [new Dictionary<string, string>(), installation, GameType.ZeroHour]);
 
     private static GameInstallation InstallationWithZeroHour(string? zeroHourPath)
     {
@@ -203,6 +205,11 @@ public class RetailArchiveRootValidationTests : IDisposable
         return installation;
     }
 
+    private static void BuildEnvironment(Dictionary<string, string> environment, GameInstallation installation) =>
+        typeof(GameLauncher)
+            .GetMethod("AddRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, [environment, installation]);
+
     private string CreateRoot(string name, bool withArchive)
     {
         var root = Directory.CreateDirectory(Path.Combine(_tempDir, name)).FullName;
@@ -213,9 +220,4 @@ public class RetailArchiveRootValidationTests : IDisposable
 
         return root;
     }
-    private static void BuildEnvironment(Dictionary<string, string> environment, GameInstallation installation) =>
-        typeof(GameLauncher)
-            .GetMethod("AddRetailArchiveRoots", BindingFlags.NonPublic | BindingFlags.Static)!
-            .Invoke(null, [environment, installation]);
-
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
@@ -446,56 +446,6 @@ public class ContentManifestPoolTests : IDisposable
     }
 
     /// <summary>
-    /// Creates a test content manifest.
-    /// </summary>
-    /// <param name="id">The manifest ID.</param>
-    /// <param name="name">The manifest name.</param>
-    /// <param name="contentType">The content type.</param>
-    /// <param name="targetGame">The target game.</param>
-    /// <returns>A <see cref="ContentManifest"/> instance.</returns>
-    private static ContentManifest CreateTestManifest(
-        string id = "1.0.genhub.mod.mod",
-        string name = "Test Manifest",
-        ContentType contentType = ContentType.Mod,
-        GameType targetGame = GameType.Generals)
-    {
-        return new ContentManifest
-        {
-            Id = id,
-            Name = name,
-            ContentType = contentType,
-            TargetGame = targetGame,
-            Version = "1.0.0",
-            Metadata = new ContentMetadata
-            {
-                Description = "Test manifest for unit tests",
-            },
-            Files =
-            [
-                new() { RelativePath = "test.txt", Size = 100, SourceType = ContentSourceType.LocalFile, },
-            ],
-        };
-    }
-
-    /// <summary>
-    /// Sets up manifests in storage for testing.
-    /// </summary>
-    /// <param name="manifests">The list of manifests to set up.</param>
-    private void SetupManifestsInStorage(List<ContentManifest> manifests)
-    {
-        var manifestsDir = Path.Combine(_tempDirectory, "Manifests");
-        Directory.CreateDirectory(manifestsDir);
-
-        foreach (var manifest in manifests)
-        {
-            var manifestPath = Path.Combine(manifestsDir, $"{manifest.Id}.manifest.json");
-            File.WriteAllText(manifestPath, System.Text.Json.JsonSerializer.Serialize(manifest));
-        }
-
-        _storageServiceMock.Setup(x => x.GetContentStorageRoot())
-            .Returns(_tempDirectory);
-    }
-    /// <summary>
     /// A variant manifest must be rejected before any content is written.
     /// </summary>
     /// <remarks>
@@ -570,4 +520,54 @@ public class ContentManifestPoolTests : IDisposable
         Assert.True(result.Success, $"Expected success but got: {result.FirstError}");
     }
 
+    /// <summary>
+    /// Creates a test content manifest.
+    /// </summary>
+    /// <param name="id">The manifest ID.</param>
+    /// <param name="name">The manifest name.</param>
+    /// <param name="contentType">The content type.</param>
+    /// <param name="targetGame">The target game.</param>
+    /// <returns>A <see cref="ContentManifest"/> instance.</returns>
+    private static ContentManifest CreateTestManifest(
+        string id = "1.0.genhub.mod.mod",
+        string name = "Test Manifest",
+        ContentType contentType = ContentType.Mod,
+        GameType targetGame = GameType.Generals)
+    {
+        return new ContentManifest
+        {
+            Id = id,
+            Name = name,
+            ContentType = contentType,
+            TargetGame = targetGame,
+            Version = "1.0.0",
+            Metadata = new ContentMetadata
+            {
+                Description = "Test manifest for unit tests",
+            },
+            Files =
+            [
+                new() { RelativePath = "test.txt", Size = 100, SourceType = ContentSourceType.LocalFile, },
+            ],
+        };
+    }
+
+    /// <summary>
+    /// Sets up manifests in storage for testing.
+    /// </summary>
+    /// <param name="manifests">The list of manifests to set up.</param>
+    private void SetupManifestsInStorage(List<ContentManifest> manifests)
+    {
+        var manifestsDir = Path.Combine(_tempDirectory, "Manifests");
+        Directory.CreateDirectory(manifestsDir);
+
+        foreach (var manifest in manifests)
+        {
+            var manifestPath = Path.Combine(manifestsDir, $"{manifest.Id}.manifest.json");
+            File.WriteAllText(manifestPath, System.Text.Json.JsonSerializer.Serialize(manifest));
+        }
+
+        _storageServiceMock.Setup(x => x.GetContentStorageRoot())
+            .Returns(_tempDirectory);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -24,6 +24,14 @@ public partial class WorkspaceValidatorTests : IDisposable
     private readonly string _workspaceDir;
 
     /// <summary>
+    /// Effective user ID, POSIX <c>geteuid(2)</c>. Declared here because the production
+    /// equivalent is internal to the GenHub assembly.
+    /// </summary>
+    /// <returns>The effective user ID; 0 is root.</returns>
+    [LibraryImport("libc", EntryPoint = "geteuid")]
+    private static partial uint GetEffectiveUserId();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="WorkspaceValidatorTests"/> class.
     /// </summary>
     public WorkspaceValidatorTests()
@@ -365,12 +373,4 @@ public partial class WorkspaceValidatorTests : IDisposable
             Strategy = WorkspaceStrategy.FullCopy,
         };
     }
-
-    /// <summary>
-    /// Effective user ID, POSIX <c>geteuid(2)</c>. Declared here because the production
-    /// equivalent is internal to the GenHub assembly.
-    /// </summary>
-    /// <returns>The effective user ID; 0 is root.</returns>
-    [LibraryImport("libc", EntryPoint = "geteuid")]
-    private static partial uint GetEffectiveUserId();
 }

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -400,7 +400,7 @@ public class GameClientDetector(
             }
         }
 
-        // Fallback: try to detect version from generals.exe/generalszh.exe file info
+        // Fallback: try to detect version from the default executable's file info
         var defaultExecutableName = gameType == GameType.Generals
             ? GameClientConstants.GeneralsExecutable
             : GameClientConstants.ZeroHourExecutable;

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -330,9 +330,19 @@ public class GameProcessManager(
                     }
                     else
                     {
-                        // If it exits with 0 and we didn't find a spawned child, still fail the launch
-                        // because we don't have a valid process to track, preventing the UI from getting stuck in a 'running' state
-                        return OperationResult<GameProcessInfo>.CreateFailure("Process exited immediately after launch.");
+                        // A clean exit with no spawned child is still an unexplained failure, and
+                        // stderr was already drained above — reporting it only on a non-zero exit
+                        // discarded the one diagnostic available for this case.
+                        var stderrTail = capturedErrors.ToString();
+                        var suffix = string.IsNullOrWhiteSpace(stderrTail) ? string.Empty : $" {stderrTail}";
+
+                        logger.LogError(
+                            "[Process] Process exited immediately with code 0 and no spawned process was found. Output: {Output}",
+                            string.IsNullOrWhiteSpace(stderrTail) ? "No output was captured." : stderrTail);
+
+                        // Still a failure: without a process to track the UI would sit in 'running'.
+                        return OperationResult<GameProcessInfo>.CreateFailure(
+                            $"Process exited immediately after launch.{suffix}");
                     }
                 }
             }

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -755,6 +755,32 @@ public class GameProcessManager(
         }
     }
 
+    /// <summary>
+    /// Determines whether a file carries the Unix execute bit for the current user.
+    /// </summary>
+    /// <param name="path">The executable path.</param>
+    /// <returns><c>true</c> on Windows, or when any execute bit is set.</returns>
+    private static bool HasExecutePermission(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            return mode.HasFlag(UnixFileMode.UserExecute)
+                || mode.HasFlag(UnixFileMode.GroupExecute)
+                || mode.HasFlag(UnixFileMode.OtherExecute);
+        }
+        catch (Exception)
+        {
+            // Unreadable metadata should not block a launch that might otherwise work.
+            return true;
+        }
+    }
+
     private void OnProcessExited(object? sender, EventArgs e)
     {
         if (sender is not Process process)
@@ -862,32 +888,6 @@ public class GameProcessManager(
     }
 
     /// <summary>
-    /// Determines whether a file carries the Unix execute bit for the current user.
-    /// </summary>
-    /// <param name="path">The executable path.</param>
-    /// <returns><c>true</c> on Windows, or when any execute bit is set.</returns>
-    private static bool HasExecutePermission(string path)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return true;
-        }
-
-        try
-        {
-            var mode = File.GetUnixFileMode(path);
-            return mode.HasFlag(UnixFileMode.UserExecute)
-                || mode.HasFlag(UnixFileMode.GroupExecute)
-                || mode.HasFlag(UnixFileMode.OtherExecute);
-        }
-        catch (Exception)
-        {
-            // Unreadable metadata should not block a launch that might otherwise work.
-            return true;
-        }
-    }
-
-    /// <summary>
     /// Retains the last few lines written to standard error.
     /// <para>
     /// Bounded on purpose. The interesting output from a process that dies during startup
@@ -950,6 +950,24 @@ public class GameProcessManager(
         private int _droppedLines;
         private bool _endOfStream;
 
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            lock (_gate)
+            {
+                var parts = new List<string>(_head);
+
+                if (_droppedLines > 0)
+                {
+                    parts.Add($"…[{_droppedLines} line(s) omitted]");
+                }
+
+                parts.AddRange(_tail);
+
+                return string.Join(" | ", parts);
+            }
+        }
+
         /// <summary>
         /// Gets a value indicating whether the stream signalled end of output.
         /// </summary>
@@ -1009,24 +1027,5 @@ public class GameProcessManager(
                 }
             }
         }
-
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            lock (_gate)
-            {
-                var parts = new List<string>(_head);
-
-                if (_droppedLines > 0)
-                {
-                    parts.Add($"…[{_droppedLines} line(s) omitted]");
-                }
-
-                parts.AddRange(_tail);
-
-                return string.Join(" | ", parts);
-            }
-        }
     }
-
 }

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -68,6 +68,16 @@ public class GameProcessManager(
                 return OperationResult<GameProcessInfo>.CreateFailure($"Executable not found: {configuration.ExecutablePath}");
             }
 
+            // Verify, never fix. Setting the bit here could mutate a shared content-store
+            // blob under the hard-link workspace strategy; the workspace build already
+            // applies it to a copy it owns. A failure here means that step did not run.
+            if (!OperatingSystem.IsWindows() && !HasExecutePermission(configuration.ExecutablePath))
+            {
+                logger.LogError("[Process] Executable is not marked executable: {ExecutablePath}", configuration.ExecutablePath);
+                return OperationResult<GameProcessInfo>.CreateFailure(
+                    $"'{configuration.ExecutablePath}' does not have the execute permission set, so it cannot be launched.");
+            }
+
             logger.LogInformation("[Process] Starting process for executable: {ExecutablePath}", configuration.ExecutablePath);
 
             var workingDirectory = configuration.WorkingDirectory
@@ -89,6 +99,12 @@ public class GameProcessManager(
                 FileName = configuration.ExecutablePath,
                 UseShellExecute = false,
                 CreateNoWindow = false,
+
+                // Captured so that a process which dies during startup can say why.
+                // A dynamic-loader failure prints "library not loaded" here and then exits;
+                // without this the user sees no window and no error, and the exit code
+                // alone does not identify the missing library.
+                RedirectStandardError = true,
             };
 
             // Add arguments using Arguments string
@@ -190,6 +206,20 @@ public class GameProcessManager(
 
             logger.LogDebug("[Process] Process {ProcessId} started successfully", process.Id);
 
+            // Drained continuously via the event handler rather than read at exit, so a
+            // chatty process cannot fill the pipe buffer and deadlock. Only a bounded tail
+            // is retained.
+            var capturedErrors = new BoundedErrorBuffer();
+            process.ErrorDataReceived += (_, e) => capturedErrors.Append(e.Data);
+            try
+            {
+                process.BeginErrorReadLine();
+            }
+            catch (InvalidOperationException ex)
+            {
+                logger.LogDebug(ex, "[Process] Could not capture stderr for process {ProcessId}", process.Id);
+            }
+
             // Check if process exited immediately (launcher pattern)
             // Only apply delay if we need to detect a spawned process
             if (!isBatchFile)
@@ -201,9 +231,18 @@ public class GameProcessManager(
                 {
                     var exitCode = process.ExitCode;
 
-                    // For Generals/Zero Hour, exit code 0 indicates the launcher spawned the actual game and exited
-                    // Try to find the actual game process by executable name
-                    if (exitCode == 0)
+                    // Windows-only launcher-stub heuristic. Some Windows game clients are
+                    // stubs that spawn the real process and exit 0, so the PID that was
+                    // started is not the one to track. Finding the replacement matches on
+                    // the executable's base name.
+                    //
+                    // Not applied on Unix, for two reasons. Native clients exec directly and
+                    // never fork-and-exit, so there is nothing to find. And base-name
+                    // matching strips the extension, which makes the native "generalszh"
+                    // indistinguishable from TheSuperHackers' "generalszh.exe" — so a
+                    // running Windows client under Wine could be adopted as if it were this
+                    // launch, and later terminated on its owner's behalf.
+                    if (exitCode == 0 && OperatingSystem.IsWindows())
                     {
                         logger.LogInformation(
                             "[Process] Launcher process {ProcessId} exited with code 0 - attempting to find spawned game process",
@@ -269,7 +308,18 @@ public class GameProcessManager(
                     // If it exits immediately with a non-zero code (like a crash or missing DLL), this is a genuine failure
                     if (exitCode != 0)
                     {
-                        return OperationResult<GameProcessInfo>.CreateFailure($"Process exited immediately with code {exitCode}");
+                        var stderrTail = capturedErrors.ToString();
+                        var detail = string.IsNullOrWhiteSpace(stderrTail)
+                            ? "No output was captured."
+                            : stderrTail;
+
+                        logger.LogError(
+                            "[Process] Process exited immediately with code {ExitCode}. Output: {Output}",
+                            exitCode,
+                            detail);
+
+                        return OperationResult<GameProcessInfo>.CreateFailure(
+                            $"Process exited immediately with code {exitCode}. {detail}");
                     }
                     else
                     {
@@ -797,4 +847,76 @@ public class GameProcessManager(
             return null;
         }
     }
+
+    /// <summary>
+    /// Determines whether a file carries the Unix execute bit for the current user.
+    /// </summary>
+    /// <param name="path">The executable path.</param>
+    /// <returns><c>true</c> on Windows, or when any execute bit is set.</returns>
+    private static bool HasExecutePermission(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            return mode.HasFlag(UnixFileMode.UserExecute)
+                || mode.HasFlag(UnixFileMode.GroupExecute)
+                || mode.HasFlag(UnixFileMode.OtherExecute);
+        }
+        catch (Exception)
+        {
+            // Unreadable metadata should not block a launch that might otherwise work.
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Retains the last few lines written to standard error.
+    /// <para>
+    /// Bounded on purpose. The interesting output from a process that dies during startup
+    /// is the last thing it said, and a game that runs for hours would otherwise
+    /// accumulate its entire log in memory for no benefit.
+    /// </para>
+    /// </summary>
+    private sealed class BoundedErrorBuffer
+    {
+        private const int MaxLines = 20;
+        private readonly Queue<string> _lines = new();
+        private readonly object _gate = new();
+
+        /// <summary>
+        /// Appends a line, discarding the oldest once the cap is reached.
+        /// </summary>
+        /// <param name="line">The line received, or null at end of stream.</param>
+        internal void Append(string? line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                _lines.Enqueue(line);
+                while (_lines.Count > MaxLines)
+                {
+                    _lines.Dequeue();
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            lock (_gate)
+            {
+                return string.Join(" | ", _lines);
+            }
+        }
+    }
+
 }

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -888,14 +888,6 @@ public class GameProcessManager(
     }
 
     /// <summary>
-    /// Retains the last few lines written to standard error.
-    /// <para>
-    /// Bounded on purpose. The interesting output from a process that dies during startup
-    /// is the last thing it said, and a game that runs for hours would otherwise
-    /// accumulate its entire log in memory for no benefit.
-    /// </para>
-    /// </summary>
-    /// <summary>
     /// Waits for the asynchronous stderr handlers to finish before the capture is read.
     /// </summary>
     /// <remarks>

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -303,6 +303,13 @@ public class GameProcessManager(
 
                     logger.LogWarning("Process {ProcessId} exited immediately with code {ExitCode}", process.Id, exitCode);
 
+                    // The process has exited, but the async stderr handlers may not have
+                    // delivered their final lines yet — and this is exactly the path where
+                    // that output explains the failure. The parameterless overload is the
+                    // documented way to wait for those handlers; the timed overloads
+                    // return as soon as the process is gone and leave the capture short.
+                    DrainStandardError(process, capturedErrors);
+
                     process.Dispose();
 
                     // If it exits immediately with a non-zero code (like a crash or missing DLL), this is a genuine failure
@@ -335,7 +342,13 @@ public class GameProcessManager(
             if (configuration.WaitForExit)
             {
                 var timeoutMs = configuration.Timeout.HasValue ? (int)configuration.Timeout.Value.TotalMilliseconds : Timeout.Infinite;
-                process.WaitForExit(timeoutMs);
+                if (process.WaitForExit(timeoutMs))
+                {
+                    // Only once the process is known to have exited: the timed overload
+                    // does not wait for the redirected-output handlers, so the capture
+                    // would otherwise be read while lines are still in flight.
+                    DrainStandardError(process, capturedErrors);
+                }
             }
 
             try
@@ -882,29 +895,117 @@ public class GameProcessManager(
     /// accumulate its entire log in memory for no benefit.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// Waits for the asynchronous stderr handlers to finish before the capture is read.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Process.WaitForExit()"/> without a timeout additionally waits for
+    /// redirected-output handlers to complete; the timed overloads do not, so reading the
+    /// buffer straight after the process exits can miss the final lines. Only stderr is
+    /// redirected, so there is no stdout stream to drain.
+    /// </remarks>
+    /// <param name="process">The exited process.</param>
+    /// <param name="capturedErrors">The buffer receiving stderr lines.</param>
+    private void DrainStandardError(Process process, BoundedErrorBuffer capturedErrors)
+    {
+        try
+        {
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            // The process may already be disposed or inaccessible; the capture is then
+            // whatever arrived, which is better than propagating from a diagnostics path.
+            logger.LogDebug(ex, "[Process] Could not wait for stderr handlers to complete");
+        }
+
+        if (!capturedErrors.EndOfStreamReached)
+        {
+            logger.LogDebug(
+                "[Process] stderr did not signal end of stream; the captured output may be incomplete");
+        }
+    }
+
+    /// <summary>
+    /// Retains a bounded excerpt of a process's stderr for diagnostics.
+    /// </summary>
+    /// <remarks>
+    /// Keeps the first lines as well as the last. A tail-only buffer loses the startup
+    /// context — the missing library, the rejected argument — which is usually where the
+    /// cause is, while the tail holds the symptom. Both are bounded by line count, by
+    /// individual line length and by total size, so a process writing a pathological
+    /// volume cannot exhaust memory.
+    /// </remarks>
     private sealed class BoundedErrorBuffer
     {
-        private const int MaxLines = 20;
-        private readonly Queue<string> _lines = new();
+        private const int MaxHeadLines = 10;
+        private const int MaxTailLines = 20;
+        private const int MaxLineLength = 2000;
+        private const int MaxTotalChars = 64 * 1024;
+
+        private readonly List<string> _head = [];
+        private readonly Queue<string> _tail = new();
         private readonly object _gate = new();
+        private int _retainedChars;
+        private int _droppedLines;
+        private bool _endOfStream;
 
         /// <summary>
-        /// Appends a line, discarding the oldest once the cap is reached.
+        /// Gets a value indicating whether the stream signalled end of output.
+        /// </summary>
+        /// <remarks>
+        /// The framework raises the handler once with a null <c>Data</c> when the stream
+        /// closes. That, not process exit, is the point at which the capture is known to
+        /// be complete.
+        /// </remarks>
+        internal bool EndOfStreamReached
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _endOfStream;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Appends a line, or records end of stream when <paramref name="line"/> is null.
         /// </summary>
         /// <param name="line">The line received, or null at end of stream.</param>
         internal void Append(string? line)
         {
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                return;
-            }
-
             lock (_gate)
             {
-                _lines.Enqueue(line);
-                while (_lines.Count > MaxLines)
+                if (line is null)
                 {
-                    _lines.Dequeue();
+                    _endOfStream = true;
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    return;
+                }
+
+                var trimmed = line.Length > MaxLineLength
+                    ? string.Concat(line.AsSpan(0, MaxLineLength), "…[line truncated]")
+                    : line;
+
+                if (_head.Count < MaxHeadLines)
+                {
+                    _head.Add(trimmed);
+                    _retainedChars += trimmed.Length;
+                    return;
+                }
+
+                _tail.Enqueue(trimmed);
+                _retainedChars += trimmed.Length;
+
+                while (_tail.Count > MaxTailLines || (_retainedChars > MaxTotalChars && _tail.Count > 0))
+                {
+                    _retainedChars -= _tail.Dequeue().Length;
+                    _droppedLines++;
                 }
             }
         }
@@ -914,7 +1015,16 @@ public class GameProcessManager(
         {
             lock (_gate)
             {
-                return string.Join(" | ", _lines);
+                var parts = new List<string>(_head);
+
+                if (_droppedLines > 0)
+                {
+                    parts.Add($"…[{_droppedLines} line(s) omitted]");
+                }
+
+                parts.AddRange(_tail);
+
+                return string.Join(" | ", parts);
             }
         }
     }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
@@ -32,6 +32,7 @@ using GenHub.Core.Models.Manifest;
 using GenHub.Features.GameProfiles.Services;
 using GenHub.Features.GameProfiles.Views;
 using Microsoft.Extensions.Logging;
+using GenHub.Core.Extensions.GameInstallations;
 
 namespace GenHub.Features.GameProfiles.ViewModels;
 
@@ -1648,8 +1649,11 @@ public partial class GameProfileLauncherViewModel(
                 GameClientConstants.SuperHackersGeneralsExecutable,
             ];
 
-            bool hasZeroHour = zeroHourExecutables.Any(exe => File.Exists(Path.Combine(selectedPath, exe)));
-            bool hasGenerals = generalsExecutables.Any(exe => File.Exists(Path.Combine(selectedPath, exe)));
+            // Case-insensitive, matching the nine sibling detectors. Retail data copied
+            // from a disc or a Windows machine is frequently upper-cased (GENERALS.EXE),
+            // and Linux volumes plus case-sensitive APFS will not match it otherwise.
+            bool hasZeroHour = zeroHourExecutables.Any(exe => Path.Combine(selectedPath, exe).FileExistsCaseInsensitive());
+            bool hasGenerals = generalsExecutables.Any(exe => Path.Combine(selectedPath, exe).FileExistsCaseInsensitive());
 
             if (hasZeroHour || hasGenerals)
             {
@@ -1677,12 +1681,12 @@ public partial class GameProfileLauncherViewModel(
 
             if (Directory.Exists(generalsSubdir))
             {
-                hasGenerals = generalsExecutables.Any(exe => File.Exists(Path.Combine(generalsSubdir, exe)));
+                hasGenerals = generalsExecutables.Any(exe => Path.Combine(generalsSubdir, exe).FileExistsCaseInsensitive());
             }
 
             if (Directory.Exists(zeroHourSubdir))
             {
-                hasZeroHour = zeroHourExecutables.Any(exe => File.Exists(Path.Combine(zeroHourSubdir, exe)));
+                hasZeroHour = zeroHourExecutables.Any(exe => Path.Combine(zeroHourSubdir, exe).FileExistsCaseInsensitive());
             }
 
             if (hasGenerals || hasZeroHour)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -14,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using GenHub.Common.ViewModels;
 using GenHub.Core.Constants;
+using GenHub.Core.Extensions.GameInstallations;
 using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameClients;
@@ -32,7 +26,13 @@ using GenHub.Core.Models.Manifest;
 using GenHub.Features.GameProfiles.Services;
 using GenHub.Features.GameProfiles.Views;
 using Microsoft.Extensions.Logging;
-using GenHub.Core.Extensions.GameInstallations;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GenHub.Features.GameProfiles.ViewModels;
 

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -979,6 +979,7 @@ public class GameLauncher(
                 logger.LogError("[GameLauncher] Retail archive root validation failed: {Error}", archiveRootError);
                 return LaunchOperationResult<GameLaunchInfo>.CreateFailure(archiveRootError, launchId, profile.Id);
             }
+
             logger.LogInformation("[GameLauncher] Starting game process...");
             OperationResult<GameProcessInfo> processResult;
 
@@ -1176,77 +1177,6 @@ public class GameLauncher(
     }
 
     /// <summary>
-    /// Applies GeneralsOnline-specific settings to the settings.json file.
-    /// </summary>
-    /// <param name="profile">The game profile containing the settings.</param>
-    private async Task ApplyGeneralsOnlineSettingsAsync(GameProfile profile)
-    {
-        // Only apply if it's Zero Hour (as GO settings only apply there currently)
-        if (profile.GameClient?.GameType != GameType.ZeroHour)
-        {
-            return;
-        }
-
-        try
-        {
-            logger.LogInformation("[GameLauncher] Applying GeneralsOnline settings to settings.json for profile {ProfileId}", profile.Id);
-
-            // Clean Launch Strategy: Create fresh settings object to ensure isolation and prevent pollution
-            var settings = new GeneralsOnlineSettings();
-
-            // Map GO settings from profile using the centralized mapper
-            GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
-
-            var saveResult = await gameSettingsService.SaveGeneralsOnlineSettingsAsync(settings);
-            if (!saveResult.Success)
-            {
-                logger.LogWarning("[GameLauncher] Failed to save GeneralsOnline settings: {Error}", saveResult.FirstError);
-            }
-            else
-            {
-                logger.LogInformation("[GameLauncher] Successfully saved GeneralsOnline settings to settings.json");
-            }
-        }
-        catch (Exception ex)
-        {
-            // Log and continue
-            logger.LogError(ex, "[GameLauncher] Failed to apply GeneralsOnline settings, continuing with launch");
-        }
-    }
-
-    /// <summary>
-    /// Performs a preflight check to ensure all CAS content required by the manifests is available.
-    /// </summary>
-    /// <param name="manifests">The manifests to check.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A result indicating success or failure.</returns>
-    private async Task<OperationResult<bool>> PreflightCasCheckAsync(IEnumerable<ContentManifest> manifests, CancellationToken cancellationToken)
-    {
-        var missingHashes = new List<string>();
-        foreach (var manifest in manifests)
-        {
-            if (manifest.Files != null)
-            {
-                foreach (var file in manifest.Files.Where(f => f.SourceType == ContentSourceType.ContentAddressable && !string.IsNullOrEmpty(f.Hash)))
-                {
-                    var existsResult = await casService.ExistsAsync(file.Hash, manifest.ContentType, cancellationToken);
-                    if (!existsResult.Success || !existsResult.Data)
-                    {
-                        missingHashes.Add(file.Hash);
-                    }
-                }
-            }
-        }
-
-        if (missingHashes.Count > 0)
-        {
-            return OperationResult<bool>.CreateFailure($"Missing CAS objects: {string.Join(", ", missingHashes.Distinct())}");
-        }
-
-        return OperationResult<bool>.CreateSuccess(true);
-    }
-
-    /// <summary>
     /// Builds the child process environment for a game client.
     /// </summary>
     /// <remarks>
@@ -1288,31 +1218,6 @@ public class GameLauncher(
         return environment;
     }
 
-
-    /// <summary>
-    /// Points the engine at the user's retail archives without copying them.
-    /// </summary>
-    /// <remarks>
-    /// A non-Windows engine build reads <c>InstallPath</c> through
-    /// <c>GetStringFromRegistry</c>, which on these platforms checks
-    /// <c>$CNC_ZH_INSTALLPATH</c> and <c>$CNC_GENERALS_INSTALLPATH</c> first. The engine
-    /// then mounts <c>*.big</c> from those roots in addition to the working directory.
-    /// <para>
-    /// That matters a great deal for workspace cost. Zero Hour needs both its own and the
-    /// base Generals archives — roughly 3 GB — and without this the only way to satisfy it
-    /// is to materialise every one of them into each profile's workspace. With it, a
-    /// workspace holds the engine and whatever content actually differs per profile, and
-    /// the bulk retail data stays where the user already has it.
-    /// </para>
-    /// <para>
-    /// The trailing separator is required, not cosmetic. The engine concatenates this
-    /// value with the archive filename directly, so a root without one produces paths like
-    /// <c>/path/to/GeneralsZHINIZH.big</c>. Every archive then fails to open, and the game
-    /// still starts — with no content and no error the user can act on.
-    /// </para>
-    /// </remarks>
-    /// <param name="environment">The environment being built.</param>
-    /// <param name="installation">The installation supplying retail data, if any.</param>
     /// <summary>
     /// Verifies that every configured retail archive root actually contains archives.
     /// </summary>
@@ -1386,6 +1291,30 @@ public class GameLauncher(
         return null;
     }
 
+    /// <summary>
+    /// Points the engine at the user's retail archives without copying them.
+    /// </summary>
+    /// <remarks>
+    /// A non-Windows engine build reads <c>InstallPath</c> through
+    /// <c>GetStringFromRegistry</c>, which on these platforms checks
+    /// <c>$CNC_ZH_INSTALLPATH</c> and <c>$CNC_GENERALS_INSTALLPATH</c> first. The engine
+    /// then mounts <c>*.big</c> from those roots in addition to the working directory.
+    /// <para>
+    /// That matters a great deal for workspace cost. Zero Hour needs both its own and the
+    /// base Generals archives — roughly 3 GB — and without this the only way to satisfy it
+    /// is to materialise every one of them into each profile's workspace. With it, a
+    /// workspace holds the engine and whatever content actually differs per profile, and
+    /// the bulk retail data stays where the user already has it.
+    /// </para>
+    /// <para>
+    /// The trailing separator is required, not cosmetic. The engine concatenates this
+    /// value with the archive filename directly, so a root without one produces paths like
+    /// <c>/path/to/GeneralsZHINIZH.big</c>. Every archive then fails to open, and the game
+    /// still starts — with no content and no error the user can act on.
+    /// </para>
+    /// </remarks>
+    /// <param name="environment">The environment being built.</param>
+    /// <param name="installation">The installation supplying retail data, if any.</param>
     private static void AddRetailArchiveRoots(
         Dictionary<string, string> environment,
         GameInstallation? installation)
@@ -1421,4 +1350,74 @@ public class GameLauncher(
             : path + Path.DirectorySeparatorChar;
     }
 
+    /// <summary>
+    /// Applies GeneralsOnline-specific settings to the settings.json file.
+    /// </summary>
+    /// <param name="profile">The game profile containing the settings.</param>
+    private async Task ApplyGeneralsOnlineSettingsAsync(GameProfile profile)
+    {
+        // Only apply if it's Zero Hour (as GO settings only apply there currently)
+        if (profile.GameClient?.GameType != GameType.ZeroHour)
+        {
+            return;
+        }
+
+        try
+        {
+            logger.LogInformation("[GameLauncher] Applying GeneralsOnline settings to settings.json for profile {ProfileId}", profile.Id);
+
+            // Clean Launch Strategy: Create fresh settings object to ensure isolation and prevent pollution
+            var settings = new GeneralsOnlineSettings();
+
+            // Map GO settings from profile using the centralized mapper
+            GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+            var saveResult = await gameSettingsService.SaveGeneralsOnlineSettingsAsync(settings);
+            if (!saveResult.Success)
+            {
+                logger.LogWarning("[GameLauncher] Failed to save GeneralsOnline settings: {Error}", saveResult.FirstError);
+            }
+            else
+            {
+                logger.LogInformation("[GameLauncher] Successfully saved GeneralsOnline settings to settings.json");
+            }
+        }
+        catch (Exception ex)
+        {
+            // Log and continue
+            logger.LogError(ex, "[GameLauncher] Failed to apply GeneralsOnline settings, continuing with launch");
+        }
+    }
+
+    /// <summary>
+    /// Performs a preflight check to ensure all CAS content required by the manifests is available.
+    /// </summary>
+    /// <param name="manifests">The manifests to check.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result indicating success or failure.</returns>
+    private async Task<OperationResult<bool>> PreflightCasCheckAsync(IEnumerable<ContentManifest> manifests, CancellationToken cancellationToken)
+    {
+        var missingHashes = new List<string>();
+        foreach (var manifest in manifests)
+        {
+            if (manifest.Files != null)
+            {
+                foreach (var file in manifest.Files.Where(f => f.SourceType == ContentSourceType.ContentAddressable && !string.IsNullOrEmpty(f.Hash)))
+                {
+                    var existsResult = await casService.ExistsAsync(file.Hash, manifest.ContentType, cancellationToken);
+                    if (!existsResult.Success || !existsResult.Data)
+                    {
+                        missingHashes.Add(file.Hash);
+                    }
+                }
+            }
+        }
+
+        if (missingHashes.Count > 0)
+        {
+            return OperationResult<bool>.CreateFailure($"Missing CAS objects: {string.Join(", ", missingHashes.Distinct())}");
+        }
+
+        return OperationResult<bool>.CreateSuccess(true);
+    }
 }

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -1230,14 +1230,19 @@ public class GameLauncher(
     /// </summary>
     /// <remarks>
     /// A native client ships its dynamic libraries beside the executable in the workspace.
-    /// The reference launch wrapper for the BGFX port does exactly this before exec:
+    /// The reference launch wrapper for the BGFX port does the same before exec:
     /// <c>export DYLD_LIBRARY_PATH="${script_dir}:${DYLD_LIBRARY_PATH:-}"</c>.
     /// <para>
-    /// Bundled libraries are normally reachable through <c>@executable_path</c> or
-    /// <c>$ORIGIN</c> rpath entries, so this is a fallback rather than the primary
-    /// mechanism — but when an rpath is missing the loader fails with "library not
-    /// loaded", the process dies before it draws a window, and the user sees nothing at
-    /// all. Setting the variable costs nothing and removes that failure mode.
+    /// This is a fallback, not a requirement, and that has been verified rather than
+    /// assumed: the current BGFX build declares every dependency as
+    /// <c>@executable_path/…</c> with an <c>@executable_path/</c> rpath, and launches
+    /// correctly with the variable cleared. It matters only for a build whose rpath is
+    /// incomplete, where the loader would otherwise fail with "library not loaded", the
+    /// process would die before drawing a window, and the user would see nothing at all.
+    /// </para>
+    /// <para>
+    /// It is safe alongside <c>@executable_path</c>: those references are resolved
+    /// directly against the executable's directory and do not consult this variable.
     /// </para>
     /// <para>
     /// Windows resolves DLLs from the executable's own directory already, so nothing is

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -478,6 +478,180 @@ public class GameLauncher(
         return true;
     }
 
+    /// <summary>
+    /// Builds the child process environment for a game client.
+    /// </summary>
+    /// <remarks>
+    /// No dynamic-loader search path is set. GenHub previously prepended the workspace to
+    /// <c>DYLD_LIBRARY_PATH</c> / <c>LD_LIBRARY_PATH</c> as a fallback for a build with an
+    /// incomplete rpath. That was measured to be unnecessary — the BGFX build declares
+    /// every dependency as <c>@executable_path/…</c> with an <c>@executable_path/</c>
+    /// rpath and launches correctly with the variable cleared — and it carried two costs
+    /// that outweighed a fallback for a build we do not ship:
+    /// <para>
+    /// dyld consults <c>DYLD_LIBRARY_PATH</c> before <c>@executable_path</c> for
+    /// leaf-name references, so any same-named library elsewhere on that path silently
+    /// takes precedence over the one shipped beside the executable.
+    /// </para>
+    /// <para>
+    /// The hardened runtime ignores <c>DYLD_LIBRARY_PATH</c> outright, so the variable
+    /// would stop having any effect the moment GenHub is signed and notarized. Keeping it
+    /// meant launch behaviour would change silently at signing time rather than now.
+    /// </para>
+    /// </remarks>
+    /// <param name="profileEnvironment">Environment variables configured on the profile.</param>
+    /// <param name="installation">The retail installation supplying archive roots.</param>
+    /// <returns>The environment to pass to the child process.</returns>
+    private static Dictionary<string, string> BuildEnvironmentVariables(
+        Dictionary<string, string>? profileEnvironment,
+        GameInstallation? installation)
+    {
+        var environment = profileEnvironment is null
+            ? []
+            : new Dictionary<string, string>(profileEnvironment);
+
+        if (OperatingSystem.IsWindows())
+        {
+            return environment;
+        }
+
+        AddRetailArchiveRoots(environment, installation);
+
+        return environment;
+    }
+
+    /// <summary>
+    /// Verifies that every configured retail archive root actually contains archives.
+    /// </summary>
+    /// <remarks>
+    /// The engine mounts its content from these roots, but reaches its main loop with zero
+    /// content and no error when they are wrong — no exit code, no log line, nothing a
+    /// host process can observe. A launch that "succeeded" is therefore indistinguishable
+    /// from one that produced an empty game, so this has to be checked before spawn.
+    /// <para>
+    /// Existence of at least one <c>.big</c> archive is used as the sentinel rather than a
+    /// specific filename, which varies by localisation and version. This only catches a
+    /// root that is wrong or empty; an archive that exists but fails to mount still needs
+    /// a machine-readable failure from the engine itself.
+    /// </para>
+    /// </remarks>
+    /// <param name="environment">The environment built for the child process.</param>
+    /// <param name="installation">The installation whose declared paths were used.</param>
+    /// <returns>An error message naming the offending root, or <c>null</c> when valid.</returns>
+    private static string? ValidateRetailArchiveRoots(
+        Dictionary<string, string> environment,
+        GameInstallation? installation)
+    {
+        // Validated against the installation's declared paths, not only the variables that
+        // survived into the environment. AddArchiveRoot drops a path that does not exist,
+        // so validating the environment alone would silently skip the exact case this
+        // exists to catch: a stale installation root reaching spawn unnoticed.
+        var declaredPaths = new (string Variable, string? Path)[]
+        {
+            (RetailArchiveRootVariables[0], installation?.ZeroHourPath),
+            (RetailArchiveRootVariables[1], installation?.GeneralsPath),
+        };
+
+        foreach (var (variableName, declaredPath) in declaredPaths)
+        {
+            // A profile override is the root actually used, so it is what gets checked.
+            var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
+                ? configured
+                : declaredPath;
+
+            // Nothing configured for this game means it is simply not installed.
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                continue;
+            }
+
+            if (!Directory.Exists(root))
+            {
+                return $"The retail archive root for {variableName} does not exist: {root}. " +
+                       "The game would start with no content and no error, so the launch was stopped.";
+            }
+
+            bool hasArchive;
+            try
+            {
+                hasArchive = Directory
+                    .EnumerateFiles(root, "*.big", SearchOption.TopDirectoryOnly)
+                    .Any();
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
+            }
+
+            if (!hasArchive)
+            {
+                return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
+                       "The game would start with no content and no error, so the launch was stopped.";
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Points the engine at the user's retail archives without copying them.
+    /// </summary>
+    /// <remarks>
+    /// A non-Windows engine build reads <c>InstallPath</c> through
+    /// <c>GetStringFromRegistry</c>, which on these platforms checks
+    /// <c>$CNC_ZH_INSTALLPATH</c> and <c>$CNC_GENERALS_INSTALLPATH</c> first. The engine
+    /// then mounts <c>*.big</c> from those roots in addition to the working directory.
+    /// <para>
+    /// That matters a great deal for workspace cost. Zero Hour needs both its own and the
+    /// base Generals archives — roughly 3 GB — and without this the only way to satisfy it
+    /// is to materialise every one of them into each profile's workspace. With it, a
+    /// workspace holds the engine and whatever content actually differs per profile, and
+    /// the bulk retail data stays where the user already has it.
+    /// </para>
+    /// <para>
+    /// The trailing separator is required, not cosmetic. The engine concatenates this
+    /// value with the archive filename directly, so a root without one produces paths like
+    /// <c>/path/to/GeneralsZHINIZH.big</c>. Every archive then fails to open, and the game
+    /// still starts — with no content and no error the user can act on.
+    /// </para>
+    /// </remarks>
+    /// <param name="environment">The environment being built.</param>
+    /// <param name="installation">The installation supplying retail data, if any.</param>
+    private static void AddRetailArchiveRoots(
+        Dictionary<string, string> environment,
+        GameInstallation? installation)
+    {
+        if (installation is null)
+        {
+            return;
+        }
+
+        AddArchiveRoot(environment, RetailArchiveRootVariables[0], installation.ZeroHourPath);
+        AddArchiveRoot(environment, RetailArchiveRootVariables[1], installation.GeneralsPath);
+    }
+
+    /// <summary>
+    /// Sets one archive-root variable, with the trailing separator the engine requires.
+    /// </summary>
+    /// <param name="environment">The environment being built.</param>
+    /// <param name="variableName">The environment variable to set.</param>
+    /// <param name="path">The retail directory, or null/empty to skip.</param>
+    private static void AddArchiveRoot(
+        Dictionary<string, string> environment,
+        string variableName,
+        string? path)
+    {
+        // A profile that sets this explicitly wins.
+        if (string.IsNullOrWhiteSpace(path) || environment.ContainsKey(variableName) || !Directory.Exists(path))
+        {
+            return;
+        }
+
+        environment[variableName] = path.EndsWith(Path.DirectorySeparatorChar)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+    }
+
     private async Task<LaunchOperationResult<GameLaunchInfo>> LaunchProfileAsync(GameProfile profile, bool skipUserDataCleanup, IProgress<LaunchProgress>? progress, string launchId, CancellationToken cancellationToken)
     {
         IDisposable? steamInstallationLock = null;
@@ -1174,180 +1348,6 @@ public class GameLauncher(
             // Don't fail the launch if Options.ini writing fails - log and continue
             logger.LogError(ex, "Failed to apply profile settings to Options.ini, continuing with launch");
         }
-    }
-
-    /// <summary>
-    /// Builds the child process environment for a game client.
-    /// </summary>
-    /// <remarks>
-    /// No dynamic-loader search path is set. GenHub previously prepended the workspace to
-    /// <c>DYLD_LIBRARY_PATH</c> / <c>LD_LIBRARY_PATH</c> as a fallback for a build with an
-    /// incomplete rpath. That was measured to be unnecessary — the BGFX build declares
-    /// every dependency as <c>@executable_path/…</c> with an <c>@executable_path/</c>
-    /// rpath and launches correctly with the variable cleared — and it carried two costs
-    /// that outweighed a fallback for a build we do not ship:
-    /// <para>
-    /// dyld consults <c>DYLD_LIBRARY_PATH</c> before <c>@executable_path</c> for
-    /// leaf-name references, so any same-named library elsewhere on that path silently
-    /// takes precedence over the one shipped beside the executable.
-    /// </para>
-    /// <para>
-    /// The hardened runtime ignores <c>DYLD_LIBRARY_PATH</c> outright, so the variable
-    /// would stop having any effect the moment GenHub is signed and notarized. Keeping it
-    /// meant launch behaviour would change silently at signing time rather than now.
-    /// </para>
-    /// </remarks>
-    /// <param name="profileEnvironment">Environment variables configured on the profile.</param>
-    /// <param name="installation">The retail installation supplying archive roots.</param>
-    /// <returns>The environment to pass to the child process.</returns>
-    private static Dictionary<string, string> BuildEnvironmentVariables(
-        Dictionary<string, string>? profileEnvironment,
-        GameInstallation? installation)
-    {
-        var environment = profileEnvironment is null
-            ? []
-            : new Dictionary<string, string>(profileEnvironment);
-
-        if (OperatingSystem.IsWindows())
-        {
-            return environment;
-        }
-
-        AddRetailArchiveRoots(environment, installation);
-
-        return environment;
-    }
-
-    /// <summary>
-    /// Verifies that every configured retail archive root actually contains archives.
-    /// </summary>
-    /// <remarks>
-    /// The engine mounts its content from these roots, but reaches its main loop with zero
-    /// content and no error when they are wrong — no exit code, no log line, nothing a
-    /// host process can observe. A launch that "succeeded" is therefore indistinguishable
-    /// from one that produced an empty game, so this has to be checked before spawn.
-    /// <para>
-    /// Existence of at least one <c>.big</c> archive is used as the sentinel rather than a
-    /// specific filename, which varies by localisation and version. This only catches a
-    /// root that is wrong or empty; an archive that exists but fails to mount still needs
-    /// a machine-readable failure from the engine itself.
-    /// </para>
-    /// </remarks>
-    /// <param name="environment">The environment built for the child process.</param>
-    /// <param name="installation">The installation whose declared paths were used.</param>
-    /// <returns>An error message naming the offending root, or <c>null</c> when valid.</returns>
-    private static string? ValidateRetailArchiveRoots(
-        Dictionary<string, string> environment,
-        GameInstallation? installation)
-    {
-        // Validated against the installation's declared paths, not only the variables that
-        // survived into the environment. AddArchiveRoot drops a path that does not exist,
-        // so validating the environment alone would silently skip the exact case this
-        // exists to catch: a stale installation root reaching spawn unnoticed.
-        var declaredPaths = new (string Variable, string? Path)[]
-        {
-            (RetailArchiveRootVariables[0], installation?.ZeroHourPath),
-            (RetailArchiveRootVariables[1], installation?.GeneralsPath),
-        };
-
-        foreach (var (variableName, declaredPath) in declaredPaths)
-        {
-            // A profile override is the root actually used, so it is what gets checked.
-            var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
-                ? configured
-                : declaredPath;
-
-            // Nothing configured for this game means it is simply not installed.
-            if (string.IsNullOrWhiteSpace(root))
-            {
-                continue;
-            }
-
-            if (!Directory.Exists(root))
-            {
-                return $"The retail archive root for {variableName} does not exist: {root}. " +
-                       "The game would start with no content and no error, so the launch was stopped.";
-            }
-
-            bool hasArchive;
-            try
-            {
-                hasArchive = Directory
-                    .EnumerateFiles(root, "*.big", SearchOption.TopDirectoryOnly)
-                    .Any();
-            }
-            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-            {
-                return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
-            }
-
-            if (!hasArchive)
-            {
-                return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
-                       "The game would start with no content and no error, so the launch was stopped.";
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Points the engine at the user's retail archives without copying them.
-    /// </summary>
-    /// <remarks>
-    /// A non-Windows engine build reads <c>InstallPath</c> through
-    /// <c>GetStringFromRegistry</c>, which on these platforms checks
-    /// <c>$CNC_ZH_INSTALLPATH</c> and <c>$CNC_GENERALS_INSTALLPATH</c> first. The engine
-    /// then mounts <c>*.big</c> from those roots in addition to the working directory.
-    /// <para>
-    /// That matters a great deal for workspace cost. Zero Hour needs both its own and the
-    /// base Generals archives — roughly 3 GB — and without this the only way to satisfy it
-    /// is to materialise every one of them into each profile's workspace. With it, a
-    /// workspace holds the engine and whatever content actually differs per profile, and
-    /// the bulk retail data stays where the user already has it.
-    /// </para>
-    /// <para>
-    /// The trailing separator is required, not cosmetic. The engine concatenates this
-    /// value with the archive filename directly, so a root without one produces paths like
-    /// <c>/path/to/GeneralsZHINIZH.big</c>. Every archive then fails to open, and the game
-    /// still starts — with no content and no error the user can act on.
-    /// </para>
-    /// </remarks>
-    /// <param name="environment">The environment being built.</param>
-    /// <param name="installation">The installation supplying retail data, if any.</param>
-    private static void AddRetailArchiveRoots(
-        Dictionary<string, string> environment,
-        GameInstallation? installation)
-    {
-        if (installation is null)
-        {
-            return;
-        }
-
-        AddArchiveRoot(environment, RetailArchiveRootVariables[0], installation.ZeroHourPath);
-        AddArchiveRoot(environment, RetailArchiveRootVariables[1], installation.GeneralsPath);
-    }
-
-    /// <summary>
-    /// Sets one archive-root variable, with the trailing separator the engine requires.
-    /// </summary>
-    /// <param name="environment">The environment being built.</param>
-    /// <param name="variableName">The environment variable to set.</param>
-    /// <param name="path">The retail directory, or null/empty to skip.</param>
-    private static void AddArchiveRoot(
-        Dictionary<string, string> environment,
-        string variableName,
-        string? path)
-    {
-        // A profile that sets this explicitly wins.
-        if (string.IsNullOrWhiteSpace(path) || environment.ContainsKey(variableName) || !Directory.Exists(path))
-        {
-            return;
-        }
-
-        environment[variableName] = path.EndsWith(Path.DirectorySeparatorChar)
-            ? path
-            : path + Path.DirectorySeparatorChar;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -21,6 +21,7 @@ using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Interfaces.UserData;
 using GenHub.Core.Interfaces.Workspace;
 using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.GameProfile;
 using GenHub.Core.Models.GameSettings;
 using GenHub.Core.Models.Launching;
@@ -955,7 +956,7 @@ public class GameLauncher(
                 ExecutablePath = finalExecutablePath,
                 WorkingDirectory = workspaceInfo.WorkspacePath,
                 Arguments = arguments,
-                EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, workspaceInfo.WorkspacePath),
+                EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, workspaceInfo.WorkspacePath, installation),
             };
             logger.LogInformation("[GameLauncher] Starting game process...");
             OperationResult<GameProcessInfo> processResult;
@@ -1254,7 +1255,8 @@ public class GameLauncher(
     /// <returns>The environment to pass to the child process.</returns>
     private static Dictionary<string, string> BuildEnvironmentVariables(
         Dictionary<string, string>? profileEnvironment,
-        string workspacePath)
+        string workspacePath,
+        GameInstallation? installation)
     {
         var environment = profileEnvironment is null
             ? []
@@ -1264,6 +1266,8 @@ public class GameLauncher(
         {
             return environment;
         }
+
+        AddRetailArchiveRoots(environment, installation);
 
         var variableName = OperatingSystem.IsMacOS() ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH";
 
@@ -1280,6 +1284,66 @@ public class GameLauncher(
             : $"{workspacePath}{Path.PathSeparator}{inherited}";
 
         return environment;
+    }
+
+
+    /// <summary>
+    /// Points the engine at the user's retail archives without copying them.
+    /// </summary>
+    /// <remarks>
+    /// A non-Windows engine build reads <c>InstallPath</c> through
+    /// <c>GetStringFromRegistry</c>, which on these platforms checks
+    /// <c>$CNC_ZH_INSTALLPATH</c> and <c>$CNC_GENERALS_INSTALLPATH</c> first. The engine
+    /// then mounts <c>*.big</c> from those roots in addition to the working directory.
+    /// <para>
+    /// That matters a great deal for workspace cost. Zero Hour needs both its own and the
+    /// base Generals archives — roughly 3 GB — and without this the only way to satisfy it
+    /// is to materialise every one of them into each profile's workspace. With it, a
+    /// workspace holds the engine and whatever content actually differs per profile, and
+    /// the bulk retail data stays where the user already has it.
+    /// </para>
+    /// <para>
+    /// The trailing separator is required, not cosmetic. The engine concatenates this
+    /// value with the archive filename directly, so a root without one produces paths like
+    /// <c>/path/to/GeneralsZHINIZH.big</c>. Every archive then fails to open, and the game
+    /// still starts — with no content and no error the user can act on.
+    /// </para>
+    /// </remarks>
+    /// <param name="environment">The environment being built.</param>
+    /// <param name="installation">The installation supplying retail data, if any.</param>
+    private static void AddRetailArchiveRoots(
+        Dictionary<string, string> environment,
+        GameInstallation? installation)
+    {
+        if (installation is null)
+        {
+            return;
+        }
+
+        AddArchiveRoot(environment, "CNC_ZH_INSTALLPATH", installation.ZeroHourPath);
+        AddArchiveRoot(environment, "CNC_GENERALS_INSTALLPATH", installation.GeneralsPath);
+    }
+
+    /// <summary>
+    /// Sets one archive-root variable, with the trailing separator the engine requires.
+    /// </summary>
+    /// <param name="environment">The environment being built.</param>
+    /// <param name="variableName">The environment variable to set.</param>
+    /// <param name="path">The retail directory, or null/empty to skip.</param>
+    private static void AddArchiveRoot(
+        Dictionary<string, string> environment,
+        string variableName,
+        string? path)
+    {
+        // A profile that sets this explicitly wins.
+        if (string.IsNullOrWhiteSpace(path) || environment.ContainsKey(variableName) || !Directory.Exists(path))
+        {
+            return;
+        }
+
+        environment[variableName] = path.EndsWith(Path.DirectorySeparatorChar)
+            ? path
+            : path + Path.DirectorySeparatorChar;
     }
 
 }

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -527,10 +527,12 @@ public class GameLauncher(
     /// </remarks>
     /// <param name="environment">The environment built for the child process.</param>
     /// <param name="installation">The installation whose declared paths were used.</param>
+    /// <param name="gameType">The game being launched; only its root is checked.</param>
     /// <returns>An error message naming the offending root, or <c>null</c> when valid.</returns>
     private static string? ValidateRetailArchiveRoots(
         Dictionary<string, string> environment,
-        GameInstallation? installation)
+        GameInstallation? installation,
+        GameType gameType)
     {
         // Windows resolves install paths from the registry and never reads these variables,
         // so a Windows layout without loose top-level archives is not a misconfiguration and
@@ -546,48 +548,46 @@ public class GameLauncher(
         // survived into the environment. AddArchiveRoot drops a path that does not exist,
         // so validating the environment alone would silently skip the exact case this
         // exists to catch: a stale installation root reaching spawn unnoticed.
-        var declaredPaths = new (string Variable, string? Path)[]
+        // Only the launching game's root. The other game's path may be stale or absent on
+        // the same installation, and that has no bearing on whether this launch will find
+        // its content — failing on a sibling would block a launch that would have worked.
+        var (variableName, declaredPath) = gameType == GameType.Generals
+            ? (RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath)
+            : (RetailArchiveConstants.ZeroHourInstallPathVariable, installation?.ZeroHourPath);
+
+        // A profile override is the root actually used, so it is what gets checked.
+        var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
+            ? configured
+            : declaredPath;
+
+        // Nothing configured for this game means it is simply not installed.
+        if (string.IsNullOrWhiteSpace(root))
         {
-            (RetailArchiveConstants.ZeroHourInstallPathVariable, installation?.ZeroHourPath),
-            (RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath),
-        };
+            return null;
+        }
 
-        foreach (var (variableName, declaredPath) in declaredPaths)
+        if (!Directory.Exists(root))
         {
-            // A profile override is the root actually used, so it is what gets checked.
-            var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
-                ? configured
-                : declaredPath;
+            return $"The retail archive root for {variableName} does not exist: {root}. " +
+                   "The game would start with no content and no error, so the launch was stopped.";
+        }
 
-            // Nothing configured for this game means it is simply not installed.
-            if (string.IsNullOrWhiteSpace(root))
-            {
-                continue;
-            }
+        bool hasArchive;
+        try
+        {
+            hasArchive = Directory
+                .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, SearchOption.TopDirectoryOnly)
+                .Any();
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
+        }
 
-            if (!Directory.Exists(root))
-            {
-                return $"The retail archive root for {variableName} does not exist: {root}. " +
-                       "The game would start with no content and no error, so the launch was stopped.";
-            }
-
-            bool hasArchive;
-            try
-            {
-                hasArchive = Directory
-                    .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, SearchOption.TopDirectoryOnly)
-                    .Any();
-            }
-            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-            {
-                return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
-            }
-
-            if (!hasArchive)
-            {
-                return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
-                       "The game would start with no content and no error, so the launch was stopped.";
-            }
+        if (!hasArchive)
+        {
+            return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
+                   "The game would start with no content and no error, so the launch was stopped.";
         }
 
         return null;
@@ -1162,7 +1162,8 @@ public class GameLauncher(
             // starts, reaches its main loop and reports nothing — it simply has no content.
             // Launch therefore "succeeds" while the user gets a broken game, and no
             // post-spawn check can tell the difference.
-            var archiveRootError = ValidateRetailArchiveRoots(launchConfig.EnvironmentVariables, installation);
+            var archiveRootError = ValidateRetailArchiveRoots(
+                launchConfig.EnvironmentVariables, installation, gameClient.GameType);
             if (archiveRootError is not null)
             {
                 logger.LogError("[GameLauncher] Retail archive root validation failed: {Error}", archiveRootError);

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -51,6 +51,16 @@ public class GameLauncher(
     ISteamLauncher steamLauncher,
     IConfigurationProviderService configurationProvider) : IGameLauncher
 {
+    /// <summary>
+    /// Environment variables naming the retail directories the engine mounts archives from.
+    /// Ordered Zero Hour first, matching <see cref="AddRetailArchiveRoots"/>.
+    /// </summary>
+    private static readonly string[] RetailArchiveRootVariables =
+    [
+        "CNC_ZH_INSTALLPATH",
+        "CNC_GENERALS_INSTALLPATH",
+    ];
+
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _profileLaunchLocks = new();
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _steamInstallationLaunchLocks =
         new(InstallationPathLockKey.Comparer);
@@ -958,6 +968,17 @@ public class GameLauncher(
                 Arguments = arguments,
                 EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, installation),
             };
+
+            // Must happen before spawn. When the archive roots are wrong the engine still
+            // starts, reaches its main loop and reports nothing — it simply has no content.
+            // Launch therefore "succeeds" while the user gets a broken game, and no
+            // post-spawn check can tell the difference.
+            var archiveRootError = ValidateRetailArchiveRoots(launchConfig.EnvironmentVariables, installation);
+            if (archiveRootError is not null)
+            {
+                logger.LogError("[GameLauncher] Retail archive root validation failed: {Error}", archiveRootError);
+                return LaunchOperationResult<GameLaunchInfo>.CreateFailure(archiveRootError, launchId, profile.Id);
+            }
             logger.LogInformation("[GameLauncher] Starting game process...");
             OperationResult<GameProcessInfo> processResult;
 
@@ -1292,6 +1313,79 @@ public class GameLauncher(
     /// </remarks>
     /// <param name="environment">The environment being built.</param>
     /// <param name="installation">The installation supplying retail data, if any.</param>
+    /// <summary>
+    /// Verifies that every configured retail archive root actually contains archives.
+    /// </summary>
+    /// <remarks>
+    /// The engine mounts its content from these roots, but reaches its main loop with zero
+    /// content and no error when they are wrong — no exit code, no log line, nothing a
+    /// host process can observe. A launch that "succeeded" is therefore indistinguishable
+    /// from one that produced an empty game, so this has to be checked before spawn.
+    /// <para>
+    /// Existence of at least one <c>.big</c> archive is used as the sentinel rather than a
+    /// specific filename, which varies by localisation and version. This only catches a
+    /// root that is wrong or empty; an archive that exists but fails to mount still needs
+    /// a machine-readable failure from the engine itself.
+    /// </para>
+    /// </remarks>
+    /// <param name="environment">The environment built for the child process.</param>
+    /// <param name="installation">The installation whose declared paths were used.</param>
+    /// <returns>An error message naming the offending root, or <c>null</c> when valid.</returns>
+    private static string? ValidateRetailArchiveRoots(
+        Dictionary<string, string> environment,
+        GameInstallation? installation)
+    {
+        // Validated against the installation's declared paths, not only the variables that
+        // survived into the environment. AddArchiveRoot drops a path that does not exist,
+        // so validating the environment alone would silently skip the exact case this
+        // exists to catch: a stale installation root reaching spawn unnoticed.
+        var declaredPaths = new (string Variable, string? Path)[]
+        {
+            (RetailArchiveRootVariables[0], installation?.ZeroHourPath),
+            (RetailArchiveRootVariables[1], installation?.GeneralsPath),
+        };
+
+        foreach (var (variableName, declaredPath) in declaredPaths)
+        {
+            // A profile override is the root actually used, so it is what gets checked.
+            var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
+                ? configured
+                : declaredPath;
+
+            // Nothing configured for this game means it is simply not installed.
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                continue;
+            }
+
+            if (!Directory.Exists(root))
+            {
+                return $"The retail archive root for {variableName} does not exist: {root}. " +
+                       "The game would start with no content and no error, so the launch was stopped.";
+            }
+
+            bool hasArchive;
+            try
+            {
+                hasArchive = Directory
+                    .EnumerateFiles(root, "*.big", SearchOption.TopDirectoryOnly)
+                    .Any();
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
+            }
+
+            if (!hasArchive)
+            {
+                return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
+                       "The game would start with no content and no error, so the launch was stopped.";
+            }
+        }
+
+        return null;
+    }
+
     private static void AddRetailArchiveRoots(
         Dictionary<string, string> environment,
         GameInstallation? installation)
@@ -1301,8 +1395,8 @@ public class GameLauncher(
             return;
         }
 
-        AddArchiveRoot(environment, "CNC_ZH_INSTALLPATH", installation.ZeroHourPath);
-        AddArchiveRoot(environment, "CNC_GENERALS_INSTALLPATH", installation.GeneralsPath);
+        AddArchiveRoot(environment, RetailArchiveRootVariables[0], installation.ZeroHourPath);
+        AddArchiveRoot(environment, RetailArchiveRootVariables[1], installation.GeneralsPath);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -955,7 +955,7 @@ public class GameLauncher(
                 ExecutablePath = finalExecutablePath,
                 WorkingDirectory = workspaceInfo.WorkspacePath,
                 Arguments = arguments,
-                EnvironmentVariables = profile.EnvironmentVariables,
+                EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, workspaceInfo.WorkspacePath),
             };
             logger.LogInformation("[GameLauncher] Starting game process...");
             OperationResult<GameProcessInfo> processResult;
@@ -1223,4 +1223,58 @@ public class GameLauncher(
 
         return OperationResult<bool>.CreateSuccess(true);
     }
+
+    /// <summary>
+    /// Builds the child process environment, adding the dynamic-loader search path a
+    /// native Unix game client needs.
+    /// </summary>
+    /// <remarks>
+    /// A native client ships its dynamic libraries beside the executable in the workspace.
+    /// The reference launch wrapper for the BGFX port does exactly this before exec:
+    /// <c>export DYLD_LIBRARY_PATH="${script_dir}:${DYLD_LIBRARY_PATH:-}"</c>.
+    /// <para>
+    /// Bundled libraries are normally reachable through <c>@executable_path</c> or
+    /// <c>$ORIGIN</c> rpath entries, so this is a fallback rather than the primary
+    /// mechanism — but when an rpath is missing the loader fails with "library not
+    /// loaded", the process dies before it draws a window, and the user sees nothing at
+    /// all. Setting the variable costs nothing and removes that failure mode.
+    /// </para>
+    /// <para>
+    /// Windows resolves DLLs from the executable's own directory already, so nothing is
+    /// added there.
+    /// </para>
+    /// </remarks>
+    /// <param name="profileEnvironment">Environment variables configured on the profile.</param>
+    /// <param name="workspacePath">The workspace root, which is also the working directory.</param>
+    /// <returns>The environment to pass to the child process.</returns>
+    private static Dictionary<string, string> BuildEnvironmentVariables(
+        Dictionary<string, string>? profileEnvironment,
+        string workspacePath)
+    {
+        var environment = profileEnvironment is null
+            ? []
+            : new Dictionary<string, string>(profileEnvironment);
+
+        if (OperatingSystem.IsWindows())
+        {
+            return environment;
+        }
+
+        var variableName = OperatingSystem.IsMacOS() ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH";
+
+        // A profile that sets the variable explicitly wins; prepending the workspace
+        // silently would override a deliberate choice.
+        if (environment.ContainsKey(variableName))
+        {
+            return environment;
+        }
+
+        var inherited = Environment.GetEnvironmentVariable(variableName);
+        environment[variableName] = string.IsNullOrEmpty(inherited)
+            ? workspacePath
+            : $"{workspacePath}{Path.PathSeparator}{inherited}";
+
+        return environment;
+    }
+
 }

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -609,7 +609,7 @@ public class GameLauncher(
             try
             {
                 hasArchive = Directory
-                    .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, SearchOption.TopDirectoryOnly)
+                    .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, RetailArchiveConstants.ArchiveSearch)
                     .Any();
             }
             catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -51,16 +51,6 @@ public class GameLauncher(
     ISteamLauncher steamLauncher,
     IConfigurationProviderService configurationProvider) : IGameLauncher
 {
-    /// <summary>
-    /// Environment variables naming the retail directories the engine mounts archives from.
-    /// Ordered Zero Hour first, matching <see cref="AddRetailArchiveRoots"/>.
-    /// </summary>
-    private static readonly string[] RetailArchiveRootVariables =
-    [
-        "CNC_ZH_INSTALLPATH",
-        "CNC_GENERALS_INSTALLPATH",
-    ];
-
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _profileLaunchLocks = new();
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _steamInstallationLaunchLocks =
         new(InstallationPathLockKey.Comparer);
@@ -542,14 +532,24 @@ public class GameLauncher(
         Dictionary<string, string> environment,
         GameInstallation? installation)
     {
+        // Windows resolves install paths from the registry and never reads these variables,
+        // so a Windows layout without loose top-level archives is not a misconfiguration and
+        // must not fail the launch. BuildEnvironmentVariables returns before setting them on
+        // Windows; this validates the installation's declared paths, so it needs the same
+        // guard rather than inheriting it.
+        if (OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
         // Validated against the installation's declared paths, not only the variables that
         // survived into the environment. AddArchiveRoot drops a path that does not exist,
         // so validating the environment alone would silently skip the exact case this
         // exists to catch: a stale installation root reaching spawn unnoticed.
         var declaredPaths = new (string Variable, string? Path)[]
         {
-            (RetailArchiveRootVariables[0], installation?.ZeroHourPath),
-            (RetailArchiveRootVariables[1], installation?.GeneralsPath),
+            (RetailArchiveConstants.ZeroHourInstallPathVariable, installation?.ZeroHourPath),
+            (RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath),
         };
 
         foreach (var (variableName, declaredPath) in declaredPaths)
@@ -575,7 +575,7 @@ public class GameLauncher(
             try
             {
                 hasArchive = Directory
-                    .EnumerateFiles(root, "*.big", SearchOption.TopDirectoryOnly)
+                    .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, SearchOption.TopDirectoryOnly)
                     .Any();
             }
             catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
@@ -626,8 +626,8 @@ public class GameLauncher(
             return;
         }
 
-        AddArchiveRoot(environment, RetailArchiveRootVariables[0], installation.ZeroHourPath);
-        AddArchiveRoot(environment, RetailArchiveRootVariables[1], installation.GeneralsPath);
+        AddArchiveRoot(environment, RetailArchiveConstants.ZeroHourInstallPathVariable, installation.ZeroHourPath);
+        AddArchiveRoot(environment, RetailArchiveConstants.GeneralsInstallPathVariable, installation.GeneralsPath);
     }
 
     /// <summary>
@@ -641,16 +641,31 @@ public class GameLauncher(
         string variableName,
         string? path)
     {
-        // A profile that sets this explicitly wins.
-        if (string.IsNullOrWhiteSpace(path) || environment.ContainsKey(variableName) || !Directory.Exists(path))
+        // A profile that sets this explicitly chooses the directory, but not whether the
+        // trailing separator is applied: the engine concatenates the value with the archive
+        // filename directly, so one without a separator produces paths like
+        // "/path/toINIZH.big" and silently mounts nothing.
+        if (environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured))
+        {
+            environment[variableName] = EnsureTrailingSeparator(configured);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
         {
             return;
         }
 
-        environment[variableName] = path.EndsWith(Path.DirectorySeparatorChar)
-            ? path
-            : path + Path.DirectorySeparatorChar;
+        environment[variableName] = EnsureTrailingSeparator(path);
     }
+
+    /// <summary>
+    /// Appends the directory separator the engine requires, if it is not already present.
+    /// </summary>
+    /// <param name="path">The retail root.</param>
+    /// <returns>The path, guaranteed to end in a directory separator.</returns>
+    private static string EnsureTrailingSeparator(string path) =>
+        path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
 
     private async Task<LaunchOperationResult<GameLaunchInfo>> LaunchProfileAsync(GameProfile profile, bool skipUserDataCleanup, IProgress<LaunchProgress>? progress, string launchId, CancellationToken cancellationToken)
     {

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -548,46 +548,62 @@ public class GameLauncher(
         // survived into the environment. AddArchiveRoot drops a path that does not exist,
         // so validating the environment alone would silently skip the exact case this
         // exists to catch: a stale installation root reaching spawn unnoticed.
-        // Only the launching game's root. The other game's path may be stale or absent on
-        // the same installation, and that has no bearing on whether this launch will find
-        // its content — failing on a sibling would block a launch that would have worked.
-        var (variableName, declaredPath) = gameType == GameType.Generals
-            ? (RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath)
-            : (RetailArchiveConstants.ZeroHourInstallPathVariable, installation?.ZeroHourPath);
-
-        // A profile override is the root actually used, so it is what gets checked.
-        var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
-            ? configured
-            : declaredPath;
-
-        // Nothing configured for this game means it is simply not installed.
-        if (string.IsNullOrWhiteSpace(root))
+        // Which roots matter depends on the game. Generals reads only its own. Zero Hour is
+        // an expansion and mounts the base Generals archives as well, so a stale Generals
+        // root would leave it running without base content — the same silent failure, one
+        // directory over. Launching Generals must not fail over a stale Zero Hour root
+        // though: that one has no bearing on it.
+        var roots = new List<(string Variable, string? Path, bool Required)>
         {
-            return null;
+            gameType == GameType.Generals
+                ? (RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath, true)
+                : (RetailArchiveConstants.ZeroHourInstallPathVariable, installation?.ZeroHourPath, true),
+        };
+
+        if (gameType == GameType.ZeroHour)
+        {
+            // Checked only when declared. A Zero Hour installation that carries the base
+            // archives itself needs no separate Generals root, so an absent one is not an
+            // error — but a declared one that is broken is.
+            roots.Add((RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath, false));
         }
 
-        if (!Directory.Exists(root))
+        foreach (var (variableName, declaredPath, _) in roots)
         {
-            return $"The retail archive root for {variableName} does not exist: {root}. " +
-                   "The game would start with no content and no error, so the launch was stopped.";
-        }
+            // A profile override is the root actually used, so it is what gets checked.
+            var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
+                ? configured
+                : declaredPath;
 
-        bool hasArchive;
-        try
-        {
-            hasArchive = Directory
-                .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, SearchOption.TopDirectoryOnly)
-                .Any();
-        }
-        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-        {
-            return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
-        }
+            // Nothing configured means that game is simply not installed separately.
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                continue;
+            }
 
-        if (!hasArchive)
-        {
-            return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
-                   "The game would start with no content and no error, so the launch was stopped.";
+            if (!Directory.Exists(root))
+            {
+                return $"The retail archive root for {variableName} does not exist: {root}. " +
+                       "The game would start with no content and no error, so the launch was stopped.";
+            }
+
+            bool hasArchive;
+            try
+            {
+                hasArchive = Directory
+                    .EnumerateFiles(root, RetailArchiveConstants.ArchiveSearchPattern, SearchOption.TopDirectoryOnly)
+                    .Any();
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                return $"The retail archive root for {variableName} could not be read: {root} ({ex.Message}).";
+            }
+
+            if (!hasArchive)
+            {
+                return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
+                       "The game would start with no content and no error, so the launch was stopped.";
+            }
         }
 
         return null;

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -561,11 +561,11 @@ public class GameLauncher(
         // root would leave it running without base content — the same silent failure, one
         // directory over. Launching Generals must not fail over a stale Zero Hour root
         // though: that one has no bearing on it.
-        var roots = new List<(string Variable, string? Path, bool Required)>
+        var roots = new List<(string Variable, string? Path)>
         {
             gameType == GameType.Generals
-                ? (RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath, true)
-                : (RetailArchiveConstants.ZeroHourInstallPathVariable, installation?.ZeroHourPath, true),
+                ? (RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath)
+                : (RetailArchiveConstants.ZeroHourInstallPathVariable, installation?.ZeroHourPath),
         };
 
         if (gameType == GameType.ZeroHour)
@@ -583,10 +583,10 @@ public class GameLauncher(
             // needs the engine to report a failed mount; see the engine-side work tracked
             // for GeneralsGameCode. A workspace "*.big" check was considered and rejected:
             // a Zero Hour workspace always contains archives, so it would always pass.
-            roots.Add((RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath, false));
+            roots.Add((RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath));
         }
 
-        foreach (var (variableName, declaredPath, _) in roots)
+        foreach (var (variableName, declaredPath) in roots)
         {
             // A profile override is the root actually used, so it is what gets checked.
             var root = environment.TryGetValue(variableName, out var configured) && !string.IsNullOrWhiteSpace(configured)
@@ -602,7 +602,7 @@ public class GameLauncher(
             if (!Directory.Exists(root))
             {
                 return $"The retail archive root for {variableName} does not exist: {root}. " +
-                       "The game would start with no content and no error, so the launch was stopped.";
+                       "The engine would abort during initialisation with a generic crash naming nothing, so the launch was stopped.";
             }
 
             bool hasArchive;
@@ -620,7 +620,7 @@ public class GameLauncher(
             if (!hasArchive)
             {
                 return $"The retail archive root for {variableName} contains no .big archives: {root}. " +
-                       "The game would start with no content and no error, so the launch was stopped.";
+                       "The engine would abort during initialisation with a generic crash naming nothing, so the launch was stopped.";
             }
         }
 
@@ -645,8 +645,10 @@ public class GameLauncher(
     /// <para>
     /// The trailing separator is required, not cosmetic. The engine concatenates this
     /// value with the archive filename directly, so a root without one produces paths like
-    /// <c>/path/to/GeneralsZHINIZH.big</c>. Every archive then fails to open, and the game
-    /// still starts — with no content and no error the user can act on.
+    /// <c>/path/to/GeneralsZHINIZH.big</c>. Every archive from that root then fails to
+    /// open. A workspace carrying its own archives starts without the retail content; one
+    /// that does not aborts during initialisation with a generic crash. Neither failure
+    /// names the root.
     /// </para>
     /// </remarks>
     /// <param name="environment">The environment being built.</param>

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -562,9 +562,19 @@ public class GameLauncher(
 
         if (gameType == GameType.ZeroHour)
         {
-            // Checked only when declared. A Zero Hour installation that carries the base
-            // archives itself needs no separate Generals root, so an absent one is not an
-            // error — but a declared one that is broken is.
+            // Checked only when declared, because an absent Generals root is not by itself
+            // wrong: the engine mounts archives from the working directory as well, so base
+            // content may legitimately sit in the workspace instead of a retail root. That
+            // is the arrangement this whole mechanism replaces, but it remains valid.
+            //
+            // KNOWN GAP: when no Generals root is declared and the workspace does not carry
+            // base content either, Zero Hour still starts with nothing to mount and this
+            // check cannot tell. Archive filenames are arbitrary — a real install holds mod,
+            // hotkey and control-bar archives alongside the retail ones — so presence of
+            // "*.big" anywhere proves nothing about base content specifically. Detecting it
+            // needs the engine to report a failed mount; see the engine-side work tracked
+            // for GeneralsGameCode. A workspace "*.big" check was considered and rejected:
+            // a Zero Hour workspace always contains archives, so it would always pass.
             roots.Add((RetailArchiveConstants.GeneralsInstallPathVariable, installation?.GeneralsPath, false));
         }
 

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -956,7 +956,7 @@ public class GameLauncher(
                 ExecutablePath = finalExecutablePath,
                 WorkingDirectory = workspaceInfo.WorkspacePath,
                 Arguments = arguments,
-                EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, workspaceInfo.WorkspacePath, installation),
+                EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, installation),
             };
             logger.LogInformation("[GameLauncher] Starting game process...");
             OperationResult<GameProcessInfo> processResult;
@@ -1226,36 +1226,31 @@ public class GameLauncher(
     }
 
     /// <summary>
-    /// Builds the child process environment, adding the dynamic-loader search path a
-    /// native Unix game client needs.
+    /// Builds the child process environment for a game client.
     /// </summary>
     /// <remarks>
-    /// A native client ships its dynamic libraries beside the executable in the workspace.
-    /// The reference launch wrapper for the BGFX port does the same before exec:
-    /// <c>export DYLD_LIBRARY_PATH="${script_dir}:${DYLD_LIBRARY_PATH:-}"</c>.
+    /// No dynamic-loader search path is set. GenHub previously prepended the workspace to
+    /// <c>DYLD_LIBRARY_PATH</c> / <c>LD_LIBRARY_PATH</c> as a fallback for a build with an
+    /// incomplete rpath. That was measured to be unnecessary — the BGFX build declares
+    /// every dependency as <c>@executable_path/…</c> with an <c>@executable_path/</c>
+    /// rpath and launches correctly with the variable cleared — and it carried two costs
+    /// that outweighed a fallback for a build we do not ship:
     /// <para>
-    /// This is a fallback, not a requirement, and that has been verified rather than
-    /// assumed: the current BGFX build declares every dependency as
-    /// <c>@executable_path/…</c> with an <c>@executable_path/</c> rpath, and launches
-    /// correctly with the variable cleared. It matters only for a build whose rpath is
-    /// incomplete, where the loader would otherwise fail with "library not loaded", the
-    /// process would die before drawing a window, and the user would see nothing at all.
+    /// dyld consults <c>DYLD_LIBRARY_PATH</c> before <c>@executable_path</c> for
+    /// leaf-name references, so any same-named library elsewhere on that path silently
+    /// takes precedence over the one shipped beside the executable.
     /// </para>
     /// <para>
-    /// It is safe alongside <c>@executable_path</c>: those references are resolved
-    /// directly against the executable's directory and do not consult this variable.
-    /// </para>
-    /// <para>
-    /// Windows resolves DLLs from the executable's own directory already, so nothing is
-    /// added there.
+    /// The hardened runtime ignores <c>DYLD_LIBRARY_PATH</c> outright, so the variable
+    /// would stop having any effect the moment GenHub is signed and notarized. Keeping it
+    /// meant launch behaviour would change silently at signing time rather than now.
     /// </para>
     /// </remarks>
     /// <param name="profileEnvironment">Environment variables configured on the profile.</param>
-    /// <param name="workspacePath">The workspace root, which is also the working directory.</param>
+    /// <param name="installation">The retail installation supplying archive roots.</param>
     /// <returns>The environment to pass to the child process.</returns>
     private static Dictionary<string, string> BuildEnvironmentVariables(
         Dictionary<string, string>? profileEnvironment,
-        string workspacePath,
         GameInstallation? installation)
     {
         var environment = profileEnvironment is null
@@ -1268,20 +1263,6 @@ public class GameLauncher(
         }
 
         AddRetailArchiveRoots(environment, installation);
-
-        var variableName = OperatingSystem.IsMacOS() ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH";
-
-        // A profile that sets the variable explicitly wins; prepending the workspace
-        // silently would override a deliberate choice.
-        if (environment.ContainsKey(variableName))
-        {
-            return environment;
-        }
-
-        var inherited = Environment.GetEnvironmentVariable(variableName);
-        environment[variableName] = string.IsNullOrEmpty(inherited)
-            ? workspacePath
-            : $"{workspacePath}{Path.PathSeparator}{inherited}";
 
         return environment;
     }

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -514,15 +514,23 @@ public class GameLauncher(
     /// Verifies that every configured retail archive root actually contains archives.
     /// </summary>
     /// <remarks>
-    /// The engine mounts its content from these roots, but reaches its main loop with zero
-    /// content and no error when they are wrong — no exit code, no log line, nothing a
-    /// host process can observe. A launch that "succeeded" is therefore indistinguishable
-    /// from one that produced an empty game, so this has to be checked before spawn.
+    /// Checked before spawn so a misconfigured root fails with the path named, rather than
+    /// as a generic engine abort the host has to interpret.
     /// <para>
-    /// Existence of at least one <c>.big</c> archive is used as the sentinel rather than a
-    /// specific filename, which varies by localisation and version. This only catches a
-    /// root that is wrong or empty; an archive that exists but fails to mount still needs
-    /// a machine-readable failure from the engine itself.
+    /// The engine does report these failures: a root holding no archives aborts during
+    /// initialisation with exit code 1 and a <c>ReleaseCrashInfo.txt</c>, and an archive
+    /// that fails to mount also writes <c>[ggc] ARCHIVE MOUNT FAILED</c> to stderr. Neither
+    /// reaches the main loop. Validating first is still worth it — exit 1 is generic, the
+    /// stderr sentinel exists only in the non-Windows filesystem, and on Windows
+    /// <c>ReleaseCrash</c> shows a system-modal dialog before exiting, so a host-launched
+    /// child hangs rather than dying. An earlier check with an actionable message avoids
+    /// depending on any of that.
+    /// </para>
+    /// <para>
+    /// Existence of at least one <c>.big</c> archive is the sentinel rather than a specific
+    /// filename, which varies by localisation, version and installed mods. That bounds what
+    /// this can catch: a root that is absent, unreadable or archive-free. It cannot tell
+    /// whether the archives present are the ones the engine needs.
     /// </para>
     /// </remarks>
     /// <param name="environment">The environment built for the child process.</param>
@@ -1184,10 +1192,10 @@ public class GameLauncher(
                 EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, installation),
             };
 
-            // Must happen before spawn. When the archive roots are wrong the engine still
-            // starts, reaches its main loop and reports nothing — it simply has no content.
-            // Launch therefore "succeeds" while the user gets a broken game, and no
-            // post-spawn check can tell the difference.
+            // Before spawn, so a misconfigured root is reported with the path named. The
+            // engine does abort on a bad root, but generically (exit 1 plus a crash file),
+            // and on Windows it blocks on a modal dialog first — so relying on the child's
+            // exit is both less precise and, there, unreliable.
             var archiveRootError = ValidateRetailArchiveRoots(
                 launchConfig.EnvironmentVariables, installation, gameClient.GameType);
             if (archiveRootError is not null)

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -607,24 +607,6 @@ public abstract class WorkspaceStrategyBase<T>(
     }
 
     /// <summary>
-    /// Strips a leading directory name from a path if present.
-    /// Handles both forward and back slashes.
-    /// </summary>
-    private static string StripLeadingDirectory(string path, string directoryName)
-    {
-        // Handle both forward and back slashes
-        var normalized = path.Replace('\\', '/');
-        var prefix = directoryName + "/";
-
-        if (normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-        {
-            return normalized[prefix.Length..];
-        }
-
-        return path;
-    }
-
-    /// <summary>
     /// Gives a materialised file the Unix execute bit, on a copy that the workspace owns.
     /// <para>
     /// The copy is the point. Under the hard-link strategy the workspace file <em>is</em>
@@ -711,5 +693,23 @@ public abstract class WorkspaceStrategyBase<T>(
                 file.RelativePath);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Strips a leading directory name from a path if present.
+    /// Handles both forward and back slashes.
+    /// </summary>
+    private static string StripLeadingDirectory(string path, string directoryName)
+    {
+        // Handle both forward and back slashes
+        var normalized = path.Replace('\\', '/');
+        var prefix = directoryName + "/";
+
+        if (normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return normalized[prefix.Length..];
+        }
+
+        return path;
     }
 }

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -607,6 +607,24 @@ public abstract class WorkspaceStrategyBase<T>(
     }
 
     /// <summary>
+    /// Strips a leading directory name from a path if present.
+    /// Handles both forward and back slashes.
+    /// </summary>
+    private static string StripLeadingDirectory(string path, string directoryName)
+    {
+        // Handle both forward and back slashes
+        var normalized = path.Replace('\\', '/');
+        var prefix = directoryName + "/";
+
+        if (normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return normalized[prefix.Length..];
+        }
+
+        return path;
+    }
+
+    /// <summary>
     /// Gives a materialised file the Unix execute bit, on a copy that the workspace owns.
     /// <para>
     /// The copy is the point. Under the hard-link strategy the workspace file <em>is</em>
@@ -695,21 +713,4 @@ public abstract class WorkspaceStrategyBase<T>(
         }
     }
 
-    /// <summary>
-    /// Strips a leading directory name from a path if present.
-    /// Handles both forward and back slashes.
-    /// </summary>
-    private static string StripLeadingDirectory(string path, string directoryName)
-    {
-        // Handle both forward and back slashes
-        var normalized = path.Replace('\\', '/');
-        var prefix = directoryName + "/";
-
-        if (normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-        {
-            return normalized[prefix.Length..];
-        }
-
-        return path;
-    }
 }

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -712,5 +712,4 @@ public abstract class WorkspaceStrategyBase<T>(
             throw;
         }
     }
-
 }

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -595,7 +595,7 @@ Constants related to game client detection and management.
 | Constant                         | Value              | Description                                |
 | -------------------------------- | ------------------ | ------------------------------------------ |
 | `SuperHackersGeneralsExecutable` | `"generalsV.exe"`  | SuperHackers Generals executable filename  |
-| `SuperHackersZeroHourExecutable` | `"generalsZH.exe"` | SuperHackers Zero Hour executable filename |
+| `SuperHackersZeroHourExecutable` | `"generalszh.exe"` | SuperHackers Zero Hour executable filename |
 
 ### Game Directory Names
 


### PR DESCRIPTION
## Summary

Launches the community's native BGFX Zero Hour client against the user's retail data — no Wine. Final PR of the mac stack, after #328 (platform-neutral paths, manifests and Unix workspaces), #329 (macOS host) and #331 (the macOS service registrations the merged state required).

## Changes

- **Surface native launch failures and set the loader search path.** A launch that dies before drawing a window previously reported success.
- **Reach retail archives via the install-path environment instead of copying them.** The engine reads `CNC_ZH_INSTALLPATH` / `CNC_GENERALS_INSTALLPATH` on non-Windows and mounts `*.big` from those roots. Zero Hour needs its own and the base Generals archives — roughly 3 GB — so without this every profile workspace had to materialise all of them.
- **Validate retail archive roots before spawning.** Checked before spawn so a misconfigured root fails with the path named, rather than as a generic engine abort the host has to interpret.

  *Corrected from this PR's original description, which claimed the engine reaches its main loop with zero content and no error and that nothing was observable. Verified against `bobtista/GeneralsGameCode` at `bobtista/topic/trunk`, that is false: a root holding no archives aborts during initialisation with exit 1 and a `ReleaseCrashInfo.txt`, and an unmountable archive also writes `[ggc] ARCHIVE MOUNT FAILED` to stderr. Neither reaches the main loop.*

  Validating first still earns its place for reasons that hold: exit 1 is generic; the stderr sentinel exists only in `StdBIGFileSystem`, not `Win32BIGFileSystem`; `ReleaseCrash` shows a system-modal dialog before `_exit(1)`, so a host-launched child on Windows hangs rather than dying; and GenHub's own immediate-exit detection is a 500 ms window. An earlier check with an actionable message avoids depending on any of that. Validation runs against the installation's *declared* paths, not the filtered environment — the environment builder drops a path that does not exist, so validating it alone would skip the stale-installation case this exists to catch.
- **Stop setting `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH`.** Measured unnecessary: the BGFX build declares every dependency as `@executable_path/…` with a matching rpath and launches with the variable cleared. Two costs outweighed a fallback for a build we do not ship — dyld consults it *before* `@executable_path` for leaf-name references, so a same-named library elsewhere silently wins; and the hardened runtime ignores it, so behaviour would change silently once GenHub is signed and notarized (#322).
- **Capture complete stderr when a launch fails.** The buffer was read as soon as the process exited, but the asynchronous handlers had not necessarily delivered their final lines — truncating diagnostics precisely where they explain the failure. Now drains via the parameterless `WaitForExit()`, which also waits for redirected-output handlers. The buffer treats a null line as end-of-stream rather than content, retains the head as well as the tail so startup context survives alongside the symptom, and bounds line length and total size.

## Testing

- `GenHub.Tests.Core`: **1427 passed**, 0 failed.
- `GenHub.Tests.MacOS` composition root: 3 passed.
- Builds with **0 warnings**.

### The launch tests pass locally and skip in CI — please read this before trusting a green tick

Six tests exercise the real client: three launch it and assert it is still alive after 14 seconds, three assert a misconfigured launch does *not* survive. All six pass on a machine with a native install (`GENHUB_NATIVE_CLIENT_DIR`, 6/6 in 54s).

**They skip in CI**, which has no native fixture and no retail data. A green CI run on this PR therefore says nothing about whether launching works — it only covers the unit and composition tests. The engine-only CI smoke test that would close this gap is #324, and it is deliberately out of scope here.

## Fork dependency worth stating

The install-path mechanism this PR validates is **fork-only**. `CNC_ZH_INSTALLPATH` and
`CNC_GENERALS_INSTALLPATH` are read by `bobtista/GeneralsGameCode` on `bobtista/topic/trunk`
and do not exist in `TheSuperHackers/GeneralsGameCode@main` — upstream resolves install paths
from the Windows registry only.

That is fine, since GenHub launches our client, but it bounds what the validation means:
against an upstream build these variables are ignored and the roots have no effect. The
constants and their rationale live in `RetailArchiveConstants` so this is discoverable rather
than implicit.

The engine behaviour the validation *complements* is upstream, though — the `INI`
`filesRead == 0` throw, the unnamed enum that routes it to `catch (...)`, and `ReleaseCrash`
showing a system-modal dialog before `_exit(1)` are all in upstream `main`. So the reasons
for checking before spawn rather than relying on the child's exit hold for any build.

## Risks and rollback

Revert-safe; no persisted-data conversion. The archive-root validation stops launches before spawn that would previously have failed only after spawn, with a generic engine crash naming nothing — intended, and the validation message names the offending root.

## Related

Part of Alpha 5 (#327).

Closes #315.
Closes #317.
Closes #318.

*(One keyword per line: GitHub links only the first reference in `Closes #315, #317, #318`, which would have left #317 and #318 open after merge.)*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables native BGFX clients to launch against retail archive roots and improves startup diagnostics.
- Centralizes the retail archive environment-variable contract and normalizes configured roots.
- Validates applicable archive roots before spawning native clients, with Windows excluded from the non-Windows contract.
- Captures bounded stderr output and reports immediate process failures.
- Adds unit and opt-in native integration coverage for archive roots, manifests, permissions, and diagnostics.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because native Zero Hour can still be spawned without any validated source of its required base Generals archives.

The current validation skips an absent GeneralsPath, while supported engine-only workspaces contain no archives and rely entirely on environment-provided retail roots; that leaves the previously reported missing-base-content startup failure reachable.

**Files Needing Attention:** GenHub/GenHub/Features/Launching/GameLauncher.cs; GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Launching/GameLauncher.cs | Builds and validates native retail archive environments; the previous missing-Generals-root failure remains reachable. |
| GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs | Adds Unix execute-permission checks, bounded asynchronous stderr capture, and clearer immediate-exit handling. |
| GenHub/GenHub.Core/Constants/RetailArchiveConstants.cs | Centralizes archive environment names and case-insensitive top-level archive enumeration settings. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/RetailArchiveRootValidationTests.cs | Covers archive-root validation behavior but codifies acceptance of a Zero Hour launch with no Generals root. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs | Adds opt-in native coverage proving engine-only workspaces rely on both retail archive environment roots. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Launcher as GameLauncher
    participant Install as GameInstallation
    participant Process as GameProcessManager
    participant Engine as Native BGFX Client
    Launcher->>Install: Read Zero Hour / Generals roots
    Launcher->>Launcher: Build normalized environment
    Launcher->>Launcher: Validate declared archive roots
    alt Validation fails
        Launcher-->>Launcher: Return actionable launch error
    else Validation passes
        Launcher->>Process: StartProcessAsync(configuration)
        Process->>Engine: Spawn with redirected stderr
        alt Immediate exit
            Process->>Process: Drain and bound stderr
            Process-->>Launcher: Return failure diagnostics
        else Process survives startup window
            Process-->>Launcher: Return tracked process
        end
    end
```
</details>

<sub>Reviews (10): Last reviewed commit: ["chore(launching): reference launch const..."](https://github.com/community-outpost/genhub/commit/d1adeeb570f233e4a2bec48b9512adf6766e2cd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48562981)</sub>

**Context used:**

- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)

<!-- /greptile_comment -->