### PR TITLE
fix(workspace): materialize and classify executables correctly (backport of #338, #339)

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/Workspace/IWorkspaceValidator.cs
+++ b/GenHub/GenHub.Core/Interfaces/Workspace/IWorkspaceValidator.cs
@@ -32,4 +32,18 @@ public interface IWorkspaceValidator
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The validation result.</returns>
     Task<OperationResult<ValidationResult>> ValidateWorkspaceAsync(WorkspaceInfo workspaceInfo, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ensures the workspace entry point is executable by the current process, restoring
+    /// the Unix execute mode on a workspace-owned copy when the file exists without it.
+    /// A missing entry point is reported as a failure, never created, and an entry point
+    /// resolving outside the workspace root is refused without being touched.
+    /// </summary>
+    /// <param name="workspaceInfo">The workspace whose entry point is checked.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>
+    /// A successful result whose data indicates whether a repair was performed, or a
+    /// failed result when the entry point is missing or could not be made executable.
+    /// </returns>
+    Task<OperationResult<bool>> EnsureEntryPointExecutableAsync(WorkspaceInfo workspaceInfo, CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
@@ -135,7 +135,7 @@ public static class ManifestVariantResolver
         var executable = files
             .Where(f =>
                 f.IsExecutable
-                && ExecutableFileClassifier.IsLegacyLaunchCandidate(f.RelativePath))
+                && ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(f.RelativePath))
             .ToList();
         if (executable.Count == 1)
         {
@@ -145,7 +145,7 @@ public static class ManifestVariantResolver
         if (executable.Count == 0)
         {
             var legacy = files
-                .Where(f => ExecutableFileClassifier.IsLegacyLaunchCandidate(f.RelativePath))
+                .Where(f => ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(f.RelativePath))
                 .ToList();
 
             if (legacy.Count == 1)

--- a/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
+++ b/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.IO;
 
 namespace GenHub.Core.Utilities;
@@ -32,6 +33,19 @@ namespace GenHub.Core.Utilities;
 public static class ExecutableFileClassifier
 {
     /// <summary>
+    /// Bytes needed to recognise every supported magic number, including the second
+    /// 32-bit word used to tell a Mach-O universal binary from a Java class file.
+    /// </summary>
+    private const int MagicHeaderLength = 8;
+
+    /// <summary>
+    /// A Mach-O universal (fat) header's second word is the architecture count, which is
+    /// realistically single-digit. A Java class file shares the 0xCAFEBABE magic, but its
+    /// second word encodes the class-file version, which is at least 45 (Java 1.1).
+    /// </summary>
+    private const uint MaxPlausibleFatArchCount = 30;
+
+    /// <summary>
     /// Extensions for loadable code that is never itself launched and never needs the
     /// execute bit. Dynamic libraries are mapped by the loader, which requires read
     /// access only.
@@ -44,19 +58,44 @@ public static class ExecutableFileClassifier
     private static readonly string[] RunnableExtensions = [".exe", ".sh", ".command"];
 
     /// <summary>
-    /// Determines whether a file needs the Unix execute bit to be runnable.
+    /// Determines whether a file needs the Unix execute bit to be runnable, from its
+    /// name alone.
     /// <para>
     /// This is what <c>ManifestFile.IsExecutable</c> means. It is a permission fact, not
     /// a statement about which file the profile launches.
     /// </para>
     /// <para>
-    /// Extensionless files count: that is the shape of a native Mach-O or ELF binary,
-    /// and it is the case the previous inconsistency got wrong.
+    /// This is a compatibility heuristic for metadata-only contexts — remote release
+    /// asset names, manifests whose content has not been acquired — where extensionless
+    /// is assumed to mean native binary because that is the shape of a Mach-O or ELF
+    /// game client. It is not content classification: whenever the file is on disk,
+    /// call <see cref="RequiresExecutePermission(string, string?)"/> so the answer
+    /// comes from the file's magic bytes instead.
     /// </para>
     /// </summary>
     /// <param name="path">A file name or relative path. Not required to exist on disk.</param>
     /// <returns><c>true</c> when the file should be marked executable.</returns>
-    public static bool RequiresExecutePermission(string path)
+    public static bool RequiresExecutePermissionFromName(string path)
+        => RequiresExecutePermission(path, absolutePath: null);
+
+    /// <summary>
+    /// Determines whether a file needs the Unix execute bit, sniffing the file header
+    /// to classify extensionless files by content rather than by name.
+    /// <para>
+    /// An extensionless <c>README</c> or <c>LICENSE</c> is neither a native binary nor a
+    /// shebang script, and only the file's first bytes can tell these cases apart.
+    /// Extension-based classification is unchanged: libraries stay non-executable and
+    /// known runnable extensions stay executable, whatever the content says.
+    /// </para>
+    /// </summary>
+    /// <param name="path">A file name or relative path.</param>
+    /// <param name="absolutePath">
+    /// The file's location on disk, when it exists there; <c>null</c> falls back to
+    /// name-only classification. An extensionless file that cannot be read, or whose
+    /// header is neither native executable magic nor a shebang, is not executable.
+    /// </param>
+    /// <returns><c>true</c> when the file should be marked executable.</returns>
+    public static bool RequiresExecutePermission(string path, string? absolutePath)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -65,11 +104,11 @@ public static class ExecutableFileClassifier
 
         var extension = Path.GetExtension(path);
 
-        // Extensionless: a native binary. Directories and dotfiles are excluded by the
-        // caller, which only ever passes real file entries.
+        // Extensionless: the shape of a native binary, but also of a README. Content is
+        // the only reliable way to tell them apart, so use it whenever we have it.
         if (string.IsNullOrEmpty(extension))
         {
-            return true;
+            return absolutePath is null || HasExecutePermissionHeader(absolutePath);
         }
 
         if (MatchesAny(extension, LibraryExtensions))
@@ -82,15 +121,36 @@ public static class ExecutableFileClassifier
 
     /// <summary>
     /// Determines whether a file could be the launch target when a manifest declares no
-    /// explicit entry point.
+    /// explicit entry point, from its name alone.
     /// <para>
     /// This exists only to keep manifests written before entry points were declarable
     /// working. New content should declare its entry point rather than rely on this.
     /// </para>
+    /// <para>
+    /// This is a compatibility heuristic for metadata-only contexts — remote release
+    /// asset names, manifests whose content has not been acquired. It is not content
+    /// classification: whenever the file is on disk, call
+    /// <see cref="IsLegacyLaunchCandidate(string, string?)"/> so extensionless files
+    /// are judged by their magic bytes instead.
+    /// </para>
     /// </summary>
     /// <param name="path">A file name or relative path.</param>
     /// <returns><c>true</c> when the file is a plausible legacy launch target.</returns>
-    public static bool IsLegacyLaunchCandidate(string path)
+    public static bool IsLegacyLaunchCandidateFromName(string path)
+        => IsLegacyLaunchCandidate(path, absolutePath: null);
+
+    /// <summary>
+    /// Determines whether a file could be the launch target when a manifest declares no
+    /// explicit entry point, sniffing magic bytes to classify extensionless files by
+    /// content rather than by name.
+    /// </summary>
+    /// <param name="path">A file name or relative path.</param>
+    /// <param name="absolutePath">
+    /// The file's location on disk, when it exists there; <c>null</c> falls back to
+    /// name-only classification.
+    /// </param>
+    /// <returns><c>true</c> when the file is a plausible legacy launch target.</returns>
+    public static bool IsLegacyLaunchCandidate(string path, string? absolutePath)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -102,8 +162,116 @@ public static class ExecutableFileClassifier
         // Extensionless native binaries and Windows executables only. Notably not .dat:
         // the Steam layout launches game.dat through a proxy, but that is a launch
         // *strategy* chosen by the Steam integration, not a property of the file.
-        return string.IsNullOrEmpty(extension)
-            || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(extension))
+        {
+            return absolutePath is null || HasExecutableMagicBytes(absolutePath);
+        }
+
+        return extension.Equals(".exe", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determines whether the file at <paramref name="absolutePath"/> starts with the
+    /// magic bytes of a native executable format. Reads at most
+    /// <see cref="MagicHeaderLength"/> bytes; never loads the file.
+    /// </summary>
+    /// <param name="absolutePath">The file to sniff.</param>
+    /// <returns>
+    /// <c>true</c> when the header matches a known executable format; <c>false</c> for
+    /// any other content and for files that are missing, too short, or unreadable.
+    /// </returns>
+    public static bool HasExecutableMagicBytes(string absolutePath)
+    {
+        Span<byte> header = stackalloc byte[MagicHeaderLength];
+
+        return TryReadHeader(absolutePath, header, out var read)
+            && HasExecutableMagicBytes(header[..read]);
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="header"/> starts with the magic bytes of a
+    /// native executable format: MZ (Windows PE), ELF (Linux), or Mach-O (macOS), in
+    /// thin and universal flavours and both byte orders.
+    /// </summary>
+    /// <param name="header">The first bytes of a file; <see cref="MagicHeaderLength"/> suffice.</param>
+    /// <returns><c>true</c> when the header matches a known executable format.</returns>
+    public static bool HasExecutableMagicBytes(ReadOnlySpan<byte> header)
+    {
+        if (header.Length < 4)
+        {
+            return false;
+        }
+
+        // MZ: DOS/PE. Two bytes of magic, but anything shorter than four bytes cannot
+        // be a real executable of any kind, which the length gate above enforces.
+        if (header[0] == 0x4D && header[1] == 0x5A)
+        {
+            return true;
+        }
+
+        // ELF: 0x7F 'E' 'L' 'F'.
+        if (header[0] == 0x7F && header[1] == (byte)'E' && header[2] == (byte)'L' && header[3] == (byte)'F')
+        {
+            return true;
+        }
+
+        var magic = BinaryPrimitives.ReadUInt32BigEndian(header);
+
+        // Mach-O thin: MH_MAGIC / MH_MAGIC_64 and their byte-swapped forms.
+        if (magic is 0xFEEDFACE or 0xFEEDFACF or 0xCEFAEDFE or 0xCFFAEDFE)
+        {
+            return true;
+        }
+
+        // Mach-O universal (fat), 32-bit (FAT_MAGIC) and 64-bit (FAT_MAGIC_64) headers.
+        // Java class files share 0xCAFEBABE, so require the second word: a fat header's
+        // is the architecture count (tiny), a class file's is the class-file version
+        // (>= 45). The byte-swapped magics store the count byte-swapped as well.
+        if (magic is 0xCAFEBABE or 0xCAFEBABF && header.Length >= MagicHeaderLength)
+        {
+            return BinaryPrimitives.ReadUInt32BigEndian(header[4..]) < MaxPlausibleFatArchCount;
+        }
+
+        if (magic is 0xBEBAFECA or 0xBFBAFECA && header.Length >= MagicHeaderLength)
+        {
+            return BinaryPrimitives.ReadUInt32LittleEndian(header[4..]) < MaxPlausibleFatArchCount;
+        }
+
+        return false;
+    }
+
+    private static bool HasExecutePermissionHeader(string absolutePath)
+    {
+        Span<byte> header = stackalloc byte[MagicHeaderLength];
+
+        if (!TryReadHeader(absolutePath, header, out var read))
+        {
+            return false;
+        }
+
+        var fileHeader = header[..read];
+
+        // A shebang is a Unix permission fact, not native executable magic. Keep it out
+        // of HasExecutableMagicBytes so scripts never become legacy launch candidates.
+        return HasExecutableMagicBytes(fileHeader)
+            || fileHeader is [0x23, 0x21, ..];
+    }
+
+    private static bool TryReadHeader(string absolutePath, Span<byte> header, out int read)
+    {
+        try
+        {
+            using var stream = new FileStream(
+                absolutePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            read = stream.ReadAtLeast(header, MagicHeaderLength, throwOnEndOfStream: false);
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            read = 0;
+            return false;
+        }
     }
 
     private static bool MatchesAny(string extension, string[] candidates)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Workspace;
 using GenHub.Features.Workspace;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -107,7 +108,6 @@ public class ExecutablePermissionIsolationTests : IDisposable
 
         await _service.CreateHardLinkAsync(workspaceFile, casBlob);
 
-        var temporaryPath = workspaceFile + ".genhub-exec-tmp";
         await _strategy.TestEnsureExecutableAsync(
             new ManifestFile { RelativePath = "workspace-file", IsExecutable = true },
             workspaceFile);
@@ -117,9 +117,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
             File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
             "The stored blob was modified, so every other profile using this hash is affected.");
 
-        Assert.False(
-            File.Exists(temporaryPath),
-            "The temporary copy must not survive; workspace validation would report it.");
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.genhub-exec-tmp-*"));
 
         // Content must survive the round trip; a broken link is only acceptable if the
         // bytes are identical.
@@ -127,9 +125,9 @@ public class ExecutablePermissionIsolationTests : IDisposable
     }
 
     /// <summary>
-    /// The destination must never be observable as missing or non-executable. Verification
-    /// never mutates, so a workspace left with a non-executable entry point stays broken
-    /// for every later launch — the failure this sequence exists to prevent.
+    /// The destination must never be observable as missing or non-executable. Validation
+    /// can restore a lost execute bit on the entry point, but on no other executable the
+    /// manifest names, so materialisation must not expose either state in the first place.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
@@ -144,7 +142,6 @@ public class ExecutablePermissionIsolationTests : IDisposable
         await File.WriteAllTextAsync(workspaceFile, "engine binary");
         File.SetUnixFileMode(workspaceFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
 
-        var temporaryPath = workspaceFile + ".genhub-exec-tmp";
         await _strategy.TestEnsureExecutableAsync(
             new ManifestFile { RelativePath = "atomic-entry-point", IsExecutable = true },
             workspaceFile);
@@ -153,8 +150,46 @@ public class ExecutablePermissionIsolationTests : IDisposable
         Assert.True(
             File.GetUnixFileMode(workspaceFile).HasFlag(UnixFileMode.UserExecute),
             "The replacement was already executable before it became the destination.");
-        Assert.False(File.Exists(temporaryPath));
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.genhub-exec-tmp-*"));
         Assert.Equal("engine binary", await File.ReadAllTextAsync(workspaceFile));
+    }
+
+    /// <summary>
+    /// Workspaces bricked before materialisation became atomic can hold an entry point
+    /// that is still hard-linked into the content store with its execute bit lost. The
+    /// validator's repair must restore the bit the same way materialisation grants it:
+    /// on a private copy, so the stored blob keeps the mode it was ingested with.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task RepairingABrickedEntryPoint_LeavesTheStoredBlobUntouched()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var casBlob = Path.Combine(_tempDir, "cas-blob");
+        var entryPoint = Path.Combine(_tempDir, "entry-point");
+        await File.WriteAllTextAsync(casBlob, "engine binary");
+        File.SetUnixFileMode(casBlob, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        await _service.CreateHardLinkAsync(entryPoint, casBlob);
+
+        var validator = new WorkspaceValidator(NullLogger<WorkspaceValidator>.Instance);
+        var result = await validator.EnsureEntryPointExecutableAsync(new WorkspaceInfo
+        {
+            Id = "bricked-workspace",
+            WorkspacePath = _tempDir,
+            ExecutablePath = entryPoint,
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(entryPoint).HasFlag(UnixFileMode.UserExecute));
+        Assert.False(
+            File.GetUnixFileMode(casBlob).HasFlag(UnixFileMode.UserExecute),
+            "The stored blob was modified, so every other profile using this hash is affected.");
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(entryPoint));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
@@ -16,6 +16,7 @@ using GenHub.Features.Storage.Services;
 using GenHub.Features.Workspace;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -181,6 +182,9 @@ public class WorkspaceManagerReuseTests : IDisposable
         _mockWorkspaceValidator.Setup(x => x.ValidateWorkspaceAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult<ValidationResult>.CreateSuccess(successValidation));
 
+        _mockWorkspaceValidator.Setup(x => x.EnsureEntryPointExecutableAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+
         // Act
         var result = await _manager.PrepareWorkspaceAsync(config);
 
@@ -250,6 +254,127 @@ public class WorkspaceManagerReuseTests : IDisposable
                 It.IsAny<IProgress<WorkspacePreparationProgress>>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a reusable workspace whose entry point cannot be made executable is recreated.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenEntryPointCannotBeRepaired_ShouldRecreateWorkspace()
+    {
+        // Arrange
+        var workspaceId = "test-workspace";
+        var manifestId = "1.0.local.mod.testmanifest";
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
+        Directory.CreateDirectory(workspacePath);
+        File.WriteAllText(Path.Combine(workspacePath, "test.txt"), "content");
+
+        var cachedWorkspace = new WorkspaceInfo
+        {
+            Id = workspaceId,
+            WorkspacePath = workspacePath,
+            ManifestIds = [manifestId],
+            ManifestVersions = new Dictionary<string, string> { { manifestId, "1.0" } },
+            Strategy = WorkspaceStrategy.HardLink,
+            IsPrepared = true,
+            FileCount = 1,
+            IsValid = true,
+        };
+        await File.WriteAllTextAsync(_metadataPath, System.Text.Json.JsonSerializer.Serialize(new[] { cachedWorkspace }));
+
+        var config = new WorkspaceConfiguration
+        {
+            Id = workspaceId,
+            Strategy = WorkspaceStrategy.HardLink,
+            Manifests = [new ContentManifest { Id = ManifestId.Create(manifestId), Version = "1.0", Files = [new ManifestFile { RelativePath = "test.txt" }] }],
+            BaseInstallationPath = _tempPath,
+            WorkspaceRootPath = _tempPath,
+            ValidateAfterPreparation = false,
+        };
+
+        _mockWorkspaceValidator.Setup(x => x.ValidateConfigurationAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(workspaceId, []));
+        _mockWorkspaceValidator.Setup(x => x.ValidatePrerequisitesAsync(It.IsAny<IWorkspaceStrategy>(), It.IsAny<WorkspaceConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(workspaceId, []));
+        _mockWorkspaceValidator.Setup(x => x.EnsureEntryPointExecutableAsync(It.IsAny<WorkspaceInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("Workspace entry point not found"));
+
+        _mockStrategy.Setup(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WorkspaceInfo { Id = workspaceId, IsPrepared = true, WorkspacePath = workspacePath });
+
+        // Act
+        var result = await _manager.PrepareWorkspaceAsync(config);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _mockStrategy.Verify(x => x.PrepareAsync(It.Is<WorkspaceConfiguration>(c => c.ForceRecreate == true), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a reused workspace whose entry point lost its execute bit is repaired
+    /// in place so launch preparation proceeds without recreating the workspace.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenEntryPointBricked_RepairsAndReusesWorkspace()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // Arrange
+        var workspaceId = "test-workspace";
+        var manifestId = "1.0.local.mod.testmanifest";
+        var workspacePath = Path.Combine(_tempPath, workspaceId);
+        Directory.CreateDirectory(workspacePath);
+        var executablePath = Path.Combine(workspacePath, "generals");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var cachedWorkspace = new WorkspaceInfo
+        {
+            Id = workspaceId,
+            WorkspacePath = workspacePath,
+            ExecutablePath = executablePath,
+            ManifestIds = [manifestId],
+            ManifestVersions = new Dictionary<string, string> { { manifestId, "1.0" } },
+            Strategy = WorkspaceStrategy.HardLink,
+            IsPrepared = true,
+            FileCount = 1,
+            IsValid = true,
+        };
+        await File.WriteAllTextAsync(_metadataPath, System.Text.Json.JsonSerializer.Serialize(new[] { cachedWorkspace }));
+
+        var config = new WorkspaceConfiguration
+        {
+            Id = workspaceId,
+            Strategy = WorkspaceStrategy.HardLink,
+            Manifests = [new ContentManifest { Id = ManifestId.Create(manifestId), Version = "1.0", Files = [new ManifestFile { RelativePath = "generals", IsExecutable = true }] }],
+            BaseInstallationPath = _tempPath,
+            WorkspaceRootPath = _tempPath,
+            ValidateAfterPreparation = false,
+        };
+
+        var manager = new WorkspaceManager(
+            [_mockStrategy.Object],
+            _mockConfigProvider.Object,
+            _mockLogger.Object,
+            _casTracker,
+            new WorkspaceValidator(NullLogger<WorkspaceValidator>.Instance),
+            _reconciler);
+
+        // Act
+        var result = await manager.PrepareWorkspaceAsync(config);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute).Should().BeTrue();
+        (await File.ReadAllTextAsync(executablePath)).Should().Be("engine binary");
+
+        // Repair happens on the reuse fast path; the strategy never re-materialises.
+        _mockStrategy.Verify(x => x.PrepareAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -254,11 +254,12 @@ public partial class WorkspaceValidatorTests : IDisposable
 
     /// <summary>
     /// An execute bit for an identity other than the effective process identity must not
-    /// make a workspace entry point appear executable.
+    /// make a workspace entry point appear executable — validation repairs the entry
+    /// point on a workspace-owned copy instead of reporting a warning.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_ReturnsAccessWarning()
+    public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_RepairsEntryPoint()
     {
         // Root bypasses the permission bits entirely: faccessat reports execute access for
         // an other-only bit, so the behaviour under test does not exist for uid 0. Checked
@@ -286,10 +287,413 @@ public partial class WorkspaceValidatorTests : IDisposable
 
         Assert.True(result.Success);
         Assert.NotNull(result.Data);
+        Assert.DoesNotContain(
+            result.Data.Issues,
+            issue => issue.IssueType == ValidationIssueType.AccessDenied);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+    }
+
+    /// <summary>
+    /// A workspace bricked before executable modes were applied atomically — entry point
+    /// present, execute bit lost — is repaired so launch preparation can proceed.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_BrickedEntryPoint_RestoresExecuteMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = "client",
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+        Assert.Empty(Directory.GetFiles(_workspaceDir, "*.genhub-exec-tmp-*"));
+    }
+
+    /// <summary>
+    /// An entry point that is already executable is left alone.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_AlreadyExecutable_ReportsNoRepair()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+        File.SetUnixFileMode(executablePath, originalMode);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.False(result.Data);
+        Assert.Equal(originalMode, File.GetUnixFileMode(executablePath));
+    }
+
+    /// <summary>
+    /// A missing entry point is an error, not something repair may create.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_MissingEntryPoint_FailsWithoutCreatingFile()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "missing-client");
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.False(File.Exists(executablePath));
+    }
+
+    /// <summary>
+    /// Validation keeps reporting a missing entry point as an error rather than creating one.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ValidateWorkspaceAsync_MissingEntryPoint_ReportsErrorWithoutCreatingFile()
+    {
+        var executablePath = Path.Combine(_workspaceDir, "missing-client");
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.ValidateWorkspaceAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
         Assert.Contains(
             result.Data.Issues,
-            issue => issue.IssueType == ValidationIssueType.AccessDenied
-                && issue.Severity == ValidationSeverity.Warning);
+            issue => issue.IssueType == ValidationIssueType.MissingFile
+                && issue.Severity == ValidationSeverity.Error);
+        Assert.False(File.Exists(executablePath));
+    }
+
+    /// <summary>
+    /// A rooted entry point outside the workspace root is refused without being touched,
+    /// even when the outside directory shares the root as a name prefix.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_RootedPathOutsideWorkspace_RefusesWithoutMutation()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // The sibling shares the workspace root as a prefix, so a containment check
+        // without the trailing separator would wrongly accept it.
+        var evilDir = _workspaceDir + "-evil";
+        Directory.CreateDirectory(evilDir);
+        var outsidePath = Path.Combine(evilDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(outsidePath, originalMode);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = outsidePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.Contains("outside the workspace root", result.FirstError);
+        Assert.Equal(originalMode, File.GetUnixFileMode(outsidePath));
+        Assert.Equal("outside binary", await File.ReadAllTextAsync(outsidePath));
+    }
+
+    /// <summary>
+    /// A relative entry point that traverses out of the workspace root is refused
+    /// without being touched.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_TraversalPath_RefusesWithoutMutation()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var outsidePath = Path.Combine(_sourceDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(outsidePath, originalMode);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = Path.Combine("..", "source", "client"),
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.Contains("outside the workspace root", result.FirstError);
+        Assert.Equal(originalMode, File.GetUnixFileMode(outsidePath));
+    }
+
+    /// <summary>
+    /// Strategies store the entry point as an absolute path inside the workspace, so a
+    /// rooted in-workspace path must still be repaired.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_RootedPathInsideWorkspace_StillRepairs()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+    }
+
+    /// <summary>
+    /// Validation reports an entry point that escapes the workspace root as an error and
+    /// leaves the outside file untouched.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ValidateWorkspaceAsync_EntryPointOutsideWorkspace_ReportsErrorWithoutMutation()
+    {
+        var outsidePath = Path.Combine(_sourceDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(outsidePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = outsidePath,
+        };
+
+        var result = await _validator.ValidateWorkspaceAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains(
+            result.Data.Issues,
+            issue => issue.IssueType == ValidationIssueType.UnexpectedFile
+                && issue.Severity == ValidationSeverity.Error
+                && issue.Message.Contains("outside the workspace root"));
+
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.False(File.GetUnixFileMode(outsidePath).HasFlag(UnixFileMode.UserExecute));
+        }
+
+        Assert.Equal("outside binary", await File.ReadAllTextAsync(outsidePath));
+    }
+
+    /// <summary>
+    /// Lexical containment cannot see through links, so a symlinked intermediate
+    /// directory pointing outside the workspace must make the repair refuse without
+    /// touching the outside file.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_SymlinkedIntermediateDirectory_RefusesWithoutMutation()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var outsideDir = Path.Combine(_sourceDir, "payload");
+        Directory.CreateDirectory(outsideDir);
+        var outsidePath = Path.Combine(outsideDir, "client");
+        await File.WriteAllTextAsync(outsidePath, "outside binary");
+        var originalMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(outsidePath, originalMode);
+
+        Directory.CreateSymbolicLink(Path.Combine(_workspaceDir, "bin"), outsideDir);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = Path.Combine("bin", "client"),
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.False(result.Success);
+        Assert.Contains("is a symlink", result.FirstError);
+        Assert.Equal(originalMode, File.GetUnixFileMode(outsidePath));
+        Assert.Equal("outside binary", await File.ReadAllTextAsync(outsidePath));
+    }
+
+    /// <summary>
+    /// A symlinked leaf executable in an ordinary workspace is replaced with a private
+    /// executable copy while the symlink target keeps its bytes and mode — the same
+    /// store-safe behaviour materialisation applies.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_SymlinkedLeafExecutable_RepairsCopyAndLeavesTargetUntouched()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var targetPath = Path.Combine(_sourceDir, "client-target");
+        await File.WriteAllTextAsync(targetPath, "engine binary");
+        var targetMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(targetPath, targetMode);
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        File.CreateSymbolicLink(executablePath, targetPath);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.Null(new FileInfo(executablePath).LinkTarget);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(executablePath));
+        Assert.Equal(targetMode, File.GetUnixFileMode(targetPath));
+        Assert.Equal("engine binary", await File.ReadAllTextAsync(targetPath));
+    }
+
+    /// <summary>
+    /// Temporary swap names carry a fresh GUID, so a pre-existing file left at an
+    /// old-style temporary name is never clobbered by a repair.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_PreExistingTemporaryFile_IsNotClobbered()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var stalePath = executablePath + ".genhub-exec-tmp";
+        await File.WriteAllTextAsync(stalePath, "precious leftover");
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+        Assert.True(File.GetUnixFileMode(executablePath).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("precious leftover", await File.ReadAllTextAsync(stalePath));
+    }
+
+    /// <summary>
+    /// Windows has no execute bit, so the repair is a no-op that leaves the file untouched.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EnsureEntryPointExecutableAsync_OnWindows_IsANoOp()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var executablePath = Path.Combine(_workspaceDir, "client.exe");
+        await File.WriteAllTextAsync(executablePath, "engine binary");
+        var lastWrite = File.GetLastWriteTimeUtc(executablePath);
+
+        var workspaceInfo = new WorkspaceInfo
+        {
+            Id = "test-workspace",
+            WorkspacePath = _workspaceDir,
+            ExecutablePath = executablePath,
+        };
+
+        var result = await _validator.EnsureEntryPointExecutableAsync(workspaceInfo);
+
+        Assert.True(result.Success);
+        Assert.False(result.Data);
+        Assert.Equal(lastWrite, File.GetLastWriteTimeUtc(executablePath));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ExecutableFileClassifierTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Text;
 using GenHub.Core.Utilities;
 using Xunit;
 
@@ -7,8 +10,17 @@ namespace GenHub.Tests.Core.Utilities;
 /// Table-driven tests for <see cref="ExecutableFileClassifier"/>, which replaced five
 /// disagreeing implementations of "is this executable".
 /// </summary>
-public class ExecutableFileClassifierTests
+public class ExecutableFileClassifierTests : IDisposable
 {
+    private readonly string _tempDirectory = Directory.CreateTempSubdirectory("classifier-tests").FullName;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Directory.Delete(_tempDirectory, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
     /// <summary>
     /// Verifies which files are marked as needing the Unix execute bit.
     /// </summary>
@@ -38,7 +50,7 @@ public class ExecutableFileClassifierTests
     [InlineData("", false)]
     public void RequiresExecutePermission_ClassifiesCorrectly(string path, bool expected)
     {
-        Assert.Equal(expected, ExecutableFileClassifier.RequiresExecutePermission(path));
+        Assert.Equal(expected, ExecutableFileClassifier.RequiresExecutePermissionFromName(path));
     }
 
     /// <summary>
@@ -63,7 +75,7 @@ public class ExecutableFileClassifierTests
     [InlineData("", false)]
     public void IsLegacyLaunchCandidate_ClassifiesCorrectly(string path, bool expected)
     {
-        Assert.Equal(expected, ExecutableFileClassifier.IsLegacyLaunchCandidate(path));
+        Assert.Equal(expected, ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(path));
     }
 
     /// <summary>
@@ -74,13 +86,167 @@ public class ExecutableFileClassifierTests
     [Fact]
     public void TheTwoQuestionsAreIndependent()
     {
-        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("run.sh"));
-        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("run.sh"));
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermissionFromName("run.sh"));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidateFromName("run.sh"));
 
-        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generalszh"));
-        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("generalszh"));
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermissionFromName("generalszh"));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidateFromName("generalszh"));
 
