### PR TITLE
fix(cas): fall back from unwritable installation pools (backport of #349)

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/Common/IStorageWritabilityProbe.cs
+++ b/GenHub/GenHub.Core/Interfaces/Common/IStorageWritabilityProbe.cs
@@ -1,0 +1,24 @@
+namespace GenHub.Core.Interfaces.Common;
+
+/// <summary>
+/// Determines whether GenHub can create storage at a filesystem location.
+/// </summary>
+public interface IStorageWritabilityProbe
+{
+    /// <summary>
+    /// Checks whether a directory can be created at, or files written into, the given path.
+    /// </summary>
+    /// <remarks>
+    /// A successful check creates the storage directory when it does not already exist and leaves
+    /// that directory in place. Callers should account for this filesystem side effect.
+    /// </remarks>
+    /// <param name="storagePath">The storage path to check.</param>
+    /// <returns><c>true</c> when the location accepts writes; otherwise, <c>false</c>.</returns>
+    bool CanCreateStorageAt(string storagePath);
+
+    /// <summary>
+    /// Discards any cached result for a storage path so the next check probes the filesystem again.
+    /// </summary>
+    /// <param name="storagePath">The storage path to re-probe, or <c>null</c> to discard every cached result.</param>
+    void Invalidate(string? storagePath = null);
+}

--- a/GenHub/GenHub.Core/Interfaces/Storage/ICasPoolResolver.cs
+++ b/GenHub/GenHub.Core/Interfaces/Storage/ICasPoolResolver.cs
@@ -29,6 +29,12 @@ public interface ICasPoolResolver
     string GetPoolRootPath(ContentType contentType);
 
     /// <summary>
+    /// Gets the previous installation-pool roots retained for read-only lookup.
+    /// </summary>
+    /// <returns>The legacy roots, or an empty list when none are configured.</returns>
+    IReadOnlyList<string> GetLegacyInstallationPoolRootPaths();
+
+    /// <summary>
     /// Checks if the installation pool is configured and available.
     /// </summary>
     /// <returns>True if the installation pool is available, false otherwise.</returns>

--- a/GenHub/GenHub.Core/Interfaces/Storage/IInstallationCasPoolService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Storage/IInstallationCasPoolService.cs
@@ -1,0 +1,19 @@
+using GenHub.Core.Models.GameInstallations;
+
+namespace GenHub.Core.Interfaces.Storage;
+
+/// <summary>
+/// Selects and persists an effective installation CAS pool from detected installations.
+/// </summary>
+public interface IInstallationCasPoolService
+{
+    /// <summary>
+    /// Ensures installation-pool settings reflect the currently detected installations.
+    /// </summary>
+    /// <param name="installations">The detected game installations.</param>
+    /// <param name="cancellationToken">A token that can cancel the settings update.</param>
+    /// <returns><c>true</c> when content acquisition may continue; otherwise, <c>false</c>.</returns>
+    Task<bool> EnsurePoolPathAsync(
+        IReadOnlyList<GameInstallation> installations,
+        CancellationToken cancellationToken = default);
+}

--- a/GenHub/GenHub.Core/Models/Storage/CasConfiguration.cs
+++ b/GenHub/GenHub.Core/Models/Storage/CasConfiguration.cs
@@ -46,6 +46,20 @@ public class CasConfiguration : ICloneable
     public string InstallationPoolRootPath { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets a value indicating whether <see cref="InstallationPoolRootPath"/> was
+    /// selected automatically from a detected game installation.
+    /// </summary>
+    public bool IsInstallationPoolRootPathAutoDerived { get; set; }
+
+    /// <summary>
+    /// Gets or sets the previous installation-pool roots that remain available for read-only
+    /// object lookup after new writes have fallen back to another pool. Every root the pool has
+    /// previously used is retained, because objects written to any of them stay reachable only
+    /// through this list.
+    /// </summary>
+    public List<string> LegacyInstallationPoolRootPaths { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the hash algorithm to use for content addressing.
     /// </summary>
     public HashAlgorithm HashAlgorithm { get; set; } = HashAlgorithm.Sha256;
@@ -133,6 +147,8 @@ public class CasConfiguration : ICloneable
             EnableAutomaticGc = EnableAutomaticGc,
             CasRootPath = CasRootPath,
             InstallationPoolRootPath = InstallationPoolRootPath,
+            IsInstallationPoolRootPathAutoDerived = IsInstallationPoolRootPathAutoDerived,
+            LegacyInstallationPoolRootPaths = [.. LegacyInstallationPoolRootPaths],
             HashAlgorithm = HashAlgorithm,
             GcGracePeriod = GcGracePeriod,
             MaxCacheSizeBytes = MaxCacheSizeBytes,

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
@@ -3,6 +3,7 @@ using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Storage;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -82,6 +83,30 @@ public class ConfigurationProviderServiceTests
                 _mockAppConfig.Object,
                 _mockUserSettings.Object,
                 null!));
+    }
+
+    /// <summary>
+    /// Preserves every CAS option when applying the default primary pool path.
+    /// </summary>
+    [Fact]
+    public void GetCasConfiguration_WhenPrimaryPathIsEmpty_PreservesGcLockTimeout()
+    {
+        var expectedTimeout = TimeSpan.FromSeconds(91);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                CasRootPath = string.Empty,
+                GcLockTimeout = expectedTimeout,
+            },
+        };
+        _mockUserSettings.Setup(service => service.Get()).Returns(settings);
+        var provider = CreateProvider();
+
+        var result = provider.GetCasConfiguration();
+
+        Assert.Equal(expectedTimeout, result.GcLockTimeout);
+        Assert.False(string.IsNullOrWhiteSpace(result.CasRootPath));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/StorageLocationServiceTests.cs
@@ -5,6 +5,7 @@ using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Storage;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -21,6 +22,7 @@ public sealed class StorageLocationServiceTests : IDisposable
     private readonly Mock<IConfigurationProviderService> _configurationProviderService = new();
     private readonly Mock<IGameInstallationService> _gameInstallationService = new();
     private readonly string _applicationDataPath;
+    private readonly string _primaryCasPath;
     private readonly string _tempPath;
 
     /// <summary>
@@ -30,9 +32,75 @@ public sealed class StorageLocationServiceTests : IDisposable
     {
         _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         _applicationDataPath = Path.Combine(_tempPath, "AppData");
+        _primaryCasPath = Path.Combine(_applicationDataPath, DirectoryNames.CasPool);
         Directory.CreateDirectory(_applicationDataPath);
 
         _configurationProviderService.Setup(service => service.GetApplicationDataPath()).Returns(_applicationDataPath);
+        _configurationProviderService
+            .Setup(service => service.GetCasConfiguration())
+            .Returns(new CasConfiguration { CasRootPath = _primaryCasPath });
+    }
+
+    /// <summary>
+    /// Reports the effective primary CAS path when installation-adjacent storage is unavailable.
+    /// </summary>
+    [Fact]
+    public void GetCasPoolPath_WhenAdjacentPathIsUnavailable_UsesPrimaryPool()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var installationPath = Path.Combine(_tempPath, "Game");
+        var installation = new GameInstallation(installationPath, GameInstallationType.Retail);
+        var adjacentPath = Path.Combine(installationPath, DirectoryNames.GenHubCasPool);
+        var probe = new Mock<IStorageWritabilityProbe>();
+        probe.Setup(service => service.CanCreateStorageAt(adjacentPath)).Returns(false);
+        var service = CreateService(probe.Object);
+
+        var result = service.GetCasPoolPath(installation);
+
+        Assert.Equal(_primaryCasPath, result);
+    }
+
+    /// <summary>
+    /// Reports a writable user-configured installation CAS path.
+    /// </summary>
+    [Fact]
+    public void GetCasPoolPath_WhenConfiguredPathIsWritable_UsesConfiguredPool()
+    {
+        var configuredPath = Path.Combine(_tempPath, "CustomCas");
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration { InstallationPoolRootPath = configuredPath },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var probe = new Mock<IStorageWritabilityProbe>();
+        probe.Setup(service => service.CanCreateStorageAt(configuredPath)).Returns(true);
+        var service = CreateService(probe.Object);
+        var installation = new GameInstallation(Path.Combine(_tempPath, "Game"), GameInstallationType.Retail);
+
+        var result = service.GetCasPoolPath(installation);
+
+        Assert.Equal(configuredPath, result);
+    }
+
+    /// <summary>
+    /// Keeps a dotted installation directory intact when resolving adjacent CAS storage.
+    /// </summary>
+    [Fact]
+    public void GetCasPoolPath_WhenInstallationDirectoryContainsDot_UsesFullDirectory()
+    {
+        var settings = new UserSettings { UseInstallationAdjacentStorage = true };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var installationPath = Path.Combine(_tempPath, "ZeroHour v1.04");
+        var installation = new GameInstallation(installationPath, GameInstallationType.Retail);
+        var adjacentPath = Path.Combine(installationPath, DirectoryNames.GenHubCasPool);
+        var probe = new Mock<IStorageWritabilityProbe>();
+        probe.Setup(service => service.CanCreateStorageAt(adjacentPath)).Returns(true);
+        var service = CreateService(probe.Object);
+
+        var result = service.GetCasPoolPath(installation);
+
+        Assert.Equal(adjacentPath, result);
     }
 
     /// <summary>
@@ -185,9 +253,10 @@ public sealed class StorageLocationServiceTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private StorageLocationService CreateService() => new(
+    private StorageLocationService CreateService(IStorageWritabilityProbe? writabilityProbe = null) => new(
         _userSettingsService.Object,
         _configurationProviderService.Object,
         _gameInstallationService.Object,
+        writabilityProbe ?? new StorageWritabilityProbe(new Mock<ILogger<StorageWritabilityProbe>>().Object),
         new Mock<ILogger<StorageLocationService>>().Object);
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/UserSettingsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/UserSettingsServiceTests.cs
@@ -4,6 +4,7 @@ using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Storage;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -129,6 +130,39 @@ public class UserSettingsServiceTests : IDisposable
         Assert.Equal("Light", loadedSettings.Theme);
         Assert.Equal("/test/path", loadedSettings.WorkspacePath);
         Assert.Equal(NavigationTab.Downloads, loadedSettings.LastSelectedTab);
+    }
+
+    /// <summary>
+    /// Verifies that the historical installation-pool provenance marker survives settings persistence.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task LoadSettings_AfterSave_PreservesInstallationPoolProvenanceMarker()
+    {
+        var settingsPath = Path.Combine(_tempDirectory, "provenance", FileTypes.SettingsFileName);
+        var historicalPoolPath = "/historical/installation/.genhub-cas";
+        Directory.CreateDirectory(Path.GetDirectoryName(settingsPath)!);
+        var service1 = new TestableUserSettingsService(
+            _mockLogger.Object,
+            CreateAppConfigMock(),
+            settingsPath);
+        service1.Update(settings =>
+        {
+            settings.CasConfiguration.InstallationPoolRootPath = historicalPoolPath;
+            settings.MarkAsExplicitlySet(nameof(CasConfiguration.InstallationPoolRootPath));
+        });
+        await service1.SaveAsync();
+
+        var service2 = new TestableUserSettingsService(
+            _mockLogger.Object,
+            CreateAppConfigMock(),
+            settingsPath);
+        var loadedSettings = service2.Get();
+
+        Assert.Contains(
+            nameof(CasConfiguration.InstallationPoolRootPath),
+            loadedSettings.ExplicitlySetProperties);
+        Assert.Equal(historicalPoolPath, loadedSettings.CasConfiguration.InstallationPoolRootPath);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -2,7 +2,9 @@ using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Content;
+using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
 using GenHub.Core.Models.Results.Content;
@@ -10,6 +12,8 @@ using GenHub.Core.Models.Validation;
 using GenHub.Features.Content.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+using GameInstallationType = GenHub.Core.Models.Enums.GameInstallationType;
 
 namespace GenHub.Tests.Core.Features.Content;
 
@@ -22,7 +26,7 @@ public class ContentOrchestratorTests
     private readonly Mock<IContentValidator> _contentValidatorMock = default!;
     private readonly Mock<IContentManifestPool> _manifestPoolMock = default!;
     private readonly Mock<IGameInstallationService> _installationServiceMock = default!;
-    private readonly Mock<IUserSettingsService> _userSettingsServiceMock = default!;
+    private readonly Mock<IInstallationCasPoolService> _installationCasPoolServiceMock = default!;
     private readonly Mock<ILogger<ContentOrchestrator>> _loggerMock = default!;
 
     /// <summary>
@@ -34,7 +38,7 @@ public class ContentOrchestratorTests
         _contentValidatorMock = new Mock<IContentValidator>();
         _manifestPoolMock = new Mock<IContentManifestPool>();
         _installationServiceMock = new Mock<IGameInstallationService>();
-        _userSettingsServiceMock = new Mock<IUserSettingsService>();
+        _installationCasPoolServiceMock = new Mock<IInstallationCasPoolService>();
         _loggerMock = new Mock<ILogger<ContentOrchestrator>>();
     }
 
