### PR TITLE
fix(workspace): materialize executables atomically and repair stale modes

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/Workspace/IWorkspaceValidator.cs
+++ b/GenHub/GenHub.Core/Interfaces/Workspace/IWorkspaceValidator.cs
@@ -32,4 +32,17 @@ public interface IWorkspaceValidator
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The validation result.</returns>
     Task<OperationResult<ValidationResult>> ValidateWorkspaceAsync(WorkspaceInfo workspaceInfo, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ensures the workspace entry point is executable by the current process, restoring
+    /// the Unix execute mode on a workspace-owned copy when the file exists without it.
+    /// A missing entry point is reported as a failure, never created.
+    /// </summary>
+    /// <param name="workspaceInfo">The workspace whose entry point is checked.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>
+    /// A successful result whose data indicates whether a repair was performed, or a
+    /// failed result when the entry point is missing or could not be made executable.
+    /// </returns>
+    Task<OperationResult<bool>> EnsureEntryPointExecutableAsync(WorkspaceInfo workspaceInfo, CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Core/Interfaces/Workspace/IWorkspaceValidator.cs
+++ b/GenHub/GenHub.Core/Interfaces/Workspace/IWorkspaceValidator.cs
@@ -36,7 +36,8 @@ public interface IWorkspaceValidator
     /// <summary>
     /// Ensures the workspace entry point is executable by the current process, restoring
     /// the Unix execute mode on a workspace-owned copy when the file exists without it.
-    /// A missing entry point is reported as a failure, never created.
+    /// A missing entry point is reported as a failure, never created, and an entry point
+    /// resolving outside the workspace root is refused without being touched.
     /// </summary>
     /// <param name="workspaceInfo">The workspace whose entry point is checked.</param>
     /// <param name="cancellationToken">A cancellation token.</param>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
@@ -108,7 +108,6 @@ public class ExecutablePermissionIsolationTests : IDisposable
 
         await _service.CreateHardLinkAsync(workspaceFile, casBlob);
 
-        var temporaryPath = workspaceFile + ".genhub-exec-tmp";
         await _strategy.TestEnsureExecutableAsync(
             new ManifestFile { RelativePath = "workspace-file", IsExecutable = true },
             workspaceFile);
@@ -118,9 +117,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
             File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
             "The stored blob was modified, so every other profile using this hash is affected.");
 
-        Assert.False(
-            File.Exists(temporaryPath),
-            "The temporary copy must not survive; workspace validation would report it.");
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.genhub-exec-tmp-*"));
 
         // Content must survive the round trip; a broken link is only acceptable if the
         // bytes are identical.
@@ -145,7 +142,6 @@ public class ExecutablePermissionIsolationTests : IDisposable
         await File.WriteAllTextAsync(workspaceFile, "engine binary");
         File.SetUnixFileMode(workspaceFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
 
-        var temporaryPath = workspaceFile + ".genhub-exec-tmp";
         await _strategy.TestEnsureExecutableAsync(
             new ManifestFile { RelativePath = "atomic-entry-point", IsExecutable = true },
             workspaceFile);
@@ -154,7 +150,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
         Assert.True(
             File.GetUnixFileMode(workspaceFile).HasFlag(UnixFileMode.UserExecute),
             "The replacement was already executable before it became the destination.");
-        Assert.False(File.Exists(temporaryPath));
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.genhub-exec-tmp-*"));
         Assert.Equal("engine binary", await File.ReadAllTextAsync(workspaceFile));
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Workspace;
 using GenHub.Features.Workspace;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -127,9 +128,9 @@ public class ExecutablePermissionIsolationTests : IDisposable
     }
 
     /// <summary>
-    /// The destination must never be observable as missing or non-executable. Verification
-    /// never mutates, so a workspace left with a non-executable entry point stays broken
-    /// for every later launch — the failure this sequence exists to prevent.
+    /// The destination must never be observable as missing or non-executable. Validation
+    /// can restore a lost execute bit on the entry point, but on no other executable the
+    /// manifest names, so materialisation must not expose either state in the first place.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
@@ -155,6 +156,44 @@ public class ExecutablePermissionIsolationTests : IDisposable
             "The replacement was already executable before it became the destination.");
         Assert.False(File.Exists(temporaryPath));
         Assert.Equal("engine binary", await File.ReadAllTextAsync(workspaceFile));