-        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("libSDL3.dylib"));
-        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("libSDL3.dylib"));
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermissionFromName("libSDL3.dylib"));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidateFromName("libSDL3.dylib"));
+    }
+
+    /// <summary>
+    /// Verifies magic-byte recognition of every supported executable format, and
+    /// rejection of everything else.
+    /// </summary>
+    /// <param name="header">The first bytes of a file.</param>
+    /// <param name="expected">Whether the header denotes a native executable.</param>
+    [Theory]
+
+    // MZ (Windows PE), ELF (Linux).
+    [InlineData(new byte[] { 0x4D, 0x5A, 0x90, 0x00 }, true)]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 }, true)]
+
+    // Mach-O thin, 32- and 64-bit, both byte orders on disk.
+    [InlineData(new byte[] { 0xFE, 0xED, 0xFA, 0xCE }, true)]
+    [InlineData(new byte[] { 0xFE, 0xED, 0xFA, 0xCF }, true)]
+    [InlineData(new byte[] { 0xCE, 0xFA, 0xED, 0xFE }, true)]
+    [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE }, true)]
+
+    // Mach-O universal (fat), 32- and 64-bit headers: second word is the architecture
+    // count, byte-swapped alongside the swapped magics.
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02 }, true)]
+    [InlineData(new byte[] { 0xBE, 0xBA, 0xFE, 0xCA, 0x02, 0x00, 0x00, 0x00 }, true)]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBF, 0x00, 0x00, 0x00, 0x02 }, true)]
+    [InlineData(new byte[] { 0xBF, 0xBA, 0xFE, 0xCA, 0x02, 0x00, 0x00, 0x00 }, true)]
+
+    // A Java class file shares the fat magic, but its second word is the class-file
+    // version (>= 45); 0x34 is Java 8.
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x34 }, false)]
+
+    // A fat magic with no second word cannot be confirmed as a fat binary.
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE }, false)]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBF }, false)]
+
+    // Text, shebang scripts, truncated headers, and nothing at all.
+    [InlineData(new byte[] { 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73 }, false)]
+    [InlineData(new byte[] { 0x23, 0x21, 0x2F, 0x62, 0x69, 0x6E, 0x2F }, false)]
+    [InlineData(new byte[] { 0x4D, 0x5A }, false)]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C }, false)]
+    [InlineData(new byte[] { }, false)]
+    public void HasExecutableMagicBytes_ClassifiesHeaders(byte[] header, bool expected)
+    {
+        Assert.Equal(expected, ExecutableFileClassifier.HasExecutableMagicBytes(header));
+    }
+
+    /// <summary>
+    /// An extensionless file whose content is text is exactly the false positive the
+    /// name-only heuristic produced: a README is not a native binary.
+    /// </summary>
+    [Fact]
+    public void ExtensionlessTextFile_IsNotClassifiedExecutable()
+    {
+        var readme = Path.Combine(_tempDirectory, "README");
+        File.WriteAllText(readme, "This project is a mod for Zero Hour.\n");
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("README", readme));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("README", readme));
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(readme));
+    }
+
+    /// <summary>
+    /// An extensionless shebang script needs the Unix execute bit, but is not native
+    /// executable code and must not become a legacy inferred game entry point.
+    /// </summary>
+    [Fact]
+    public void ExtensionlessShebangScript_RequiresPermissionButIsNotLaunchCandidate()
+    {
+        var script = Path.Combine(_tempDirectory, "launch");
+        File.WriteAllText(script, "#!/bin/sh\nexec ./generalszh\n", Encoding.ASCII);
+
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("launch", script));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("launch", script));
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(script));
+    }
+
+    /// <summary>
+    /// Files shorter than any magic number must be rejected without throwing.
+    /// </summary>
+    /// <param name="content">The whole file content.</param>
+    [Theory]
+    [InlineData(new byte[] { })]
+    [InlineData(new byte[] { 0x4D })]
+    [InlineData(new byte[] { 0x4D, 0x5A })]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C })]
+    public void TinyFiles_AreRejectedWithoutThrowing(byte[] content)
+    {
+        var path = Path.Combine(_tempDirectory, $"tiny-{content.Length}");
+        File.WriteAllBytes(path, content);
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission(Path.GetFileName(path), path));
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(path));
+    }
+
+    /// <summary>
+    /// An extensionless file that really is a native binary keeps both classifications,
+    /// whichever platform's format it carries.
+    /// </summary>
+    /// <param name="header">The magic bytes to write.</param>
+    [Theory]
+    [InlineData(new byte[] { 0x4D, 0x5A, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00 })]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 })]
+    [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01 })]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02 })]
+    [InlineData(new byte[] { 0xCA, 0xFE, 0xBA, 0xBF, 0x00, 0x00, 0x00, 0x02 })]
+    public void ExtensionlessNativeBinary_IsClassifiedExecutable(byte[] header)
+    {
+        var path = Path.Combine(_tempDirectory, "generalszh");
+        File.WriteAllBytes(path, header);
+
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generalszh", path));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("GeneralsMD/Release/generalszh", path));
+    }
+
+    /// <summary>
+    /// A missing or unreadable file cannot be confirmed as a binary and must not throw.
+    /// </summary>
+    [Fact]
+    public void MissingFile_IsNotClassifiedExecutable()
+    {
+        var path = Path.Combine(_tempDirectory, "does-not-exist");
+
+        Assert.False(ExecutableFileClassifier.HasExecutableMagicBytes(path));
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("does-not-exist", path));
+    }
+
+    /// <summary>
+    /// Extension-based classification does not consult content: a library stays
+    /// non-executable even though it is a real native image, and known runnable
+    /// extensions do not require one.
+    /// </summary>
+    [Fact]
+    public void ExtensionRules_AreUnchangedByContent()
+    {
+        var dylib = Path.Combine(_tempDirectory, "libSDL3.dylib");
+        File.WriteAllBytes(dylib, [0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01]);
+
+        var script = Path.Combine(_tempDirectory, "run.sh");
+        File.WriteAllText(script, "#!/bin/sh\nexec ./generalszh\n", Encoding.ASCII);
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("libSDL3.dylib", dylib));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("libSDL3.dylib", dylib));
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("run.sh", script));
+    }
+
+    /// <summary>
+    /// Callers that hold only a name (manifest entries, remote release assets) keep the
+    /// legacy behaviour: extensionless means native binary.
+    /// </summary>
+    [Fact]
+    public void NameOnlyClassification_KeepsLegacyExtensionlessBehaviour()
+    {
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generalszh", null));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("generalszh", null));
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -146,7 +146,7 @@ public class CommunityOutpostDeliverer(
                 RelativePath = relativePath,
                 Size = fileInfo.Length,
                 IsRequired = true,
-                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(relativePath),
+                IsExecutable = ExecutableFileClassifier.RequiresExecutePermission(relativePath, file),
                 SourceType = ContentSourceType.ExtractedPackage,
             });
         }

