### PR TITLE
test(launching): add engine-only launch smoke test and macos-15 CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,6 +535,66 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # Launches the real native engine with no game data at all and requires the abort the
+  # engine is known to produce (exit code 1 once INI loading finds nothing to read). No
+  # licensed retail content is involved; what this covers is everything before that
+  # point — the binary loads, its dylibs resolve, and startup fails fast instead of
+  # hanging. No other job executes the native launch path at all.
+  engine-launch-smoke:
+    name: Engine Launch Smoke Test
+    needs: detect-changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.any == 'true' }}
+    # macos-14 and newer are Apple Silicon, matching the arm64 engine asset.
+    runs-on: macos-15
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet Packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      # `latest-bgfx` is a moving tag, republished as the engine advances. Deliberate
+      # tradeoff: this job tracks the current engine build rather than pinning a
+      # reproducible one, so an engine regression surfaces here first.
+      - name: Download Native Engine
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download latest-bgfx \
+            --repo bobtista/GeneralsGameCode \
+            --pattern 'GeneralsZH-macos-arm64.zip' \
+            --dir engine-download
+          unzip -q engine-download/GeneralsZH-macos-arm64.zip -d native-client
+          chmod +x native-client/generalszh
+          ls -l native-client
+
+      # GENHUB_REQUIRE_NATIVE_SMOKE turns "no client found" from a silent skip into a
+      # failure. Without it a broken download would leave the test skipping and this
+      # job permanently, meaninglessly green.
+      - name: Run Engine Launch Smoke Test
+        env:
+          GENHUB_NATIVE_CLIENT_DIR: ${{ github.workspace }}/native-client
+          GENHUB_REQUIRE_NATIVE_SMOKE: '1'
+        run: |
+          dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj \
+            -c ${{ env.BUILD_CONFIGURATION }} \
+            --filter "FullyQualifiedName~EngineLaunchSmokeTests" \
+            --verbosity normal
+
   summary:
     name: Build Summary
     needs: [build-windows, build-linux, build-macos]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,7 +578,17 @@ jobs:
             --repo bobtista/GeneralsGameCode \
             --pattern 'GeneralsZH-macos-arm64.zip' \
             --dir engine-download
-          unzip -q engine-download/GeneralsZH-macos-arm64.zip -d native-client
+          # The archive wraps everything in a GeneralsZH-macos-arm64/ directory, so it is
+          # staged and the wrapper's contents lifted out. Not `unzip -j`: that would also
+          # flatten Data/INI/, which the engine reads by path.
+          unzip -q engine-download/GeneralsZH-macos-arm64.zip -d engine-staging
+          root="$(find engine-staging -mindepth 1 -maxdepth 1 -type d)"
+          if [ ! -f "$root/generalszh" ]; then
+            echo "::error::generalszh not found in the release archive; contents were:"
+            find engine-staging -maxdepth 2
+            exit 1
+          fi
+          mv "$root" native-client
           chmod +x native-client/generalszh
           ls -l native-client
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,7 +597,9 @@ jobs:
 
   summary:
     name: Build Summary
-    needs: [build-windows, build-linux, build-macos, engine-launch-smoke]
+    # detect-changes is in `needs` so its own failure reaches the gate below. Without it a
+    # failed detect-changes skips every build, and all-skipped reads as a clean pass.
+    needs: [detect-changes, build-windows, build-linux, build-macos, engine-launch-smoke]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,7 +597,7 @@ jobs:
 
   summary:
     name: Build Summary
-    needs: [build-windows, build-linux, build-macos]
+    needs: [build-windows, build-linux, build-macos, engine-launch-smoke]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -612,3 +612,4 @@ jobs:
           echo "| Windows | ${{ needs.build-windows.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Linux | ${{ needs.build-linux.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| macOS | ${{ needs.build-macos.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Engine Smoke | ${{ needs.engine-launch-smoke.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,9 +613,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       # A job skipped by detect-changes gating is a legitimate outcome, rendered as
       # such rather than as a failure.
       - name: Generate Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
               - '**/*.axaml'
               - '**/*.csproj'
               - '**/*.sln'
