### PR TITLE
fix(content): classify executables by magic bytes instead of the extensionless heuristic

### DIFF
--- a/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
@@ -135,7 +135,7 @@ public static class ManifestVariantResolver
         var executable = files
             .Where(f =>
                 f.IsExecutable
-                && ExecutableFileClassifier.IsLegacyLaunchCandidate(f.RelativePath))
+                && ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(f.RelativePath))
             .ToList();
         if (executable.Count == 1)
         {
@@ -145,7 +145,7 @@ public static class ManifestVariantResolver
         if (executable.Count == 0)
         {
             var legacy = files
-                .Where(f => ExecutableFileClassifier.IsLegacyLaunchCandidate(f.RelativePath))
+                .Where(f => ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(f.RelativePath))
                 .ToList();
 
             if (legacy.Count == 1)

--- a/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
+++ b/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.IO;
 
 namespace GenHub.Core.Utilities;
@@ -32,6 +33,19 @@ namespace GenHub.Core.Utilities;
 public static class ExecutableFileClassifier
 {
     /// <summary>
+    /// Bytes needed to recognise every supported magic number, including the second
+    /// 32-bit word used to tell a Mach-O universal binary from a Java class file.
+    /// </summary>
+    private const int MagicHeaderLength = 8;
+
+    /// <summary>
+    /// A Mach-O universal (fat) header's second word is the architecture count, which is
+    /// realistically single-digit. A Java class file shares the 0xCAFEBABE magic, but its
+    /// second word encodes the class-file version, which is at least 45 (Java 1.1).
+    /// </summary>
+    private const uint MaxPlausibleFatArchCount = 30;
+
+    /// <summary>
     /// Extensions for loadable code that is never itself launched and never needs the
     /// execute bit. Dynamic libraries are mapped by the loader, which requires read
     /// access only.
@@ -50,13 +64,36 @@ public static class ExecutableFileClassifier
     /// a statement about which file the profile launches.
     /// </para>
     /// <para>
-    /// Extensionless files count: that is the shape of a native Mach-O or ELF binary,
-    /// and it is the case the previous inconsistency got wrong.
+    /// Extensionless files are assumed to be native binaries: that is the shape of a
+    /// Mach-O or ELF game client. This name-only overload exists for callers that hold
+    /// nothing but a relative path (manifest entries, remote release assets); whenever
+    /// the file is on disk, prefer the overload that takes an absolute path so the
+    /// answer comes from the file's magic bytes instead.
     /// </para>
     /// </summary>
     /// <param name="path">A file name or relative path. Not required to exist on disk.</param>
     /// <returns><c>true</c> when the file should be marked executable.</returns>
     public static bool RequiresExecutePermission(string path)
+        => RequiresExecutePermission(path, absolutePath: null);
+
+    /// <summary>
+    /// Determines whether a file needs the Unix execute bit, sniffing the file's magic
+    /// bytes to classify extensionless files by content rather than by name.
+    /// <para>
+    /// An extensionless <c>README</c> or <c>LICENSE</c> is not a native binary, and only
+    /// the file's first bytes can tell it apart from one. Extension-based classification
+    /// is unchanged: libraries stay non-executable and known runnable extensions stay
+    /// executable, whatever the content says.
+    /// </para>
+    /// </summary>
+    /// <param name="path">A file name or relative path.</param>
+    /// <param name="absolutePath">
+    /// The file's location on disk, when it exists there; <c>null</c> falls back to
+    /// name-only classification. An extensionless file that cannot be read, or whose
+    /// header matches no known executable format, is not executable.
+    /// </param>
+    /// <returns><c>true</c> when the file should be marked executable.</returns>
+    public static bool RequiresExecutePermission(string path, string? absolutePath)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -65,11 +102,11 @@ public static class ExecutableFileClassifier
 
         var extension = Path.GetExtension(path);
 
-        // Extensionless: a native binary. Directories and dotfiles are excluded by the
-        // caller, which only ever passes real file entries.
+        // Extensionless: the shape of a native binary, but also of a README. Content is
+        // the only reliable way to tell them apart, so use it whenever we have it.
         if (string.IsNullOrEmpty(extension))
         {
-            return true;
+            return absolutePath is null || HasExecutableMagicBytes(absolutePath);
         }
 
         if (MatchesAny(extension, LibraryExtensions))
@@ -91,6 +128,20 @@ public static class ExecutableFileClassifier
     /// <param name="path">A file name or relative path.</param>
     /// <returns><c>true</c> when the file is a plausible legacy launch target.</returns>
     public static bool IsLegacyLaunchCandidate(string path)
+        => IsLegacyLaunchCandidate(path, absolutePath: null);
+
+    /// <summary>
+    /// Determines whether a file could be the launch target when a manifest declares no
+    /// explicit entry point, sniffing magic bytes to classify extensionless files by
+    /// content rather than by name.
+    /// </summary>
+    /// <param name="path">A file name or relative path.</param>
+    /// <param name="absolutePath">
+    /// The file's location on disk, when it exists there; <c>null</c> falls back to
+    /// name-only classification.
+    /// </param>
+    /// <returns><c>true</c> when the file is a plausible legacy launch target.</returns>
+    public static bool IsLegacyLaunchCandidate(string path, string? absolutePath)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -102,8 +153,92 @@ public static class ExecutableFileClassifier
         // Extensionless native binaries and Windows executables only. Notably not .dat:
         // the Steam layout launches game.dat through a proxy, but that is a launch
         // *strategy* chosen by the Steam integration, not a property of the file.
-        return string.IsNullOrEmpty(extension)
-            || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(extension))
+        {
+            return absolutePath is null || HasExecutableMagicBytes(absolutePath);
+        }
+
+        return extension.Equals(".exe", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determines whether the file at <paramref name="absolutePath"/> starts with the
+    /// magic bytes of a native executable format. Reads at most
+    /// <see cref="MagicHeaderLength"/> bytes; never loads the file.
+    /// </summary>
+    /// <param name="absolutePath">The file to sniff.</param>
+    /// <returns>
+    /// <c>true</c> when the header matches a known executable format; <c>false</c> for
+    /// any other content and for files that are missing, too short, or unreadable.
+    /// </returns>
+    public static bool HasExecutableMagicBytes(string absolutePath)
+    {
+        Span<byte> header = stackalloc byte[MagicHeaderLength];
+
+        try
+        {
+            using var stream = new FileStream(
+                absolutePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var read = stream.ReadAtLeast(header, MagicHeaderLength, throwOnEndOfStream: false);
+            return HasExecutableMagicBytes(header[..read]);
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="header"/> starts with the magic bytes of a
+    /// native executable format: MZ (Windows PE), ELF (Linux), or Mach-O (macOS), in
+    /// thin and universal flavours and both byte orders.
+    /// </summary>
+    /// <param name="header">The first bytes of a file; <see cref="MagicHeaderLength"/> suffice.</param>
+    /// <returns><c>true</c> when the header matches a known executable format.</returns>
+    public static bool HasExecutableMagicBytes(ReadOnlySpan<byte> header)
+    {
+        if (header.Length < 4)
+        {
+            return false;
+        }
+
+        // MZ: DOS/PE. Two bytes of magic, but anything shorter than four bytes cannot
+        // be a real executable of any kind, which the length gate above enforces.
+        if (header[0] == 0x4D && header[1] == 0x5A)
+        {
+            return true;
+        }
+
+        // ELF: 0x7F 'E' 'L' 'F'.
+        if (header[0] == 0x7F && header[1] == (byte)'E' && header[2] == (byte)'L' && header[3] == (byte)'F')
+        {
+            return true;
+        }
+
+        var magic = BinaryPrimitives.ReadUInt32BigEndian(header);
+
+        // Mach-O thin: MH_MAGIC / MH_MAGIC_64 and their byte-swapped forms.
+        if (magic is 0xFEEDFACE or 0xFEEDFACF or 0xCEFAEDFE or 0xCFFAEDFE)
+        {
+            return true;
+        }
+
+        // Mach-O universal (fat). Java class files share 0xCAFEBABE, so require the
+        // second word: a fat header's is the architecture count (tiny), a class file's
+        // is the class-file version (>= 45). The byte-swapped magic stores the count
+        // byte-swapped as well.
+        if (magic == 0xCAFEBABE && header.Length >= MagicHeaderLength)
+        {
+            return BinaryPrimitives.ReadUInt32BigEndian(header[4..]) < MaxPlausibleFatArchCount;
+        }
+
+        if (magic == 0xBEBAFECA && header.Length >= MagicHeaderLength)
+        {
+            return BinaryPrimitives.ReadUInt32LittleEndian(header[4..]) < MaxPlausibleFatArchCount;
+        }
+
+        return false;
     }
 
     private static bool MatchesAny(string extension, string[] candidates)

--- a/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
+++ b/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
@@ -58,22 +58,24 @@ public static class ExecutableFileClassifier
     private static readonly string[] RunnableExtensions = [".exe", ".sh", ".command"];
 
     /// <summary>
-    /// Determines whether a file needs the Unix execute bit to be runnable.
+    /// Determines whether a file needs the Unix execute bit to be runnable, from its
+    /// name alone.
     /// <para>
     /// This is what <c>ManifestFile.IsExecutable</c> means. It is a permission fact, not
     /// a statement about which file the profile launches.
     /// </para>
     /// <para>
-    /// Extensionless files are assumed to be native binaries: that is the shape of a
-    /// Mach-O or ELF game client. This name-only overload exists for callers that hold
-    /// nothing but a relative path (manifest entries, remote release assets); whenever
-    /// the file is on disk, prefer the overload that takes an absolute path so the
-    /// answer comes from the file's magic bytes instead.
+    /// This is a compatibility heuristic for metadata-only contexts — remote release
+    /// asset names, manifests whose content has not been acquired — where extensionless
+    /// is assumed to mean native binary because that is the shape of a Mach-O or ELF
+    /// game client. It is not content classification: whenever the file is on disk,
+    /// call <see cref="RequiresExecutePermission(string, string?)"/> so the answer
+    /// comes from the file's magic bytes instead.
     /// </para>
     /// </summary>
     /// <param name="path">A file name or relative path. Not required to exist on disk.</param>
     /// <returns><c>true</c> when the file should be marked executable.</returns>
-    public static bool RequiresExecutePermission(string path)
+    public static bool RequiresExecutePermissionFromName(string path)
         => RequiresExecutePermission(path, absolutePath: null);
 
     /// <summary>
@@ -119,15 +121,22 @@ public static class ExecutableFileClassifier
 
     /// <summary>
     /// Determines whether a file could be the launch target when a manifest declares no
-    /// explicit entry point.
+    /// explicit entry point, from its name alone.
     /// <para>
     /// This exists only to keep manifests written before entry points were declarable
     /// working. New content should declare its entry point rather than rely on this.
     /// </para>
+    /// <para>
+    /// This is a compatibility heuristic for metadata-only contexts — remote release
+    /// asset names, manifests whose content has not been acquired. It is not content
+    /// classification: whenever the file is on disk, call
+    /// <see cref="IsLegacyLaunchCandidate(string, string?)"/> so extensionless files
+    /// are judged by their magic bytes instead.
+    /// </para>
     /// </summary>
     /// <param name="path">A file name or relative path.</param>
     /// <returns><c>true</c> when the file is a plausible legacy launch target.</returns>
-    public static bool IsLegacyLaunchCandidate(string path)
+    public static bool IsLegacyLaunchCandidateFromName(string path)
         => IsLegacyLaunchCandidate(path, absolutePath: null);
 
     /// <summary>
@@ -224,16 +233,16 @@ public static class ExecutableFileClassifier
             return true;
         }
 
-        // Mach-O universal (fat). Java class files share 0xCAFEBABE, so require the
-        // second word: a fat header's is the architecture count (tiny), a class file's
-        // is the class-file version (>= 45). The byte-swapped magic stores the count
-        // byte-swapped as well.
-        if (magic == 0xCAFEBABE && header.Length >= MagicHeaderLength)
+        // Mach-O universal (fat), 32-bit (FAT_MAGIC) and 64-bit (FAT_MAGIC_64) headers.
+        // Java class files share 0xCAFEBABE, so require the second word: a fat header's
+        // is the architecture count (tiny), a class file's is the class-file version
+        // (>= 45). The byte-swapped magics store the count byte-swapped as well.
+        if (magic is 0xCAFEBABE or 0xCAFEBABF && header.Length >= MagicHeaderLength)
         {
             return BinaryPrimitives.ReadUInt32BigEndian(header[4..]) < MaxPlausibleFatArchCount;
         }
 
-        if (magic == 0xBEBAFECA && header.Length >= MagicHeaderLength)
+        if (magic is 0xBEBAFECA or 0xBFBAFECA && header.Length >= MagicHeaderLength)
         {
             return BinaryPrimitives.ReadUInt32LittleEndian(header[4..]) < MaxPlausibleFatArchCount;
         }

--- a/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
+++ b/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
@@ -79,20 +79,20 @@ public static class ExecutableFileClassifier
         => RequiresExecutePermission(path, absolutePath: null);
 
     /// <summary>
-    /// Determines whether a file needs the Unix execute bit, sniffing the file's magic
-    /// bytes to classify extensionless files by content rather than by name.
+    /// Determines whether a file needs the Unix execute bit, sniffing the file header
+    /// to classify extensionless files by content rather than by name.
     /// <para>
-    /// An extensionless <c>README</c> or <c>LICENSE</c> is not a native binary, and only
-    /// the file's first bytes can tell it apart from one. Extension-based classification
-    /// is unchanged: libraries stay non-executable and known runnable extensions stay
-    /// executable, whatever the content says.
+    /// An extensionless <c>README</c> or <c>LICENSE</c> is neither a native binary nor a
+    /// shebang script, and only the file's first bytes can tell these cases apart.
+    /// Extension-based classification is unchanged: libraries stay non-executable and
+    /// known runnable extensions stay executable, whatever the content says.
     /// </para>
     /// </summary>
     /// <param name="path">A file name or relative path.</param>
     /// <param name="absolutePath">
     /// The file's location on disk, when it exists there; <c>null</c> falls back to
     /// name-only classification. An extensionless file that cannot be read, or whose
-    /// header matches no known executable format, is not executable.
+    /// header is neither native executable magic nor a shebang, is not executable.
     /// </param>
     /// <returns><c>true</c> when the file should be marked executable.</returns>
     public static bool RequiresExecutePermission(string path, string? absolutePath)
@@ -108,7 +108,7 @@ public static class ExecutableFileClassifier
         // the only reliable way to tell them apart, so use it whenever we have it.
         if (string.IsNullOrEmpty(extension))
         {
-            return absolutePath is null || HasExecutableMagicBytes(absolutePath);
+            return absolutePath is null || HasExecutePermissionHeader(absolutePath);
         }
 
         if (MatchesAny(extension, LibraryExtensions))
@@ -184,18 +184,8 @@ public static class ExecutableFileClassifier
     {
         Span<byte> header = stackalloc byte[MagicHeaderLength];
 
-        try
-        {
-            using var stream = new FileStream(
-                absolutePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            var read = stream.ReadAtLeast(header, MagicHeaderLength, throwOnEndOfStream: false);
-            return HasExecutableMagicBytes(header[..read]);
-        }
-        catch (Exception ex) when (
-            ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
-        {
-            return false;
-        }
+        return TryReadHeader(absolutePath, header, out var read)
+            && HasExecutableMagicBytes(header[..read]);
     }
 
     /// <summary>
@@ -248,6 +238,40 @@ public static class ExecutableFileClassifier
         }
 
         return false;
+    }
+
+    private static bool HasExecutePermissionHeader(string absolutePath)
+    {
+        Span<byte> header = stackalloc byte[MagicHeaderLength];
+
+        if (!TryReadHeader(absolutePath, header, out var read))
+        {
+            return false;
+        }
+
+        var fileHeader = header[..read];
+
+        // A shebang is a Unix permission fact, not native executable magic. Keep it out
+        // of HasExecutableMagicBytes so scripts never become legacy launch candidates.
+        return HasExecutableMagicBytes(fileHeader)
+            || fileHeader is [0x23, 0x21, ..];
+    }
+
+    private static bool TryReadHeader(string absolutePath, Span<byte> header, out int read)
+    {
+        try
+        {
+            using var stream = new FileStream(
+                absolutePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            read = stream.ReadAtLeast(header, MagicHeaderLength, throwOnEndOfStream: false);
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            read = 0;
+            return false;
+        }
     }
 
     private static bool MatchesAny(string extension, string[] candidates)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
@@ -50,7 +50,7 @@ public class ExecutableFileClassifierTests : IDisposable
     [InlineData("", false)]
     public void RequiresExecutePermission_ClassifiesCorrectly(string path, bool expected)
     {
-        Assert.Equal(expected, ExecutableFileClassifier.RequiresExecutePermission(path));
+        Assert.Equal(expected, ExecutableFileClassifier.RequiresExecutePermissionFromName(path));
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ public class ExecutableFileClassifierTests : IDisposable
     [InlineData("", false)]
     public void IsLegacyLaunchCandidate_ClassifiesCorrectly(string path, bool expected)
     {
-        Assert.Equal(expected, ExecutableFileClassifier.IsLegacyLaunchCandidate(path));
+        Assert.Equal(expected, ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(path));
     }
 
     /// <summary>
@@ -86,14 +86,14 @@ public class ExecutableFileClassifierTests : IDisposable
     [Fact]
     public void TheTwoQuestionsAreIndependent()
     {
-        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("run.sh"));
-        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("run.sh"));
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermissionFromName("run.sh"));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidateFromName("run.sh"));
 
-        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generalszh"));
-        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("generalszh"));
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermissionFromName("generalszh"));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidateFromName("generalszh"));
 
-        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("libSDL3.dylib"));
-        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("libSDL3.dylib"));
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermissionFromName("libSDL3.dylib"));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidateFromName("libSDL3.dylib"));
     }
 
     /// <summary>