--- a/GenHub/GenHub/Features/Content/Services/Helpers/GitHubInferenceHelper.cs
+++ b/GenHub/GenHub/Features/Content/Services/Helpers/GitHubInferenceHelper.cs
@@ -191,7 +191,7 @@ public static class GitHubInferenceHelper
     /// <returns>True when the extension matches a known executable type.</returns>
     public static bool IsExecutableFile(string fileName)
     {
-        return ExecutableFileClassifier.RequiresExecutePermission(fileName);
+        return ExecutableFileClassifier.RequiresExecutePermissionFromName(fileName);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
@@ -34,7 +34,8 @@ public partial class FileTreeItem : ObservableObject
     /// <summary>
     /// Gets a value indicating whether this file is an executable (.exe).
     /// </summary>
-    public bool IsExecutable => IsFile && ExecutableFileClassifier.IsLegacyLaunchCandidate(Name);
+    public bool IsExecutable => IsFile && ExecutableFileClassifier.IsLegacyLaunchCandidate(
+        Name, string.IsNullOrEmpty(FullPath) ? null : FullPath);
 
     /// <summary>
     /// Gets or sets a value indicating whether this item is selected as the executable.

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -734,10 +734,10 @@ public partial class ContentManifestBuilder(
 
     private static bool IsExecutableFile(string filePath)
     {
-        // Delegates to the shared classifier. The previous implementation also required
-        // File.Exists, which made classification depend on disk state at build time:
-        // the same manifest could classify differently depending on when it was built.
-        return ExecutableFileClassifier.RequiresExecutePermission(filePath);
+        // Delegates to the shared classifier. The caller has just enumerated filePath
+        // from disk, so the classifier can sniff its magic bytes and an extensionless
+        // README is not mistaken for a native binary.
+        return ExecutableFileClassifier.RequiresExecutePermission(filePath, filePath);
     }
 
     /// <returns>The normalized version string.</returns>

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -949,7 +949,7 @@ public class ManifestGenerationService(
                     // the Steam layout launches game.dat through a proxy, which is a launch
                     // strategy rather than a property of the file, and it forced
                     // SteamManifestPatcher to keep flipping the flag by hand.
-                    var isExecutable = ExecutableFileClassifier.RequiresExecutePermission(finalPath);
+                    var isExecutable = ExecutableFileClassifier.RequiresExecutePermission(finalPath, fullPath);
 
                     await builder.AddGameInstallationFileAsync(finalPath, fullPath, isExecutable);
                     _fileCount++;

--- a/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
+++ b/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+
+namespace GenHub.Features.Workspace;
+
+/// <summary>
+/// Replaces a workspace file with a private copy that carries the Unix execute bit.
+/// <para>
+/// The private copy is what keeps the content store safe: a hard-linked workspace file
+/// shares its inode — and therefore its file mode — with the stored blob, so setting the
+/// execute bit in place would change that blob for every profile referencing the hash.
+/// Copying first gives the workspace its own inode, and because the copy is made
+/// executable before it atomically replaces the destination, the file is never
+/// observable as missing or present-but-not-executable.
+/// </para>
+/// <para>
+/// Meant for Unix; callers gate on the operating system. Windows has no execute bit,
+/// so the mode change is skipped there defensively.
+/// </para>
+/// </summary>
+internal static class ExecutableFileSwap
+{
+    /// <summary>
+    /// The recognisable marker in the name of the temporary file used while the swap is
+    /// in flight. A fresh GUID follows it, so concurrent swaps of the same file can
+    /// never collide with each other or with a stale leftover.
+    /// </summary>
+    internal const string TemporaryMarker = ".genhub-exec-tmp-";
+
+    private const UnixFileMode ExecutableMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+    /// <summary>
+    /// Swaps the file at <paramref name="targetPath"/> for an executable private copy.
+    /// </summary>
+    /// <param name="targetPath">The absolute path of the workspace file.</param>
+    internal static void MakeExecutable(string targetPath)
+    {
+        var temporaryPath = targetPath + TemporaryMarker + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            // The GUID makes the name unique by construction; copying without overwrite
+            // turns the impossible collision into an exception instead of a clobber.
+            File.Copy(targetPath, temporaryPath);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(temporaryPath, ExecutableMode);
+            }
+
+            File.Move(temporaryPath, targetPath, overwrite: true);
+        }
+        catch
+        {
+            // The move is the last step, so a failure means the temporary copy may still
+            // exist. Remove it: the original entry is untouched and correct, and a stray
+            // temporary file would otherwise be reported by workspace validation.
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            throw;
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -634,59 +634,22 @@ public abstract class WorkspaceStrategyBase<T>(
             return;
         }
 
-        var temporaryPath = targetPath + ".genhub-exec-tmp";
-
         try
         {
-            // Replace the entry with a private copy so the mode change cannot reach a
-            // shared blob.
-            //
             // The copy is made executable *before* it is moved into place, and the move
             // replaces the destination atomically. There is therefore no observable state
             // in which the destination is missing or present-but-not-executable: it is
             // either the original entry or the finished private copy.
             //
-            // A delete-then-move sequence would expose both of those states, and the
-            // second is unrecoverable — verification never mutates, so a workspace left
-            // with a non-executable entry point stays broken for every later launch.
-            await Task.Run(
-                () =>
-                {
-                    File.Copy(targetPath, temporaryPath, overwrite: true);
-
-                    if (!OperatingSystem.IsWindows())
-                    {
-                        const UnixFileMode executableMode =
-                            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-                            UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
-
-                        File.SetUnixFileMode(temporaryPath, executableMode);
-                    }
-
-                    File.Move(temporaryPath, targetPath, overwrite: true);
-                },
-                cancellationToken);
+            // A delete-then-move sequence would expose both of those states. The second
+            // is only papered over later — validation can restore a lost execute bit on
+            // the entry point, but not on any other executable the manifest names.
+            await Task.Run(() => ExecutableFileSwap.MakeExecutable(targetPath), cancellationToken);
 
             Logger.LogDebug("Marked {RelativePath} executable on a workspace-owned copy", file.RelativePath);
         }
         catch (Exception ex)
         {
-            // The move is the last step, so a failure here means the temporary copy may
-            // still exist. Remove it: the original entry is untouched and correct, and a
-            // stray .genhub-exec-tmp would otherwise be reported by workspace validation.
-            try
-            {
-                File.Delete(temporaryPath);
-            }
-            catch (Exception cleanupEx)
-            {
-                Logger.LogDebug(
-                    cleanupEx,
-                    "Could not remove the temporary executable copy at {TemporaryPath}",
-                    temporaryPath);
-            }
-
             Logger.LogError(
                 ex,
                 "Could not mark {RelativePath} executable",

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -149,10 +149,23 @@ public class WorkspaceManager(
                             }
                             else if (!configuration.ForceRecreate && (workspace.FileCount > 0 || Directory.Exists(workspace.WorkspacePath)))
                             {
-                                logger.LogInformation(
-                                    "[Workspace] Reusing existing workspace {Id} for fast launch",
-                                    configuration.Id);
-                                return OperationResult<WorkspaceInfo>.CreateSuccess(workspace);
+                                // Reuse skips materialisation entirely, so this is the only
+                                // moment a workspace bricked by a lost execute bit can be
+                                // repaired before launch.
+                                var entryPointResult = await workspaceValidator.EnsureEntryPointExecutableAsync(workspace, cancellationToken);
+                                if (entryPointResult.Success)
+                                {
+                                    logger.LogInformation(
+                                        "[Workspace] Reusing existing workspace {Id} for fast launch",
+                                        configuration.Id);
+                                    return OperationResult<WorkspaceInfo>.CreateSuccess(workspace);
+                                }
+
+                                logger.LogWarning(
+                                    "[Workspace] Entry point check failed for workspace {Id}: {Error}. Workspace will be recreated.",
+                                    configuration.Id,
+                                    entryPointResult.FirstError);
+                                configuration.ForceRecreate = true;
                             }
                             else
                             {

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -219,11 +219,17 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             // Validate executable exists if specified
             if (!string.IsNullOrEmpty(workspaceInfo.ExecutablePath))
             {
-                var executablePath = Path.IsPathRooted(workspaceInfo.ExecutablePath)
-                    ? workspaceInfo.ExecutablePath
-                    : Path.Combine(workspaceInfo.WorkspacePath, workspaceInfo.ExecutablePath);
-
-                if (!File.Exists(executablePath))
+                if (!TryResolveContainedEntryPointPath(workspaceInfo, out var executablePath))
+                {
+                    issues.Add(new ValidationIssue
+                    {
+                        IssueType = ValidationIssueType.UnexpectedFile,
+                        Severity = ValidationSeverity.Error,
+                        Message = $"Executable path '{workspaceInfo.ExecutablePath}' resolves outside the workspace root '{workspaceInfo.WorkspacePath}'",
+                        Path = workspaceInfo.ExecutablePath,
+                    });
+                }
+                else if (!File.Exists(executablePath))
                 {
                     issues.Add(new ValidationIssue
                     {
@@ -233,44 +239,21 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
                         Path = executablePath,
                     });
                 }
-                else
+                else if (!OperatingSystem.IsWindows())
                 {
-                    // Check if executable has execute permissions (on Unix systems)
-                    if (!OperatingSystem.IsWindows())
+                    // A lost execute bit is repaired rather than merely reported: the
+                    // entry point is a workspace-owned copy, so restoring its mode cannot
+                    // reach a shared content-store blob.
+                    var repairResult = await EnsureEntryPointExecutableAsync(workspaceInfo, cancellationToken);
+                    if (!repairResult.Success)
                     {
-                        try
+                        issues.Add(new ValidationIssue
                         {
-                            var fileInfo = new FileInfo(executablePath);
-
-                            // Check if file exists and has execute permission for the current user
-                            if (!fileInfo.Exists)
-                            {
-                                issues.Add(new ValidationIssue
-                                {
-                                    IssueType = ValidationIssueType.AccessDenied,
-                                    Severity = ValidationSeverity.Warning,
-                                    Message = $"Cannot verify execute permissions for: {executablePath}",
-                                    Path = executablePath,
-                                });
-                            }
-                            else
-                            {
-                                if (!HasUnixExecutePermission(executablePath))
-                                {
-                                    issues.Add(new ValidationIssue
-                                    {
-                                        IssueType = ValidationIssueType.AccessDenied,
-                                        Severity = ValidationSeverity.Warning,
-                                        Message = $"File is not executable by the current process: {executablePath}",
-                                        Path = executablePath,
-                                    });
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogWarning(ex, "Could not check execute permissions for {ExecutablePath}", executablePath);
-                        }
+                            IssueType = ValidationIssueType.AccessDenied,
+                            Severity = ValidationSeverity.Warning,
+                            Message = $"File is not executable by the current process: {executablePath}",
+                            Path = executablePath,
+                        });
                     }
                 }
             }
@@ -321,6 +304,189 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             logger.LogError(ex, "Failed to validate workspace {WorkspaceId}", workspaceInfo.Id);
             return OperationResult<ValidationResult>.CreateFailure($"Workspace validation failed: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Ensures the workspace entry point is executable by the current process, restoring
+    /// the Unix execute mode on a workspace-owned copy when the file exists without it.
+    /// <para>
+    /// This exists for workspaces materialised before executable modes were applied
+    /// atomically: their entry point can be present with the execute bit lost, and no
+    /// later materialisation ever runs to restore it. The repair swaps the file for a
+    /// private executable copy, so even an entry point that is still hard-linked into
+    /// the content store never has its shared blob touched.
+    /// </para>
+    /// <para>
+    /// A missing entry point is reported as a failure, never created — materialisation
+    /// owns producing the file; this method only restores its mode. An entry point that
+    /// resolves outside the workspace root is likewise refused without touching it, so
+    /// stale or corrupted metadata can never redirect the repair at a foreign file.
+    /// </para>
+    /// </summary>
+    /// <param name="workspaceInfo">The workspace whose entry point is checked.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>
+    /// A successful result whose data indicates whether a repair was performed, or a
+    /// failed result when the entry point is missing or could not be made executable.
+    /// </returns>
+    public async Task<OperationResult<bool>> EnsureEntryPointExecutableAsync(WorkspaceInfo workspaceInfo, CancellationToken cancellationToken = default)
+    {
+        if (OperatingSystem.IsWindows() || string.IsNullOrEmpty(workspaceInfo.ExecutablePath))
+        {
+            return OperationResult<bool>.CreateSuccess(false);
+        }
+
+        if (!TryResolveContainedEntryPointPath(workspaceInfo, out var executablePath))
+        {
+            return OperationResult<bool>.CreateFailure(
+                $"Workspace entry point '{workspaceInfo.ExecutablePath}' resolves outside the workspace root '{workspaceInfo.WorkspacePath}'");
+        }
+
+        if (!File.Exists(executablePath))
+        {
+            return OperationResult<bool>.CreateFailure($"Workspace entry point not found: {executablePath}");
+        }
+
+        if (HasUnixExecutePermission(executablePath))
+        {
+            return OperationResult<bool>.CreateSuccess(false);
+        }
+
+        if (TryFindLinkedParentDirectory(workspaceInfo.WorkspacePath, executablePath, out var linkedDirectory))
+        {
+            return OperationResult<bool>.CreateFailure(
+                $"Cannot repair workspace entry point '{executablePath}': directory '{linkedDirectory}' is a symlink, so the file may resolve outside the workspace root '{workspaceInfo.WorkspacePath}'");
+        }
+
+        try
+        {
+            await Task.Run(() => ExecutableFileSwap.MakeExecutable(executablePath), cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not restore the execute mode on workspace entry point {ExecutablePath}", executablePath);
+            return OperationResult<bool>.CreateFailure($"Could not restore the execute mode on {executablePath}: {ex.Message}");
+        }
+
+        if (!HasUnixExecutePermission(executablePath))
+        {
+            return OperationResult<bool>.CreateFailure($"Workspace entry point is still not executable after repair: {executablePath}");
+        }
+
+        logger.LogInformation("Restored the execute mode on workspace entry point {ExecutablePath}", executablePath);
+        return OperationResult<bool>.CreateSuccess(true);
+    }
+
+    /// <summary>
+    /// Resolves the workspace entry point to a full path and requires it to be strictly
+    /// inside the workspace root.
+    /// <para>
+    /// Containment is load-bearing here because the entry point is not only read but
+    /// repaired in place: stale or corrupted workspace metadata must never cause a file
+    /// outside the workspace to be replaced. The check appends the directory separator
+    /// to the root before comparing, so a sibling such as <c>foo-evil</c> cannot pass
+    /// for a root named <c>foo</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="workspaceInfo">The workspace whose entry point is resolved.</param>
+    /// <param name="executablePath">The fully resolved entry point path, when contained.</param>
+    /// <returns><c>true</c> when the entry point resolves inside the workspace root.</returns>
+    private static bool TryResolveContainedEntryPointPath(WorkspaceInfo workspaceInfo, out string executablePath)
+    {
+        executablePath = string.Empty;
+
+        try
+        {
+            var workspaceRoot = Path.GetFullPath(workspaceInfo.WorkspacePath);
+            var candidate = Path.IsPathRooted(workspaceInfo.ExecutablePath)
+                ? workspaceInfo.ExecutablePath
+                : Path.Combine(workspaceRoot, workspaceInfo.ExecutablePath);
+            var resolved = Path.GetFullPath(candidate);
+
+            var rootWithSeparator = Path.EndsInDirectorySeparator(workspaceRoot)
+                ? workspaceRoot
+                : workspaceRoot + Path.DirectorySeparatorChar;
+
+            // Ordinal on Unix; Windows path comparisons are case-insensitive.
+            var comparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!resolved.StartsWith(rootWithSeparator, comparison))
+            {
+                return false;
+            }
+
+            executablePath = resolved;
+            return true;
+        }
+        catch (Exception)
+        {
+            // An entry point that cannot even be resolved is treated as escaping.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Walks from the workspace root down to the entry point's parent directory looking
+    /// for a symlinked directory.
+    /// <para>
+    /// Lexical containment cannot see through links: a symlinked directory inside the
+    /// workspace can point anywhere, so repairing through one could replace a file
+    /// outside the workspace root. The leaf itself is deliberately not checked —
+    /// replacing a leaf symlink with a private executable copy is the intended,
+    /// store-safe repair. Workspace strategies materialise directories with
+    /// <c>Directory.CreateDirectory</c> and only ever symlink individual files
+    /// (SymlinkOnlyStrategy and HybridCopySymlinkStrategy pass per-file manifest
+    /// targets to <c>CreateSymlinkAsync</c>), so no normally generated workspace is
+    /// refused by this check.
+    /// </para>
+    /// </summary>
+    /// <param name="workspaceRootPath">The workspace root directory.</param>
+    /// <param name="executablePath">The fully resolved, lexically contained entry point path.</param>
+    /// <param name="linkedDirectory">The first symlinked directory found, when any.</param>
+    /// <returns><c>true</c> when the root or an intermediate directory is a symlink.</returns>
+    private static bool TryFindLinkedParentDirectory(string workspaceRootPath, string executablePath, out string linkedDirectory)
+    {
+        linkedDirectory = string.Empty;
+
+        var workspaceRoot = Path.GetFullPath(workspaceRootPath);
+        if (IsLinkedDirectory(workspaceRoot))
+        {
+            linkedDirectory = workspaceRoot;
+            return true;
+        }
+
+        var parentDirectory = Path.GetDirectoryName(executablePath);
+        if (string.IsNullOrEmpty(parentDirectory))
+        {
+            return false;
+        }
+
+        var relative = Path.GetRelativePath(workspaceRoot, parentDirectory);
+        if (relative == ".")
+        {
+            return false;
+        }
+
+        var current = workspaceRoot;
+        foreach (var segment in relative.Split(Path.DirectorySeparatorChar))
+        {
+            current = Path.Combine(current, segment);
+            if (IsLinkedDirectory(current))
+            {
+                linkedDirectory = current;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsLinkedDirectory(string path)
+    {
+        var info = new DirectoryInfo(path);
+        return info.Exists && (info.Attributes & FileAttributes.ReparsePoint) != 0;
     }
 
     private static bool IsRunningAsAdministrator()


### PR DESCRIPTION
## Summary

Backports #338 and #339 into `release/alpha-4`.

- **#338** — materialize executables atomically and repair stale execute modes.
- **#339** — classify executables by magic bytes instead of the extensionless
  heuristic.

Both bear on whether a prepared workspace produces a launchable entry point,
which is the `A profile can be created and launched` box still open for both
platforms in #307.

## Why these two

They are the same class of user-facing workspace fix as #346 and #350, both
already backported. The remaining `development` commits are deliberately left
out:

- #328, #329, #331 — Alpha 5 platform work, excluded by the split described in #335.
- #332 — native BGFX client launch, a feature rather than a fix.
- #345 — only touches `NativeClientManifestLaunchTests.cs`, a file created by
  #332, so it is a no-op on this branch.

## Backport notes

#339 cherry-picked clean. #338 required one adaptation, worth recording because
a clean textual merge hides it:

On `development`, #338 merged **before** #348, the forward-port of #346. This
branch already carries #346, so the cherry-pick applies #338 **after** it —
reversing the integration order. #348 had amended #338's own tests to coexist
with the workspace-root change, rewriting
`Path.Combine(_tempPath, "workspace")` to `Path.Combine(_tempPath, workspaceId)`
so the cached workspace path matches the root-derived path and the recreate
branch does not fire.

Without that adaptation the cherry-pick still compiles and reports no conflict in
`WorkspaceManager.cs`, but
`PrepareWorkspaceAsync_WhenEntryPointBricked_RepairsAndReusesWorkspace` fails.
The same two-line adaptation #348 made is folded into the #338 commit here, so
both commits are individually green.

The one genuine conflict was in `WorkspaceManagerReuseTests.cs`, where #346's
`WhenStorageRootChanges` test and #338's two new tests landed adjacently. All
three are kept; #338's change to that file is purely additive.

## Testing

- `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release`
  - At `#338`: 1,478 passed, 0 failed
  - At `#339` (tip): 1,510 passed, 0 failed
- `dotnet build GenHub/GenHub.Linux/GenHub.Linux.csproj -c Release` — passed
- Formatting verification and `git diff --check` — passed

## Risks and rollback

- `release/alpha-4` still lacks the blank-root guard #348 added on top of #346 in
  `WorkspaceManager`. No test exercises it and nothing here depends on it, but
  this branch carries a slightly older variant of that fix than `development`.
- Reverting either commit restores the previous executable materialization and
  classification behavior.

## Outstanding

Packaged Windows and Linux validation per #307 still applies; these commits
change workspace materialization, so the `profile can be created and launched`
checks should be re-run against a build containing them.

Backport of #338 and #339

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport makes Unix executable materialization atomic, repairs stale executable modes when reusing workspaces, and centralizes executable classification around file extensions and magic bytes.
- Adds private-copy executable swaps to protect hard-linked CAS content.
- Validates and repairs cached workspace entry points before reuse.
- Distinguishes native binaries, scripts, libraries, and legacy launch candidates across manifest-generation paths.
- Adds focused tests for atomic replacement, CAS isolation, path containment, workspace reuse, and executable magic formats.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The executable swap preserves CAS isolation, workspace reuse repairs only contained entry points, unsafe or missing paths fall back to recreation, and changed classifier callers consistently select content-aware or metadata-only classification according to the available file state.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs | Adds bounded header sniffing for PE, ELF, and Mach-O files while retaining explicit name-only APIs for metadata contexts. |
| GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs | Introduces unique temporary copies and atomic replacement so execute-mode changes cannot mutate shared hard-link targets. |
| GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs | Adds contained-path entry-point repair with parent-symlink checks and structured failures that trigger recreation. |
| GenHub/GenHub/Features/Workspace/WorkspaceManager.cs | Checks and repairs the entry point before returning a reused workspace, recreating the workspace when repair is unsafe or impossible. |
| GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs | Delegates executable materialization to the shared atomic swap helper. |
| GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs | Explicitly uses name-only legacy launch classification because manifest resolution operates on metadata rather than acquired files. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Prepare workspace] --> B{Reusable cached workspace?}
    B -- No --> C[Materialize files]
    C --> D[Copy executable to unique temporary path]
    D --> E[Apply Unix execute mode]
    E --> F[Atomically replace workspace file]
    B -- Yes --> G[Resolve contained entry point]
    G --> H{Exists and executable?}
    H -- Yes --> I[Reuse workspace]
    H -- Missing or unsafe --> C
    H -- Mode missing --> J[Create executable private copy]
    J --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(content): classify executables by ma..."](https://github.com/community-outpost/genhub/commit/f7ad62fb69652e1e1fb78290f130330f792b98a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49650618)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Workspace Assembly](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/workspace-assembly.md)
- Knowledge Base — [Content Manifest System](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-manifest-system.md)
- Knowledge Base — [Content Acquisition Pipeline](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-acquisition-pipeline.md)
</details>

<!-- /greptile_comment -->