### PR TITLE
fix(workspace): fall back from protected adjacent storage (forward-port of #346)

### DIFF
--- a/GenHub/GenHub.Core/Constants/StorageConstants.cs
+++ b/GenHub/GenHub.Core/Constants/StorageConstants.cs
@@ -5,6 +5,11 @@ namespace GenHub.Core.Constants;
 /// </summary>
 public static class StorageConstants
 {
+    /// <summary>
+    /// Prefix used for temporary files that verify a storage location is writable.
+    /// </summary>
+    public const string WriteProbeFilePrefix = ".genhub-write-probe-";
+
     // CAS retry constants
 
     /// <summary>

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace GenHub.Core.Helpers;
@@ -7,6 +8,24 @@ namespace GenHub.Core.Helpers;
 /// </summary>
 public static class PathHelper
 {
+    /// <summary>
+    /// Gets the string comparison to use when comparing filesystem paths. Windows paths
+    /// are compared case-insensitively; other platforms use conservative case-sensitive semantics.
+    /// </summary>
+    public static StringComparison PathComparison =>
+        OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Gets the string comparer to use when keying collections by filesystem path. Windows paths
+    /// are compared case-insensitively; other platforms use conservative case-sensitive semantics.
+    /// </summary>
+    public static StringComparer PathComparer =>
+        OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
     /// <summary>
     /// Gets the parent directory of a path, with fallback to the path itself if at drive root.
     /// </summary>

--- a/GenHub/GenHub.Core/Interfaces/Common/IStorageLocationService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Common/IStorageLocationService.cs
@@ -15,7 +15,7 @@ public interface IStorageLocationService
     string GetCasPoolPath(IGameInstallation installation);
 
     /// <summary>
-    /// Gets the workspace path adjacent to the specified game installation.
+    /// Gets a writable workspace path for the specified game installation.
     /// </summary>
     /// <param name="installation">The game installation to base the path on.</param>
     /// <returns>The absolute path to the workspace directory.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
@@ -1,0 +1,193 @@
+using GenHub.Common.Services;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GenHub.Tests.Core.Common.Services;
+
+/// <summary>
+/// Tests writable workspace path resolution.
+/// </summary>
+public sealed class StorageLocationServiceTests : IDisposable
+{
+    private const string ProbeSearchPattern = StorageConstants.WriteProbeFilePrefix + "*";
+
+    private readonly Mock<IUserSettingsService> _userSettingsService = new();
+    private readonly Mock<IConfigurationProviderService> _configurationProviderService = new();
+    private readonly Mock<IGameInstallationService> _gameInstallationService = new();
+    private readonly string _applicationDataPath;
+    private readonly string _tempPath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StorageLocationServiceTests"/> class.
+    /// </summary>
+    public StorageLocationServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        _applicationDataPath = Path.Combine(_tempPath, "AppData");
+        Directory.CreateDirectory(_applicationDataPath);
+
+        _configurationProviderService.Setup(service => service.GetApplicationDataPath()).Returns(_applicationDataPath);
+    }
+
+    /// <summary>
+    /// Uses installation-adjacent storage when its parent is writable.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenInstallationParentIsWritable_UsesAdjacentPath()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installationRoot = Path.Combine(_tempPath, "EA Games");
+        var installationPath = Path.Combine(installationRoot, "Command and Conquer Generals Zero Hour");
+        Directory.CreateDirectory(installationPath);
+        var installation = new GameInstallation(installationPath, GameInstallationType.EaApp);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+
+        Assert.Equal(Path.Combine(installationRoot, DirectoryNames.GenHubWorkspace), workspacePath);
+        Assert.True(Directory.Exists(workspacePath));
+        Assert.Empty(Directory.GetFiles(workspacePath, ProbeSearchPattern));
+    }
+
+    /// <summary>
+    /// Falls back to user storage when the installation parent cannot contain a workspace.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenInstallationParentIsUnavailable_UsesCentralPath()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var unavailableRoot = Path.Combine(_tempPath, "protected-root");
+        File.WriteAllText(unavailableRoot, "not a directory");
+        var installation = new GameInstallation(
+            Path.Combine(unavailableRoot, "Command and Conquer Generals Zero Hour"),
+            GameInstallationType.EaApp);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+
+        Assert.Equal(Path.Combine(_applicationDataPath, DirectoryNames.Workspaces), workspacePath);
+    }
+
+    /// <summary>
+    /// Honors a writable user-configured workspace path when adjacent storage is disabled.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenCustomPathIsConfigured_UsesCustomPath()
+    {
+        var customWorkspacePath = Path.Combine(_tempPath, "CustomWorkspace");
+        var settings = new UserSettings
+        {
+            UseInstallationAdjacentStorage = false,
+            WorkspacePath = customWorkspacePath,
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+
+        Assert.Equal(customWorkspacePath, workspacePath);
+        Assert.True(Directory.Exists(customWorkspacePath));
+        Assert.Empty(Directory.GetFiles(customWorkspacePath, ProbeSearchPattern));
+    }
+
+    /// <summary>
+    /// Honors a creatable custom workspace path when its immediate parent does not exist yet.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenCustomPathParentDoesNotExist_UsesCustomPath()
+    {
+        var missingParent = Path.Combine(_tempPath, "Missing", "Parents");
+        var customWorkspacePath = Path.Combine(missingParent, "CustomWorkspace");
+        var settings = new UserSettings
+        {
+            UseInstallationAdjacentStorage = false,
+            WorkspacePath = customWorkspacePath,
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+
+        Assert.Equal(customWorkspacePath, workspacePath);
+        Assert.True(Directory.Exists(customWorkspacePath));
+        Assert.Empty(Directory.GetFiles(customWorkspacePath, ProbeSearchPattern));
+    }
+
+    /// <summary>
+    /// Falls back to user storage when the configured workspace path cannot be created.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenCustomPathIsUnavailable_UsesCentralPath()
+    {
+        var unavailableRoot = Path.Combine(_tempPath, "custom-root");
+        File.WriteAllText(unavailableRoot, "not a directory");
+        var settings = new UserSettings
+        {
+            UseInstallationAdjacentStorage = false,
+            WorkspacePath = Path.Combine(unavailableRoot, "CustomWorkspace"),
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
+
+        var workspacePath = service.GetWorkspacePath(installation);
+
+        Assert.Equal(Path.Combine(_applicationDataPath, DirectoryNames.Workspaces), workspacePath);
+    }
+
+    /// <summary>
+    /// Probes a storage location once and reuses the result for later resolutions.
+    /// </summary>
+    [Fact]
+    public void GetWorkspacePath_WhenCalledRepeatedly_ProbesOnce()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var service = CreateService();
+        var installationRoot = Path.Combine(_tempPath, "EA Games");
+        var installationPath = Path.Combine(installationRoot, "Command and Conquer Generals Zero Hour");
+        Directory.CreateDirectory(installationPath);
+        var installation = new GameInstallation(installationPath, GameInstallationType.EaApp);
+
+        var first = service.GetWorkspacePath(installation);
+        Directory.Delete(installationRoot, true);
+        var second = service.GetWorkspacePath(installation);
+
+        Assert.Equal(first, second);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempPath, true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private StorageLocationService CreateService() => new(
+        _userSettingsService.Object,
+        _configurationProviderService.Object,
+        _gameInstallationService.Object,
+        new Mock<ILogger<StorageLocationService>>().Object);
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
@@ -164,6 +164,9 @@ public sealed class StorageLocationServiceTests : IDisposable
         var second = service.GetWorkspacePath(installation);
 
         Assert.Equal(first, second);
+
+        // A second probe would recreate the storage directory, so its absence proves the cache was used.
+        Assert.False(Directory.Exists(installationRoot));
     }
 
     /// <inheritdoc/>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
@@ -6,6 +6,7 @@ using GenHub.Core.Models.Workspace;
 using GenHub.Features.Workspace.Strategies;
 using Microsoft.Extensions.Logging;
 using Moq;
+using ManifestContentType = GenHub.Core.Models.Enums.ContentType;
 
 namespace GenHub.Tests.Core.Features.Workspace;
 
@@ -249,6 +250,69 @@ public class StrategyTests : IDisposable
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(
             () => strategy.PrepareAsync(null!, null, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Verifies that hard-link preparation copies CAS content instead of rejecting a cross-volume workspace.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task HardLinkStrategy_WhenVolumesDiffer_FallsBackToCopy()
+    {
+        const string Hash = "test-hash";
+        var strategy = new HardLinkStrategy(_fileOps.Object, new Mock<ILogger<HardLinkStrategy>>().Object);
+        var configuration = new WorkspaceConfiguration
+        {
+            Id = "cross-volume",
+            Strategy = WorkspaceStrategy.HardLink,
+            WorkspaceRootPath = _tempDir,
+            BaseInstallationPath = "relative-installation-path",
+            GameClient = new GameClient { Id = "test" },
+            Manifests =
+            [
+                new ContentManifest
+                {
+                    ContentType = ManifestContentType.GameClient,
+                    Files =
+                    [
+                        new ManifestFile
+                        {
+                            RelativePath = "game.exe",
+                            Hash = Hash,
+                            Size = 1024,
+                            InstallTarget = ContentInstallTarget.Workspace,
+                            SourceType = ContentSourceType.ContentAddressable,
+                        },
+                    ],
+                },
+            ],
+        };
+        _fileOps
+            .Setup(service => service.LinkFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                true,
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _fileOps
+            .Setup(service => service.CopyFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await strategy.PrepareAsync(configuration, null, CancellationToken.None);
+
+        Assert.True(result.IsPrepared);
+        _fileOps.Verify(
+            service => service.CopyFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
@@ -82,7 +82,7 @@ public class WorkspaceManagerReuseTests : IDisposable
         // Arrange
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";
-        var workspacePath = Path.Combine(_tempPath, "workspace");
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
         Directory.CreateDirectory(workspacePath);
         File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
 
@@ -142,7 +142,7 @@ public class WorkspaceManagerReuseTests : IDisposable
         // Arrange
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";
-        var workspacePath = Path.Combine(_tempPath, "workspace");
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
         Directory.CreateDirectory(workspacePath);
         File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
 
@@ -205,7 +205,7 @@ public class WorkspaceManagerReuseTests : IDisposable
         // Arrange
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";
-        var workspacePath = Path.Combine(_tempPath, "workspace");
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
         Directory.CreateDirectory(workspacePath);
         File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
 
@@ -266,7 +266,7 @@ public class WorkspaceManagerReuseTests : IDisposable
         // Arrange
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";
-        var workspacePath = Path.Combine(_tempPath, "workspace");
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
         Directory.CreateDirectory(workspacePath);
         var executablePath = Path.Combine(workspacePath, "generals");
         await File.WriteAllTextAsync(executablePath, "engine binary");
@@ -314,6 +314,67 @@ public class WorkspaceManagerReuseTests : IDisposable
 
         // Repair happens on the reuse fast path; the strategy never re-materialises.
         _mockStrategy.Verify(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that a workspace is recreated when storage resolution moves it to a new root.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenStorageRootChanges_ShouldRecreateWorkspace()
+    {
+        var workspaceId = "test-workspace";
+        var manifestId = "1.0.local.mod.testmanifest";
+        var oldWorkspaceRoot = Path.Combine(_tempPath, "protected-root");
+        var oldWorkspacePath = Path.Combine(oldWorkspaceRoot, workspaceId);
+        var newWorkspaceRoot = Path.Combine(_tempPath, "AppData", "Workspaces");
+        var newWorkspacePath = Path.Combine(newWorkspaceRoot, workspaceId);
+        Directory.CreateDirectory(oldWorkspacePath);
+        File.WriteAllText(Path.Combine(oldWorkspacePath, "test.txt"), "content");
+
+        var cachedWorkspace = new WorkspaceInfo
+        {
+            Id = workspaceId,
+            WorkspacePath = oldWorkspacePath,
+            ManifestIds = [manifestId],
+            ManifestVersions = new Dictionary<string, string> { { manifestId, "1.0" } },
+            Strategy = WorkspaceStrategy.HardLink,
+            IsPrepared = true,
+            FileCount = 1,
+            IsValid = true,
+        };
+        await File.WriteAllTextAsync(_metadataPath, System.Text.Json.JsonSerializer.Serialize(new[] { cachedWorkspace }));
+
+        var config = new WorkspaceConfiguration
+        {
+            Id = workspaceId,
+            Strategy = WorkspaceStrategy.HardLink,
+            Manifests = [new ContentManifest { Id = ManifestId.Create(manifestId), Version = "1.0" }],
+            BaseInstallationPath = _tempPath,
+            WorkspaceRootPath = newWorkspaceRoot,
+            ValidateAfterPreparation = false,
+        };
+        var successValidation = new ValidationResult(workspaceId, []);
+        _mockWorkspaceValidator
+            .Setup(x => x.ValidateConfigurationAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successValidation);
+        _mockWorkspaceValidator
+            .Setup(x => x.ValidatePrerequisitesAsync(It.IsAny<IWorkspaceStrategy>(), It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successValidation);
+        _mockStrategy
+            .Setup(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WorkspaceInfo { Id = workspaceId, IsPrepared = true, WorkspacePath = newWorkspacePath });
+
+        var result = await _manager.PrepareWorkspaceAsync(config);
+
+        result.Success.Should().BeTrue();
+        result.Data!.WorkspacePath.Should().Be(newWorkspacePath);
+        _mockStrategy.Verify(
+            x => x.PrepareAsync(
+                It.Is<WorkspaceConfiguration>(configuration => configuration.ForceRecreate),
+                It.IsAny<IProgress<WorkspacePreparationProgress>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
@@ -317,6 +317,66 @@ public class WorkspaceManagerReuseTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that a configuration without a workspace root reuses the existing workspace
+    /// instead of resolving a working-directory-relative path and recreating it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceRootIsBlank_ShouldReuseWorkspace()
+    {
+        var workspaceId = "test-workspace";
+        var manifestId = "1.0.local.mod.testmanifest";
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
+        Directory.CreateDirectory(workspacePath);
+        File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
+
+        var cachedWorkspace = new WorkspaceInfo
+        {
+            Id = workspaceId,
+            WorkspacePath = workspacePath,
+            ManifestIds = [manifestId],
+            ManifestVersions = new Dictionary<string, string> { { manifestId, "1.0" } },
+            Strategy = WorkspaceStrategy.HardLink,
+            IsPrepared = true,
+            FileCount = 1,
+            IsValid = true,
+        };
+        await File.WriteAllTextAsync(_metadataPath, System.Text.Json.JsonSerializer.Serialize(new[] { cachedWorkspace }));
+
+        var config = new WorkspaceConfiguration
+        {
+            Id = workspaceId,
+            Strategy = WorkspaceStrategy.HardLink,
+            Manifests = [new ContentManifest { Id = ManifestId.Create(manifestId), Version = "1.0", Files = [new ManifestFile { RelativePath = "test.txt" }] }],
+            BaseInstallationPath = _tempPath,
+            WorkspaceRootPath = string.Empty,
+            ValidateAfterPreparation = false,
+        };
+
+        var successValidation = new ValidationResult(workspaceId, []);
+        _mockWorkspaceValidator
+            .Setup(x => x.ValidateConfigurationAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successValidation);
+        _mockWorkspaceValidator
+            .Setup(x => x.ValidatePrerequisitesAsync(It.IsAny<IWorkspaceStrategy>(), It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successValidation);
+        _mockWorkspaceValidator
+            .Setup(x => x.ValidateWorkspaceAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ValidationResult>.CreateSuccess(successValidation));
+        _mockWorkspaceValidator
+            .Setup(x => x.EnsureEntryPointExecutableAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+
+        var result = await _manager.PrepareWorkspaceAsync(config);
+
+        result.Success.Should().BeTrue();
+        Directory.Exists(workspacePath).Should().BeTrue();
+        _mockStrategy.Verify(
+            x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Verifies that a workspace is recreated when storage resolution moves it to a new root.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -1,0 +1,37 @@
+using GenHub.Core.Helpers;
+
+namespace GenHub.Tests.Core.Helpers;
+
+/// <summary>
+/// Tests platform-aware filesystem path comparison behavior.
+/// </summary>
+public sealed class PathHelperTests
+{
+    /// <summary>
+    /// Uses case-insensitive comparison only on Windows so case-sensitive Unix volumes remain distinct.
+    /// </summary>
+    [Fact]
+    public void PathComparison_UsesWindowsOnlyCaseFolding()
+    {
+        var firstPath = Path.Combine(Path.GetTempPath(), "GenHub");
+        var secondPath = Path.Combine(Path.GetTempPath(), "genhub");
+
+        var pathsAreEqual = string.Equals(firstPath, secondPath, PathHelper.PathComparison);
+
+        Assert.Equal(OperatingSystem.IsWindows(), pathsAreEqual);
+    }
+
+    /// <summary>
+    /// Uses the same platform case behavior when paths are collection keys.
+    /// </summary>
+    [Fact]
+    public void PathComparer_UsesWindowsOnlyCaseFolding()
+    {
+        var firstPath = Path.Combine(Path.GetTempPath(), "GenHub");
+        var secondPath = Path.Combine(Path.GetTempPath(), "genhub");
+
+        var pathsAreEqual = PathHelper.PathComparer.Equals(firstPath, secondPath);
+
+        Assert.Equal(OperatingSystem.IsWindows(), pathsAreEqual);
+    }
+}

--- a/GenHub/GenHub/Common/Services/StorageLocationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageLocationService.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
@@ -18,9 +20,16 @@ namespace GenHub.Common.Services;
 /// </summary>
 public class StorageLocationService(
     IUserSettingsService userSettingsService,
+    IConfigurationProviderService configurationProviderService,
     IGameInstallationService gameInstallationService,
     ILogger<StorageLocationService> logger) : IStorageLocationService
 {
+    /// <summary>
+    /// Caches write-probe results for the process lifetime, so a permission change
+    /// on a probed location only takes effect after a restart.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, bool> _writableStorageCache = new(PathHelper.PathComparer);
+
     /// <inheritdoc/>
     public string GetCasPoolPath(IGameInstallation installation)
     {
@@ -50,20 +59,25 @@ public class StorageLocationService(
         ArgumentNullException.ThrowIfNull(installation);
 
         var settings = userSettingsService.Get();
-        if (!settings.UseInstallationAdjacentStorage)
+        if (settings.UseInstallationAdjacentStorage &&
+            TryGetWritableInstallationAdjacentPath(installation, DirectoryNames.GenHubWorkspace, out var adjacentPath))
         {
-            // Fall back to centralized AppData location
-            var appDataPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                AppConstants.AppName,
-                DirectoryNames.Workspaces);
-            logger.LogDebug("Using centralized workspace path: {WorkspacePath} (installation-adjacent disabled)", appDataPath);
-            return appDataPath;
+            logger.LogDebug(
+                "Resolved installation-adjacent workspace path: {WorkspacePath} for installation {InstallationId}",
+                adjacentPath,
+                installation.Id);
+            return adjacentPath;
         }
 
-        var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
-        var workspacePath = Path.Combine(installationRoot, DirectoryNames.GenHubWorkspace);
-        logger.LogDebug("Resolved workspace path: {WorkspacePath} for installation {InstallationId}", workspacePath, installation.Id);
+        var configuredWorkspacePath = settings.WorkspacePath;
+        var workspacePath = !string.IsNullOrWhiteSpace(configuredWorkspacePath) && CanCreateStorageAt(configuredWorkspacePath)
+            ? Path.GetFullPath(configuredWorkspacePath)
+            : Path.Combine(configurationProviderService.GetApplicationDataPath(), DirectoryNames.Workspaces);
+
+        logger.LogInformation(
+            "Using centralized workspace path {WorkspacePath} for installation {InstallationId}",
+            workspacePath,
+            installation.Id);
         return workspacePath;
     }
 
@@ -153,5 +167,104 @@ public class StorageLocationService(
             sameVolume);
 
         return sameVolume;
+    }
+
+    private bool TryGetWritableInstallationAdjacentPath(
+        IGameInstallation installation,
+        string directoryName,
+        out string path)
+    {
+        var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
+        path = Path.Combine(installationRoot, directoryName);
+        if (CanCreateStorageAt(path))
+        {
+            return true;
+        }
+
+        logger.LogWarning(
+            "Installation-adjacent storage path {StoragePath} is not writable for installation {InstallationId}; falling back to user storage",
+            path,
+            installation.Id);
+        return false;
+    }
+
+    private bool CanCreateStorageAt(string storagePath)
+    {
+        string fullStoragePath;
+
+        try
+        {
+            fullStoragePath = Path.GetFullPath(storagePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or SecurityException or IOException)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
+            return false;
+        }
+
+        return _writableStorageCache.GetOrAdd(fullStoragePath, ProbeStorageLocation);
+    }
+
+    private bool ProbeStorageLocation(string fullStoragePath)
+    {
+        string? probePath = null;
+        var storageDirectoryExisted = Directory.Exists(fullStoragePath);
+        var storageDirectoryCreated = false;
+        var probeSucceeded = false;
+
+        try
+        {
+            Directory.CreateDirectory(fullStoragePath);
+            storageDirectoryCreated = !storageDirectoryExisted;
+
+            probePath = Path.Combine(
+                fullStoragePath,
+                $"{StorageConstants.WriteProbeFilePrefix}{Guid.NewGuid():N}.tmp");
+            using var probe = new FileStream(
+                probePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
+            probe.WriteByte(0);
+            probeSucceeded = true;
+            return true;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or SecurityException)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} is not writable", fullStoragePath);
+            return false;
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(probePath) && File.Exists(probePath))
+            {
+                try
+                {
+                    File.Delete(probePath);
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                {
+                    logger.LogDebug(ex, "Could not remove storage write probe {ProbePath}", probePath);
+                }
+            }
+
+            if (!probeSucceeded && storageDirectoryCreated)
+            {
+                try
+                {
+                    if (Directory.Exists(fullStoragePath) &&
+                        !Directory.EnumerateFileSystemEntries(fullStoragePath).Any())
+                    {
+                        Directory.Delete(fullStoragePath);
+                    }
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or SecurityException)
+                {
+                    logger.LogDebug(ex, "Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
+                }
+            }
+        }
     }
 }

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs
@@ -30,6 +30,7 @@ public class ProfileEditorFacade(
     IContentManifestPool manifestPool,
     IConfigurationProviderService config,
     IDependencyResolver dependencyResolver,
+    IStorageLocationService storageLocationService,
     ILogger<ProfileEditorFacade> logger) : IProfileEditorFacade
 {
     private readonly IGameProfileManager _profileManager = profileManager ?? throw new ArgumentNullException(nameof(profileManager));
@@ -39,6 +40,7 @@ public class ProfileEditorFacade(
     private readonly IContentManifestPool _manifestPool = manifestPool ?? throw new ArgumentNullException(nameof(manifestPool));
     private readonly IConfigurationProviderService _config = config ?? throw new ArgumentNullException(nameof(config));
     private readonly IDependencyResolver _dependencyResolver = dependencyResolver ?? throw new ArgumentNullException(nameof(dependencyResolver));
+    private readonly IStorageLocationService _storageLocationService = storageLocationService ?? throw new ArgumentNullException(nameof(storageLocationService));
     private readonly ILogger<ProfileEditorFacade> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <inheritdoc/>
@@ -120,7 +122,7 @@ public class ProfileEditorFacade(
                 }
 
                 workspaceConfig.BaseInstallationPath = install.Data.InstallationPath;
-                workspaceConfig.WorkspaceRootPath = _config.GetWorkspacePath();
+                workspaceConfig.WorkspaceRootPath = _storageLocationService.GetWorkspacePath(install.Data);
 
                 // Build manifests from enabled content IDs
                 if (profile.EnabledContentIds != null && profile.EnabledContentIds.Count > 0)

--- a/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
@@ -117,25 +117,6 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
             var destRoot = Path.GetPathRoot(workspacePath);
             var sameVolume = string.Equals(sourceRoot, destRoot, StringComparison.OrdinalIgnoreCase);
 
-            if (!sameVolume)
-            {
-                var errorMessage = $"HardLink strategy cannot be used across different drives.\n" +
-                    $"Game installation: {configuration.BaseInstallationPath} (drive {sourceRoot})\n" +
-                    $"Workspace location: {workspacePath} (drive {destRoot})\n" +
-                    $"Please manually change to FullCopy strategy in profile settings or move your workspace to the same drive as your game.";
-                Logger.LogError("{ErrorMessage}", errorMessage);
-
-                workspaceInfo.IsPrepared = false;
-                workspaceInfo.ValidationIssues.Add(new()
-                {
-                    Message = errorMessage,
-                    Severity = Core.Models.Validation.ValidationSeverity.Error,
-                });
-
-                CleanupWorkspaceOnFailure(workspacePath);
-                return workspaceInfo;
-            }
-
             Logger.LogDebug("Processing {TotalFiles} files (prioritized by content type)", totalFiles);
             ReportProgress(progress, 0, totalFiles, "Initializing", string.Empty);
 

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Interfaces.Workspace;
@@ -65,7 +66,18 @@ public class WorkspaceManager(
                         configuration.Id,
                         workspace.WorkspacePath);
 
-                    if (workspace.Strategy != configuration.Strategy)
+                    var expectedWorkspacePath = Path.GetFullPath(Path.Combine(configuration.WorkspaceRootPath, configuration.Id));
+                    var existingWorkspacePath = Path.GetFullPath(workspace.WorkspacePath);
+                    if (!string.Equals(expectedWorkspacePath, existingWorkspacePath, PathHelper.PathComparison))
+                    {
+                        logger.LogInformation(
+                            "[Workspace] Storage root changed for workspace {Id} from {ExistingPath} to {ExpectedPath}; workspace will be recreated.",
+                            configuration.Id,
+                            existingWorkspacePath,
+                            expectedWorkspacePath);
+                        configuration.ForceRecreate = true;
+                    }
+                    else if (workspace.Strategy != configuration.Strategy)
                     {
                         logger.LogWarning(
                             "[Workspace] Strategy mismatch detected - existing: {ExistingStrategy}, requested: {RequestedStrategy}. Workspace will be recreated.",

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -66,8 +66,13 @@ public class WorkspaceManager(
                         configuration.Id,
                         workspace.WorkspacePath);
 
-                    var expectedWorkspacePath = Path.GetFullPath(Path.Combine(configuration.WorkspaceRootPath, configuration.Id));
                     var existingWorkspacePath = Path.GetFullPath(workspace.WorkspacePath);
+
+                    // Without a configured root there is nothing to compare against, and resolving
+                    // a blank root would produce a working-directory-relative path that always differs.
+                    var expectedWorkspacePath = string.IsNullOrWhiteSpace(configuration.WorkspaceRootPath)
+                        ? existingWorkspacePath
+                        : Path.GetFullPath(Path.Combine(configuration.WorkspaceRootPath, configuration.Id));
                     if (!string.Equals(expectedWorkspacePath, existingWorkspacePath, PathHelper.PathComparison))
                     {
                         logger.LogInformation(


### PR DESCRIPTION
## Summary

Forward-ports `96c18a6` from `release/alpha-4`. Without this, `development` regresses the protected-path launch fix from #344 as soon as the next release branches from it.

Behavior is unchanged from the merged Alpha 4 fix: probe installation-adjacent workspace storage before selecting it, fall back to configured user storage or the application-data directory, resolve the profile workspace root through `IStorageLocationService` in both the editor and launcher facades, recreate workspaces whose persisted metadata points at an obsolete storage root, and let the Hard Link strategy copy content when workspace storage lands on another volume.

The branches have diverged: `release/alpha-4` carries `96c18a6` and `3885195` that `development` lacks, while `development` is 8 commits ahead. This ports `96c18a6` only. #288 needs its own decision.

## Conflict resolution

`WorkspaceManagerReuseTests.cs` conflicted with #338. Both branches added tests at the same location; all are kept.

The resolution is not purely textual. #338's entry-point tests set `WorkspacePath` to `<temp>/workspace` while `WorkspaceRootPath` was `<temp>`. Under the storage-root check introduced here, the expected path is `WorkspaceRootPath/Id`, so those fixtures mismatch and force recreation — which makes `PrepareWorkspaceAsync_WhenEntryPointCannotBeRepaired_ShouldRecreateWorkspace` pass for the wrong reason, and makes `PrepareWorkspaceAsync_WhenEntryPointBricked_RepairsAndReusesWorkspace` fail, since it asserts the strategy is never invoked. Both now use `<temp>/<workspaceId>` so they exercise entry-point repair rather than root migration.

## Testing

- `~/.dotnet/dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release --nologo -v minimal`
  - Passed: 1,499
  - Failed: 3
- The three failures are `NativeClientLaunchIntegrationTests`, `NativeClientManifestLaunchTests`, and `RetailArchiveRootTests`. They fail identically on unmodified `development` in the same environment, which has no engine binary for them to launch. This change does not touch them.
- `GenHub.Core`, `GenHub`, and `GenHub.Linux` build with no compiler or StyleCop warnings. `GenHub.Windows` cannot be built on macOS (`NETSDK1100`) and fails the same way before this change, so Windows compilation needs CI.

## Follow-up

The CAS installation pool has a separate protected-path problem tracked in #347. It is not addressed here.

## Related issues

Related to #344, #346, #307

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores writable workspace-location selection from the release branch and consistently applies the resolved location to profile editing and workspace reuse.
- Probes installation-adjacent and configured workspace storage, falling back to application data when necessary.
- Recreates persisted workspaces after their resolved storage root changes.
- Allows the Hard Link strategy to copy files when workspace storage is on another volume.
- Adds platform-aware path comparison and coverage for storage resolution, migration, and cross-volume preparation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains within the eligible follow-up review scope.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Common/Services/StorageLocationService.cs | Adds writable-location probing, caching, and centralized fallback selection for workspace roots. |
| GenHub/GenHub/Features/Workspace/WorkspaceManager.cs | Detects persisted workspaces under obsolete roots and forces their recreation at the resolved location. |
| GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs | Replaces cross-volume rejection with copy fallback and accounts for copied disk usage. |
| GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs | Uses IStorageLocationService when preparing refreshed profile workspaces. |
| GenHub/GenHub.Core/Helpers/PathHelper.cs | Centralizes platform-aware filesystem path comparison semantics. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Resolve game installation] --> B{Adjacent storage enabled and writable?}
    B -->|Yes| C[Use installation-adjacent workspace root]
    B -->|No| D{Configured workspace path writable?}
    D -->|Yes| E[Use configured workspace root]
    D -->|No| F[Use application-data workspace root]
    C --> G{Persisted workspace matches resolved root?}
    E --> G
    F --> G
    G -->|Yes| H[Validate and reuse workspace]
    G -->|No| I[Force workspace recreation]
    I --> J{Hard links available on target volume?}
    J -->|Yes| K[Materialize with hard links]
    J -->|No| L[Copy workspace content]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workspace): keep a blank workspace r..."](https://github.com/community-outpost/genhub/commit/2a0230f5b3f4edb1602a3324cb6db5cd574eefc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49395910)</sub>

**Context used:**

- Knowledge Base — [Workspace Assembly](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/workspace-assembly.md)
- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)

<!-- /greptile_comment -->