@@ -114,9 +114,12 @@ public class ExecutableFileClassifierTests : IDisposable
     [InlineData(new byte[] { 0xCE, 0xFA, 0xED, 0xFE }, true)]
     [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE }, true)]
 
-    // Mach-O universal (fat): second word is the architecture count.
+    // Mach-O universal (fat), 32- and 64-bit headers: second word is the architecture
+    // count, byte-swapped alongside the swapped magics.
     [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02 }, true)]
     [InlineData(new byte[] { 0xBE, 0xBA, 0xFE, 0xCA, 0x02, 0x00, 0x00, 0x00 }, true)]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBF, 0x00, 0x00, 0x00, 0x02 }, true)]
+    [InlineData(new byte[] { 0xBF, 0xBA, 0xFE, 0xCA, 0x02, 0x00, 0x00, 0x00 }, true)]
 
     // A Java class file shares the fat magic, but its second word is the class-file
     // version (>= 45); 0x34 is Java 8.
@@ -124,6 +127,7 @@ public class ExecutableFileClassifierTests : IDisposable
 
     // A fat magic with no second word cannot be confirmed as a fat binary.
     [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE }, false)]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBF }, false)]
 
     // Text, shebang scripts, truncated headers, and nothing at all.
     [InlineData(new byte[] { 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73 }, false)]