+              - '**/*.props'
+              - '**/*.targets'
               - '.github/workflows/**'
 
       - name: Changes Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,12 +604,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # A job skipped by detect-changes gating is a legitimate outcome, rendered as
+      # such rather than as a failure.
       - name: Generate Summary
         run: |
           echo "### 🚀 GenHub Build Results" >> $GITHUB_STEP_SUMMARY
           echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
           echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
-          echo "| Windows | ${{ needs.build-windows.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Linux | ${{ needs.build-linux.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| macOS | ${{ needs.build-macos.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Engine Smoke | ${{ needs.engine-launch-smoke.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Windows | ${{ needs.build-windows.result == 'success' && '✅ Passed' || needs.build-windows.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Linux | ${{ needs.build-linux.result == 'success' && '✅ Passed' || needs.build-linux.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| macOS | ${{ needs.build-macos.result == 'success' && '✅ Passed' || needs.build-macos.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Engine Smoke | ${{ needs.engine-launch-smoke.result == 'success' && '✅ Passed' || needs.engine-launch-smoke.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+
+      # Turns the summary into a real gate: branch protection can require this one
+      # check and a failed or cancelled job anywhere in `needs` blocks the merge.
+      # Skipped jobs pass — being gated off by detect-changes is not a failure.
+      - name: Fail when a required job failed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/EngineLaunchSmokeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/EngineLaunchSmokeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Models.Launching;
 using GenHub.Features.GameProfiles.Infrastructure;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -92,12 +93,25 @@ public class EngineLaunchSmokeTests : IDisposable
         var exited = new TaskCompletionSource<int?>(TaskCreationOptions.RunContinuationsAsynchronously);
         _processManager.ProcessExited += (_, e) => exited.TrySetResult(e.ExitCode);
 
+        // The install-path variables are pinned to the empty workspace so a developer who
+        // has them exported cannot feed this "no data" launch their real retail content
+        // through the inherited environment. GameProcessManager assigns these into
+        // ProcessStartInfo.EnvironmentVariables by indexer, which the framework
+        // pre-populates from the parent environment — so an inherited value is replaced,
+        // not merely joined. The trailing separator matches how GameLauncher sets these
+        // for real launches: the engine requires it on the value.
+        var pinnedInstallPath = workspace + Path.DirectorySeparatorChar;
         var configuration = new GameLaunchConfiguration
         {
             ExecutablePath = Path.Combine(workspace, NativeClientFixture.BinaryName),
             WorkingDirectory = workspace,
             Arguments = new() { ["-headless"] = string.Empty },
-            EnvironmentVariables = new() { ["HOME"] = sandboxHome },
+            EnvironmentVariables = new()
+            {
+                ["HOME"] = sandboxHome,
+                [RetailArchiveConstants.ZeroHourInstallPathVariable] = pinnedInstallPath,
+                [RetailArchiveConstants.GeneralsInstallPathVariable] = pinnedInstallPath,
+            },
         };
 
         var result = await _processManager.StartProcessAsync(configuration);
@@ -156,8 +170,9 @@ public class EngineLaunchSmokeTests : IDisposable
     /// what the engine leaves behind is a crash report named <c>ReleaseCrashInfo.txt</c>
     /// under HOME (on macOS beneath <c>Library/Application Support</c>). Searched
     /// recursively so the intermediate segments — engine behaviour, and platform
-    /// dependent — are not hardcoded. Finding it in the sandbox also proves the HOME
-    /// redirection worked: the report landed here, not in the user's real profile.
+    /// dependent — are not hardcoded. The sandbox HOME is created empty by this test, so
+    /// any report found here was newly written by this launch; finding it in the sandbox
+    /// also proves the HOME redirection worked, keeping the user's real profile untouched.
     /// </summary>
     /// <param name="sandboxHome">The redirected HOME directory.</param>
     private static void AssertCrashReportWasWritten(string sandboxHome)
@@ -172,6 +187,19 @@ public class EngineLaunchSmokeTests : IDisposable
             + "exiting, so its absence means this was a different failure than the "
             + "no-game-data INI abort this test pins down.";
         Assert.True(reports.Count > 0, missingReportMessage);