+    }
+
+    /// <summary>
+    /// Workspaces bricked before materialisation became atomic can hold an entry point
+    /// that is still hard-linked into the content store with its execute bit lost. The
+    /// validator's repair must restore the bit the same way materialisation grants it:
+    /// on a private copy, so the stored blob keeps the mode it was ingested with.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task RepairingABrickedEntryPoint_LeavesTheStoredBlobUntouched()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var casBlob = Path.Combine(_tempDir, "cas-blob");
+        var entryPoint = Path.Combine(_tempDir, "entry-point");
+        await File.WriteAllTextAsync(casBlob, "engine binary");
+        File.SetUnixFileMode(casBlob, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        await _service.CreateHardLinkAsync(entryPoint, casBlob);
+
+        var validator = new WorkspaceValidator(NullLogger<WorkspaceValidator>.Instance);
+        var result = await validator.EnsureEntryPointExecutableAsync(new WorkspaceInfo
+        {
+            Id = "bricked-workspace",
+            WorkspacePath = _tempDir,
+            ExecutablePath = entryPoint,
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(entryPoint).HasFlag(UnixFileMode.UserExecute));
+        Assert.False(
+            File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
+            "The stored blob was modified, so every other profile using this hash is affected.");
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(entryPoint));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
@@ -15,6 +15,7 @@ using GenHub.Core.Models.Workspace;
 using GenHub.Features.Storage.Services;
 using GenHub.Features.Workspace;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -181,6 +182,9 @@ public class WorkspaceManagerReuseTests : IDisposable
         _mockWorkspaceValidator.Setup(x => x.ValidateWorkspaceAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult<ValidationResult>.CreateSuccess(successValidation));
 
+        _mockWorkspaceValidator.Setup(x => x.EnsureEntryPointExecutableAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+
         // Act
         var result = await _manager.PrepareWorkspaceAsync(config);
 
@@ -188,6 +192,127 @@ public class WorkspaceManagerReuseTests : IDisposable
         result.Success.Should().BeTrue();
 
         // Should NOT call strategy.PrepareAsync because it reuses existing
+        _mockStrategy.Verify(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that a reusable workspace whose entry point cannot be made executable is recreated.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenEntryPointCannotBeRepaired_ShouldRecreateWorkspace()
+    {
+        // Arrange
+        var workspaceId = "test-workspace";
+        var manifestId = "1.0.local.mod.testmanifest";
+        var workspacePath = Path.Combine(_tempPath, "workspace");
+        Directory.CreateDirectory(workspacePath);
+        File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
+
+        var cachedWorkspace = new WorkspaceInfo
+        {
+            Id = workspaceId,
+            WorkspacePath = workspacePath,
+            ManifestIds = [manifestId],
+            ManifestVersions = new Dictionary<string, string> { { manifestId, "1.0" } },
+            Strategy = WorkspaceStrategy.HardLink,
+            IsPrepared = true,
+            FileCount = 1,
+            IsValid = true,
+        };
+        await File.WriteAllTextAsync(_metadataPath, System.Text.Json.JsonSerializer.Serialize(new[] { cachedWorkspace }));
+
+        var config = new WorkspaceConfiguration
+        {
+            Id = workspaceId,
+            Strategy = WorkspaceStrategy.HardLink,
+            Manifests = [new ContentManifest { Id = ManifestId.Create(manifestId), Version = "1.0", Files = [new ManifestFile { RelativePath = "test.txt" }] }],
+            BaseInstallationPath = _tempPath,
+            WorkspaceRootPath = _tempPath,
+            ValidateAfterPreparation = false,
+        };
+
+        _mockWorkspaceValidator.Setup(x => x.ValidateConfigurationAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(workspaceId, []));
+        _mockWorkspaceValidator.Setup(x => x.ValidatePrerequisitesAsync(It.IsAny<IWorkspaceStrategy>(), It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(workspaceId, []));
+        _mockWorkspaceValidator.Setup(x => x.EnsureEntryPointExecutableAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("Workspace entry point not found"));
+
+        _mockStrategy.Setup(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WorkspaceInfo { Id = workspaceId, IsPrepared = true, WorkspacePath = workspacePath });
+
+        // Act
+        var result = await _manager.PrepareWorkspaceAsync(config);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _mockStrategy.Verify(x => x.PrepareAsync(It.Is<WorkspaceConfiguration>(c => c.ForceRecreate == true), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a reused workspace whose entry point lost its execute bit is repaired
+    /// in place so launch preparation proceeds without recreating the workspace.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenEntryPointBricked_RepairsAndReusesWorkspace()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // Arrange
+        var workspaceId = "test-workspace";
+        var manifestId = "1.0.local.mod.testmanifest";
+        var workspacePath = Path.Combine(_tempPath, "workspace");
+        Directory.CreateDirectory(workspacePath);
+        var executablePath = Path.Combine(workspacePath, "generals");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var cachedWorkspace = new WorkspaceInfo
+        {
+            Id = workspaceId,
+            WorkspacePath = workspacePath,
+            ExecutablePath = executablePath,
+            ManifestIds = [manifestId],
+            ManifestVersions = new Dictionary<string, string> { { manifestId, "1.0" } },
+            Strategy = WorkspaceStrategy.HardLink,
+            IsPrepared = true,
+            FileCount = 1,
+            IsValid = true,
+        };
+        await File.WriteAllTextAsync(_metadataPath, System.Text.Json.JsonSerializer.Serialize(new[] { cachedWorkspace }));
+
+        var config = new WorkspaceConfiguration
+        {
+            Id = workspaceId,
+            Strategy = WorkspaceStrategy.HardLink,
+            Manifests = [new ContentManifest { Id = ManifestId.Create(manifestId), Version = "1.0", Files = [new ManifestFile { RelativePath = "generals", IsExecutable = true }] }],
+            BaseInstallationPath = _tempPath,
+            WorkspaceRootPath = _tempPath,
+            ValidateAfterPreparation = false,
+        };
+
+        var manager = new WorkspaceManager(
+            [_mockStrategy.Object],
+            _mockConfigProvider.Object,
+            _mockLogger.Object,
+            _casTracker,
+            new WorkspaceValidator(NullLogger<WorkspaceValidator>.Instance),
+            _reconciler);
+
+        // Act
+        var result = await manager.PrepareWorkspaceAsync(config);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute).Should().BeTrue();
+        (await File.ReadAllTextAsync(executablePath)).Should().Be("engine binary");
+
+        // Repair happens on the reuse fast path; the strategy never re-materialises.
         _mockStrategy.Verify(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -413,6 +413,147 @@ public partial class WorkspaceValidatorTests : IDisposable
     }
 
     /// <summary>
+    /// A rooted entry point outside the workspace root is refused without being touched,
+    /// even when the outside directory shares the root as a name prefix.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_RootedPathOutsideWorkspace_RefusesWithoutMutation()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // The sibling shares the workspace root as a prefix, so a containment check
+        // without the trailing separator would wrongly accept it.
+        var evilDir = _workspaceDir + "-evil";
+        Directory.CreateDirectory(evilDir);
+        var outsidePath = Path.Combine(evilDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(outsidePath, originalMode);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = outsidePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.Contains("outside the workspace root", result.FirstError);
+        Assert.Equal(originalMode, File.GetUnixFileMode(outsidePath));
+        Assert.Equal("outside binary", await File.ReadAllTextAsync(outsidePath));
+    }
+
+    /// <summary>
+    /// A relative entry point that traverses out of the workspace root is refused
+    /// without being touched.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_TraversalPath_RefusesWithoutMutation()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var outsidePath = Path.Combine(_sourceDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(outsidePath, originalMode);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = Path.Combine("..", "source", "client"),
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.Contains("outside the workspace root", result.FirstError);
+        Assert.Equal(originalMode, File.GetUnixFileMode(outsidePath));
+    }
+
+    /// <summary>
+    /// Strategies store the entry point as an absolute path inside the workspace, so a
+    /// rooted in-workspace path must still be repaired.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_RootedPathInsideWorkspace_StillRepairs()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+    }
+
+    /// <summary>
+    /// Validation reports an entry point that escapes the workspace root as an error and
+    /// leaves the outside file untouched.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ValidateWorkspaceAsync_EntryPointOutsideWorkspace_ReportsErrorWithoutMutation()
+    {
+        var outsidePath = Path.Combine(_sourceDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(outsidePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = outsidePath,
+        };
+
+        var result = await _validator.ValidateWorkspaceAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains(
+            result.Data.Issues,
+            issue => issue.IssueType == ValidationIssueType.UnexpectedFile
+                && issue.Severity == ValidationSeverity.Error
+                && issue.Message.Contains("outside the workspace root"));
+
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.False(File.GetUnixFileMode(outsidePath).HasFlag(UnixFileMode.UserExecute));
+        }
+
+        Assert.Equal("outside binary", await File.ReadAllTextAsync(outsidePath));
+    }
+
+    /// <summary>
     /// Windows has no execute bit, so the repair is a no-op that leaves the file untouched.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -254,11 +254,12 @@ public partial class WorkspaceValidatorTests : IDisposable
 
     /// <summary>
     /// An execute bit for an identity other than the effective process identity must not
-    /// make a workspace entry point appear executable.
+    /// make a workspace entry point appear executable — validation repairs the entry
+    /// point on a workspace-owned copy instead of reporting a warning.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_ReturnsAccessWarning()
+    public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_RepairsEntryPoint()
     {
         // Root bypasses the permission bits entirely: faccessat reports execute access for
         // an other-only bit, so the behaviour under test does not exist for uid 0. Checked
@@ -286,10 +287,159 @@ public partial class WorkspaceValidatorTests : IDisposable
 
         Assert.True(result.Success);
         Assert.NotNull(result.Data);
+        Assert.DoesNotContain(
+            result.Data.Issues,
+            issue => issue.IssueType == ValidationIssueType.AccessDenied);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+    }
+
+    /// <summary>
+    /// A workspace bricked before executable modes were applied atomically — entry point
+    /// present, execute bit lost — is repaired so launch preparation can proceed.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_BrickedEntryPoint_RestoresExecuteMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = "client",
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+        Assert.False(File.Exists(executablePath + ".genhub-exec-tmp"));
+    }
+
+    /// <summary>
+    /// An entry point that is already executable is left alone.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_AlreadyExecutable_ReportsNoRepair()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+        File.SetUnixFileMode(executablePath, originalMode);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.False(result.Data);
+        Assert.Equal(originalMode, File.GetUnixFileMode(executablePath));
+    }
+
+    /// <summary>
+    /// A missing entry point is an error, not something repair may create.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_MissingEntryPoint_FailsWithoutCreatingFile()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "missing-client");
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.False(File.Exists(executablePath));
+    }
+
+    /// <summary>
+    /// Validation keeps reporting a missing entry point as an error rather than creating one.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ValidateWorkspaceAsync_MissingEntryPoint_ReportsErrorWithoutCreatingFile()
+    {
+        var executablePath = Path.Combine(_workspaceDir, "missing-client");
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.ValidateWorkspaceAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
         Assert.Contains(
             result.Data.Issues,
-            issue => issue.IssueType == ValidationIssueType.AccessDenied
-                && issue.Severity == ValidationSeverity.Warning);
+            issue => issue.IssueType == ValidationIssueType.MissingFile
+                && issue.Severity == ValidationSeverity.Error);
+        Assert.False(File.Exists(executablePath));
+    }
+
+    /// <summary>
+    /// Windows has no execute bit, so the repair is a no-op that leaves the file untouched.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_OnWindows_IsANoOp()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client.exe");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        var lastWrite = File.GetLastWriteTimeUtc(executablePath);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.False(result.Data);
+        Assert.Equal(lastWrite, File.GetLastWriteTimeUtc(executablePath));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -324,7 +324,7 @@ public partial class WorkspaceValidatorTests : IDisposable
         Assert.True(result.Data);
         Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
         Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
-        Assert.False(File.Exists(executablePath + ".genhub-exec-tmp"));
+        Assert.Empty(Directory.GetFiles(_workspaceDir, "*.genhub-exec-tmp-*"));
     }
 
     /// <summary>