@@ -179,6 +183,7 @@ public class ExecutableFileClassifierTests : IDisposable
     [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 })]
     [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01 })]
     [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02 })]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBF, 0x00, 0x00, 0x00, 0x02 })]
     public void ExtensionlessNativeBinary_IsClassifiedExecutable(byte[] header)
     {
         var path = Path.Combine(_tempDirectory, "generalszh");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Text;
 using GenHub.Core.Utilities;
 using Xunit;
 
@@ -7,8 +10,17 @@ namespace GenHub.Tests.Core.Utilities;
 /// Table-driven tests for <see cref="ExecutableFileClassifier"/>, which replaced five
 /// disagreeing implementations of "is this executable".
 /// </summary>
-public class ExecutableFileClassifierTests
+public class ExecutableFileClassifierTests : IDisposable
 {
+    private readonly string _tempDirectory = Directory.CreateTempSubdirectory("classifier-tests").FullName;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Directory.Delete(_tempDirectory, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
     /// <summary>
     /// Verifies which files are marked as needing the Unix execute bit.
     /// </summary>
@@ -82,5 +94,139 @@ public class ExecutableFileClassifierTests
 
         Assert.False(ExecutableFileClassifier.RequiresExecutePermission("libSDL3.dylib"));
         Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("libSDL3.dylib"));
+    }
+
+    /// <summary>
+    /// Verifies magic-byte recognition of every supported executable format, and
+    /// rejection of everything else.
+    /// </summary>
+    /// <param name="header">The first bytes of a file.</param>
+    /// <param name="expected">Whether the header denotes a native executable.</param>
+    [Theory]
+
+    // MZ (Windows PE), ELF (Linux).
+    [InlineData(new byte[] { 0x4D, 0x5A, 0x90, 0x00 }, true)]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 }, true)]
+
+    // Mach-O thin, 32- and 64-bit, both byte orders on disk.
+    [InlineData(new byte[] { 0xFE, 0xED, 0xFA, 0xCE }, true)]
+    [InlineData(new byte[] { 0xFE, 0xED, 0xFA, 0xCF }, true)]
+    [InlineData(new byte[] { 0xCE, 0xFA, 0xED, 0xFE }, true)]
+    [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE }, true)]
+
+    // Mach-O universal (fat): second word is the architecture count.
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02 }, true)]
+    [InlineData(new byte[] { 0xBE, 0xBA, 0xFE, 0xCA, 0x02, 0x00, 0x00, 0x00 }, true)]
+
+    // A Java class file shares the fat magic, but its second word is the class-file
+    // version (>= 45); 0x34 is Java 8.
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x34 }, false)]
+
+    // A fat magic with no second word cannot be confirmed as a fat binary.
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE }, false)]
+
+    // Text, shebang scripts, truncated headers, and nothing at all.
+    [InlineData(new byte[] { 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73 }, false)]
+    [InlineData(new byte[] { 0x23, 0x21, 0x2F, 0x62, 0x69, 0x6E, 0x2F }, false)]
+    [InlineData(new byte[] { 0x4D, 0x5A }, false)]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C }, false)]
+    [InlineData(new byte[] { }, false)]
+    public void HasExecutableMagicBytes_ClassifiesHeaders(byte[] header, bool expected)
+    {
+        Assert.Equal(expected, ExecutableFileClassifier.HasExecutableMagicBytes(header));
+    }
+
+    /// <summary>
+    /// An extensionless file whose content is text is exactly the false positive the
+    /// name-only heuristic produced: a README is not a native binary.
+    /// </summary>
+    [Fact]
+    public void ExtensionlessTextFile_IsNotClassifiedExecutable()
+    {
+        var readme = Path.Combine(_tempDirectory, "README");
+        File.WriteAllText(readme, "This project is a mod for Zero Hour.\n");
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("README", readme));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("README", readme));
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(readme));
+    }
+
+    /// <summary>
+    /// Files shorter than any magic number must be rejected without throwing.
+    /// </summary>
+    /// <param name="content">The whole file content.</param>
+    [Theory]
+    [InlineData(new byte[] { })]
+    [InlineData(new byte[] { 0x4D })]
+    [InlineData(new byte[] { 0x4D, 0x5A })]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C })]
+    public void TinyFiles_AreRejectedWithoutThrowing(byte[] content)
+    {
+        var path = Path.Combine(_tempDirectory, $"tiny-{content.Length}");
+        File.WriteAllBytes(path, content);
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission(Path.GetFileName(path), path));
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(path));
+    }
+
+    /// <summary>
+    /// An extensionless file that really is a native binary keeps both classifications,
+    /// whichever platform's format it carries.
+    /// </summary>
+    /// <param name="header">The magic bytes to write.</param>
+    [Theory]
+    [InlineData(new byte[] { 0x4D, 0x5A, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00 })]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 })]
+    [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01 })]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02 })]
+    public void ExtensionlessNativeBinary_IsClassifiedExecutable(byte[] header)
+    {
+        var path = Path.Combine(_tempDirectory, "generalszh");
+        File.WriteAllBytes(path, header);
+
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generalszh", path));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("GeneralsMD/Release/generalszh", path));
+    }
+
+    /// <summary>
+    /// A missing or unreadable file cannot be confirmed as a binary and must not throw.
+    /// </summary>
+    [Fact]
+    public void MissingFile_IsNotClassifiedExecutable()
+    {
+        var path = Path.Combine(_tempDirectory, "does-not-exist");
+
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(path));
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("does-not-exist", path));
+    }
+
+    /// <summary>
+    /// Extension-based classification does not consult content: a library stays
+    /// non-executable even though it is a real native image, and known runnable
+    /// extensions do not require one.
+    /// </summary>
+    [Fact]
+    public void ExtensionRules_AreUnchangedByContent()
+    {
+        var dylib = Path.Combine(_tempDirectory, "libSDL3.dylib");
+        File.WriteAllBytes(dylib, [0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01]);
+
+        var script = Path.Combine(_tempDirectory, "run.sh");
+        File.WriteAllText(script, "#!/bin/sh\nexec ./generalszh\n", Encoding.ASCII);
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("libSDL3.dylib", dylib));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("libSDL3.dylib", dylib));
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("run.sh", script));
+    }
+
+    /// <summary>
+    /// Callers that hold only a name (manifest entries, remote release assets) keep the
+    /// legacy behaviour: extensionless means native binary.
+    /// </summary>
+    [Fact]
+    public void NameOnlyClassification_KeepsLegacyExtensionlessBehaviour()
+    {
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generalszh", null));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("generalszh", null));
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
@@ -156,6 +156,21 @@ public class ExecutableFileClassifierTests : IDisposable
     }
 
     /// <summary>