+
+        var reportContents = File.ReadAllText(reports[0]);
+        Assert.False(
+            string.IsNullOrWhiteSpace(reportContents),
+            $"The crash report at '{reports[0]}' is empty; the known abort records its reason.");
+
+        // The stable line the abort writes is "; Reason Uncaught Exception during
+        // initialization." — asserted without the leading punctuation so a formatting
+        // change there cannot break the test, while the reason itself stays pinned.
+        Assert.Contains(
+            "Reason Uncaught Exception during initialization.",
+            reportContents,
+            StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/EngineLaunchSmokeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/EngineLaunchSmokeTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using GenHub.Core.Models.Launching;
+using GenHub.Features.GameProfiles.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.GameProfiles;
+
+/// <summary>
+/// Engine-only launch smoke test: starts the native client with no game data at all and
+/// requires the failure the engine is known to produce.
+/// <para>
+/// The engine cannot reach its main loop without content — with no readable INI it aborts
+/// with exit code 1 during initialisation. Launching it in an empty workspace therefore
+/// still proves the things CI otherwise never covers: the binary loads, its dylibs resolve
+/// relative to the executable, initialisation runs as far as INI loading, and the failure
+/// is a prompt exit rather than a hang. No licensed retail data is involved.
+/// </para>
+/// <para>
+/// Like the other native-client tests this skips when no client is present — unless
+/// <c>GENHUB_REQUIRE_NATIVE_SMOKE</c> is set, which CI uses to turn a missing client into
+/// a failure instead of a silent green run.
+/// </para>
+/// </summary>
+[Collection(NativeClientLaunchCollection.Name)]
+public class EngineLaunchSmokeTests : IDisposable
+{
+    /// <summary>
+    /// Environment variable that forbids skipping: when set to <c>1</c> or <c>true</c>, a
+    /// missing native client fails the test rather than passing it vacuously.
+    /// </summary>
+    public const string RequireEnvironmentVariable = "GENHUB_REQUIRE_NATIVE_SMOKE";
+
+    /// <summary>
+    /// How long the engine gets to exit before the test declares a hang. The observed
+    /// failure takes about a second; the margin covers a cold CI runner, not the engine.
+    /// </summary>
+    private static readonly TimeSpan ExitTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly string _tempRoot = Path.Combine(
+        Path.GetTempPath(),
+        $"genhub-engine-smoke-{Guid.NewGuid():N}");
+
+    private readonly GameProcessManager _processManager = new(NullLogger<GameProcessManager>.Instance);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EngineLaunchSmokeTests"/> class.
+    /// </summary>
+    public EngineLaunchSmokeTests() => Directory.CreateDirectory(_tempRoot);
+
+    private static bool IsSmokeRequired
+    {
+        get
+        {
+            var value = Environment.GetEnvironmentVariable(RequireEnvironmentVariable);
+            return string.Equals(value, "1", StringComparison.Ordinal)
+                || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// Stages the engine binary and its libraries into an empty workspace — no archives,
+    /// no retail roots — and launches headless with HOME redirected so the crash report
+    /// lands in the sandbox. The engine must exit, and exit with code 1.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task EngineWithNoGameData_ExitsWithCodeOne()
+    {
+        var installDirectory = NativeClientFixture.Directory;
+        if (installDirectory is null)
+        {
+            var missingClientMessage =
+                $"{RequireEnvironmentVariable} is set but no native client was found. "
+                + $"Point {NativeClientFixture.EnvironmentOverride} at a directory containing "
+                + $"'{NativeClientFixture.BinaryName}'.";
+            Assert.False(IsSmokeRequired, missingClientMessage);
+            return;
+        }
+
+        var workspace = StageEngineOnlyWorkspace(installDirectory);
+        var sandboxHome = Path.Combine(_tempRoot, "home");
+        Directory.CreateDirectory(sandboxHome);
+
+        // The exit code is only observable through the manager's exit event: the process
+        // handle stays internal, and GetProcessInfoAsync reports an exited process as
+        // not found. Subscribed before launch so a fast exit cannot slip past.
+        var exited = new TaskCompletionSource<int?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _processManager.ProcessExited += (_, e) => exited.TrySetResult(e.ExitCode);
+
+        var configuration = new GameLaunchConfiguration
+        {
+            ExecutablePath = Path.Combine(workspace, NativeClientFixture.BinaryName),
+            WorkingDirectory = workspace,
+            Arguments = new() { ["-headless"] = string.Empty },
+            EnvironmentVariables = new() { ["HOME"] = sandboxHome },
+        };
+
+        var result = await _processManager.StartProcessAsync(configuration);
+
+        if (!result.Success)
+        {
+            // The engine beat the launcher-detection delay. The manager folds the exit
+            // code into the error, so the assertion still pins it to exactly 1.
+            Assert.Contains(
+                "exited immediately with code 1",
+                string.Join(" ", result.Errors),
+                StringComparison.OrdinalIgnoreCase);
+            return;
+        }
+
+        var completed = await Task.WhenAny(exited.Task, Task.Delay(ExitTimeout));
+        if (completed != exited.Task)
+        {
+            await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
+            Assert.Fail(
+                $"The engine was still running {ExitTimeout.TotalSeconds:F0}s after launch with "
+                + "no game data. The known behaviour is a prompt abort with exit code 1; a hang "
+                + "here means startup no longer fails fast and the launcher could wait forever.");
+        }
+
+        var exitCode = await exited.Task;
+        Assert.NotNull(exitCode);
+        Assert.Equal(1, exitCode);
+    }
+
+    /// <summary>
+    /// Releases the temporary workspace and sandbox HOME.
+    /// </summary>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        _processManager.Dispose();
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test over.
+        }
+    }
+
+    /// <summary>
+    /// Copies only the engine binary and its dynamic libraries into a fresh directory.
+    /// Everything else in the source install — archives, retail roots, user files — is
+    /// deliberately left behind; their absence is the point of the test.
+    /// </summary>
+    /// <param name="installDirectory">The native client install to stage from.</param>
+    /// <returns>The staged workspace directory.</returns>
+    private string StageEngineOnlyWorkspace(string installDirectory)
+    {
+        var workspace = Path.Combine(_tempRoot, "workspace");
+        Directory.CreateDirectory(workspace);
+
+        foreach (var path in Directory.EnumerateFiles(installDirectory, "*", SearchOption.TopDirectoryOnly))
+        {
+            var name = Path.GetFileName(path);
+            if (name != NativeClientFixture.BinaryName && !NativeClientFixture.IsDynamicLibrary(name))
+            {
+                continue;
+            }
+
+            File.Copy(path, Path.Combine(workspace, name));
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                Path.Combine(workspace, NativeClientFixture.BinaryName),
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return workspace;
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/EngineLaunchSmokeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/EngineLaunchSmokeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using GenHub.Core.Models.Launching;
 using GenHub.Features.GameProfiles.Infrastructure;
@@ -63,7 +64,8 @@ public class EngineLaunchSmokeTests : IDisposable
     /// <summary>
     /// Stages the engine binary and its libraries into an empty workspace — no archives,
     /// no retail roots — and launches headless with HOME redirected so the crash report
-    /// lands in the sandbox. The engine must exit, and exit with code 1.
+    /// lands in the sandbox. The engine must exit with code 1 and leave its crash report
+    /// in the redirected HOME — the diagnostic that identifies this as the known abort.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
@@ -108,22 +110,25 @@ public class EngineLaunchSmokeTests : IDisposable
                 "exited immediately with code 1",
                 string.Join(" ", result.Errors),
                 StringComparison.OrdinalIgnoreCase);
-            return;
         }
-
-        var completed = await Task.WhenAny(exited.Task, Task.Delay(ExitTimeout));
-        if (completed != exited.Task)
+        else
         {
-            await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
-            Assert.Fail(
-                $"The engine was still running {ExitTimeout.TotalSeconds:F0}s after launch with "
-                + "no game data. The known behaviour is a prompt abort with exit code 1; a hang "
-                + "here means startup no longer fails fast and the launcher could wait forever.");
+            var completed = await Task.WhenAny(exited.Task, Task.Delay(ExitTimeout));
+            if (completed != exited.Task)
+            {
+                await _processManager.TerminateProcessAsync(result.Data!.ProcessId);
+                Assert.Fail(
+                    $"The engine was still running {ExitTimeout.TotalSeconds:F0}s after launch with "
+                    + "no game data. The known behaviour is a prompt abort with exit code 1; a hang "
+                    + "here means startup no longer fails fast and the launcher could wait forever.");
+            }
+
+            var exitCode = await exited.Task;
+            Assert.NotNull(exitCode);
+            Assert.Equal(1, exitCode);
         }
 
-        var exitCode = await exited.Task;
-        Assert.NotNull(exitCode);
-        Assert.Equal(1, exitCode);
+        AssertCrashReportWasWritten(sandboxHome);
     }
 
     /// <summary>
@@ -144,6 +149,29 @@ public class EngineLaunchSmokeTests : IDisposable
         {
             // A leftover temp directory is not worth failing a test over.
         }
+    }
+
+    /// <summary>
+    /// Asserts the abort produced its diagnostic. In this failure mode stderr is empty;
+    /// what the engine leaves behind is a crash report named <c>ReleaseCrashInfo.txt</c>
+    /// under HOME (on macOS beneath <c>Library/Application Support</c>). Searched
+    /// recursively so the intermediate segments — engine behaviour, and platform
+    /// dependent — are not hardcoded. Finding it in the sandbox also proves the HOME
+    /// redirection worked: the report landed here, not in the user's real profile.
+    /// </summary>
+    /// <param name="sandboxHome">The redirected HOME directory.</param>
+    private static void AssertCrashReportWasWritten(string sandboxHome)
+    {
+        var reports = Directory
+            .EnumerateFiles(sandboxHome, "ReleaseCrashInfo.txt", SearchOption.AllDirectories)
+            .ToList();
+
+        var missingReportMessage =
+            "The engine exited with code 1 but wrote no ReleaseCrashInfo.txt under the "
+            + $"redirected HOME '{sandboxHome}'. The known abort writes that report before "
+            + "exiting, so its absence means this was a different failure than the "
+            + "no-game-data INI abort this test pins down.";
+        Assert.True(reports.Count > 0, missingReportMessage);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds an engine-only launch smoke test and a `macos-15` CI job, and makes the build
summary report job outcomes accurately.

Closes #324.

## Why this needs no retail data

The test asserts the engine's documented failure path rather than a successful
launch. With no readable content the engine aborts during initialisation with exit 1
and writes `ReleaseCrashInfo.txt` — the same property #315 relies on for pre-spawn
validation. Asserting that abort exercises the real binary end to end without
shipping or fixturing any retail archives.

The test pins the retail install-path variables, asserts the crash report's reason
line, and confirms the report lands under the sandboxed `HOME` so CI leaves nothing
behind.

## Build summary changes

Two related fixes, both in `ci.yml`:

- `engine-launch-smoke` is included in the summary's `needs`, so its result is
  reflected rather than ignored.
- Failed jobs now fail the summary, and skipped jobs render as skipped instead of
  as "❌ Failed". A skipped `build-macos` previously reported as a failure, which
  made a green run look broken.

## Rebase note

This branch was stacked on `feat/native-launch`, which squash-merged as #332. Its
five commits were replayed onto `development` with
`git rebase --onto origin/development d1adeeb`. No conflicts and no adaptation
needed.

## Testing

- `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release`
  - Passed: 1,538
  - Failed: 0
- The `macos-15` job itself is exercised by this PR's own CI run.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a macOS engine-only launch smoke test and updates the Build Summary to account for all prerequisite jobs accurately.
- Downloads and stages the ARM64 native engine on `macos-15`.
- Exercises the engine’s expected no-content abort and validates its crash report.
- Adds `detect-changes` and the smoke job to the summary dependencies and propagates failed or cancelled results.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the summary now directly observes `detect-changes`, runs regardless of prerequisite outcomes, and fails when any required job fails or is cancelled.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the macOS smoke job and correctly closes the previously reported gate hole by including `detect-changes` directly in the summary’s dependencies. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/EngineLaunchSmokeTests.cs | Adds an engine-only smoke test that launches in an isolated workspace and verifies the documented no-content failure path. |

</details>

<sub>Reviews (4): Last reviewed commit: ["ci: drop the unused checkout from the bu..."](https://github.com/community-outpost/genhub/commit/caeadd60b0455cd831d099436e48e3e48d8af0d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49662145)</sub>

<!-- /greptile_comment -->