### PR TITLE
fix(tests): pass the absolute path to the executable classifier

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
@@ -135,7 +135,7 @@ public class NativeClientManifestLaunchTests
             engineFiles.Add(new ManifestFile
             {
                 RelativePath = name,
-                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(name),
+                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(name, path),
             });
         }
 


### PR DESCRIPTION
`development` does not compile: #332 and #339 merged without a textual conflict, but #339 changed `ExecutableFileClassifier.RequiresExecutePermission` to require an `absolutePath` argument, leaving one stale call site in the tests #332 added.

All three CI jobs fail at **Run Tests** with:

```
NativeClientManifestLaunchTests.cs(138,57): error CS7036: There is no argument given that
corresponds to the required parameter 'absolutePath' of
'ExecutableFileClassifier.RequiresExecutePermission(string, string?)'
```

The loop already has the absolute path in hand, so it is passed through rather than switching to `RequiresExecutePermissionFromName`. That gives the magic-byte check #339 introduced, matching what `ManifestGenerationService` and `ContentManifestBuilder` do in production. This was the only remaining stale call site.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR repairs the native-client manifest launch tests after the executable classifier began requiring an absolute path.
- Passes the enumerated file’s absolute path to `ExecutableFileClassifier.RequiresExecutePermission`.
- Aligns the test manifest’s executable classification with production’s content-aware classification behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the stale test call corrected to match the classifier’s current contract.

The enumerated file path is passed in the expected absolute-path parameter position, restoring compilation and enabling the intended magic-byte classification for extensionless native binaries.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs | Correctly supplies the full fixture file path to the executable classifier while retaining the filename for extension-based classification. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): pass the absolute path to th..."](https://github.com/community-outpost/genhub/commit/426314625fc8f03e7c86d14201480e0d9b295ddb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49369260)</sub>

<!-- /greptile_comment -->