### PR TITLE
fix(workspace): fall back from protected adjacent storage

### DIFF
--- a/GenHub/GenHub.Core/Constants/StorageConstants.cs
+++ b/GenHub/GenHub.Core/Constants/StorageConstants.cs
@@ -5,6 +5,11 @@ namespace GenHub.Core.Constants;
 /// </summary>
 public static class StorageConstants
 {
+    /// <summary>
+    /// Prefix used for temporary files that verify a storage location is writable.
+    /// </summary>
+    public const string WriteProbeFilePrefix = ".genhub-write-probe-";
+
     // CAS retry constants
 
     /// <summary>

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -18,6 +18,15 @@ public static class PathHelper
             : StringComparison.Ordinal;
 
     /// <summary>
+    /// Gets the string comparer to use when keying collections by filesystem path, matching
+    /// the case sensitivity of the current platform's default filesystem.
+    /// </summary>
+    public static StringComparer PathComparer =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+    /// <summary>
     /// Gets the parent directory of a path, with fallback to the path itself if at drive root.
     /// </summary>
     /// <param name="path">The path to get the parent directory from.</param>

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace GenHub.Core.Helpers;
@@ -7,6 +8,15 @@ namespace GenHub.Core.Helpers;
 /// </summary>
 public static class PathHelper
 {
+    /// <summary>
+    /// Gets the string comparison to use when comparing filesystem paths, matching the
+    /// case sensitivity of the current platform's default filesystem.
+    /// </summary>
+    public static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
     /// <summary>
     /// Gets the parent directory of a path, with fallback to the path itself if at drive root.
     /// </summary>

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -9,20 +9,20 @@ namespace GenHub.Core.Helpers;
 public static class PathHelper
 {
     /// <summary>
-    /// Gets the string comparison to use when comparing filesystem paths, matching the
-    /// case sensitivity of the current platform's default filesystem.
+    /// Gets the string comparison to use when comparing filesystem paths. Windows paths
+    /// are compared case-insensitively; other platforms use conservative case-sensitive semantics.
     /// </summary>
     public static StringComparison PathComparison =>
-        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+        OperatingSystem.IsWindows()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 
     /// <summary>
-    /// Gets the string comparer to use when keying collections by filesystem path, matching
-    /// the case sensitivity of the current platform's default filesystem.
+    /// Gets the string comparer to use when keying collections by filesystem path. Windows paths
+    /// are compared case-insensitively; other platforms use conservative case-sensitive semantics.
     /// </summary>
     public static StringComparer PathComparer =>
-        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+        OperatingSystem.IsWindows()
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
 

--- a/GenHub/GenHub.Core/Interfaces/Common/IStorageLocationService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Common/IStorageLocationService.cs
@@ -8,14 +8,14 @@ namespace GenHub.Core.Interfaces.Common;
 public interface IStorageLocationService
 {
     /// <summary>
-    /// Gets the CAS pool path adjacent to the specified game installation.
+    /// Gets a writable CAS pool path for the specified game installation.
     /// </summary>
     /// <param name="installation">The game installation to base the path on.</param>
     /// <returns>The absolute path to the CAS pool directory.</returns>
     string GetCasPoolPath(IGameInstallation installation);
 
     /// <summary>
-    /// Gets the workspace path adjacent to the specified game installation.
+    /// Gets a writable workspace path for the specified game installation.
     /// </summary>
     /// <param name="installation">The game installation to base the path on.</param>
     /// <returns>The absolute path to the workspace directory.</returns>

--- a/GenHub/GenHub.Core/Interfaces/Common/IStorageLocationService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Common/IStorageLocationService.cs
@@ -8,7 +8,7 @@ namespace GenHub.Core.Interfaces.Common;
 public interface IStorageLocationService
 {
     /// <summary>
-    /// Gets a writable CAS pool path for the specified game installation.
+    /// Gets the CAS pool path adjacent to the specified game installation.
     /// </summary>
     /// <param name="installation">The game installation to base the path on.</param>
     /// <returns>The absolute path to the CAS pool directory.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
@@ -52,7 +52,8 @@ public sealed class StorageLocationServiceTests : IDisposable
         var workspacePath = service.GetWorkspacePath(installation);
 
         Assert.Equal(Path.Combine(installationRoot, DirectoryNames.GenHubWorkspace), workspacePath);
-        Assert.Empty(Directory.GetFiles(installationRoot, ProbeSearchPattern));
+        Assert.True(Directory.Exists(workspacePath));
+        Assert.Empty(Directory.GetFiles(workspacePath, ProbeSearchPattern));
     }
 
     /// <summary>
@@ -94,7 +95,8 @@ public sealed class StorageLocationServiceTests : IDisposable
         var workspacePath = service.GetWorkspacePath(installation);
 
         Assert.Equal(customWorkspacePath, workspacePath);
-        Assert.Empty(Directory.GetFiles(_tempPath, ProbeSearchPattern));
+        Assert.True(Directory.Exists(customWorkspacePath));
+        Assert.Empty(Directory.GetFiles(customWorkspacePath, ProbeSearchPattern));
     }
 
     /// <summary>
@@ -117,8 +119,8 @@ public sealed class StorageLocationServiceTests : IDisposable
         var workspacePath = service.GetWorkspacePath(installation);
 
         Assert.Equal(customWorkspacePath, workspacePath);
-        Assert.False(Directory.Exists(missingParent));
-        Assert.Empty(Directory.GetFiles(_tempPath, ProbeSearchPattern));
+        Assert.True(Directory.Exists(customWorkspacePath));
+        Assert.Empty(Directory.GetFiles(customWorkspacePath, ProbeSearchPattern));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
@@ -5,22 +5,22 @@ using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
-using GenHub.Core.Models.Storage;
 using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace GenHub.Tests.Core.Common.Services;
 
 /// <summary>
-/// Tests writable storage path resolution.
+/// Tests writable workspace path resolution.
 /// </summary>
 public sealed class StorageLocationServiceTests : IDisposable
 {
+    private const string ProbeSearchPattern = ".genhub-write-probe-*";
+
     private readonly Mock<IUserSettingsService> _userSettingsService = new();
     private readonly Mock<IConfigurationProviderService> _configurationProviderService = new();
     private readonly Mock<IGameInstallationService> _gameInstallationService = new();
     private readonly string _applicationDataPath;
-    private readonly string _centralCasPath;
     private readonly string _tempPath;
 
     /// <summary>
@@ -30,20 +30,16 @@ public sealed class StorageLocationServiceTests : IDisposable
     {
         _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         _applicationDataPath = Path.Combine(_tempPath, "AppData");
-        _centralCasPath = Path.Combine(_applicationDataPath, DirectoryNames.CasPool);
         Directory.CreateDirectory(_applicationDataPath);
 
         _configurationProviderService.Setup(service => service.GetApplicationDataPath()).Returns(_applicationDataPath);
-        _configurationProviderService
-            .Setup(service => service.GetCasConfiguration())
-            .Returns(new CasConfiguration { CasRootPath = _centralCasPath });
     }
 
     /// <summary>
     /// Uses installation-adjacent storage when its parent is writable.
     /// </summary>
     [Fact]
-    public void GetStoragePaths_WhenInstallationParentIsWritable_UsesAdjacentPaths()
+    public void GetWorkspacePath_WhenInstallationParentIsWritable_UsesAdjacentPath()
     {
         var settings = new UserSettings { UseInstallationAdjacentStorage = true };
         _userSettingsService.Setup(service => service.Get()).Returns(settings);
@@ -54,18 +50,16 @@ public sealed class StorageLocationServiceTests : IDisposable
         var installation = new GameInstallation(installationPath, GameInstallationType.EaApp);
 
         var workspacePath = service.GetWorkspacePath(installation);
-        var casPath = service.GetCasPoolPath(installation);
 
         Assert.Equal(Path.Combine(installationRoot, DirectoryNames.GenHubWorkspace), workspacePath);
-        Assert.Equal(Path.Combine(installationRoot, DirectoryNames.GenHubCasPool), casPath);
-        Assert.Empty(Directory.GetFiles(installationRoot, ".genhub-write-probe-*"));
+        Assert.Empty(Directory.GetFiles(installationRoot, ProbeSearchPattern));
     }
 
     /// <summary>
     /// Falls back to user storage when the installation parent cannot contain a workspace.
     /// </summary>
     [Fact]
-    public void GetStoragePaths_WhenInstallationParentIsUnavailable_UsesCentralPaths()
+    public void GetWorkspacePath_WhenInstallationParentIsUnavailable_UsesCentralPath()
     {
         var settings = new UserSettings { UseInstallationAdjacentStorage = true };
         _userSettingsService.Setup(service => service.Get()).Returns(settings);
@@ -77,36 +71,73 @@ public sealed class StorageLocationServiceTests : IDisposable
             GameInstallationType.EaApp);
 
         var workspacePath = service.GetWorkspacePath(installation);
-        var casPath = service.GetCasPoolPath(installation);
 
         Assert.Equal(Path.Combine(_applicationDataPath, DirectoryNames.Workspaces), workspacePath);
-        Assert.Equal(_centralCasPath, casPath);
     }
 
     /// <summary>
-    /// Honors writable user-configured storage when adjacent storage is disabled.
+    /// Honors a writable user-configured workspace path when adjacent storage is disabled.
     /// </summary>
     [Fact]
-    public void GetStoragePaths_WhenCustomPathsAreConfigured_UsesCustomPaths()
+    public void GetWorkspacePath_WhenCustomPathIsConfigured_UsesCustomPath()
     {
         var customWorkspacePath = Path.Combine(_tempPath, "CustomWorkspace");
-        var customCasPath = Path.Combine(_tempPath, "CustomCas");
         var settings = new UserSettings
         {
             UseInstallationAdjacentStorage = false,
             WorkspacePath = customWorkspacePath,
-            CasConfiguration = new CasConfiguration { CasRootPath = customCasPath },
         };
         _userSettingsService.Setup(service => service.Get()).Returns(settings);
         var service = CreateService();
         var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
 
         var workspacePath = service.GetWorkspacePath(installation);
-        var casPath = service.GetCasPoolPath(installation);
 
         Assert.Equal(customWorkspacePath, workspacePath);
-        Assert.Equal(customCasPath, casPath);
-        Assert.Empty(Directory.GetFiles(_tempPath, ".genhub-write-probe-*"));
+        Assert.Empty(Directory.GetFiles(_tempPath, ProbeSearchPattern));
+    }
+
+    /// <summary>
+    /// Falls back to user storage when the configured workspace path cannot be created.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenCustomPathIsUnavailable_UsesCentralPath()
+    {
+        var unavailableRoot = Path.Combine(_tempPath, "custom-root");
+        File.WriteAllText(unavailableRoot, "not a directory");
+        var settings = new UserSettings
+        {
+            UseInstallationAdjacentStorage = false,
+            WorkspacePath = Path.Combine(unavailableRoot, "CustomWorkspace"),
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+
+        Assert.Equal(Path.Combine(_applicationDataPath, DirectoryNames.Workspaces), workspacePath);
+    }
+
+    /// <summary>
+    /// Probes a storage location once and reuses the result for later resolutions.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenCalledRepeatedly_ProbesOnce()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installationRoot = Path.Combine(_tempPath, "EA Games");
+        var installationPath = Path.Combine(installationRoot, "Command and Conquer Generals Zero Hour");
+        Directory.CreateDirectory(installationPath);
+        var installation = new GameInstallation(installationPath, GameInstallationType.EaApp);
+
+        var first = service.GetWorkspacePath(installation);
+        Directory.Delete(installationRoot, true);
+        var second = service.GetWorkspacePath(installation);
+
+        Assert.Equal(first, second);
     }
 
     /// <inheritdoc/>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
@@ -15,7 +15,7 @@ namespace GenHub.Tests.Core.Common.Services;
 /// </summary>
 public sealed class StorageLocationServiceTests : IDisposable
 {
-    private const string ProbeSearchPattern = ".genhub-write-probe-*";
+    private const string ProbeSearchPattern = StorageConstants.WriteProbeFilePrefix + "*";
 
     private readonly Mock<IUserSettingsService> _userSettingsService = new();
     private readonly Mock<IConfigurationProviderService> _configurationProviderService = new();
@@ -94,6 +94,30 @@ public sealed class StorageLocationServiceTests : IDisposable
         var workspacePath = service.GetWorkspacePath(installation);
 
         Assert.Equal(customWorkspacePath, workspacePath);
+        Assert.Empty(Directory.GetFiles(_tempPath, ProbeSearchPattern));
+    }
+
+    /// <summary>
+    /// Honors a creatable custom workspace path when its immediate parent does not exist yet.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenCustomPathParentDoesNotExist_UsesCustomPath()
+    {
+        var missingParent = Path.Combine(_tempPath, "Missing", "Parents");
+        var customWorkspacePath = Path.Combine(missingParent, "CustomWorkspace");
+        var settings = new UserSettings
+        {
+            UseInstallationAdjacentStorage = false,
+            WorkspacePath = customWorkspacePath,
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+
+        Assert.Equal(customWorkspacePath, workspacePath);
+        Assert.False(Directory.Exists(missingParent));
         Assert.Empty(Directory.GetFiles(_tempPath, ProbeSearchPattern));
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
@@ -1,0 +1,136 @@
+using GenHub.Common.Services;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Storage;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GenHub.Tests.Core.Common.Services;
+
+/// <summary>
+/// Tests writable storage path resolution.
+/// </summary>
+public sealed class StorageLocationServiceTests : IDisposable
+{
+    private readonly Mock<IUserSettingsService> _userSettingsService = new();
+    private readonly Mock<IConfigurationProviderService> _configurationProviderService = new();
+    private readonly Mock<IGameInstallationService> _gameInstallationService = new();
+    private readonly string _applicationDataPath;
+    private readonly string _centralCasPath;
+    private readonly string _tempPath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StorageLocationServiceTests"/> class.
+    /// </summary>
+    public StorageLocationServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        _applicationDataPath = Path.Combine(_tempPath, "AppData");
+        _centralCasPath = Path.Combine(_applicationDataPath, DirectoryNames.CasPool);
+        Directory.CreateDirectory(_applicationDataPath);
+
+        _configurationProviderService.Setup(service => service.GetApplicationDataPath()).Returns(_applicationDataPath);
+        _configurationProviderService
+            .Setup(service => service.GetCasConfiguration())
+            .Returns(new CasConfiguration { CasRootPath = _centralCasPath });
+    }
+
+    /// <summary>
+    /// Uses installation-adjacent storage when its parent is writable.
+    /// </summary>
+    [Fact]
+    public void GetStoragePaths_WhenInstallationParentIsWritable_UsesAdjacentPaths()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installationRoot = Path.Combine(_tempPath, "EA Games");
+        var installationPath = Path.Combine(installationRoot, "Command and Conquer Generals Zero Hour");
+        Directory.CreateDirectory(installationPath);
+        var installation = new GameInstallation(installationPath, GameInstallationType.EaApp);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+        var casPath = service.GetCasPoolPath(installation);
+
+        Assert.Equal(Path.Combine(installationRoot, DirectoryNames.GenHubWorkspace), workspacePath);
+        Assert.Equal(Path.Combine(installationRoot, DirectoryNames.GenHubCasPool), casPath);
+        Assert.Empty(Directory.GetFiles(installationRoot, ".genhub-write-probe-*"));
+    }
+
+    /// <summary>
+    /// Falls back to user storage when the installation parent cannot contain a workspace.
+    /// </summary>
+    [Fact]
+    public void GetStoragePaths_WhenInstallationParentIsUnavailable_UsesCentralPaths()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var unavailableRoot = Path.Combine(_tempPath, "protected-root");
+        File.WriteAllText(unavailableRoot, "not a directory");
+        var installation = new GameInstallation(
+            Path.Combine(unavailableRoot, "Command and Conquer Generals Zero Hour"),
+            GameInstallationType.EaApp);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+        var casPath = service.GetCasPoolPath(installation);
+
+        Assert.Equal(Path.Combine(_applicationDataPath, DirectoryNames.Workspaces), workspacePath);
+        Assert.Equal(_centralCasPath, casPath);
+    }
+
+    /// <summary>
+    /// Honors writable user-configured storage when adjacent storage is disabled.
+    /// </summary>
+    [Fact]
+    public void GetStoragePaths_WhenCustomPathsAreConfigured_UsesCustomPaths()
+    {
+        var customWorkspacePath = Path.Combine(_tempPath, "CustomWorkspace");
+        var customCasPath = Path.Combine(_tempPath, "CustomCas");
+        var settings = new UserSettings
+        {
+            UseInstallationAdjacentStorage = false,
+            WorkspacePath = customWorkspacePath,
+            CasConfiguration = new CasConfiguration { CasRootPath = customCasPath },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+        var casPath = service.GetCasPoolPath(installation);
+
+        Assert.Equal(customWorkspacePath, workspacePath);
+        Assert.Equal(customCasPath, casPath);
+        Assert.Empty(Directory.GetFiles(_tempPath, ".genhub-write-probe-*"));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempPath, true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private StorageLocationService CreateService() => new(
+        _userSettingsService.Object,
+        _configurationProviderService.Object,
+        _gameInstallationService.Object,
+        new Mock<ILogger<StorageLocationService>>().Object);
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
@@ -6,6 +6,7 @@ using GenHub.Core.Models.Workspace;
 using GenHub.Features.Workspace.Strategies;
 using Microsoft.Extensions.Logging;
 using Moq;
+using ManifestContentType = GenHub.Core.Models.Enums.ContentType;
 
 namespace GenHub.Tests.Core.Features.Workspace;
 
@@ -249,6 +250,69 @@ public class StrategyTests : IDisposable
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(
             () => strategy.PrepareAsync(null!, null, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Verifies that hard-link preparation copies CAS content instead of rejecting a cross-volume workspace.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task HardLinkStrategy_WhenVolumesDiffer_FallsBackToCopy()
+    {
+        const string Hash = "test-hash";
+        var strategy = new HardLinkStrategy(_fileOps.Object, new Mock<ILogger<HardLinkStrategy>>().Object);
+        var configuration = new WorkspaceConfiguration
+        {
+            Id = "cross-volume",
+            Strategy = WorkspaceStrategy.HardLink,
+            WorkspaceRootPath = _tempDir,
+            BaseInstallationPath = "relative-installation-path",
+            GameClient = new GameClient { Id = "test" },
+            Manifests =
+            [
+                new ContentManifest
+                {
+                    ContentType = ManifestContentType.GameClient,
+                    Files =
+                    [
+                        new ManifestFile
+                        {
+                            RelativePath = "game.exe",
+                            Hash = Hash,
+                            Size = 1024,
+                            InstallTarget = ContentInstallTarget.Workspace,
+                            SourceType = ContentSourceType.ContentAddressable,
+                        },
+                    ],
+                },
+            ],
+        };
+        _fileOps
+            .Setup(service => service.LinkFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                true,
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _fileOps
+            .Setup(service => service.CopyFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await strategy.PrepareAsync(configuration, null, CancellationToken.None);
+
+        Assert.True(result.IsPrepared);
+        _fileOps.Verify(
+            service => service.CopyFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
@@ -81,7 +81,7 @@ public class WorkspaceManagerReuseTests : IDisposable
         // Arrange
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";
-        var workspacePath = Path.Combine(_tempPath, "workspace");
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
         Directory.CreateDirectory(workspacePath);
         File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
 
@@ -141,7 +141,7 @@ public class WorkspaceManagerReuseTests : IDisposable
         // Arrange
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";
-        var workspacePath = Path.Combine(_tempPath, "workspace");
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
         Directory.CreateDirectory(workspacePath);
         File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
 
@@ -189,6 +189,67 @@ public class WorkspaceManagerReuseTests : IDisposable
 
         // Should NOT call strategy.PrepareAsync because it reuses existing
         _mockStrategy.Verify(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that a workspace is recreated when storage resolution moves it to a new root.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenStorageRootChanges_ShouldRecreateWorkspace()
+    {
+        var workspaceId = "test-workspace";
+        var manifestId = "1.0.local.mod.testmanifest";
+        var oldWorkspaceRoot = Path.Combine(_tempPath, "protected-root");
+        var oldWorkspacePath = Path.Combine(oldWorkspaceRoot, workspaceId);
+        var newWorkspaceRoot = Path.Combine(_tempPath, "AppData", "Workspaces");
+        var newWorkspacePath = Path.Combine(newWorkspaceRoot, workspaceId);
+        Directory.CreateDirectory(oldWorkspacePath);
+        File.WriteAllText(Path.Combine(oldWorkspacePath, "test.txt"), "content");
+
+        var cachedWorkspace = new WorkspaceInfo
+        {
+            Id = workspaceId,
+            WorkspacePath = oldWorkspacePath,
+            ManifestIds = [manifestId],
+            ManifestVersions = new Dictionary<string, string> { { manifestId, "1.0" } },
+            Strategy = WorkspaceStrategy.HardLink,
+            IsPrepared = true,
+            FileCount = 1,
+            IsValid = true,
+        };
+        await File.WriteAllTextAsync(_metadataPath, System.Text.Json.JsonSerializer.Serialize(new[] { cachedWorkspace }));
+
+        var config = new WorkspaceConfiguration
+        {
+            Id = workspaceId,
+            Strategy = WorkspaceStrategy.HardLink,
+            Manifests = [new ContentManifest { Id = ManifestId.Create(manifestId), Version = "1.0" }],
+            BaseInstallationPath = _tempPath,
+            WorkspaceRootPath = newWorkspaceRoot,
+            ValidateAfterPreparation = false,
+        };
+        var successValidation = new ValidationResult(workspaceId, []);
+        _mockWorkspaceValidator
+            .Setup(x => x.ValidateConfigurationAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successValidation);
+        _mockWorkspaceValidator
+            .Setup(x => x.ValidatePrerequisitesAsync(It.IsAny<IWorkspaceStrategy>(), It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successValidation);
+        _mockStrategy
+            .Setup(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WorkspaceInfo { Id = workspaceId, IsPrepared = true, WorkspacePath = newWorkspacePath });
+
+        var result = await _manager.PrepareWorkspaceAsync(config);
+
+        result.Success.Should().BeTrue();
+        result.Data!.WorkspacePath.Should().Be(newWorkspacePath);
+        _mockStrategy.Verify(
+            x => x.PrepareAsync(
+                It.Is<WorkspaceConfiguration>(configuration => configuration.ForceRecreate),
+                It.IsAny<IProgress<WorkspacePreparationProgress>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -1,0 +1,37 @@
+using GenHub.Core.Helpers;
+
+namespace GenHub.Tests.Core.Helpers;
+
+/// <summary>
+/// Tests platform-aware filesystem path comparison behavior.
+/// </summary>
+public sealed class PathHelperTests
+{
+    /// <summary>
+    /// Uses case-insensitive comparison only on Windows so case-sensitive Unix volumes remain distinct.
+    /// </summary>
+    [Fact]
+    public void PathComparison_UsesWindowsOnlyCaseFolding()
+    {
+        var firstPath = Path.Combine(Path.GetTempPath(), "GenHub");
+        var secondPath = Path.Combine(Path.GetTempPath(), "genhub");
+
+        var pathsAreEqual = string.Equals(firstPath, secondPath, PathHelper.PathComparison);
+
+        Assert.Equal(OperatingSystem.IsWindows(), pathsAreEqual);
+    }
+
+    /// <summary>
+    /// Uses the same platform case behavior when paths are collection keys.
+    /// </summary>
+    [Fact]
+    public void PathComparer_UsesWindowsOnlyCaseFolding()
+    {
+        var firstPath = Path.Combine(Path.GetTempPath(), "GenHub");
+        var secondPath = Path.Combine(Path.GetTempPath(), "genhub");
+
+        var pathsAreEqual = PathHelper.PathComparer.Equals(firstPath, secondPath);
+
+        Assert.Equal(OperatingSystem.IsWindows(), pathsAreEqual);
+    }
+}

--- a/GenHub/GenHub/Common/Services/StorageLocationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageLocationService.cs
@@ -28,7 +28,7 @@ public class StorageLocationService(
     /// Caches write-probe results for the process lifetime, so a permission change
     /// on a probed location only takes effect after a restart.
     /// </summary>
-    private readonly ConcurrentDictionary<string, bool> _writableStorageCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, bool> _writableStorageCache = new(PathHelper.PathComparer);
 
     /// <inheritdoc/>
     public string GetCasPoolPath(IGameInstallation installation)

--- a/GenHub/GenHub/Common/Services/StorageLocationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageLocationService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
@@ -18,6 +19,7 @@ namespace GenHub.Common.Services;
 /// </summary>
 public class StorageLocationService(
     IUserSettingsService userSettingsService,
+    IConfigurationProviderService configurationProviderService,
     IGameInstallationService gameInstallationService,
     ILogger<StorageLocationService> logger) : IStorageLocationService
 {
@@ -27,20 +29,25 @@ public class StorageLocationService(
         ArgumentNullException.ThrowIfNull(installation);
 
         var settings = userSettingsService.Get();
-        if (!settings.UseInstallationAdjacentStorage)
+        if (settings.UseInstallationAdjacentStorage &&
+            TryGetWritableInstallationAdjacentPath(installation, DirectoryNames.GenHubCasPool, out var adjacentPath))
         {
-            // Fall back to centralized AppData location
-            var appDataPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                AppConstants.AppName,
-                DirectoryNames.CasPool);
-            logger.LogDebug("Using centralized CAS pool path: {CasPoolPath} (installation-adjacent disabled)", appDataPath);
-            return appDataPath;
+            logger.LogDebug(
+                "Resolved installation-adjacent CAS pool path: {CasPoolPath} for installation {InstallationId}",
+                adjacentPath,
+                installation.Id);
+            return adjacentPath;
         }
 
-        var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
-        var casPoolPath = Path.Combine(installationRoot, DirectoryNames.GenHubCasPool);
-        logger.LogDebug("Resolved CAS pool path: {CasPoolPath} for installation {InstallationId}", casPoolPath, installation.Id);
+        var configuredCasPath = settings.CasConfiguration.CasRootPath;
+        var casPoolPath = !string.IsNullOrWhiteSpace(configuredCasPath) && CanCreateStorageAt(configuredCasPath)
+            ? Path.GetFullPath(configuredCasPath)
+            : configurationProviderService.GetCasConfiguration().CasRootPath;
+
+        logger.LogInformation(
+            "Using centralized CAS pool path {CasPoolPath} for installation {InstallationId}",
+            casPoolPath,
+            installation.Id);
         return casPoolPath;
     }
 
@@ -50,20 +57,25 @@ public class StorageLocationService(
         ArgumentNullException.ThrowIfNull(installation);
 
         var settings = userSettingsService.Get();
-        if (!settings.UseInstallationAdjacentStorage)
+        if (settings.UseInstallationAdjacentStorage &&
+            TryGetWritableInstallationAdjacentPath(installation, DirectoryNames.GenHubWorkspace, out var adjacentPath))
         {
-            // Fall back to centralized AppData location
-            var appDataPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                AppConstants.AppName,
-                DirectoryNames.Workspaces);
-            logger.LogDebug("Using centralized workspace path: {WorkspacePath} (installation-adjacent disabled)", appDataPath);
-            return appDataPath;
+            logger.LogDebug(
+                "Resolved installation-adjacent workspace path: {WorkspacePath} for installation {InstallationId}",
+                adjacentPath,
+                installation.Id);
+            return adjacentPath;
         }
 
-        var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
-        var workspacePath = Path.Combine(installationRoot, DirectoryNames.GenHubWorkspace);
-        logger.LogDebug("Resolved workspace path: {WorkspacePath} for installation {InstallationId}", workspacePath, installation.Id);
+        var configuredWorkspacePath = settings.WorkspacePath;
+        var workspacePath = !string.IsNullOrWhiteSpace(configuredWorkspacePath) && CanCreateStorageAt(configuredWorkspacePath)
+            ? Path.GetFullPath(configuredWorkspacePath)
+            : Path.Combine(configurationProviderService.GetApplicationDataPath(), DirectoryNames.Workspaces);
+
+        logger.LogInformation(
+            "Using centralized workspace path {WorkspacePath} for installation {InstallationId}",
+            workspacePath,
+            installation.Id);
         return workspacePath;
     }
 
@@ -153,5 +165,66 @@ public class StorageLocationService(
             sameVolume);
 
         return sameVolume;
+    }
+
+    private bool TryGetWritableInstallationAdjacentPath(
+        IGameInstallation installation,
+        string directoryName,
+        out string path)
+    {
+        var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
+        path = Path.Combine(installationRoot, directoryName);
+        if (CanCreateStorageAt(path))
+        {
+            return true;
+        }
+
+        logger.LogWarning(
+            "Installation-adjacent storage path {StoragePath} is not writable for installation {InstallationId}; falling back to user storage",
+            path,
+            installation.Id);
+        return false;
+    }
+
+    private bool CanCreateStorageAt(string storagePath)
+    {
+        string? probePath = null;
+
+        try
+        {
+            var fullStoragePath = Path.GetFullPath(storagePath);
+            var probeDirectory = Directory.Exists(fullStoragePath)
+                ? fullStoragePath
+                : Path.GetDirectoryName(fullStoragePath);
+
+            if (string.IsNullOrWhiteSpace(probeDirectory) || !Directory.Exists(probeDirectory))
+            {
+                return false;
+            }
+
+            probePath = Path.Combine(probeDirectory, $".genhub-write-probe-{Guid.NewGuid():N}.tmp");
+            using var probe = new FileStream(probePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            probe.WriteByte(0);
+            return true;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or SecurityException)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} is not writable", storagePath);
+            return false;
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(probePath))
+            {
+                try
+                {
+                    File.Delete(probePath);
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                {
+                    logger.LogDebug(ex, "Could not remove storage write probe {ProbePath}", probePath);
+                }
+            }
+        }
     }
 }

--- a/GenHub/GenHub/Common/Services/StorageLocationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageLocationService.cs
@@ -208,17 +208,17 @@ public class StorageLocationService(
     private bool ProbeStorageLocation(string fullStoragePath)
     {
         string? probePath = null;
+        var storageDirectoryExisted = Directory.Exists(fullStoragePath);
+        var storageDirectoryCreated = false;
+        var probeSucceeded = false;
 
         try
         {
-            var probeDirectory = FindNearestExistingDirectory(fullStoragePath);
-            if (string.IsNullOrWhiteSpace(probeDirectory))
-            {
-                return false;
-            }
+            Directory.CreateDirectory(fullStoragePath);
+            storageDirectoryCreated = !storageDirectoryExisted;
 
             probePath = Path.Combine(
-                probeDirectory,
+                fullStoragePath,
                 $"{StorageConstants.WriteProbeFilePrefix}{Guid.NewGuid():N}.tmp");
             using var probe = new FileStream(
                 probePath,
@@ -228,6 +228,7 @@ public class StorageLocationService(
                 bufferSize: 1,
                 FileOptions.DeleteOnClose);
             probe.WriteByte(0);
+            probeSucceeded = true;
             return true;
         }
         catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or SecurityException)
@@ -248,27 +249,22 @@ public class StorageLocationService(
                     logger.LogDebug(ex, "Could not remove storage write probe {ProbePath}", probePath);
                 }
             }
-        }
-    }
 
-    private string? FindNearestExistingDirectory(string fullStoragePath)
-    {
-        var candidate = fullStoragePath;
-        while (!string.IsNullOrWhiteSpace(candidate))
-        {
-            if (Directory.Exists(candidate))
+            if (!probeSucceeded && storageDirectoryCreated)
             {
-                return candidate;
+                try
+                {
+                    if (Directory.Exists(fullStoragePath) &&
+                        !Directory.EnumerateFileSystemEntries(fullStoragePath).Any())
+                    {
+                        Directory.Delete(fullStoragePath);
+                    }
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or SecurityException)
+                {
+                    logger.LogDebug(ex, "Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
+                }
             }
-
-            if (File.Exists(candidate))
-            {
-                return null;
-            }
-
-            candidate = Path.GetDirectoryName(candidate);
         }
-
-        return null;
     }
 }

--- a/GenHub/GenHub/Common/Services/StorageLocationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageLocationService.cs
@@ -211,16 +211,15 @@ public class StorageLocationService(
 
         try
         {
-            var probeDirectory = Directory.Exists(fullStoragePath)
-                ? fullStoragePath
-                : Path.GetDirectoryName(fullStoragePath);
-
-            if (string.IsNullOrWhiteSpace(probeDirectory) || !Directory.Exists(probeDirectory))
+            var probeDirectory = FindNearestExistingDirectory(fullStoragePath);
+            if (string.IsNullOrWhiteSpace(probeDirectory))
             {
                 return false;
             }
 
-            probePath = Path.Combine(probeDirectory, $".genhub-write-probe-{Guid.NewGuid():N}.tmp");
+            probePath = Path.Combine(
+                probeDirectory,
+                $"{StorageConstants.WriteProbeFilePrefix}{Guid.NewGuid():N}.tmp");
             using var probe = new FileStream(
                 probePath,
                 FileMode.CreateNew,
@@ -250,5 +249,26 @@ public class StorageLocationService(
                 }
             }
         }
+    }
+
+    private string? FindNearestExistingDirectory(string fullStoragePath)
+    {
+        var candidate = fullStoragePath;
+        while (!string.IsNullOrWhiteSpace(candidate))
+        {
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            if (File.Exists(candidate))
+            {
+                return null;
+            }
+
+            candidate = Path.GetDirectoryName(candidate);
+        }
+
+        return null;
     }
 }

--- a/GenHub/GenHub/Common/Services/StorageLocationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageLocationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -23,31 +24,32 @@ public class StorageLocationService(
     IGameInstallationService gameInstallationService,
     ILogger<StorageLocationService> logger) : IStorageLocationService
 {
+    /// <summary>
+    /// Caches write-probe results for the process lifetime, so a permission change
+    /// on a probed location only takes effect after a restart.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, bool> _writableStorageCache = new(StringComparer.OrdinalIgnoreCase);
+
     /// <inheritdoc/>
     public string GetCasPoolPath(IGameInstallation installation)
     {
         ArgumentNullException.ThrowIfNull(installation);
 
         var settings = userSettingsService.Get();
-        if (settings.UseInstallationAdjacentStorage &&
-            TryGetWritableInstallationAdjacentPath(installation, DirectoryNames.GenHubCasPool, out var adjacentPath))
+        if (!settings.UseInstallationAdjacentStorage)
         {
-            logger.LogDebug(
-                "Resolved installation-adjacent CAS pool path: {CasPoolPath} for installation {InstallationId}",
-                adjacentPath,
-                installation.Id);
-            return adjacentPath;
+            // Fall back to centralized AppData location
+            var appDataPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                AppConstants.AppName,
+                DirectoryNames.CasPool);
+            logger.LogDebug("Using centralized CAS pool path: {CasPoolPath} (installation-adjacent disabled)", appDataPath);
+            return appDataPath;
         }
 
-        var configuredCasPath = settings.CasConfiguration.CasRootPath;
-        var casPoolPath = !string.IsNullOrWhiteSpace(configuredCasPath) && CanCreateStorageAt(configuredCasPath)
-            ? Path.GetFullPath(configuredCasPath)
-            : configurationProviderService.GetCasConfiguration().CasRootPath;
-
-        logger.LogInformation(
-            "Using centralized CAS pool path {CasPoolPath} for installation {InstallationId}",
-            casPoolPath,
-            installation.Id);
+        var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
+        var casPoolPath = Path.Combine(installationRoot, DirectoryNames.GenHubCasPool);
+        logger.LogDebug("Resolved CAS pool path: {CasPoolPath} for installation {InstallationId}", casPoolPath, installation.Id);
         return casPoolPath;
     }
 
@@ -188,11 +190,27 @@ public class StorageLocationService(
 
     private bool CanCreateStorageAt(string storagePath)
     {
+        string fullStoragePath;
+
+        try
+        {
+            fullStoragePath = Path.GetFullPath(storagePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or SecurityException or IOException)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
+            return false;
+        }
+
+        return _writableStorageCache.GetOrAdd(fullStoragePath, ProbeStorageLocation);
+    }
+
+    private bool ProbeStorageLocation(string fullStoragePath)
+    {
         string? probePath = null;
 
         try
         {
-            var fullStoragePath = Path.GetFullPath(storagePath);
             var probeDirectory = Directory.Exists(fullStoragePath)
                 ? fullStoragePath
                 : Path.GetDirectoryName(fullStoragePath);
@@ -203,18 +221,24 @@ public class StorageLocationService(
             }
 
             probePath = Path.Combine(probeDirectory, $".genhub-write-probe-{Guid.NewGuid():N}.tmp");
-            using var probe = new FileStream(probePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            using var probe = new FileStream(
+                probePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
             probe.WriteByte(0);
             return true;
         }
         catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or SecurityException)
         {
-            logger.LogDebug(ex, "Storage path {StoragePath} is not writable", storagePath);
+            logger.LogDebug(ex, "Storage path {StoragePath} is not writable", fullStoragePath);
             return false;
         }
         finally
         {
-            if (!string.IsNullOrWhiteSpace(probePath))
+            if (!string.IsNullOrWhiteSpace(probePath) && File.Exists(probePath))
             {
                 try
                 {

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs
@@ -30,6 +30,7 @@ public class ProfileEditorFacade(
     IContentManifestPool manifestPool,
     IConfigurationProviderService config,
     IDependencyResolver dependencyResolver,
+    IStorageLocationService storageLocationService,
     ILogger<ProfileEditorFacade> logger) : IProfileEditorFacade
 {
     private readonly IGameProfileManager _profileManager = profileManager ?? throw new ArgumentNullException(nameof(profileManager));
@@ -39,6 +40,7 @@ public class ProfileEditorFacade(
     private readonly IContentManifestPool _manifestPool = manifestPool ?? throw new ArgumentNullException(nameof(manifestPool));
     private readonly IConfigurationProviderService _config = config ?? throw new ArgumentNullException(nameof(config));
     private readonly IDependencyResolver _dependencyResolver = dependencyResolver ?? throw new ArgumentNullException(nameof(dependencyResolver));
+    private readonly IStorageLocationService _storageLocationService = storageLocationService ?? throw new ArgumentNullException(nameof(storageLocationService));
     private readonly ILogger<ProfileEditorFacade> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <inheritdoc/>
@@ -120,7 +122,7 @@ public class ProfileEditorFacade(
                 }
 
                 workspaceConfig.BaseInstallationPath = install.Data.InstallationPath;
-                workspaceConfig.WorkspaceRootPath = _config.GetWorkspacePath();
+                workspaceConfig.WorkspaceRootPath = _storageLocationService.GetWorkspacePath(install.Data);
 
                 // Build manifests from enabled content IDs
                 if (profile.EnabledContentIds != null && profile.EnabledContentIds.Count > 0)

--- a/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
@@ -117,25 +117,6 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
             var destRoot = Path.GetPathRoot(workspacePath);
             var sameVolume = string.Equals(sourceRoot, destRoot, StringComparison.OrdinalIgnoreCase);
 
-            if (!sameVolume)
-            {
-                var errorMessage = $"HardLink strategy cannot be used across different drives.\n" +
-                    $"Game installation: {configuration.BaseInstallationPath} (drive {sourceRoot})\n" +
-                    $"Workspace location: {workspacePath} (drive {destRoot})\n" +
-                    $"Please manually change to FullCopy strategy in profile settings or move your workspace to the same drive as your game.";
-                Logger.LogError("{ErrorMessage}", errorMessage);
-
-                workspaceInfo.IsPrepared = false;
-                workspaceInfo.ValidationIssues.Add(new()
-                {
-                    Message = errorMessage,
-                    Severity = Core.Models.Validation.ValidationSeverity.Error,
-                });
-
-                CleanupWorkspaceOnFailure(workspacePath);
-                return workspaceInfo;
-            }
-
             Logger.LogDebug("Processing {TotalFiles} files (prioritized by content type)", totalFiles);
             ReportProgress(progress, 0, totalFiles, "Initializing", string.Empty);
 

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -65,7 +65,18 @@ public class WorkspaceManager(
                         configuration.Id,
                         workspace.WorkspacePath);
 
-                    if (workspace.Strategy != configuration.Strategy)
+                    var expectedWorkspacePath = Path.GetFullPath(Path.Combine(configuration.WorkspaceRootPath, configuration.Id));
+                    var existingWorkspacePath = Path.GetFullPath(workspace.WorkspacePath);
+                    if (!string.Equals(expectedWorkspacePath, existingWorkspacePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        logger.LogInformation(
+                            "[Workspace] Storage root changed for workspace {Id} from {ExistingPath} to {ExpectedPath}; workspace will be recreated.",
+                            configuration.Id,
+                            existingWorkspacePath,
+                            expectedWorkspacePath);
+                        configuration.ForceRecreate = true;
+                    }
+                    else if (workspace.Strategy != configuration.Strategy)
                     {
                         logger.LogWarning(
                             "[Workspace] Strategy mismatch detected - existing: {ExistingStrategy}, requested: {RequestedStrategy}. Workspace will be recreated.",

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Interfaces.Workspace;
@@ -67,7 +68,7 @@ public class WorkspaceManager(
 
                     var expectedWorkspacePath = Path.GetFullPath(Path.Combine(configuration.WorkspaceRootPath, configuration.Id));
                     var existingWorkspacePath = Path.GetFullPath(workspace.WorkspacePath);
-                    if (!string.Equals(expectedWorkspacePath, existingWorkspacePath, StringComparison.OrdinalIgnoreCase))
+                    if (!string.Equals(expectedWorkspacePath, existingWorkspacePath, PathHelper.PathComparison))
                     {
                         logger.LogInformation(
                             "[Workspace] Storage root changed for workspace {Id} from {ExistingPath} to {ExpectedPath}; workspace will be recreated.",


### PR DESCRIPTION
## Summary

Fall back from a protected installation-adjacent workspace location to user-writable storage.

This unblocks packaged, non-administrator Windows launches when the game is installed under Program Files, while retaining installation-adjacent storage where it is writable.

This PR targets `release/alpha-4` intentionally as a release blocker. The equivalent change must be forward-ported to `development`.

Scope is limited to workspace storage. CAS relocation is deliberately excluded — see "Known gap" below.

## Changes

- Probe installation-adjacent workspace storage before selecting it, and fall back to the configured user workspace path or the GenHub application-data directory.
- Resolve the profile workspace root through `IStorageLocationService` in both `ProfileEditorFacade` and `ProfileLauncherFacade`, so the two no longer disagree about where a profile's workspace lives.
- Recreate workspaces whose persisted metadata points at an obsolete storage root, comparing paths with the case sensitivity of the host filesystem.
- Allow the Hard Link strategy to copy content when fallback storage lands on another volume.
- Cache write-probe results per resolved path and open the probe with `FileOptions.DeleteOnClose` so a crash cannot leave a stray file in a game directory.
- Add regression coverage for writable, unavailable, custom, and unavailable-custom workspace paths, probe caching, cross-volume copying, and workspace-root migration.

## Known gap

`IStorageLocationService.GetCasPoolPath` is informational: its only consumers are a launch log line and the "Open CAS pool directory" button. Real CAS storage is configured from `ConfigurationProviderService.GetCasConfiguration()` via `CasModule`, and the per-installation pool used for game content resolves from `UserSettings.CasConfiguration.InstallationPoolRootPath`, which is set to `<installation>/.genhub-cas` by `ContentOrchestrator` and `CommunityOutpostDeliverer`.

Changing `GetCasPoolPath` would therefore have made the displayed path look fixed while CAS kept using the protected location, so the CAS changes were dropped from this PR.

Workspace preparation itself only reads from CAS, and non-administrator reads under Program Files succeed. That does not make the end-to-end flow safe. Installation detection pools a `GameInstallation` manifest, which writes to the installation CAS pool, and `GameInstallationService` swallows a pooling failure as a warning. Whether a profile can still be created and launched from a protected installation must therefore be established by the packaged Windows test rather than assumed from this change.

CAS relocation is tracked in #347, including a migration for the already-persisted `InstallationPoolRootPath`.

## Testing

- `~/.dotnet/dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release --nologo -v minimal`
  - Passed: 1,342
  - Failed: 0
- `GenHub.Core`, `GenHub`, `GenHub.Linux` build clean. `GenHub.Windows` cannot be built on macOS (`NETSDK1100`), and fails identically before this change; Windows compilation needs CI.
- CI does not trigger for this PR: `.github/workflows/ci.yml` runs `pull_request` only for `main` and `development`. A manual `workflow_dispatch` against this branch's head SHA is required.
- Packaged non-administrator Windows validation remains required before merging and repinning Alpha 4. It must cover acquiring client content and then launching, not launch alone, so the CAS gap above is exercised rather than skipped.

## Risks and rollback

Workspace resolution creates and removes a uniquely named write-probe file before selecting an adjacent or custom location. Cross-volume fallback may consume additional disk space because files are copied instead of hard-linked.

Probe results are cached for the process lifetime, so fixing permissions on a rejected location takes effect on the next launch of GenHub.

Profiles whose workspace root moves are regenerated under the new root using the existing workspace lifecycle. Game installation files are not modified.

Rollback is a revert of commits `2494e5a`, `752a694`, and `a88916b`.

## Related issues

Fixes #344
Related to #307

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes workspace placement fall back from protected installation-adjacent storage and aligns profile creation, reuse, and cross-volume preparation with the selected location.
- Adds target-directory write probing with process-lifetime caching and centralized fallback.
- Recreates persisted workspaces when their resolved root changes.
- Allows HardLink workspace preparation to use existing copy fallbacks across volumes.
- Adds regression coverage for path selection, migration, probing, and cross-volume preparation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no blocking failure remaining.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Common/Services/StorageLocationService.cs | Resolves and probes the actual workspace target, caches results, and falls back to application data when necessary. |
| GenHub/GenHub/Features/Workspace/WorkspaceManager.cs | Detects storage-root changes and forces recreation instead of reusing obsolete workspace metadata. |
| GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs | Removes the early cross-volume rejection so existing per-file copy fallbacks can prepare the workspace. |
| GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs | Uses the shared storage-location service when constructing profile workspace configuration. |
| GenHub/GenHub.Core/Helpers/PathHelper.cs | Centralizes platform-aware path comparison for workspace migration and probe-cache keys. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(workspace): verify storage directory..."](https://github.com/community-outpost/genhub/commit/c90f71903340cf5b1db82be9255c33ea04ceb7a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49376093)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Workspace Assembly](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/workspace-assembly.md)
- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)
- Knowledge Base — [Common UI Shell, ViewModels, and Supporting Feature Areas](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/common-ui-viewmodels.md)
</details>

<!-- /greptile_comment -->