@@ -71,7 +75,7 @@ public class ContentOrchestratorTests
             _contentValidatorMock.Object,
             _manifestPoolMock.Object,
             _installationServiceMock.Object,
-            _userSettingsServiceMock.Object);
+            _installationCasPoolServiceMock.Object);
 
         // Act
         var result = await orchestrator.SearchAsync(new ContentSearchQuery());
@@ -132,7 +136,7 @@ public class ContentOrchestratorTests
             _contentValidatorMock.Object,
             _manifestPoolMock.Object,
             _installationServiceMock.Object,
-            _userSettingsServiceMock.Object);
+            _installationCasPoolServiceMock.Object);
 
         // Act
         var result = await orchestrator.AcquireContentAsync(searchResult);
@@ -142,5 +146,84 @@ public class ContentOrchestratorTests
         Assert.Equal(manifest, result.Data);
         _manifestPoolMock.Verify(m => m.AddManifestAsync(manifest, It.IsAny<string>(), It.IsAny<IProgress<ContentStorageProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
         _contentValidatorMock.Verify(v => v.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Stops GameClient acquisition when storage settings cannot be saved safely.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AcquireContentAsync_WhenGameClientPoolCannotBeEnsured_ReturnsFailure()
+    {
+        var searchResult = new ContentSearchResult
+        {
+            Id = "1.0.genhub.gameclient.test",
+            Name = "Test Client",
+            ProviderName = "TestProvider",
+        };
+        var manifest = new ContentManifest
+        {
+            Id = searchResult.Id,
+            Name = searchResult.Name,
+            ContentType = ContentType.GameClient,
+        };
+        var providerMock = new Mock<IContentProvider>();
+        providerMock.Setup(provider => provider.SourceName).Returns(searchResult.ProviderName);
+        providerMock
+            .Setup(provider => provider.GetValidatedContentAsync(searchResult.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
+        providerMock
+            .Setup(provider => provider.PrepareContentAsync(
+                manifest,
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
+        _cacheMock
+            .Setup(cache => cache.GetAsync<ContentManifest>(manifest.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ContentManifest?)null);
+        _contentValidatorMock
+            .Setup(validator => validator.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(manifest.Id, []));
+        _contentValidatorMock
+            .Setup(validator => validator.ValidateAllAsync(
+                It.IsAny<string>(),
+                manifest,
+                It.IsAny<IProgress<ValidationProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(manifest.Id, []));
+        _manifestPoolMock
+            .Setup(pool => pool.IsManifestAcquiredAsync(manifest.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+        var installation = new GameInstallation("/game", GameInstallationType.Retail);
+        _installationServiceMock
+            .Setup(service => service.GetAllInstallationsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IReadOnlyList<GameInstallation>>.CreateSuccess([installation]));
+        _installationCasPoolServiceMock
+            .Setup(service => service.EnsurePoolPathAsync(
+                It.IsAny<IReadOnlyList<GameInstallation>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [providerMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+
+        var result = await orchestrator.AcquireContentAsync(searchResult);
+
+        Assert.False(result.Success);
+        _manifestPoolMock.Verify(
+            pool => pool.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasPoolWritabilityTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasPoolWritabilityTests.cs
@@ -1,0 +1,203 @@
+using GenHub.Common.Services;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Storage;
+using GenHub.Features.Storage.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Storage;
+
+/// <summary>
+/// Tests installation CAS pool selection when the pool location cannot be written.
+/// </summary>
+public sealed class CasPoolWritabilityTests : IDisposable
+{
+    private readonly Mock<IUserSettingsService> _userSettingsService = new();
+    private readonly Mock<IStorageWritabilityProbe> _writabilityProbe = new();
+    private readonly string _tempPath;
+    private readonly string _primaryPoolPath;
+    private readonly string _installationPoolPath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CasPoolWritabilityTests"/> class.
+    /// </summary>
+    public CasPoolWritabilityTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        _primaryPoolPath = Path.Combine(_tempPath, "primary-pool");
+        _installationPoolPath = Path.Combine(_tempPath, "Game", DirectoryNames.GenHubCasPool);
+        Directory.CreateDirectory(_primaryPoolPath);
+    }
+
+    /// <summary>
+    /// Treats a configured but unwritable installation pool as unavailable.
+    /// </summary>
+    [Fact]
+    public void IsInstallationPoolAvailable_WhenPoolIsNotWritable_ReturnsFalse()
+    {
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(_installationPoolPath)).Returns(false);
+        var resolver = CreateResolver(_installationPoolPath);
+
+        Assert.False(resolver.IsInstallationPoolAvailable());
+    }
+
+    /// <summary>
+    /// Exposes an existing unwritable pool for read-only lookup before settings migration runs.
+    /// </summary>
+    [Fact]
+    public void GetLegacyInstallationPoolRootPaths_WhenCurrentPoolIsUnwritable_ReturnsCurrentPath()
+    {
+        Directory.CreateDirectory(_installationPoolPath);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(_installationPoolPath)).Returns(false);
+        var resolver = CreateResolver(_installationPoolPath);
+
+        var result = resolver.GetLegacyInstallationPoolRootPaths();
+
+        Assert.Equal([_installationPoolPath], result);
+    }
+
+    /// <summary>
+    /// Keeps a writable installation pool selected.
+    /// </summary>
+    [Fact]
+    public void IsInstallationPoolAvailable_WhenPoolIsWritable_ReturnsTrue()
+    {
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(_installationPoolPath)).Returns(true);
+        var resolver = CreateResolver(_installationPoolPath);
+
+        Assert.True(resolver.IsInstallationPoolAvailable());
+    }
+
+    /// <summary>
+    /// Routes installation-pool content to the primary pool when the installation pool is unwritable.
+    /// </summary>
+    /// <param name="contentType">The content type normally routed to installation storage.</param>
+    [Theory]
+    [InlineData(ContentType.GameClient)]
+    [InlineData(ContentType.GameInstallation)]
+    [InlineData(ContentType.Addon)]
+    [InlineData(ContentType.Patch)]
+    [InlineData(ContentType.Map)]
+    [InlineData(ContentType.Mod)]
+    public void ResolvePool_WhenInstallationPoolIsNotWritable_UsesPrimaryPool(ContentType contentType)
+    {
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(_installationPoolPath)).Returns(false);
+        var resolver = CreateResolver(_installationPoolPath);
+
+        Assert.Equal(CasPoolType.Primary, resolver.ResolvePool(contentType));
+        Assert.Equal(_primaryPoolPath, resolver.GetPoolRootPath(contentType));
+    }
+
+    /// <summary>
+    /// Keeps routing installation-pool content to a writable installation pool.
+    /// </summary>
+    [Fact]
+    public void ResolvePool_WhenInstallationPoolIsWritable_UsesInstallationPool()
+    {
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(_installationPoolPath)).Returns(true);
+        var resolver = CreateResolver(_installationPoolPath);
+
+        Assert.Equal(CasPoolType.Installation, resolver.ResolvePool(ContentType.GameClient));
+        Assert.Equal(_installationPoolPath, resolver.GetPoolRootPath(ContentType.GameClient));
+    }
+
+    /// <summary>
+    /// Treats an empty installation pool path as unavailable without probing.
+    /// </summary>
+    [Fact]
+    public void IsInstallationPoolAvailable_WhenPathIsEmpty_ReturnsFalseWithoutProbing()
+    {
+        var resolver = CreateResolver(string.Empty);
+
+        Assert.False(resolver.IsInstallationPoolAvailable());
+        _writabilityProbe.Verify(probe => probe.CanCreateStorageAt(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Probes a real unwritable directory end to end rather than a mocked verdict.
+    /// </summary>
+    [Fact]
+    public void StorageWritabilityProbe_WhenDirectoryDeniesWrites_ReturnsFalse()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var lockedPath = Path.Combine(_tempPath, "locked");
+        Directory.CreateDirectory(lockedPath);
+        File.SetUnixFileMode(lockedPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+        try
+        {
+            var probe = new StorageWritabilityProbe(new Mock<ILogger<StorageWritabilityProbe>>().Object);
+
+            Assert.False(probe.CanCreateStorageAt(Path.Combine(lockedPath, DirectoryNames.GenHubCasPool)));
+            Assert.True(probe.CanCreateStorageAt(Path.Combine(_primaryPoolPath, DirectoryNames.GenHubCasPool)));
+        }
+        finally
+        {
+            File.SetUnixFileMode(
+                lockedPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    /// <summary>
+    /// Leaves no probe files behind after a successful check.
+    /// </summary>
+    [Fact]
+    public void StorageWritabilityProbe_WhenLocationIsWritable_LeavesNoProbeFile()
+    {
+        var probe = new StorageWritabilityProbe(new Mock<ILogger<StorageWritabilityProbe>>().Object);
+        var targetPath = Path.Combine(_primaryPoolPath, DirectoryNames.GenHubCasPool);
+
+        Assert.True(probe.CanCreateStorageAt(targetPath));
+        Assert.True(Directory.Exists(targetPath));
+        Assert.Empty(Directory.GetFiles(targetPath, StorageConstants.WriteProbeFilePrefix + "*"));
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempPath, true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private CasPoolResolver CreateResolver(string installationPoolRootPath)
+    {
+        _userSettingsService
+            .Setup(service => service.Get())
+            .Returns(new UserSettings
+            {
+                CasConfiguration = new CasConfiguration
+                {
+                    CasRootPath = _primaryPoolPath,
+                    InstallationPoolRootPath = installationPoolRootPath,
+                },
+            });
+
+        return new CasPoolResolver(
+            Options.Create(new CasConfiguration { CasRootPath = _primaryPoolPath }),
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            new Mock<ILogger<CasPoolResolver>>().Object);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/InstallationCasPoolServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/InstallationCasPoolServiceTests.cs
@@ -1,0 +1,556 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Storage;
+using GenHub.Features.Storage.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using ManifestContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Storage;
+
+/// <summary>
+/// Tests installation CAS pool selection, migration, and legacy lookup behavior.
+/// </summary>
+public sealed class InstallationCasPoolServiceTests : IDisposable
+{
+    private readonly string _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+    private readonly Mock<IUserSettingsService> _userSettingsService = new();
+    private readonly Mock<IStorageWritabilityProbe> _writabilityProbe = new();
+    private readonly Mock<ICasPoolManager> _poolManager = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InstallationCasPoolServiceTests"/> class.
+    /// </summary>
+    public InstallationCasPoolServiceTests()
+    {
+        Directory.CreateDirectory(_tempPath);
+    }
+
+    /// <summary>
+    /// Clears a historical auto-derived path and retains it for read-only lookup when it is unwritable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsurePoolPathAsync_WhenHistoricalPathIsUnwritable_PreservesLegacyLookup()
+    {
+        var installation = CreateInstallation();
+        var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
+        Directory.CreateDirectory(poolPath);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration { InstallationPoolRootPath = poolPath },
+            ExplicitlySetProperties = [nameof(CasConfiguration.InstallationPoolRootPath)],
+        };
+        ConfigureMutableSettings(settings);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(poolPath)).Returns(false);
+        var service = CreateService();
+
+        var result = await service.EnsurePoolPathAsync([installation]);
+
+        Assert.True(result);
+        Assert.Empty(settings.CasConfiguration.InstallationPoolRootPath);
+        Assert.Equal([poolPath], settings.CasConfiguration.LegacyInstallationPoolRootPaths);
+        Assert.False(settings.CasConfiguration.IsInstallationPoolRootPathAutoDerived);
+        Assert.DoesNotContain(nameof(CasConfiguration.InstallationPoolRootPath), settings.ExplicitlySetProperties);
+        _poolManager.Verify(manager => manager.ReinitializeInstallationPool(), Times.Once);
+    }
+
+    /// <summary>
+    /// Preserves a deliberate custom path instead of replacing it with an automatically derived path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsurePoolPathAsync_WhenCustomPathIsConfigured_PreservesIt()
+    {
+        var installation = CreateInstallation();
+        var customPath = Path.Combine(_tempPath, "custom-cas");
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration { InstallationPoolRootPath = customPath },
+        };
+        ConfigureMutableSettings(settings);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(customPath)).Returns(true);
+        var service = CreateService();
+
+        var result = await service.EnsurePoolPathAsync([installation]);
+
+        Assert.True(result);
+        Assert.Equal(customPath, settings.CasConfiguration.InstallationPoolRootPath);
+        _userSettingsService.Verify(
+            service => service.TryUpdateAndSaveAsync(It.IsAny<Func<UserSettings, bool>>()),
+            Times.Never);
+        _poolManager.Verify(manager => manager.ReinitializeInstallationPool(), Times.Never);
+    }
+
+    /// <summary>
+    /// Persists provenance when a writable adjacent pool is selected automatically.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsurePoolPathAsync_WhenAdjacentPathIsWritable_RecordsAutoDerivedProvenance()
+    {
+        var installation = CreateInstallation();
+        var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
+        var settings = new UserSettings();
+        ConfigureMutableSettings(settings);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(poolPath)).Returns(true);
+        var service = CreateService();
+
+        var result = await service.EnsurePoolPathAsync([installation]);
+
+        Assert.True(result);
+        Assert.Equal(poolPath, settings.CasConfiguration.InstallationPoolRootPath);
+        Assert.True(settings.CasConfiguration.IsInstallationPoolRootPathAutoDerived);
+        Assert.Equal(installation.Id, settings.PreferredStorageInstallationId);
+        _poolManager.Verify(manager => manager.ReinitializeInstallationPool(), Times.Once);
+    }
+
+    /// <summary>
+    /// Continues with primary storage when no installation is available.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsurePoolPathAsync_WhenNoInstallations_ContinuesWithPrimaryPool()
+    {
+        var service = CreateService();
+
+        var result = await service.EnsurePoolPathAsync([]);
+
+        Assert.True(result);
+        _userSettingsService.Verify(
+            settings => settings.TryUpdateAndSaveAsync(It.IsAny<Func<UserSettings, bool>>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Keeps a dotted installation directory intact when deriving the adjacent pool path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsurePoolPathAsync_WhenInstallationDirectoryContainsDot_UsesFullDirectory()
+    {
+        var installation = CreateInstallation("ZeroHour v1.04");
+        var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
+        var settings = new UserSettings();
+        ConfigureMutableSettings(settings);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(poolPath)).Returns(true);
+        var service = CreateService();
+
+        var result = await service.EnsurePoolPathAsync([installation]);
+
+        Assert.True(result);
+        Assert.Equal(poolPath, settings.CasConfiguration.InstallationPoolRootPath);
+    }
+
+    /// <summary>
+    /// Honors cancellation that arrives while resolving the pool and does not persist settings.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsurePoolPathAsync_WhenCancelledBeforeSave_DoesNotPersistSettings()
+    {
+        var installation = CreateInstallation();
+        var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
+        var settings = new UserSettings();
+        ConfigureMutableSettings(settings);
+        using var cancellationSource = new CancellationTokenSource();
+        _writabilityProbe
+            .Setup(probe => probe.CanCreateStorageAt(poolPath))
+            .Callback(cancellationSource.Cancel)
+            .Returns(true);
+        var service = CreateService();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            service.EnsurePoolPathAsync([installation], cancellationSource.Token));
+
+        _userSettingsService.Verify(
+            userSettingsService => userSettingsService.TryUpdateAndSaveAsync(It.IsAny<Func<UserSettings, bool>>()),
+            Times.Never);
+        _poolManager.Verify(manager => manager.ReinitializeInstallationPool(), Times.Never);
+    }
+
+    /// <summary>
+    /// Removes a cached installation pool from every enumeration path after it becomes unavailable.
+    /// </summary>
+    [Fact]
+    public void CasPoolManager_WhenInstallationPoolBecomesUnavailable_DiscardsCachedStorage()
+    {
+        var primaryPath = Path.Combine(_tempPath, "primary");
+        var installationPath = Path.Combine(_tempPath, "installation");
+        var legacyPath = Path.Combine(_tempPath, "legacy");
+        Directory.CreateDirectory(primaryPath);
+        Directory.CreateDirectory(installationPath);
+        Directory.CreateDirectory(legacyPath);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                InstallationPoolRootPath = installationPath,
+                LegacyInstallationPoolRootPaths = [legacyPath],
+            },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(installationPath)).Returns(true);
+        var resolver = new CasPoolResolver(
+            Options.Create(new CasConfiguration { CasRootPath = primaryPath }),
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolResolver>.Instance);
+        var manager = new CasPoolManager(
+            resolver,
+            Options.Create(new CasConfiguration { CasRootPath = primaryPath }),
+            new Mock<IFileHashProvider>().Object,
+            NullLoggerFactory.Instance,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolManager>.Instance);
+
+        Assert.Equal(3, manager.GetAllStorages().Count);
+
+        settings.CasConfiguration.InstallationPoolRootPath = string.Empty;
+        manager.ReinitializeInstallationPool();
+
+        Assert.Equal(2, manager.GetAllStorages().Count);
+        Assert.Same(manager.GetStorage(CasPoolType.Primary), manager.GetStorage(CasPoolType.Installation));
+    }
+
+    /// <summary>
+    /// Does not retain the active installation pool as a duplicate legacy pool when path formatting differs.
+    /// </summary>
+    [Fact]
+    public void CasPoolManager_WhenLegacyRootMatchesActiveRoot_DoesNotRetainDuplicateStorage()
+    {
+        var primaryPath = Path.Combine(_tempPath, "primary-normalized");
+        var installationPath = Path.Combine(_tempPath, "installation-normalized");
+        Directory.CreateDirectory(primaryPath);
+        Directory.CreateDirectory(installationPath);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                InstallationPoolRootPath = installationPath,
+                LegacyInstallationPoolRootPaths = [installationPath + Path.DirectorySeparatorChar],
+            },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(installationPath)).Returns(true);
+        var configuration = new CasConfiguration { CasRootPath = primaryPath };
+        var resolver = new CasPoolResolver(
+            Options.Create(configuration),
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolResolver>.Instance);
+
+        var manager = new CasPoolManager(
+            resolver,
+            Options.Create(configuration),
+            new Mock<IFileHashProvider>().Object,
+            NullLoggerFactory.Instance,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolManager>.Instance);
+
+        Assert.Equal(2, manager.GetAllStorages().Count);
+    }
+
+    /// <summary>
+    /// Does not retain the primary pool as a duplicate legacy pool when path formatting differs.
+    /// </summary>
+    [Fact]
+    public void CasPoolManager_WhenLegacyRootMatchesPrimaryRoot_DoesNotRetainDuplicateStorage()
+    {
+        var primaryPath = Path.Combine(_tempPath, "primary-legacy-normalized");
+        Directory.CreateDirectory(primaryPath);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                LegacyInstallationPoolRootPaths = [primaryPath + Path.DirectorySeparatorChar],
+            },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var configuration = new CasConfiguration { CasRootPath = primaryPath };
+        var resolver = new CasPoolResolver(
+            Options.Create(configuration),
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolResolver>.Instance);
+
+        var manager = new CasPoolManager(
+            resolver,
+            Options.Create(configuration),
+            new Mock<IFileHashProvider>().Object,
+            NullLoggerFactory.Instance,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolManager>.Instance);
+
+        Assert.Single(manager.GetAllStorages());
+    }
+
+    /// <summary>
+    /// Reads an existing legacy object without attempting to create writable CAS directories.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CasStorage_ObjectExistsAsync_DoesNotCreateWriteDirectories()
+    {
+        var rootPath = Path.Combine(_tempPath, "read-only-cas");
+        var hash = new string('a', 64);
+        var objectDirectory = Path.Combine(rootPath, "objects", "aa");
+        Directory.CreateDirectory(objectDirectory);
+        await File.WriteAllTextAsync(Path.Combine(objectDirectory, hash), "content");
+        var storage = new CasStorage(
+            Options.Create(new CasConfiguration { CasRootPath = rootPath }),
+            NullLogger<CasStorage>.Instance,
+            new Mock<IFileHashProvider>().Object);
+
+        Assert.True(await storage.ObjectExistsAsync(hash));
+        Assert.False(Directory.Exists(Path.Combine(rootPath, "temp")));
+        Assert.False(Directory.Exists(Path.Combine(rootPath, "locks")));
+    }
+
+    /// <summary>
+    /// Resolves content from the retained legacy pool after installation writes fall back to primary storage.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CasService_GetContentPathAsync_FindsContentInLegacyPool()
+    {
+        var primaryPath = Path.Combine(_tempPath, "primary-lookup");
+        var legacyPath = Path.Combine(_tempPath, "legacy-lookup");
+        var hash = new string('b', 64);
+        var objectDirectory = Path.Combine(legacyPath, "objects", "bb");
+        Directory.CreateDirectory(primaryPath);
+        Directory.CreateDirectory(objectDirectory);
+        var expectedPath = Path.Combine(objectDirectory, hash);
+        await File.WriteAllTextAsync(expectedPath, "legacy content");
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                LegacyInstallationPoolRootPaths = [legacyPath],
+            },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var configuration = new CasConfiguration { CasRootPath = primaryPath };
+        var resolver = new CasPoolResolver(
+            Options.Create(configuration),
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolResolver>.Instance);
+        var fileHashProvider = new Mock<IFileHashProvider>();
+        var manager = new CasPoolManager(
+            resolver,
+            Options.Create(configuration),
+            fileHashProvider.Object,
+            NullLoggerFactory.Instance,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolManager>.Instance);
+        var service = new CasService(
+            manager.GetStorage(CasPoolType.Primary),
+            new Mock<ICasReferenceTracker>().Object,
+            NullLogger<CasService>.Instance,
+            Options.Create(configuration),
+            fileHashProvider.Object,
+            new Mock<IStreamHashProvider>().Object,
+            manager);
+
+        var result = await service.GetContentPathAsync(hash, ManifestContentType.GameClient);
+
+        Assert.True(result.Success);
+        Assert.Equal(expectedPath, result.Data);
+    }
+
+    /// <summary>
+    /// Does not expose a legacy CAS pool inside the application directory.
+    /// </summary>
+    [Fact]
+    public void CasPoolManager_WhenLegacyPoolIsInsideApplicationDirectory_BlocksIt()
+    {
+        var primaryPath = Path.Combine(_tempPath, "primary-security");
+        Directory.CreateDirectory(primaryPath);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                LegacyInstallationPoolRootPaths = [AppContext.BaseDirectory],
+            },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var configuration = new CasConfiguration { CasRootPath = primaryPath };
+        var resolver = new CasPoolResolver(
+            Options.Create(configuration),
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolResolver>.Instance);
+
+        var manager = new CasPoolManager(
+            resolver,
+            Options.Create(configuration),
+            new Mock<IFileHashProvider>().Object,
+            NullLoggerFactory.Instance,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolManager>.Instance);
+
+        Assert.Single(manager.GetAllStorages());
+        Assert.StartsWith(
+            primaryPath,
+            manager.GetStorage(CasPoolType.Primary).GetObjectPath(new string('a', 64)),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Avoids refreshing installation pools during ordinary cached storage lookups.
+    /// </summary>
+    [Fact]
+    public void CasPoolManager_WhenPrimaryStorageIsCached_DoesNotRefreshInstallationPools()
+    {
+        var primaryPath = Path.Combine(_tempPath, "primary-cached");
+        Directory.CreateDirectory(primaryPath);
+        var resolver = new Mock<ICasPoolResolver>();
+        resolver
+            .Setup(service => service.GetPoolRootPath(CasPoolType.Primary))
+            .Returns(primaryPath);
+        resolver.Setup(service => service.IsInstallationPoolAvailable()).Returns(false);
+        resolver.Setup(service => service.GetLegacyInstallationPoolRootPaths()).Returns([]);
+        var configuration = new CasConfiguration { CasRootPath = primaryPath };
+        var manager = new CasPoolManager(
+            resolver.Object,
+            Options.Create(configuration),
+            new Mock<IFileHashProvider>().Object,
+            NullLoggerFactory.Instance,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolManager>.Instance);
+        resolver.Invocations.Clear();
+
+        manager.GetStorage(CasPoolType.Primary);
+        manager.GetStorage(CasPoolType.Primary);
+        manager.GetAllStorages();
+
+        resolver.Verify(service => service.IsInstallationPoolAvailable(), Times.Never);
+        resolver.Verify(service => service.GetLegacyInstallationPoolRootPaths(), Times.Never);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempPath, true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private GameInstallation CreateInstallation(string directoryName = "Game")
+    {
+        var installationPath = Path.Combine(_tempPath, directoryName);
+        Directory.CreateDirectory(installationPath);
+        return new GameInstallation(installationPath, GameInstallationType.Steam);
+    }
+
+    /// <summary>
+    /// Retains every previously used pool root when the pool moves more than once, because nothing
+    /// copies objects out of a root that is replaced.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsurePoolPathAsync_WhenPoolMovesAgain_RetainsEveryPreviousRoot()
+    {
+        var firstLegacyPath = Path.Combine(_tempPath, "first-legacy");
+        var currentInstallation = CreateInstallation("CurrentGame");
+        var currentPoolPath = Path.Combine(currentInstallation.InstallationPath, DirectoryNames.GenHubCasPool);
+        var nextInstallation = CreateInstallation("NextGame");
+        var nextPoolPath = Path.Combine(nextInstallation.InstallationPath, DirectoryNames.GenHubCasPool);
+        Directory.CreateDirectory(firstLegacyPath);
+        Directory.CreateDirectory(currentPoolPath);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                InstallationPoolRootPath = currentPoolPath,
+                IsInstallationPoolRootPathAutoDerived = true,
+                LegacyInstallationPoolRootPaths = [firstLegacyPath],
+            },
+        };
+        ConfigureMutableSettings(settings);
+        _writabilityProbe.Setup(probe => probe.CanCreateStorageAt(nextPoolPath)).Returns(true);
+        var service = CreateService();
+
+        var result = await service.EnsurePoolPathAsync([nextInstallation]);
+
+        Assert.True(result);
+        Assert.Equal(nextPoolPath, settings.CasConfiguration.InstallationPoolRootPath);
+        Assert.Equal(
+            [firstLegacyPath, currentPoolPath],
+            settings.CasConfiguration.LegacyInstallationPoolRootPaths);
+    }
+
+    /// <summary>
+    /// Exposes every retained legacy root for read-only lookup rather than only the most recent one.
+    /// </summary>
+    [Fact]
+    public void CasPoolManager_WhenMultipleLegacyRootsAreRetained_ExposesEachForLookup()
+    {
+        var primaryPath = Path.Combine(_tempPath, "primary-multi");
+        var firstLegacyPath = Path.Combine(_tempPath, "legacy-one");
+        var secondLegacyPath = Path.Combine(_tempPath, "legacy-two");
+        Directory.CreateDirectory(primaryPath);
+        Directory.CreateDirectory(firstLegacyPath);
+        Directory.CreateDirectory(secondLegacyPath);
+        var settings = new UserSettings
+        {
+            CasConfiguration = new CasConfiguration
+            {
+                LegacyInstallationPoolRootPaths = [firstLegacyPath, secondLegacyPath],
+            },
+        };
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        var configuration = new CasConfiguration { CasRootPath = primaryPath };
+        var resolver = new CasPoolResolver(
+            Options.Create(configuration),
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolResolver>.Instance);
+
+        var manager = new CasPoolManager(
+            resolver,
+            Options.Create(configuration),
+            new Mock<IFileHashProvider>().Object,
+            NullLoggerFactory.Instance,
+            _writabilityProbe.Object,
+            NullLogger<CasPoolManager>.Instance);
+
+        // The primary pool plus both retained legacy roots.
+        Assert.Equal(3, manager.GetAllStorages().Count);
+    }
+
+    private InstallationCasPoolService CreateService()
+    {
+        return new InstallationCasPoolService(
+            _userSettingsService.Object,
+            _writabilityProbe.Object,
+            _poolManager.Object,
+            NullLogger<InstallationCasPoolService>.Instance);
+    }
+
+    private void ConfigureMutableSettings(UserSettings settings)
+    {
+        _userSettingsService.Setup(service => service.Get()).Returns(settings);
+        _userSettingsService
+            .Setup(service => service.TryUpdateAndSaveAsync(It.IsAny<Func<UserSettings, bool>>()))
+            .Returns<Func<UserSettings, bool>>(applyChanges => Task.FromResult(applyChanges(settings)));
+    }
+}

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -317,17 +317,9 @@ public class ConfigurationProviderService(
                 AppConstants.AppName,
                 DirectoryNames.CasPool);
 
-            return new CasConfiguration
-            {
-                CasRootPath = defaultPath,
-                EnableAutomaticGc = casConfig.EnableAutomaticGc,
-                HashAlgorithm = casConfig.HashAlgorithm,
-                GcGracePeriod = casConfig.GcGracePeriod,
-                MaxCacheSizeBytes = casConfig.MaxCacheSizeBytes,
-                AutoGcInterval = casConfig.AutoGcInterval,
-                MaxConcurrentOperations = casConfig.MaxConcurrentOperations,
-                VerifyIntegrity = casConfig.VerifyIntegrity,
-            };
+            var defaultConfig = (CasConfiguration)casConfig.Clone();
+            defaultConfig.CasRootPath = defaultPath;
+            return defaultConfig;
         }
 
         return casConfig;

--- a/GenHub/GenHub/Common/Services/StorageLocationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageLocationService.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
@@ -22,35 +20,41 @@ public class StorageLocationService(
     IUserSettingsService userSettingsService,
     IConfigurationProviderService configurationProviderService,
     IGameInstallationService gameInstallationService,
+    IStorageWritabilityProbe writabilityProbe,
     ILogger<StorageLocationService> logger) : IStorageLocationService
 {
-    /// <summary>
-    /// Caches write-probe results for the process lifetime, so a permission change
-    /// on a probed location only takes effect after a restart.
-    /// </summary>
-    private readonly ConcurrentDictionary<string, bool> _writableStorageCache = new(PathHelper.PathComparer);
-
     /// <inheritdoc/>
     public string GetCasPoolPath(IGameInstallation installation)
     {
         ArgumentNullException.ThrowIfNull(installation);
 
         var settings = userSettingsService.Get();
-        if (!settings.UseInstallationAdjacentStorage)
+        var configuredInstallationPoolPath = settings.CasConfiguration.InstallationPoolRootPath;
+        if (!string.IsNullOrWhiteSpace(configuredInstallationPoolPath) &&
+            writabilityProbe.CanCreateStorageAt(configuredInstallationPoolPath))
         {
-            // Fall back to centralized AppData location
-            var appDataPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                AppConstants.AppName,
-                DirectoryNames.CasPool);
-            logger.LogDebug("Using centralized CAS pool path: {CasPoolPath} (installation-adjacent disabled)", appDataPath);
-            return appDataPath;
+            return Path.GetFullPath(configuredInstallationPoolPath);
         }
 
-        var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
-        var casPoolPath = Path.Combine(installationRoot, DirectoryNames.GenHubCasPool);
-        logger.LogDebug("Resolved CAS pool path: {CasPoolPath} for installation {InstallationId}", casPoolPath, installation.Id);
-        return casPoolPath;
+        if (settings.UseInstallationAdjacentStorage)
+        {
+            var installationPath = installation.InstallationPath;
+            if (!string.IsNullOrWhiteSpace(installationPath))
+            {
+                var adjacentPath = Path.Combine(installationPath, DirectoryNames.GenHubCasPool);
+                if (writabilityProbe.CanCreateStorageAt(adjacentPath))
+                {
+                    return Path.GetFullPath(adjacentPath);
+                }
+            }
+        }
+
+        var primaryPoolPath = configurationProviderService.GetCasConfiguration().CasRootPath;
+        logger.LogInformation(
+            "Using primary CAS pool path {CasPoolPath} for installation {InstallationId}",
+            primaryPoolPath,
+            installation.Id);
+        return primaryPoolPath;
     }
 
     /// <inheritdoc/>
@@ -70,7 +74,7 @@ public class StorageLocationService(
         }
 
         var configuredWorkspacePath = settings.WorkspacePath;
-        var workspacePath = !string.IsNullOrWhiteSpace(configuredWorkspacePath) && CanCreateStorageAt(configuredWorkspacePath)
+        var workspacePath = !string.IsNullOrWhiteSpace(configuredWorkspacePath) && writabilityProbe.CanCreateStorageAt(configuredWorkspacePath)
             ? Path.GetFullPath(configuredWorkspacePath)
             : Path.Combine(configurationProviderService.GetApplicationDataPath(), DirectoryNames.Workspaces);
 
@@ -176,7 +180,7 @@ public class StorageLocationService(
     {
         var installationRoot = PathHelper.GetSafeParentDirectory(installation.InstallationPath);
         path = Path.Combine(installationRoot, directoryName);
-        if (CanCreateStorageAt(path))
+        if (writabilityProbe.CanCreateStorageAt(path))
         {
             return true;
         }
@@ -186,85 +190,5 @@ public class StorageLocationService(
             path,
             installation.Id);
         return false;
-    }
-
-    private bool CanCreateStorageAt(string storagePath)
-    {
-        string fullStoragePath;
-
-        try
-        {
-            fullStoragePath = Path.GetFullPath(storagePath);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or SecurityException or IOException)
-        {
-            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
-            return false;
-        }
-
-        return _writableStorageCache.GetOrAdd(fullStoragePath, ProbeStorageLocation);
-    }
-
-    private bool ProbeStorageLocation(string fullStoragePath)
-    {
-        string? probePath = null;
-        var storageDirectoryExisted = Directory.Exists(fullStoragePath);
-        var storageDirectoryCreated = false;
-        var probeSucceeded = false;
-
-        try
-        {
-            Directory.CreateDirectory(fullStoragePath);
-            storageDirectoryCreated = !storageDirectoryExisted;
-
-            probePath = Path.Combine(
-                fullStoragePath,
-                $"{StorageConstants.WriteProbeFilePrefix}{Guid.NewGuid():N}.tmp");
-            using var probe = new FileStream(
-                probePath,
-                FileMode.CreateNew,
-                FileAccess.Write,
-                FileShare.None,
-                bufferSize: 1,
-                FileOptions.DeleteOnClose);
-            probe.WriteByte(0);
-            probeSucceeded = true;
-            return true;
-        }
-        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or SecurityException)
-        {
-            logger.LogDebug(ex, "Storage path {StoragePath} is not writable", fullStoragePath);
-            return false;
-        }
-        finally
-        {
-            if (!string.IsNullOrWhiteSpace(probePath) && File.Exists(probePath))
-            {
-                try
-                {
-                    File.Delete(probePath);
-                }
-                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-                {
-                    logger.LogDebug(ex, "Could not remove storage write probe {ProbePath}", probePath);
-                }
-            }
-
-            if (!probeSucceeded && storageDirectoryCreated)
-            {
-                try
-                {
-                    if (Directory.Exists(fullStoragePath) &&
-                        !Directory.EnumerateFileSystemEntries(fullStoragePath).Any())
-                    {
-                        Directory.Delete(fullStoragePath);
-                    }
-                }
-                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or SecurityException)
-                {
-                    logger.LogDebug(ex, "Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
-                }
-            }
-        }
     }
 }

--- a/GenHub/GenHub/Common/Services/StorageWritabilityProbe.cs
+++ b/GenHub/GenHub/Common/Services/StorageWritabilityProbe.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Security;
+using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
+using GenHub.Core.Interfaces.Common;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Common.Services;
+
+/// <summary>
+/// Determines whether GenHub can create storage at a filesystem location by writing a probe file.
+/// </summary>
+public class StorageWritabilityProbe(ILogger<StorageWritabilityProbe> logger) : IStorageWritabilityProbe
+{
+    private readonly ConcurrentDictionary<string, bool> _results = new(PathHelper.PathComparer);
+
+    /// <inheritdoc/>
+    public bool CanCreateStorageAt(string storagePath)
+    {
+        if (string.IsNullOrWhiteSpace(storagePath))
+        {
+            return false;
+        }
+
+        string fullStoragePath;
+
+        try
+        {
+            fullStoragePath = Path.GetFullPath(storagePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or SecurityException or IOException)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved", storagePath);
+            return false;
+        }
+
+        return _results.GetOrAdd(fullStoragePath, Probe);
+    }
+
+    /// <inheritdoc/>
+    public void Invalidate(string? storagePath = null)
+    {
+        if (string.IsNullOrWhiteSpace(storagePath))
+        {
+            _results.Clear();
+            return;
+        }
+
+        try
+        {
+            _results.TryRemove(Path.GetFullPath(storagePath), out _);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or SecurityException or IOException)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} could not be resolved for invalidation", storagePath);
+        }
+    }
+
+    private bool Probe(string fullStoragePath)
+    {
+        string? probePath = null;
+        var storageDirectoryExisted = Directory.Exists(fullStoragePath);
+        var storageDirectoryCreated = false;
+        var probeSucceeded = false;
+
+        try
+        {
+            Directory.CreateDirectory(fullStoragePath);
+            storageDirectoryCreated = !storageDirectoryExisted;
+
+            probePath = Path.Combine(
+                fullStoragePath,
+                $"{StorageConstants.WriteProbeFilePrefix}{Guid.NewGuid():N}.tmp");
+            using var probe = new FileStream(
+                probePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
+            probe.WriteByte(0);
+            probeSucceeded = true;
+            return true;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or SecurityException)
+        {
+            logger.LogDebug(ex, "Storage path {StoragePath} is not writable", fullStoragePath);
+            return false;
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(probePath) && File.Exists(probePath))
+            {
+                try
+                {
+                    File.Delete(probePath);
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                {
+                    logger.LogDebug(ex, "Could not remove storage write probe {ProbePath}", probePath);
+                }
+            }
+
+            if (!probeSucceeded && storageDirectoryCreated)
+            {
+                try
+                {
+                    if (Directory.Exists(fullStoragePath) &&
+                        !Directory.EnumerateFileSystemEntries(fullStoragePath).Any())
+                    {
+                        Directory.Delete(fullStoragePath);
+                    }
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or SecurityException)
+                {
+                    logger.LogDebug(ex, "Could not remove failed storage probe directory {StoragePath}", fullStoragePath);
+                }
+            }
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -36,8 +36,7 @@ public class CommunityOutpostDeliverer(
    IContentManifestPool manifestPool,
    CommunityOutpostManifestFactory manifestFactory,
    IGameInstallationService installationService,
-   IUserSettingsService userSettingsService,
-   ICasPoolManager? casPoolManager,
+   IInstallationCasPoolService installationCasPoolService,
    CompressedImageToTgaConverter avifConverter,
    ILogger<CommunityOutpostDeliverer> logger)
    : IContentDeliverer
@@ -78,37 +77,6 @@ public class CommunityOutpostDeliverer(
         }
 
         return "unknown";
-    }
-
-    /// <summary>
-    /// Gets the installation path for a game installation.
-    /// </summary>
-    private static string? GetInstallationPath(GameInstallation installation)
-    {
-        // For Zero Hour installations, use the installation path directly
-        // For Generals-only installations, use the Generals path
-        if (!string.IsNullOrEmpty(installation.InstallationPath))
-        {
-            // If the path points to a file (e.g. generals.exe), return the directory
-            if (Path.HasExtension(installation.InstallationPath))
-            {
-                return Path.GetDirectoryName(installation.InstallationPath);
-            }
-
-            return installation.InstallationPath;
-        }
-
-        if (!string.IsNullOrEmpty(installation.ZeroHourPath))
-        {
-            return installation.ZeroHourPath;
-        }
-
-        if (!string.IsNullOrEmpty(installation.GeneralsPath))
-        {
-            return installation.GeneralsPath;
-        }
-
-        return null;
     }
 
     /// <summary>
@@ -363,12 +331,12 @@ public class CommunityOutpostDeliverer(
             var hasGameClientManifest = manifests.Any(m => m.ContentType == ContentType.GameClient);
             if (hasGameClientManifest)
             {
-                await EnsureInstallationPoolPathAsync(cancellationToken);
-
-                // CRITICAL: Force the CAS pool manager to reinitialize the Installation pool
-                // after we've updated the path in settings. Without this, the pool manager
-                // will still use the old (or non-existent) Installation pool.
-                casPoolManager?.ReinitializeInstallationPool();
+                var poolPathReady = await EnsureInstallationPoolPathAsync(cancellationToken);
+                if (!poolPathReady)
+                {
+                    return OperationResult<ContentManifest>.CreateFailure(
+                        "Could not ensure storage for GameClient content.");
+                }
             }
 
             foreach (var manifest in manifests)
@@ -649,7 +617,8 @@ public class CommunityOutpostDeliverer(
     /// Ensures the InstallationPoolRootPath is set before storing GameClient content.
     /// This prevents content from being stored in the wrong CAS pool.
     /// </summary>
-    private async Task EnsureInstallationPoolPathAsync(CancellationToken cancellationToken)
+    /// <returns><c>true</c> when content acquisition may continue; otherwise, <c>false</c>.</returns>
+    private async Task<bool> EnsureInstallationPoolPathAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -663,82 +632,19 @@ public class CommunityOutpostDeliverer(
             var installationsResult = await installationService.GetAllInstallationsAsync(cancellationToken);
             if (!installationsResult.Success || installationsResult.Data == null)
             {
-                logger.LogWarning("Failed to get installations for CAS pool path resolution: {Error}", installationsResult.FirstError);
-                return;
+                logger.LogWarning(
+                    "Failed to get installations for CAS pool path resolution: {Error}; the primary CAS pool will be used",
+                    installationsResult.FirstError);
+                return true;
             }
 
             var installations = installationsResult.Data.ToList();
-
-            if (installations.Count == 0)
-            {
-                logger.LogWarning("No installations detected - cannot set InstallationPoolRootPath");
-                return;
-            }
-
-            // If only one installation, use it
-            if (installations.Count == 1)
-            {
-                var installation = installations[0];
-                var installationPath = GetInstallationPath(installation);
-                if (!string.IsNullOrEmpty(installationPath))
-                {
-                    var casPoolPath = Path.Combine(installationPath, ".genhub-cas");
-                    logger.LogInformation("Auto-setting InstallationPoolRootPath to single installation: {Path}", casPoolPath);
-
-                    var saved = await userSettingsService.TryUpdateAndSaveAsync(s =>
-                    {
-                        s.CasConfiguration.InstallationPoolRootPath = casPoolPath;
-                        s.PreferredStorageInstallationId = installation.Id;
-                        s.MarkAsExplicitlySet(nameof(s.CasConfiguration.InstallationPoolRootPath));
-                        return true;
-                    });
-
-                    if (!saved)
-                    {
-                        logger.LogError("Failed to save installation pool path settings for installation {InstallationId}", installation.Id);
-                    }
-
-                    // Verify the setting was applied
-                    var updatedSettings = userSettingsService.Get();
-                    logger.LogInformation("Verified InstallationPoolRootPath is now: {Path}", updatedSettings.CasConfiguration.InstallationPoolRootPath);
-                    return;
-                }
-            }
-
-            // If multiple installations, prefer Steam over EA App
-            var preferredInstallation = installations.FirstOrDefault(i => i.InstallationType == GameInstallationType.Steam)
-                ?? installations.FirstOrDefault(i => i.InstallationType == GameInstallationType.EaApp)
-                ?? installations.FirstOrDefault();
-
-            if (preferredInstallation != null)
-            {
-                var installationPath = GetInstallationPath(preferredInstallation);
-                if (!string.IsNullOrEmpty(installationPath))
-                {
-                    var casPoolPath = Path.Combine(installationPath, ".genhub-cas");
-                    logger.LogInformation("Auto-setting InstallationPoolRootPath to preferred installation ({InstallationType}): {Path}", preferredInstallation.InstallationType, casPoolPath);
-
-                    await userSettingsService.TryUpdateAndSaveAsync(s =>
-                    {
-                        s.CasConfiguration.InstallationPoolRootPath = casPoolPath;
-                        s.PreferredStorageInstallationId = preferredInstallation.Id;
-                        s.MarkAsExplicitlySet(nameof(s.CasConfiguration.InstallationPoolRootPath));
-                        return true;
-                    });
-
-                    // Verify the setting was applied
-                    var updatedSettings = userSettingsService.Get();
-                    logger.LogInformation("Verified InstallationPoolRootPath is now: {Path}", updatedSettings.CasConfiguration.InstallationPoolRootPath);
-                }
-            }
-            else
-            {
-                logger.LogWarning("No valid installation found for CAS pool path resolution");
-            }
+            return await installationCasPoolService.EnsurePoolPathAsync(installations, cancellationToken);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to ensure InstallationPoolRootPath is set");
+            return false;
         }
     }
 

--- a/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
@@ -10,6 +10,7 @@ using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
@@ -36,38 +37,8 @@ public class ContentOrchestrator : IContentOrchestrator
     private readonly IContentValidator _contentValidator;
     private readonly IContentManifestPool _manifestPool;
     private readonly IGameInstallationService _installationService;
-    private readonly IUserSettingsService _userSettingsService;
+    private readonly IInstallationCasPoolService _installationCasPoolService;
     private readonly object _providerLock = new();
-
-    /// <summary>
-    /// Gets the installation path for a game installation.
-    /// </summary>
-    private static string? GetInstallationPath(GenHub.Core.Models.GameInstallations.GameInstallation? installation)
-    {
-        if (installation == null)
-        {
-            return null;
-        }
-
-        // For Zero Hour installations, use the installation path directly
-        // For Generals-only installations, use the Generals path
-        if (!string.IsNullOrEmpty(installation.InstallationPath))
-        {
-            return installation.InstallationPath;
-        }
-
-        if (!string.IsNullOrEmpty(installation.ZeroHourPath))
-        {
-            return installation.ZeroHourPath;
-        }
-
-        if (!string.IsNullOrEmpty(installation.GeneralsPath))
-        {
-            return installation.GeneralsPath;
-        }
-
-        return null;
-    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ContentOrchestrator"/> class.
@@ -80,7 +51,7 @@ public class ContentOrchestrator : IContentOrchestrator
     /// <param name="contentValidator">The content validator service for manifest and content integrity.</param>
     /// <param name="manifestPool">The manifest pool for acquired content.</param>
     /// <param name="installationService">The game installation service for detecting installations.</param>
-    /// <param name="userSettingsService">The user settings service for updating CAS configuration.</param>
+    /// <param name="installationCasPoolService">The installation CAS pool selector.</param>
     public ContentOrchestrator(
         ILogger<ContentOrchestrator> logger,
         IEnumerable<IContentProvider> providers,
@@ -90,7 +61,7 @@ public class ContentOrchestrator : IContentOrchestrator
         IContentValidator contentValidator,
         IContentManifestPool manifestPool,
         IGameInstallationService installationService,
-        IUserSettingsService userSettingsService)
+        IInstallationCasPoolService installationCasPoolService)
     {
         _logger = logger;
         _providers = [.. providers];
@@ -108,7 +79,7 @@ public class ContentOrchestrator : IContentOrchestrator
         _contentValidator = contentValidator;
         _manifestPool = manifestPool;
         _installationService = installationService;
-        _userSettingsService = userSettingsService;
+        _installationCasPoolService = installationCasPoolService;
 
         _logger.LogInformation("ContentOrchestrator initialized with {ProviderCount} providers, {DiscovererCount} discoverers, {ResolverCount} resolvers", _providers.Count, _discoverers.Count, _resolvers.Count);
     }
@@ -724,64 +695,14 @@ public class ContentOrchestrator : IContentOrchestrator
             var installationsResult = await _installationService.GetAllInstallationsAsync(cancellationToken);
             if (!installationsResult.Success || installationsResult.Data == null)
             {
-                _logger.LogWarning("Failed to get installations for CAS pool path resolution: {Error}", installationsResult.FirstError);
-                return false;
+                _logger.LogWarning(
+                    "Failed to get installations for CAS pool path resolution: {Error}; the primary CAS pool will be used",
+                    installationsResult.FirstError);
+                return true;
             }
 
             var installations = installationsResult.Data.ToList();
-
-            if (installations.Count == 0)
-            {
-                _logger.LogWarning("No installations detected - cannot set InstallationPoolRootPath");
-                return false;
-            }
-
-            // If only one installation, use it
-            if (installations.Count == 1)
-            {
-                var installation = installations[0];
-                var installationPath = GetInstallationPath(installation);
-                if (!string.IsNullOrEmpty(installationPath))
-                {
-                    var casPoolPath = Path.Combine(installationPath, ".genhub-cas");
-                    _logger.LogInformation("Auto-setting InstallationPoolRootPath to single installation: {Path}", casPoolPath);
-
-                    return await _userSettingsService.TryUpdateAndSaveAsync(s =>
-                    {
-                        s.CasConfiguration.InstallationPoolRootPath = casPoolPath;
-                        s.PreferredStorageInstallationId = installation.Id;
-                        s.MarkAsExplicitlySet(nameof(s.CasConfiguration.InstallationPoolRootPath));
-                        return true;
-                    });
-                }
-            }
-
-            // If multiple installations, prefer Steam over EA App
-            // Note: Since we verified installations.Count >= 1, this will never be null
-            var preferredInstallation = installations.FirstOrDefault(i => i.InstallationType == GameInstallationType.Steam)
-                ?? installations.FirstOrDefault(i => i.InstallationType == GameInstallationType.EaApp)
-                ?? installations.First();
-
-            if (preferredInstallation != null)
-            {
-                var installationPath = GetInstallationPath(preferredInstallation);
-                if (!string.IsNullOrEmpty(installationPath))
-                {
-                    var casPoolPath = Path.Combine(installationPath, ".genhub-cas");
-                    _logger.LogInformation("Auto-setting InstallationPoolRootPath to preferred installation ({InstallationType}): {Path}", preferredInstallation.InstallationType, casPoolPath);
-
-                    return await _userSettingsService.TryUpdateAndSaveAsync(s =>
-                    {
-                        s.CasConfiguration.InstallationPoolRootPath = casPoolPath;
-                        s.PreferredStorageInstallationId = preferredInstallation.Id;
-                        s.MarkAsExplicitlySet(nameof(s.CasConfiguration.InstallationPoolRootPath));
-                        return true;
-                    });
-                }
-            }
-
-            // Should not be reachable given the checks above
-            return false;
+            return await _installationCasPoolService.EnsurePoolPathAsync(installations, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/Storage/Services/CasPoolManager.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasPoolManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Enums;
@@ -21,9 +22,13 @@ public class CasPoolManager : ICasPoolManager
     private readonly ILogger<CasPoolManager> _logger;
     private readonly IFileHashProvider _hashProvider;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly IStorageWritabilityProbe _writabilityProbe;
     private readonly CasConfiguration _config;
     private readonly ConcurrentDictionary<CasPoolType, ICasStorage> _storages = new();
     private readonly object _initLock = new();
+    private string? _installationPoolRoot;
+    private volatile IReadOnlyList<ICasStorage> _legacyInstallationStorages = [];
+    private IReadOnlyList<string> _legacyInstallationPoolRoots = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CasPoolManager"/> class.
@@ -32,28 +37,27 @@ public class CasPoolManager : ICasPoolManager
     /// <param name="config">The CAS configuration.</param>
     /// <param name="hashProvider">The file hash provider.</param>
     /// <param name="loggerFactory">The logger factory for creating storage loggers.</param>
+    /// <param name="writabilityProbe">The storage writability probe.</param>
     /// <param name="logger">The logger instance.</param>
     public CasPoolManager(
         ICasPoolResolver poolResolver,
         IOptions<CasConfiguration> config,
         IFileHashProvider hashProvider,
         ILoggerFactory loggerFactory,
+        IStorageWritabilityProbe writabilityProbe,
         ILogger<CasPoolManager> logger)
     {
         _poolResolver = poolResolver;
         _config = config.Value;
         _hashProvider = hashProvider;
         _loggerFactory = loggerFactory;
+        _writabilityProbe = writabilityProbe;
         _logger = logger;
 
         // Initialize primary pool
         InitializePool(CasPoolType.Primary);
 
-        // Initialize installation pool if configured
-        if (_poolResolver.IsInstallationPoolAvailable())
-        {
-            InitializePool(CasPoolType.Installation);
-        }
+        RefreshInstallationPools();
     }
 
     /// <inheritdoc/>
@@ -111,7 +115,16 @@ public class CasPoolManager : ICasPoolManager
     /// <inheritdoc/>
     public IReadOnlyList<ICasStorage> GetAllStorages()
     {
-        return _storages.Values.ToList().AsReadOnly();
+        var storages = _storages.Values.ToList();
+        foreach (var legacyInstallationStorage in _legacyInstallationStorages)
+        {
+            if (!storages.Contains(legacyInstallationStorage))
+            {
+                storages.Add(legacyInstallationStorage);
+            }
+        }
+
+        return storages.AsReadOnly();
     }
 
     /// <summary>
@@ -129,10 +142,8 @@ public class CasPoolManager : ICasPoolManager
             InitializePool(CasPoolType.Primary);
         }
 
-        // Try to initialize Installation pool if available
         if (!_storages.ContainsKey(CasPoolType.Installation) && _poolResolver.IsInstallationPoolAvailable())
         {
-            _logger.LogInformation("Installation pool not initialized but is available, initializing now");
             InitializePool(CasPoolType.Installation);
         }
     }
@@ -145,21 +156,21 @@ public class CasPoolManager : ICasPoolManager
     {
         _logger.LogInformation("Force reinitializing Installation CAS pool");
 
-        // Remove existing Installation pool if present
-        if (_storages.TryRemove(CasPoolType.Installation, out _))
+        _writabilityProbe.Invalidate();
+
+        lock (_initLock)
         {
-            _logger.LogDebug("Removed existing Installation pool for reinitialization");
+            if (_storages.TryRemove(CasPoolType.Installation, out _))
+            {
+                _logger.LogDebug("Removed existing Installation pool for reinitialization");
+            }
+
+            _installationPoolRoot = null;
+            _legacyInstallationStorages = [];
+            _legacyInstallationPoolRoots = [];
         }
 
-        // Reinitialize if path is available
-        if (_poolResolver.IsInstallationPoolAvailable())
-        {
-            InitializePool(CasPoolType.Installation);
-        }
-        else
-        {
-            _logger.LogWarning("Installation pool path not available, cannot reinitialize");
-        }
+        RefreshInstallationPools();
     }
 
     private void InitializePool(CasPoolType poolType)
@@ -172,50 +183,144 @@ public class CasPoolManager : ICasPoolManager
 
         lock (_initLock)
         {
-                if (_storages.ContainsKey(poolType))
-                {
-                    _logger.LogDebug("Pool {PoolType} already initialized (race condition prevented)", poolType);
-                    return;
-                }
-
-                var rootPath = _poolResolver.GetPoolRootPath(poolType);
-                if (string.IsNullOrWhiteSpace(rootPath))
-                {
-                    _logger.LogWarning("Cannot initialize {PoolType} pool: root path is not configured", poolType);
-                    return;
-                }
-
-                // Security Guard: Prevent initializing CAS in the application directory or an empty path
-                var appBaseDir = Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory);
-                var normalizedRootPath = Path.TrimEndingDirectorySeparator(rootPath);
-
-                if (normalizedRootPath.Equals(appBaseDir, StringComparison.OrdinalIgnoreCase) ||
-                    normalizedRootPath.StartsWith(appBaseDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
-                {
-                    _logger.LogError("Security Block: Attempted to initialize {PoolType} CAS pool at or inside the application directory: {Path}. This is not allowed.", poolType, rootPath);
-                    return;
-                }
-
-                // Create a configuration specific to this pool
-                var poolConfig = new CasConfiguration
-                {
-                    CasRootPath = rootPath,
-                    HashAlgorithm = _config.HashAlgorithm,
-                    GcGracePeriod = _config.GcGracePeriod,
-                    MaxCacheSizeBytes = _config.MaxCacheSizeBytes,
-                    AutoGcInterval = _config.AutoGcInterval,
-                    MaxConcurrentOperations = _config.MaxConcurrentOperations,
-                    VerifyIntegrity = _config.VerifyIntegrity,
-                    EnableAutomaticGc = _config.EnableAutomaticGc,
-                };
-
-                var poolConfigOptions = Options.Create(poolConfig);
-                var storageLogger = _loggerFactory.CreateLogger<CasStorage>();
-
-                var storage = new CasStorage(poolConfigOptions, storageLogger, _hashProvider);
-                _storages.TryAdd(poolType, storage);
-
-                _logger.LogInformation("Initialized {PoolType} CAS pool at {RootPath}", poolType, rootPath);
+            if (_storages.ContainsKey(poolType))
+            {
+                _logger.LogDebug("Pool {PoolType} already initialized (race condition prevented)", poolType);
+                return;
             }
+
+            var rootPath = _poolResolver.GetPoolRootPath(poolType);
+            if (string.IsNullOrWhiteSpace(rootPath))
+            {
+                _logger.LogWarning("Cannot initialize {PoolType} pool: root path is not configured", poolType);
+                return;
+            }
+
+            // Security Guard: Prevent initializing CAS in the application directory or an empty path
+            if (IsInsideApplicationDirectory(rootPath))
+            {
+                _logger.LogError("Security Block: Attempted to initialize {PoolType} CAS pool at or inside the application directory: {Path}. This is not allowed.", poolType, rootPath);
+                return;
+            }
+
+            var storage = CreateStorage(rootPath);
+            _storages.TryAdd(poolType, storage);
+
+            if (poolType == CasPoolType.Installation)
+            {
+                _installationPoolRoot = rootPath;
+            }
+
+            _logger.LogInformation("Initialized {PoolType} CAS pool at {RootPath}", poolType, rootPath);
+        }
+    }
+
+    private ICasStorage CreateStorage(string rootPath)
+    {
+        var poolConfig = (CasConfiguration)_config.Clone();
+        poolConfig.CasRootPath = rootPath;
+
+        return new CasStorage(
+            Options.Create(poolConfig),
+            _loggerFactory.CreateLogger<CasStorage>(),
+            _hashProvider);
+    }
+
+    private void RefreshInstallationPools()
+    {
+        lock (_initLock)
+        {
+            var installationPoolAvailable = _poolResolver.IsInstallationPoolAvailable();
+            var currentRoot = installationPoolAvailable
+                ? _poolResolver.GetPoolRootPath(CasPoolType.Installation)
+                : string.Empty;
+
+            if (_storages.ContainsKey(CasPoolType.Installation) &&
+                (!installationPoolAvailable ||
+                 !string.Equals(currentRoot, _installationPoolRoot, PathHelper.PathComparison)))
+            {
+                _storages.TryRemove(CasPoolType.Installation, out _);
+                _logger.LogInformation("Discarded cached installation CAS pool at {PreviousRoot}", _installationPoolRoot);
+                _installationPoolRoot = null;
+            }
+
+            if (installationPoolAvailable && !_storages.ContainsKey(CasPoolType.Installation))
+            {
+                InitializePool(CasPoolType.Installation);
+            }
+
+            RefreshLegacyInstallationPool(currentRoot);
+        }
+    }
+
+    private void RefreshLegacyInstallationPool(string activeInstallationRoot)
+    {
+        var normalizedActiveRoot = NormalizeRoot(activeInstallationRoot);
+        var normalizedPrimaryRoot = NormalizeRoot(_config.CasRootPath);
+        var retainedRoots = new List<string>();
+
+        foreach (var configuredRoot in _poolResolver.GetLegacyInstallationPoolRootPaths())
+        {
+            if (string.IsNullOrWhiteSpace(configuredRoot) || !Directory.Exists(configuredRoot))
+            {
+                continue;
+            }
+
+            var legacyRoot = NormalizeRoot(configuredRoot);
+
+            // Both pools are already reachable directly, so retaining them again would duplicate reads.
+            if (string.Equals(legacyRoot, normalizedActiveRoot, PathHelper.PathComparison) ||
+                string.Equals(legacyRoot, normalizedPrimaryRoot, PathHelper.PathComparison))
+            {
+                continue;
+            }
+
+            if (IsInsideApplicationDirectory(legacyRoot))
+            {
+                _logger.LogError(
+                    "Security Block: Attempted to retain a legacy CAS pool at or inside the application directory: {Path}. This is not allowed.",
+                    legacyRoot);
+                continue;
+            }
+
+            if (!retainedRoots.Contains(legacyRoot, PathHelper.PathComparer))
+            {
+                retainedRoots.Add(legacyRoot);
+            }
+        }
+
+        if (retainedRoots.SequenceEqual(_legacyInstallationPoolRoots, PathHelper.PathComparer))
+        {
+            return;
+        }
+
+        _legacyInstallationStorages = retainedRoots.Select(CreateStorage).ToList();
+        _legacyInstallationPoolRoots = retainedRoots;
+
+        if (retainedRoots.Count > 0)
+        {
+            _logger.LogInformation(
+                "Retaining {Count} legacy installation CAS pool(s) for read-only lookup: {LegacyRoots}",
+                retainedRoots.Count,
+                string.Join(", ", retainedRoots));
+        }
+    }
+
+    private static string NormalizeRoot(string? rootPath)
+    {
+        return string.IsNullOrWhiteSpace(rootPath)
+            ? string.Empty
+            : Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootPath));
+    }
+
+    private bool IsInsideApplicationDirectory(string rootPath)
+    {
+        var appBaseDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(AppContext.BaseDirectory));
+        var normalizedRootPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootPath));
+
+        return normalizedRootPath.Equals(appBaseDirectory, PathHelper.PathComparison) ||
+            normalizedRootPath.StartsWith(
+                appBaseDirectory + Path.DirectorySeparatorChar,
+                PathHelper.PathComparison);
     }
 }

--- a/GenHub/GenHub/Features/Storage/Services/CasPoolResolver.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasPoolResolver.cs
@@ -1,4 +1,8 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Enums;
@@ -14,6 +18,7 @@ namespace GenHub.Features.Storage.Services;
 public class CasPoolResolver(
     IOptions<CasConfiguration> config,
     IUserSettingsService userSettingsService,
+    IStorageWritabilityProbe writabilityProbe,
     ILogger<CasPoolResolver> logger) : ICasPoolResolver
 {
     /// <summary>
@@ -30,6 +35,7 @@ public class CasPoolResolver(
     ];
 
     private readonly CasConfiguration _config = config.Value;
+    private readonly ConcurrentDictionary<string, bool> _unwritablePoolsLogged = new(PathHelper.PathComparer);
 
     /// <inheritdoc/>
     public CasPoolType ResolvePool(ContentType contentType)
@@ -68,10 +74,59 @@ public class CasPoolResolver(
     }
 
     /// <inheritdoc/>
+    public IReadOnlyList<string> GetLegacyInstallationPoolRootPaths()
+    {
+        var configuration = userSettingsService.Get().CasConfiguration;
+        var roots = new List<string>();
+
+        foreach (var configuredRoot in configuration.LegacyInstallationPoolRootPaths)
+        {
+            AddRoot(roots, configuredRoot);
+        }
+
+        // A configured pool that exists but cannot be written has not been migrated yet, so it
+        // still holds the only copy of any object written before it became unwritable.
+        var currentPath = configuration.InstallationPoolRootPath;
+        if (!string.IsNullOrWhiteSpace(currentPath) &&
+            Directory.Exists(currentPath) &&
+            !writabilityProbe.CanCreateStorageAt(currentPath))
+        {
+            AddRoot(roots, currentPath);
+        }
+
+        return roots;
+    }
+
+    /// <inheritdoc/>
     public bool IsInstallationPoolAvailable()
     {
         var path = GetInstallationPoolRootPath();
-        return !string.IsNullOrWhiteSpace(path);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        if (writabilityProbe.CanCreateStorageAt(path))
+        {
+            return true;
+        }
+
+        if (_unwritablePoolsLogged.TryAdd(path, true))
+        {
+            logger.LogWarning(
+                "Installation CAS pool {PoolPath} is not writable; content will use the primary pool",
+                path);
+        }
+
+        return false;
+    }
+
+    private static void AddRoot(List<string> roots, string? root)
+    {
+        if (!string.IsNullOrWhiteSpace(root) && !roots.Contains(root, PathHelper.PathComparer))
+        {
+            roots.Add(root);
+        }
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Storage/Services/CasService.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasService.cs
@@ -564,6 +564,21 @@ public class CasService(
                 return OperationResult<string>.CreateSuccess(path);
             }
 
+            foreach (var fallbackStorage in poolManager.GetAllStorages())
+            {
+                if (ReferenceEquals(fallbackStorage, storage) || ReferenceEquals(fallbackStorage, primaryStorage))
+                {
+                    continue;
+                }
+
+                if (await fallbackStorage.ObjectExistsAsync(hash, cancellationToken))
+                {
+                    var path = fallbackStorage.GetObjectPath(hash);
+                    logger.LogDebug("Found content {Hash} in a legacy CAS pool", hash);
+                    return OperationResult<string>.CreateSuccess(path);
+                }
+            }
+
             return OperationResult<string>.CreateFailure($"Content not found in CAS: {hash}");
         }
         catch (Exception ex)
@@ -593,18 +608,38 @@ public class CasService(
 
             var storage = poolManager.GetStorage(contentType);
             var exists = await storage.ObjectExistsAsync(hash, cancellationToken);
+            ICasStorage? primaryStorage = null;
 
             if (!exists)
             {
                 // Not found in the pool for this content type
                 // As a fallback, check if it exists in the primary pool (may have been stored there before pool routing was implemented)
                 logger.LogDebug("Content {Hash} not found in {ContentType} pool, checking primary pool as fallback", hash, contentType);
-                var primaryStorage = poolManager.GetStorage(CasPoolType.Primary);
+                primaryStorage = poolManager.GetStorage(CasPoolType.Primary);
                 exists = await primaryStorage.ObjectExistsAsync(hash, cancellationToken);
 
                 if (exists)
                 {
                     logger.LogInformation("Found content {Hash} in primary pool (expected in {ContentType} pool)", hash, contentType);
+                }
+            }
+
+            if (!exists)
+            {
+                foreach (var fallbackStorage in poolManager.GetAllStorages())
+                {
+                    if (ReferenceEquals(fallbackStorage, storage) ||
+                        ReferenceEquals(fallbackStorage, primaryStorage))
+                    {
+                        continue;
+                    }
+
+                    if (await fallbackStorage.ObjectExistsAsync(hash, cancellationToken))
+                    {
+                        logger.LogDebug("Found content {Hash} in a legacy CAS pool", hash);
+                        exists = true;
+                        break;
+                    }
                 }
             }
 

--- a/GenHub/GenHub/Features/Storage/Services/CasStorage.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasStorage.cs
@@ -33,7 +33,6 @@ public class CasStorage(
     /// <inheritdoc/>
     public string GetObjectPath(string hash)
     {
-        EnsureDirectoriesCreated();
         ValidateHashFormat(hash);
         var subDirectory = hash[..2].ToLowerInvariant();
         return Path.Combine(_objectsDirectory, subDirectory, hash.ToLowerInvariant());

--- a/GenHub/GenHub/Features/Storage/Services/InstallationCasPoolService.cs
+++ b/GenHub/GenHub/Features/Storage/Services/InstallationCasPoolService.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Storage.Services;
+
+/// <summary>
+/// Selects a writable installation CAS pool while preserving prior readable content.
+/// </summary>
+public sealed class InstallationCasPoolService(
+    IUserSettingsService userSettingsService,
+    IStorageWritabilityProbe writabilityProbe,
+    ICasPoolManager casPoolManager,
+    ILogger<InstallationCasPoolService> logger) : IInstallationCasPoolService
+{
+    private const string ExplicitInstallationPoolPathKey = nameof(CasConfiguration.InstallationPoolRootPath);
+
+    /// <inheritdoc/>
+    public async Task<bool> EnsurePoolPathAsync(
+        IReadOnlyList<GameInstallation> installations,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(installations);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (installations.Count == 0)
+        {
+            logger.LogWarning("No installations detected; the primary CAS pool will be used");
+            return true;
+        }
+
+        var preferredInstallation = installations.Count == 1
+            ? installations[0]
+            : installations.FirstOrDefault(installation => installation.InstallationType == GameInstallationType.Steam)
+                ?? installations.FirstOrDefault(installation => installation.InstallationType == GameInstallationType.EaApp)
+                ?? installations[0];
+
+        var derivedPaths = installations
+            .Select(GetDerivedPoolPath)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(NormalizePath)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .ToHashSet(PathHelper.PathComparer);
+        var candidatePath = GetDerivedPoolPath(preferredInstallation);
+        if (string.IsNullOrWhiteSpace(candidatePath))
+        {
+            logger.LogWarning(
+                "Preferred installation {InstallationId} has no usable path; the primary CAS pool will be used",
+                preferredInstallation.Id);
+            return true;
+        }
+
+        candidatePath = NormalizePath(candidatePath);
+        if (string.IsNullOrWhiteSpace(candidatePath))
+        {
+            logger.LogWarning("The derived installation CAS pool path is invalid; the primary pool will be used");
+            return true;
+        }
+
+        var currentSettings = userSettingsService.Get();
+        var configuredCurrentPath = currentSettings.CasConfiguration.InstallationPoolRootPath;
+        var currentPath = NormalizePath(configuredCurrentPath);
+        var historicalAutoDerivedMarker =
+            currentSettings.ExplicitlySetProperties.Contains(ExplicitInstallationPoolPathKey);
+
+        // Older GenHub builds marked their automatically derived installation pool as "explicitly set".
+        // No user-facing setting wrote this nested key, so it is migration provenance rather than user intent.
+        if (!string.IsNullOrWhiteSpace(configuredCurrentPath) &&
+            string.IsNullOrWhiteSpace(currentPath) &&
+            !currentSettings.CasConfiguration.IsInstallationPoolRootPathAutoDerived &&
+            !historicalAutoDerivedMarker)
+        {
+            logger.LogWarning(
+                "User-configured installation CAS pool {PoolPath} is invalid; preserving the setting and using the primary pool",
+                configuredCurrentPath);
+            return true;
+        }
+
+        var currentIsAutoDerived = IsAutoDerived(currentSettings, currentPath, derivedPaths);
+
+        if (!string.IsNullOrWhiteSpace(currentPath) && !currentIsAutoDerived)
+        {
+            if (writabilityProbe.CanCreateStorageAt(currentPath))
+            {
+                logger.LogInformation("Keeping user-configured installation CAS pool {PoolPath}", currentPath);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "User-configured installation CAS pool {PoolPath} is not writable; preserving the setting and using the primary pool",
+                    currentPath);
+            }
+
+            return true;
+        }
+
+        var candidateIsWritable = writabilityProbe.CanCreateStorageAt(candidatePath);
+        var effectivePath = candidateIsWritable ? candidatePath : string.Empty;
+        var legacyPaths = SelectLegacyPaths(currentSettings, currentPath, candidatePath, effectivePath);
+        var settingsAlreadyMatch =
+            string.Equals(currentPath, effectivePath, PathHelper.PathComparison) &&
+            currentSettings.CasConfiguration.IsInstallationPoolRootPathAutoDerived == candidateIsWritable &&
+            currentSettings.CasConfiguration.LegacyInstallationPoolRootPaths
+                .Select(NormalizePath)
+                .SequenceEqual(legacyPaths, PathHelper.PathComparer) &&
+            string.Equals(currentSettings.PreferredStorageInstallationId, preferredInstallation.Id, StringComparison.Ordinal) &&
+            !currentSettings.ExplicitlySetProperties.Contains(ExplicitInstallationPoolPathKey);
+        if (settingsAlreadyMatch)
+        {
+            return true;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var saved = await userSettingsService.TryUpdateAndSaveAsync(settings =>
+        {
+            settings.CasConfiguration.InstallationPoolRootPath = effectivePath;
+            settings.CasConfiguration.IsInstallationPoolRootPathAutoDerived = candidateIsWritable;
+            settings.CasConfiguration.LegacyInstallationPoolRootPaths = legacyPaths;
+            settings.PreferredStorageInstallationId = preferredInstallation.Id;
+            settings.ExplicitlySetProperties.Remove(ExplicitInstallationPoolPathKey);
+            return true;
+        });
+
+        if (!saved)
+        {
+            logger.LogError("Failed to save installation CAS pool settings");
+            return false;
+        }
+
+        if (candidateIsWritable)
+        {
+            logger.LogInformation(
+                "Using installation-adjacent CAS pool {PoolPath} for installation {InstallationId}",
+                candidatePath,
+                preferredInstallation.Id);
+        }
+        else
+        {
+            logger.LogWarning(
+                "Installation-adjacent CAS pool {PoolPath} is not writable; new content will use the primary pool",
+                candidatePath);
+        }
+
+        casPoolManager.ReinitializeInstallationPool();
+        return true;
+    }
+
+    private static string? GetDerivedPoolPath(GameInstallation installation)
+    {
+        var installationPath = !string.IsNullOrWhiteSpace(installation.InstallationPath)
+            ? installation.InstallationPath
+            : !string.IsNullOrWhiteSpace(installation.ZeroHourPath)
+                ? installation.ZeroHourPath
+                : installation.GeneralsPath;
+
+        return string.IsNullOrWhiteSpace(installationPath)
+            ? null
+            : Path.Combine(installationPath, DirectoryNames.GenHubCasPool);
+    }
+
+    private static bool IsAutoDerived(
+        UserSettings settings,
+        string currentPath,
+        IReadOnlySet<string> derivedPaths)
+    {
+        if (string.IsNullOrWhiteSpace(currentPath))
+        {
+            return true;
+        }
+
+        return settings.CasConfiguration.IsInstallationPoolRootPathAutoDerived ||
+            settings.ExplicitlySetProperties.Contains(ExplicitInstallationPoolPathKey) ||
+            derivedPaths.Contains(currentPath);
+    }
+
+    private static List<string> SelectLegacyPaths(
+        UserSettings settings,
+        string currentPath,
+        string candidatePath,
+        string effectivePath)
+    {
+        // Every root the pool has previously used is retained. Dropping one would strand the
+        // objects written to it, because nothing copies them into the pool that replaces it.
+        var retainedPaths = new List<string>();
+        foreach (var existingLegacyPath in settings.CasConfiguration.LegacyInstallationPoolRootPaths)
+        {
+            AddLegacyPath(retainedPaths, NormalizePath(existingLegacyPath), effectivePath);
+        }
+
+        var previousPath = !string.IsNullOrWhiteSpace(currentPath)
+            ? currentPath
+            : candidatePath;
+        if (Directory.Exists(previousPath))
+        {
+            AddLegacyPath(retainedPaths, previousPath, effectivePath);
+        }
+
+        return retainedPaths;
+    }
+
+    private static void AddLegacyPath(List<string> retainedPaths, string path, string effectivePath)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        // The pool that now takes writes is reachable directly, so it is never also a legacy root.
+        if (string.Equals(path, effectivePath, PathHelper.PathComparison))
+        {
+            return;
+        }
+
+        if (!retainedPaths.Contains(path, PathHelper.PathComparer))
+        {
+            retainedPaths.Add(path);
+        }
+    }
+
+    private static string NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or IOException or SecurityException)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/CasModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/CasModule.cs
@@ -1,8 +1,10 @@
+using GenHub.Common.Services;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Storage;
 using GenHub.Features.Storage.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace GenHub.Infrastructure.DependencyInjection;
 
@@ -18,9 +20,13 @@ public static class CasModule
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddCasServices(this IServiceCollection services)
     {
+        // Pool selection depends on whether a pool location accepts writes
+        services.TryAddSingleton<IStorageWritabilityProbe, StorageWritabilityProbe>();
+
         // Pool management services (must be registered first for CasService to use)
         services.AddSingleton<ICasPoolResolver, CasPoolResolver>();
         services.AddSingleton<ICasPoolManager, CasPoolManager>();
+        services.AddSingleton<IInstallationCasPoolService, InstallationCasPoolService>();
 
         // CAS integration services
         services.AddSingleton<ICasService, CasService>();
@@ -35,6 +41,8 @@ public static class CasModule
             config.EnableAutomaticGc = userCasConfig.EnableAutomaticGc;
             config.CasRootPath = userCasConfig.CasRootPath;
             config.InstallationPoolRootPath = userCasConfig.InstallationPoolRootPath;
+            config.IsInstallationPoolRootPathAutoDerived = userCasConfig.IsInstallationPoolRootPathAutoDerived;
+            config.LegacyInstallationPoolRootPaths = [.. userCasConfig.LegacyInstallationPoolRootPaths];
             config.HashAlgorithm = userCasConfig.HashAlgorithm;
             config.GcGracePeriod = userCasConfig.GcGracePeriod;
             config.MaxCacheSizeBytes = userCasConfig.MaxCacheSizeBytes;

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ConfigurationModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ConfigurationModule.cs
@@ -3,6 +3,7 @@ using GenHub.Common.Services;
 using GenHub.Core.Interfaces.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace GenHub.Infrastructure.DependencyInjection;
@@ -47,12 +48,12 @@ public static class ConfigurationModule
             bootstrapLoggerFactory.CreateLogger<ConfigurationProviderService>());
         services.AddSingleton<ILogger<StorageLocationService>>(provider =>
             bootstrapLoggerFactory.CreateLogger<StorageLocationService>());
-
         services.AddSingleton<ISessionPreferenceService, SessionPreferenceService>();
         services.AddSingleton<IDialogService, DialogService>();
         services.AddSingleton<IAppConfiguration, AppConfiguration>();
         services.AddSingleton<IUserSettingsService, UserSettingsService>();
         services.AddSingleton<IConfigurationProviderService, ConfigurationProviderService>();
+        services.TryAddSingleton<IStorageWritabilityProbe, StorageWritabilityProbe>();
         services.AddSingleton<IStorageLocationService, StorageLocationService>();
 
         return services;


### PR DESCRIPTION
## Summary

Backport of #349 into `release/alpha-4`.

Prevents installation-adjacent CAS storage from breaking content acquisition when
the game is installed in a protected location such as Program Files. GenHub
verifies that it can create and write the actual installation-pool directory
before routing content there. When the location is unavailable, new content uses
the primary user-writable pool while existing readable objects remain
discoverable through read-only legacy pools.

See #349 for the full description of the change.

## Backport notes

- Cherry-picked from b3f5c4a with `-x`; no conflicts and no manual edits.
- Only 2 of the 22 touched files differed between `release/alpha-4` and the merge
  base of #349, and both auto-merged. The executable-classifier call in
  `CommunityOutpostDeliverer` correctly kept this branch's single-argument
  signature, since #339 and #345 are not on `release/alpha-4`.
- Both prerequisites the change relies on are already present here: #346 provides
  the cross-volume copy path used when materialization falls back to the primary
  pool, and #312 keeps automatic CAS garbage collection disabled so retained
  legacy pools are never mutated.

## Testing

- `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release`
  - Passed: 1,463
  - Failed: 0
- `dotnet build GenHub/GenHub.Linux/GenHub.Linux.csproj -c Release`
  - Passed
- `git diff --check`
  - Passed
- The 28 tests covering pool routing, provenance, migration, actual-directory
  probing, and legacy-content lookup all run and pass on this branch.

## Risks and rollback

- Existing objects are not moved or deleted. Previous readable installation pools
  are retained for lookup only, while new writes use the effective writable pool.
- The new provenance and legacy-path settings are additive and default to the
  prior behavior when absent.
- Reverting restores the previous installation-pool selection behavior and its
  protected-path acquisition failures.

## Manual validation

Packaged non-administrator Windows validation was completed for #349: GameClient
content acquired with the game under Program Files, GenHub restarted, profile
created, and launched.

That run covers this backport too. The CAS code here is identical to #349, and
the only production difference against `release/alpha-4` is the
executable-classifier call in `CommunityOutpostDeliverer`, which is outside the
storage-routing path.

Backport of #349
Fixes #347

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport makes installation-adjacent CAS routing conditional on actual directory writability and preserves previous installation pools for read-only object lookup.
- Adds a reusable, cached filesystem writability probe.
- Centralizes installation-pool selection, fallback, provenance migration, and settings persistence.
- Extends CAS resolution and lookup across retained legacy pools.
- Updates acquisition flows and dependency injection to use the centralized pool service.
- Adds coverage for protected paths, fallback routing, legacy lookup, persistence, and pool refresh behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

The updated routing probes the actual target directory before enabling installation-pool writes, falls back to primary storage when unavailable, and retains prior readable pools for object lookup.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Storage/Services/InstallationCasPoolService.cs | Centralizes writable installation-pool selection, fallback, migration provenance, legacy-root retention, and persistent updates. |
| GenHub/GenHub/Features/Storage/Services/CasPoolManager.cs | Refreshes active installation storage and exposes retained legacy pools without enabling writes to them. |
| GenHub/GenHub/Features/Storage/Services/CasPoolResolver.cs | Routes installation-related content only when its configured pool passes the write probe and supplies legacy lookup roots. |
| GenHub/GenHub/Features/Storage/Services/CasService.cs | Extends content-path and existence lookups to search retained legacy CAS pools after active and primary storage. |
| GenHub/GenHub/Common/Services/StorageWritabilityProbe.cs | Adds cached, invalidatable write probing against the actual target directory with probe-file cleanup. |
| GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs | Delegates pre-acquisition installation-pool preparation to the centralized service while allowing primary-pool fallback. |
| GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs | Uses the centralized pool preparation service before persisting GameClient manifests. |
| GenHub/GenHub/Infrastructure/DependencyInjection/CasModule.cs | Registers the new singleton services and propagates additive CAS configuration fields. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Acquire installation-related content] --> B[Detect game installations]
    B --> C[Derive installation-adjacent CAS path]
    C --> D{Directory accepts writes?}
    D -->|Yes| E[Persist active installation pool]
    D -->|No| F[Route new objects to primary pool]
    E --> G[Reinitialize CAS pool routing]
    F --> G
    G --> H[Store new content]
    I[Previous installation pools] --> J[Retain as read-only legacy pools]
    J --> K[Lookup active, primary, and legacy pools]
    H --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cas): fall back from unwritable inst..."](https://github.com/community-outpost/genhub/commit/7b3c71681634362f67935ec9cd0f3f78932b6895) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49643437)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Content Manifest System](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-manifest-system.md)
- Knowledge Base — [Content Acquisition Pipeline](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-acquisition-pipeline.md)
- Knowledge Base — [App Shell and Dependency Injection](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/app-shell-and-di.md)
- Knowledge Base — [Common UI Shell, ViewModels, and Supporting Feature Areas](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/common-ui-viewmodels.md)
</details>

<!-- /greptile_comment -->