+    /// An extensionless shebang script needs the Unix execute bit, but is not native
+    /// executable code and must not become a legacy inferred game entry point.
+    /// </summary>
+    [Fact]
+    public void ExtensionlessShebangScript_RequiresPermissionButIsNotLaunchCandidate()
+    {
+        var script = Path.Combine(_tempDirectory, "launch");
+        File.WriteAllText(script, "#!/bin/sh\nexec ./generalszh\n", Encoding.ASCII);
+
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("launch", script));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("launch", script));
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(script));
+    }
+
+    /// <summary>
     /// Files shorter than any magic number must be rejected without throwing.
     /// </summary>
     /// <param name="content">The whole file content.</param>

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -178,7 +178,7 @@ public class CommunityOutpostDeliverer(
                 RelativePath = relativePath,
                 Size = fileInfo.Length,
                 IsRequired = true,
-                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(relativePath),
+                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(relativePath, file),
                 SourceType = ContentSourceType.ExtractedPackage,
             });
         }

--- a/GenHub/GenHub/Features/Content/Services/Helpers/GitHubInferenceHelper.cs
+++ b/GenHub/GenHub/Features/Content/Services/Helpers/GitHubInferenceHelper.cs
@@ -191,7 +191,7 @@ public static class GitHubInferenceHelper
     /// <returns>True when the extension matches a known executable type.</returns>
     public static bool IsExecutableFile(string fileName)
     {
-        return ExecutableFileClassifier.RequiresExecutePermission(fileName);
+        return ExecutableFileClassifier.RequiresExecutePermissionFromName(fileName);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
@@ -34,7 +34,8 @@ public partial class FileTreeItem : ObservableObject
     /// <summary>
     /// Gets a value indicating whether this file is an executable (.exe).
     /// </summary>
-    public bool IsExecutable => IsFile && ExecutableFileClassifier.IsLegacyLaunchCandidate(Name);
+    public bool IsExecutable => IsFile && ExecutableFileClassifier.IsLegacyLaunchCandidate(
+        Name, string.IsNullOrEmpty(FullPath) ? null : FullPath);
 
     /// <summary>
     /// Gets or sets a value indicating whether this item is selected as the executable.

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -734,10 +734,10 @@ public partial class ContentManifestBuilder(
 
     private static bool IsExecutableFile(string filePath)
     {
-        // Delegates to the shared classifier. The previous implementation also required
-        // File.Exists, which made classification depend on disk state at build time:
-        // the same manifest could classify differently depending on when it was built.
-        return ExecutableFileClassifier.RequiresExecutePermission(filePath);
+        // Delegates to the shared classifier. The caller has just enumerated filePath
+        // from disk, so the classifier can sniff its magic bytes and an extensionless
+        // README is not mistaken for a native binary.
+        return ExecutableFileClassifier.RequiresExecutePermission(filePath, filePath);
     }
 
     /// <returns>The normalized version string.</returns>

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -949,7 +949,7 @@ public class ManifestGenerationService(
                     // the Steam layout launches game.dat through a proxy, which is a launch
                     // strategy rather than a property of the file, and it forced
                     // SteamManifestPatcher to keep flipping the flag by hand.
-                    var isExecutable = ExecutableFileClassifier.RequiresExecutePermission(finalPath);
+                    var isExecutable = ExecutableFileClassifier.RequiresExecutePermission(finalPath, fullPath);
 
                     await builder.AddGameInstallationFileAsync(finalPath, fullPath, isExecutable);
                     _fileCount++;


### PR DESCRIPTION
## Summary

Replace the extensionless-file executable heuristic with content-based
classification for files available on disk.

The shared classifier recognizes Windows PE, Linux ELF, and macOS Mach-O
binaries while rejecting ordinary extensionless files such as `README` and
`LICENSE`. Metadata-only callers retain an explicitly named compatibility
heuristic for content that has not yet been acquired.

## Changes

- Recognize MZ/PE and ELF executable headers.
- Recognize thin Mach-O headers in both byte orders.
- Recognize 32-bit and 64-bit universal Mach-O headers in both byte orders.
- Distinguish `CAFEBABE` universal binaries from Java class files using the
  architecture-count field.
- Read at most eight bytes when classifying a file on disk.
- Centralize execute-permission and legacy launch-candidate classification.
- Update manifest generation, delivery, and file-selection callers to use
  content-aware classification when an absolute path is available.
- Rename metadata-only methods to `RequiresExecutePermissionFromName` and
  `IsLegacyLaunchCandidateFromName`, preventing accidental overload selection.
- Preserve explicit script, dynamic-library, and legacy-manifest semantics.

## Testing

- `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release`
- 1,439 tests passed on macOS arm64.
- Covered MZ, ELF, thin Mach-O, FAT/FAT64 Mach-O, byte-swapped headers, Java
  class-file rejection, truncated files, missing files, and extensionless text.

## Risks and rollback

Unreadable, missing, truncated, or unrecognized on-disk files are classified as
non-executable. Metadata-only contexts retain the previous extensionless
compatibility behavior through methods whose names make that fallback explicit.

The client scanners changed by #330 must use the content-aware overload after
rebasing onto this change; the renamed method makes the old method-group call a
compile-time failure.

Rollback restores the extensionless heuristic and its false positives.

## Related issues

Fixes #325

Related to #330

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces extensionless-name executable inference with content-aware classification when file bytes are available.
- Detects PE, ELF, thin Mach-O, and universal Mach-O headers while distinguishing Java class files.
- Preserves name-only compatibility behavior for metadata-only callers.
- Recognizes extensionless shebang scripts as requiring execute permission without treating them as legacy launch candidates.
- Updates manifest generation, delivery, and file-selection callers to provide on-disk paths.
- Adds coverage for supported headers, scripts, text files, truncated files, and missing files.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the classifier now explicitly recognizes an extensionless file beginning with a shebang as requiring execute permission, and the on-disk manifest callers use that content-aware path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs | Adds bounded content-based native executable detection and separately recognizes shebang scripts for execute-permission classification, resolving the previously reported regression. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs | Adds direct coverage for native formats, byte order variants, Java-class rejection, extensionless scripts and text, and unavailable or truncated files. |
| GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs | Supplies the enumerated on-disk path so manifest executable flags use file contents. |
| GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs | Supplies the installation file path for content-aware executable-permission classification. |
| GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs | Classifies extracted files using their available on-disk contents. |
| GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs | Uses content-aware launch-candidate classification when a full path is available and retains metadata compatibility otherwise. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Classify file] --> B{Known extension?}
    B -->|Library| C[No execute permission]
    B -->|Runnable extension| D[Execute permission]
    B -->|Extensionless with disk path| E[Read up to 8 bytes]
    B -->|Extensionless without disk path| F[Use compatibility heuristic]
    E --> G{Header type}
    G -->|PE, ELF, or Mach-O| H[Native executable]
    G -->|Shebang| I[Execute permission only]
    G -->|Unknown, truncated, or unreadable| C
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(content): preserve execute permissio..."](https://github.com/community-outpost/genhub/commit/79b0562dd872529395de5affc5e28c4041560914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48757844)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Content Manifest System](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-manifest-system.md)
- Knowledge Base — [Content Acquisition Pipeline](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-acquisition-pipeline.md)
- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)
</details>

<!-- /greptile_comment -->