@@ -551,6 +551,119 @@ public partial class WorkspaceValidatorTests : IDisposable
         }
 
         Assert.Equal("outside binary", await File.ReadAllTextAsync(outsidePath));
+    }
+
+    /// <summary>
+    /// Lexical containment cannot see through links, so a symlinked intermediate
+    /// directory pointing outside the workspace must make the repair refuse without
+    /// touching the outside file.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_SymlinkedIntermediateDirectory_RefusesWithoutMutation()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var outsideDir = Path.Combine(_sourceDir, "payload");
+        Directory.CreateDirectory(outsideDir);
+        var outsidePath = Path.Combine(outsideDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(outsidePath, originalMode);
+
+        Directory.CreateSymbolicLink(Path.Combine(_workspaceDir, "bin"), outsideDir);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = Path.Combine("bin", "client"),
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.Contains("is a symlink", result.FirstError);
+        Assert.Equal(originalMode, File.GetUnixFileMode(outsidePath));
+        Assert.Equal("outside binary", await File.ReadAllTextAsync(outsidePath));
+    }
+
+    /// <summary>
+    /// A symlinked leaf executable in an ordinary workspace is replaced with a private
+    /// executable copy while the symlink target keeps its bytes and mode — the same
+    /// store-safe behaviour materialisation applies.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_SymlinkedLeafExecutable_RepairsCopyAndLeavesTargetUntouched()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var targetPath = Path.Combine(_sourceDir, "client-target");
+        await File.WriteAllTextAsync(targetPath, "engine binary");
+        var targetMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(targetPath, targetMode);
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        File.CreateSymbolicLink(executablePath, targetPath);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.Null(new FileInfo(executablePath).LinkTarget);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+        Assert.Equal(targetMode, File.GetUnixFileMode(targetPath));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(targetPath));
+    }
+
+    /// <summary>
+    /// Temporary swap names carry a fresh GUID, so a pre-existing file left at an
+    /// old-style temporary name is never clobbered by a repair.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_PreExistingTemporaryFile_IsNotClobbered()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var stalePath = executablePath + ".genhub-exec-tmp";
+        await File.WriteAllTextAsync(stalePath, "precious leftover");
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("precious leftover", await File.ReadAllTextAsync(stalePath));
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
+++ b/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
@@ -21,9 +21,11 @@ namespace GenHub.Features.Workspace;
 internal static class ExecutableFileSwap
 {
     /// <summary>
-    /// The suffix of the temporary file used while the swap is in flight.
+    /// The recognisable marker in the name of the temporary file used while the swap is
+    /// in flight. A fresh GUID follows it, so concurrent swaps of the same file can
+    /// never collide with each other or with a stale leftover.
     /// </summary>
-    internal const string TemporarySuffix = ".genhub-exec-tmp";
+    internal const string TemporaryMarker = ".genhub-exec-tmp-";
 
     private const UnixFileMode ExecutableMode =
         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
@@ -36,11 +38,13 @@ internal static class ExecutableFileSwap
     /// <param name="targetPath">The absolute path of the workspace file.</param>
     internal static void MakeExecutable(string targetPath)
     {
-        var temporaryPath = targetPath + TemporarySuffix;
+        var temporaryPath = targetPath + TemporaryMarker + Guid.NewGuid().ToString("N");
 
         try
         {
-            File.Copy(targetPath, temporaryPath, overwrite: true);
+            // The GUID makes the name unique by construction; copying without overwrite
+            // turns the impossible collision into an exception instead of a clobber.
+            File.Copy(targetPath, temporaryPath);
 
             if (!OperatingSystem.IsWindows())
             {

--- a/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
+++ b/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+
+namespace GenHub.Features.Workspace;
+
+/// <summary>
+/// Replaces a workspace file with a private copy that carries the Unix execute bit.
+/// <para>
+/// The private copy is what keeps the content store safe: a hard-linked workspace file
+/// shares its inode — and therefore its file mode — with the stored blob, so setting the
+/// execute bit in place would change that blob for every profile referencing the hash.
+/// Copying first gives the workspace its own inode, and because the copy is made
+/// executable before it atomically replaces the destination, the file is never
+/// observable as missing or present-but-not-executable.
+/// </para>
+/// <para>
+/// Meant for Unix; callers gate on the operating system. Windows has no execute bit,
+/// so the mode change is skipped there defensively.
+/// </para>
+/// </summary>
+internal static class ExecutableFileSwap
+{
+    /// <summary>
+    /// The suffix of the temporary file used while the swap is in flight.
+    /// </summary>
+    internal const string TemporarySuffix = ".genhub-exec-tmp";
+
+    private const UnixFileMode ExecutableMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+    /// <summary>
+    /// Swaps the file at <paramref name="targetPath"/> for an executable private copy.
+    /// </summary>
+    /// <param name="targetPath">The absolute path of the workspace file.</param>
+    internal static void MakeExecutable(string targetPath)
+    {
+        var temporaryPath = targetPath + TemporarySuffix;
+
+        try
+        {
+            File.Copy(targetPath, temporaryPath, overwrite: true);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(temporaryPath, ExecutableMode);
+            }
+
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch
+        {
+            // The move is the last step, so a failure means the temporary copy may still
+            // exist. Remove it: the original entry is untouched and correct, and a stray
+            // temporary file would otherwise be reported by workspace validation.
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            throw;
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -634,59 +634,22 @@ public abstract class WorkspaceStrategyBase<T>(
             return;
         }
 
-        var temporaryPath = targetPath + ".genhub-exec-tmp";
-
         try
         {
-            // Replace the entry with a private copy so the mode change cannot reach a
-            // shared blob.
-            //
             // The copy is made executable *before* it is moved into place, and the move
             // replaces the destination atomically. There is therefore no observable state
             // in which the destination is missing or present-but-not-executable: it is
             // either the original entry or the finished private copy.
             //
-            // A delete-then-move sequence would expose both of those states, and the
-            // second is unrecoverable — verification never mutates, so a workspace left
-            // with a non-executable entry point stays broken for every later launch.
-            await Task.Run(
-                () =>
-                {
-                    File.Copy(targetPath, temporaryPath, overwrite: true);
-
-                    if (!OperatingSystem.IsWindows())
-                    {
-                        const UnixFileMode executableMode =
-                            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-                            UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
-
-                        File.SetUnixFileMode(temporaryPath, executableMode);
-                    }
-
-                    File.Move(temporaryPath, targetPath, overwrite: true);
-                },
-                cancellationToken);
+            // A delete-then-move sequence would expose both of those states. The second
+            // is only papered over later — validation can restore a lost execute bit on
+            // the entry point, but not on any other executable the manifest names.
+            await Task.Run(() => ExecutableFileSwap.MakeExecutable(targetPath), cancellationToken);
 
             Logger.LogDebug("Marked {RelativePath} executable on a workspace-owned copy", file.RelativePath);
         }
         catch (Exception ex)
         {
-            // The move is the last step, so a failure here means the temporary copy may
-            // still exist. Remove it: the original entry is untouched and correct, and a
-            // stray .genhub-exec-tmp would otherwise be reported by workspace validation.
-            try
-            {
-                File.Delete(temporaryPath);
-            }
-            catch (Exception cleanupEx)
-            {
-                Logger.LogDebug(
-                    cleanupEx,
-                    "Could not remove the temporary executable copy at {TemporaryPath}",
-                    temporaryPath);
-            }
-
             Logger.LogError(
                 ex,
                 "Could not mark {RelativePath} executable",

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -137,10 +137,23 @@ public class WorkspaceManager(
                             }
                             else if (!configuration.ForceRecreate && (workspace.FileCount > 0 || Directory.Exists(workspace.WorkspacePath)))
                             {
-                                logger.LogInformation(
-                                    "[Workspace] Reusing existing workspace {Id} for fast launch",
-                                    configuration.Id);
-                                return OperationResult<WorkspaceInfo>.CreateSuccess(workspace);
+                                // Reuse skips materialisation entirely, so this is the only
+                                // moment a workspace bricked by a lost execute bit can be
+                                // repaired before launch.
+                                var entryPointResult = await workspaceValidator.EnsureEntryPointExecutableAsync(workspace, cancellationToken);
+                                if (entryPointResult.Success)
+                                {
+                                    logger.LogInformation(
+                                        "[Workspace] Reusing existing workspace {Id} for fast launch",
+                                        configuration.Id);
+                                    return OperationResult<WorkspaceInfo>.CreateSuccess(workspace);
+                                }
+
+                                logger.LogWarning(
+                                    "[Workspace] Entry point check failed for workspace {Id}: {Error}. Workspace will be recreated.",
+                                    configuration.Id,
+                                    entryPointResult.FirstError);
+                                configuration.ForceRecreate = true;
                             }
                             else
                             {

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -219,9 +219,17 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             // Validate executable exists if specified
             if (!string.IsNullOrEmpty(workspaceInfo.ExecutablePath))
             {
-                var executablePath = ResolveEntryPointPath(workspaceInfo);
-
-                if (!File.Exists(executablePath))
+                if (!TryResolveContainedEntryPointPath(workspaceInfo, out var executablePath))
+                {
+                    issues.Add(new ValidationIssue
+                    {
+                        IssueType = ValidationIssueType.UnexpectedFile,
+                        Severity = ValidationSeverity.Error,
+                        Message = $"Executable path '{workspaceInfo.ExecutablePath}' resolves outside the workspace root '{workspaceInfo.WorkspacePath}'",
+                        Path = workspaceInfo.ExecutablePath,
+                    });
+                }
+                else if (!File.Exists(executablePath))
                 {
                     issues.Add(new ValidationIssue
                     {
@@ -310,7 +318,9 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
     /// </para>
     /// <para>
     /// A missing entry point is reported as a failure, never created — materialisation
-    /// owns producing the file; this method only restores its mode.
+    /// owns producing the file; this method only restores its mode. An entry point that
+    /// resolves outside the workspace root is likewise refused without touching it, so
+    /// stale or corrupted metadata can never redirect the repair at a foreign file.
     /// </para>
     /// </summary>
     /// <param name="workspaceInfo">The workspace whose entry point is checked.</param>
@@ -326,7 +336,11 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             return OperationResult<bool>.CreateSuccess(false);
         }
 
-        var executablePath = ResolveEntryPointPath(workspaceInfo);
+        if (!TryResolveContainedEntryPointPath(workspaceInfo, out var executablePath))
+        {
+            return OperationResult<bool>.CreateFailure(
+                $"Workspace entry point '{workspaceInfo.ExecutablePath}' resolves outside the workspace root '{workspaceInfo.WorkspacePath}'");
+        }
 
         if (!File.Exists(executablePath))
         {
@@ -357,11 +371,54 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
         return OperationResult<bool>.CreateSuccess(true);
     }
 
-    private static string ResolveEntryPointPath(WorkspaceInfo workspaceInfo)
+    /// <summary>
+    /// Resolves the workspace entry point to a full path and requires it to be strictly
+    /// inside the workspace root.
+    /// <para>
+    /// Containment is load-bearing here because the entry point is not only read but
+    /// repaired in place: stale or corrupted workspace metadata must never cause a file
+    /// outside the workspace to be replaced. The check appends the directory separator
+    /// to the root before comparing, so a sibling such as <c>foo-evil</c> cannot pass
+    /// for a root named <c>foo</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="workspaceInfo">The workspace whose entry point is resolved.</param>
+    /// <param name="executablePath">The fully resolved entry point path, when contained.</param>
+    /// <returns><c>true</c> when the entry point resolves inside the workspace root.</returns>
+    private static bool TryResolveContainedEntryPointPath(WorkspaceInfo workspaceInfo, out string executablePath)
     {
-        return Path.IsPathRooted(workspaceInfo.ExecutablePath)
-            ? workspaceInfo.ExecutablePath
-            : Path.Combine(workspaceInfo.WorkspacePath, workspaceInfo.ExecutablePath);
+        executablePath = string.Empty;
+
+        try
+        {
+            var workspaceRoot = Path.GetFullPath(workspaceInfo.WorkspacePath);
+            var candidate = Path.IsPathRooted(workspaceInfo.ExecutablePath)
+                ? workspaceInfo.ExecutablePath
+                : Path.Combine(workspaceRoot, workspaceInfo.ExecutablePath);
+            var resolved = Path.GetFullPath(candidate);
+
+            var rootWithSeparator = Path.EndsInDirectorySeparator(workspaceRoot)
+                ? workspaceRoot
+                : workspaceRoot + Path.DirectorySeparatorChar;
+
+            // Ordinal on Unix; Windows path comparisons are case-insensitive.
+            var comparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!resolved.StartsWith(rootWithSeparator, comparison))
+            {
+                return false;
+            }
+
+            executablePath = resolved;
+            return true;
+        }
+        catch (Exception)
+        {
+            // An entry point that cannot even be resolved is treated as escaping.
+            return false;
+        }
     }
 
     private static bool IsRunningAsAdministrator()

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -352,6 +352,12 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             return OperationResult<bool>.CreateSuccess(false);
         }
 
+        if (TryFindLinkedParentDirectory(workspaceInfo.WorkspacePath, executablePath, out var linkedDirectory))
+        {
+            return OperationResult<bool>.CreateFailure(
+                $"Cannot repair workspace entry point '{executablePath}': directory '{linkedDirectory}' is a symlink, so the file may resolve outside the workspace root '{workspaceInfo.WorkspacePath}'");
+        }
+
         try
         {
             await Task.Run(() => ExecutableFileSwap.MakeExecutable(executablePath), cancellationToken);
@@ -419,6 +425,68 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             // An entry point that cannot even be resolved is treated as escaping.
             return false;
         }
+    }
+
+    /// <summary>
+    /// Walks from the workspace root down to the entry point's parent directory looking
+    /// for a symlinked directory.
+    /// <para>
+    /// Lexical containment cannot see through links: a symlinked directory inside the
+    /// workspace can point anywhere, so repairing through one could replace a file
+    /// outside the workspace root. The leaf itself is deliberately not checked —
+    /// replacing a leaf symlink with a private executable copy is the intended,
+    /// store-safe repair. Workspace strategies materialise directories with
+    /// <c>Directory.CreateDirectory</c> and only ever symlink individual files
+    /// (SymlinkOnlyStrategy and HybridCopySymlinkStrategy pass per-file manifest
+    /// targets to <c>CreateSymlinkAsync</c>), so no normally generated workspace is
+    /// refused by this check.
+    /// </para>
+    /// </summary>
+    /// <param name="workspaceRootPath">The workspace root directory.</param>
+    /// <param name="executablePath">The fully resolved, lexically contained entry point path.</param>
+    /// <param name="linkedDirectory">The first symlinked directory found, when any.</param>
+    /// <returns><c>true</c> when the root or an intermediate directory is a symlink.</returns>
+    private static bool TryFindLinkedParentDirectory(string workspaceRootPath, string executablePath, out string linkedDirectory)
+    {
+        linkedDirectory = string.Empty;
+
+        var workspaceRoot = Path.GetFullPath(workspaceRootPath);
+        if (IsLinkedDirectory(workspaceRoot))
+        {
+            linkedDirectory = workspaceRoot;
+            return true;
+        }
+
+        var parentDirectory = Path.GetDirectoryName(executablePath);
+        if (string.IsNullOrEmpty(parentDirectory))
+        {
+            return false;
+        }
+
+        var relative = Path.GetRelativePath(workspaceRoot, parentDirectory);
+        if (relative == ".")
+        {
+            return false;
+        }
+
+        var current = workspaceRoot;
+        foreach (var segment in relative.Split(Path.DirectorySeparatorChar))
+        {
+            current = Path.Combine(current, segment);
+            if (IsLinkedDirectory(current))
+            {
+                linkedDirectory = current;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsLinkedDirectory(string path)
+    {
+        var info = new DirectoryInfo(path);
+        return info.Exists && (info.Attributes & FileAttributes.ReparsePoint) != 0;
     }
 
     private static bool IsRunningAsAdministrator()

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -219,9 +219,7 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             // Validate executable exists if specified
             if (!string.IsNullOrEmpty(workspaceInfo.ExecutablePath))
             {
-                var executablePath = Path.IsPathRooted(workspaceInfo.ExecutablePath)
-                    ? workspaceInfo.ExecutablePath
-                    : Path.Combine(workspaceInfo.WorkspacePath, workspaceInfo.ExecutablePath);
+                var executablePath = ResolveEntryPointPath(workspaceInfo);
 
                 if (!File.Exists(executablePath))
                 {
@@ -233,44 +231,21 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
                         Path = executablePath,
                     });
                 }
-                else
+                else if (!OperatingSystem.IsWindows())
                 {
-                    // Check if executable has execute permissions (on Unix systems)
-                    if (!OperatingSystem.IsWindows())
+                    // A lost execute bit is repaired rather than merely reported: the
+                    // entry point is a workspace-owned copy, so restoring its mode cannot
+                    // reach a shared content-store blob.
+                    var repairResult = await EnsureEntryPointExecutableAsync(workspaceInfo, cancellationToken);
+                    if (!repairResult.Success)
                     {
-                        try
+                        issues.Add(new ValidationIssue
                         {
-                            var fileInfo = new FileInfo(executablePath);
-
-                            // Check if file exists and has execute permission for the current user
-                            if (!fileInfo.Exists)
-                            {
-                                issues.Add(new ValidationIssue
-                                {
-                                    IssueType = ValidationIssueType.AccessDenied,
-                                    Severity = ValidationSeverity.Warning,
-                                    Message = $"Cannot verify execute permissions for: {executablePath}",
-                                    Path = executablePath,
-                                });
-                            }
-                            else
-                            {
-                                if (!HasUnixExecutePermission(executablePath))
-                                {
-                                    issues.Add(new ValidationIssue
-                                    {
-                                        IssueType = ValidationIssueType.AccessDenied,
-                                        Severity = ValidationSeverity.Warning,
-                                        Message = $"File is not executable by the current process: {executablePath}",
-                                        Path = executablePath,
-                                    });
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogWarning(ex, "Could not check execute permissions for {ExecutablePath}", executablePath);
-                        }
+                            IssueType = ValidationIssueType.AccessDenied,
+                            Severity = ValidationSeverity.Warning,
+                            Message = $"File is not executable by the current process: {executablePath}",
+                            Path = executablePath,
+                        });
                     }
                 }
             }
@@ -321,6 +296,72 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             logger.LogError(ex, "Failed to validate workspace {WorkspaceId}", workspaceInfo.Id);
             return OperationResult<ValidationResult>.CreateFailure($"Workspace validation failed: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Ensures the workspace entry point is executable by the current process, restoring
+    /// the Unix execute mode on a workspace-owned copy when the file exists without it.
+    /// <para>
+    /// This exists for workspaces materialised before executable modes were applied
+    /// atomically: their entry point can be present with the execute bit lost, and no
+    /// later materialisation ever runs to restore it. The repair swaps the file for a
+    /// private executable copy, so even an entry point that is still hard-linked into
+    /// the content store never has its shared blob touched.
+    /// </para>
+    /// <para>
+    /// A missing entry point is reported as a failure, never created — materialisation
+    /// owns producing the file; this method only restores its mode.
+    /// </para>
+    /// </summary>
+    /// <param name="workspaceInfo">The workspace whose entry point is checked.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>
+    /// A successful result whose data indicates whether a repair was performed, or a
+    /// failed result when the entry point is missing or could not be made executable.
+    /// </returns>
+    public async Task<OperationResult<bool>> EnsureEntryPointExecutableAsync(WorkspaceInfo workspaceInfo, CancellationToken cancellationToken = default)
+    {
+        if (OperatingSystem.IsWindows() || string.IsNullOrEmpty(workspaceInfo.ExecutablePath))
+        {
+            return OperationResult<bool>.CreateSuccess(false);
+        }
+
+        var executablePath = ResolveEntryPointPath(workspaceInfo);
+
+        if (!File.Exists(executablePath))
+        {
+            return OperationResult<bool>.CreateFailure($"Workspace entry point not found: {executablePath}");
+        }
+
+        if (HasUnixExecutePermission(executablePath))
+        {
+            return OperationResult<bool>.CreateSuccess(false);
+        }
+
+        try
+        {
+            await Task.Run(() => ExecutableFileSwap.MakeExecutable(executablePath), cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not restore the execute mode on workspace entry point {ExecutablePath}", executablePath);
+            return OperationResult<bool>.CreateFailure($"Could not restore the execute mode on {executablePath}: {ex.Message}");
+        }
+
+        if (!HasUnixExecutePermission(executablePath))
+        {
+            return OperationResult<bool>.CreateFailure($"Workspace entry point is still not executable after repair: {executablePath}");
+        }
+
+        logger.LogInformation("Restored the execute mode on workspace entry point {ExecutablePath}", executablePath);
+        return OperationResult<bool>.CreateSuccess(true);
+    }
+
+    private static string ResolveEntryPointPath(WorkspaceInfo workspaceInfo)
+    {
+        return Path.IsPathRooted(workspaceInfo.ExecutablePath)
+            ? workspaceInfo.ExecutablePath
+            : Path.Combine(workspaceInfo.WorkspacePath, workspaceInfo.ExecutablePath);
     }
 
     private static bool IsRunningAsAdministrator()


### PR DESCRIPTION
## Summary

Make Unix executable materialization crash-safe and prevent permission changes
from reaching shared content-store blobs.

Executable files are copied to a private temporary inode, made executable, and
atomically moved into place. Existing workspaces whose entry point lost its
execute mode are repaired during validation or recreated when repair is unsafe.

## Changes

- Replace delete-and-move materialization with copy, chmod, and atomic replacement.
- Break hard links before changing permissions so CAS blobs are never chmodded.
- Repair non-executable entry points when reusing an existing workspace.
- Use recognizable GUID-suffixed temporary names and never overwrite an existing
  temporary file.
- Reject absolute or traversal paths that escape the workspace root.
- Refuse repair through a symlinked workspace root or intermediate directory.
- Allow a leaf executable symlink to be replaced with a private executable copy.
- Fall back to workspace recreation when safe repair is not possible.
- Cover crash-safe materialization, CAS isolation, containment, symlink handling,
  stale workspaces, and temporary-file behavior.

## Testing

- `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release`
- 1,423 tests passed on macOS arm64.
- Verified that repairing a hard-linked or symlinked entry point leaves its source
  inode and permissions unchanged.
- Verified that symlinked parent directories are refused without mutating files
  outside the workspace.

## Risks and rollback

The repair path applies only on Unix platforms. A workspace containing a
symlinked root or intermediate directory is treated as unsafe and recreated.
Current workspace strategies create real directories and only symlink individual
files, so normally generated workspaces are unaffected.

An interruption before the final move can leave a recognizable temporary file;
workspace reconciliation already treats such files as extraneous.

Rollback restores the previous materialization behavior but also restores the
crash window and leaves previously bricked workspaces unable to self-heal.

## Related issues

Fixes #316

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Unix executable materialization atomic and adds safe repair for stale workspace entry-point modes.
- Copies executable content to a GUID-suffixed private inode, applies executable permissions, and atomically replaces the destination.
- Repairs non-executable cached entry points while rejecting traversal and symlinked-parent repair paths.
- Recreates cached workspaces when entry-point repair fails and adds coverage for CAS isolation, containment, symlinks, and temporary files.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking constants-organization issue in the new executable swap helper.

The atomic materialization, containment checks, repair fallback, and reuse flow have no accepted functional failure; the remaining concern is keeping the new temporary marker and permission mask in the repository's centralized constants system.

**Files Needing Attention:** GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs | Introduces private-copy chmod and atomic replacement; its filesystem constants should be moved to the centralized constants system. |
| GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs | Adds contained-path resolution, symlink-parent rejection, and Unix entry-point mode repair without an accepted functional defect. |
| GenHub/GenHub/Features/Workspace/WorkspaceManager.cs | Checks cached entry points before reuse and falls through to forced recreation when safe repair fails. |
| GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs | Delegates executable materialization to the new atomic private-copy helper. |
| GenHub/GenHub.Core/Interfaces/Workspace/IWorkspaceValidator.cs | Extends the validator contract with the entry-point executable repair operation. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs | Adds broad coverage for stale modes, containment, missing files, symlink handling, and temporary-file preservation. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs | Verifies that executable materialization and repair do not mutate shared CAS inode permissions. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs | Covers successful in-place repair and recreation after repair failure on the reuse path. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Prepare workspace] --> B{Reusable cached workspace?}
    B -- No --> F[Materialize files]
    B -- Yes --> C[Check entry-point execute access]
    C --> D{Executable or safely repaired?}
    D -- Yes --> E[Reuse workspace]
    D -- No --> G[Force recreation]
    G --> F
    F --> H[Copy executable to private temporary inode]
    H --> I[Apply executable mode]
    I --> J[Atomically replace destination]
    J --> K[Validate and persist workspace]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs:28-35
**Centralize filesystem constants**

`TemporaryMarker` and `ExecutableMode` define a shared workspace filesystem convention inside this helper. Keeping them in the repository's dedicated constants classes gives validation, cleanup, and tests one discoverable definition and prevents those consumers from duplicating or depending on this internal implementation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workspace): refuse repair through sy..."](https://github.com/community-outpost/genhub/commit/bc92259764d120d8903c453eece42bfca02688fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48757819)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Use dedicated constants classes instead of hardcod... ([source](https://github.com/community-outpost/genhub/blob/main/docs\dev\constants.md))
- Knowledge Base — [Workspace Assembly](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/workspace-assembly.md)

<!-- /greptile_comment -->