### PR TITLE
fix(macos): clear quarantine from materialized game executables

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/QuarantineClearingTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/QuarantineClearingTests.cs
@@ -72,8 +72,11 @@ public sealed class QuarantineClearingTests : IDisposable
             SetQuarantine(path);
         }
 
-        ExecutableFileSwap.MakeExecutable(path);
+        var quarantineCleared = ExecutableFileSwap.MakeExecutable(path);
 
+        // Callers log on false, so the reported value has to be accurate and not merely
+        // a constant the call site would never act on.
+        Assert.True(quarantineCleared);
         Assert.True(File.GetUnixFileMode(path).HasFlag(UnixFileMode.UserExecute));
         Assert.Equal("engine binary", File.ReadAllText(path));
         if (OperatingSystem.IsMacOS())
@@ -122,7 +125,13 @@ public sealed class QuarantineClearingTests : IDisposable
             RedirectStandardError = true,
         })!;
 
-        var output = process.StandardOutput.ReadToEnd();
+        // Both streams are read before waiting. Draining only one risks the child
+        // blocking on a full pipe for the other, which would hang the test run rather
+        // than fail it.
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var output = outputTask.GetAwaiter().GetResult();
+        errorTask.GetAwaiter().GetResult();
         process.WaitForExit();
         return (process.ExitCode, output);
     }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/QuarantineClearingTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/QuarantineClearingTests.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics;
+using GenHub.Features.Workspace;
+
+namespace GenHub.Tests.Core.Features.Workspace;
+
+/// <summary>
+/// Tests that materialized executables do not carry macOS's quarantine attribute.
+/// </summary>
+public sealed class QuarantineClearingTests : IDisposable
+{
+    private readonly string _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuarantineClearingTests"/> class.
+    /// </summary>
+    public QuarantineClearingTests()
+    {
+        Directory.CreateDirectory(_tempPath);
+    }
+
+    /// <summary>
+    /// A quarantined file is the case that matters: it is what a downloaded GenHub
+    /// propagates onto the engine binary, and what Gatekeeper then refuses to run.
+    /// </summary>
+    [Fact]
+    public void TryClearQuarantine_WhenFileIsQuarantined_RemovesTheAttribute()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        var path = Path.Combine(_tempPath, "engine");
+        File.WriteAllText(path, "engine binary");
+        SetQuarantine(path);
+        Assert.True(HasQuarantine(path), "the fixture must start out quarantined");
+
+        Assert.True(MacOSNativeMethods.TryClearQuarantine(path));
+
+        Assert.False(HasQuarantine(path));
+    }
+
+    /// <summary>
+    /// Most files are never quarantined, so the absent case is the common one and must
+    /// report success rather than an error.
+    /// </summary>
+    [Fact]
+    public void TryClearQuarantine_WhenFileIsNotQuarantined_ReportsSuccess()
+    {
+        var path = Path.Combine(_tempPath, "plain");
+        File.WriteAllText(path, "not quarantined");
+
+        Assert.True(MacOSNativeMethods.TryClearQuarantine(path));
+    }
+
+    /// <summary>
+    /// The swap is what materialization actually calls, so the attribute must be gone
+    /// from the file it leaves behind, not merely from the temporary copy.
+    /// </summary>
+    [Fact]
+    public void MakeExecutable_LeavesTheSwappedFileWithoutQuarantine()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(_tempPath, "generals");
+        File.WriteAllText(path, "engine binary");
+        if (OperatingSystem.IsMacOS())
+        {
+            SetQuarantine(path);
+        }
+
+        ExecutableFileSwap.MakeExecutable(path);
+
+        Assert.True(File.GetUnixFileMode(path).HasFlag(UnixFileMode.UserExecute));
+        Assert.Equal("engine binary", File.ReadAllText(path));
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.False(HasQuarantine(path));
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempPath, true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort cleanup for temporary test files.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    // Applied through xattr rather than a P/Invoke of setxattr: the test should prove the
+    // production path clears what macOS itself considers quarantine, not merely the bytes
+    // this test wrote.
+    private static void SetQuarantine(string path)
+    {
+        RunXattr($"-w com.apple.quarantine 0083;00000000;GenHubTests; \"{path}\"");
+    }
+
+    private static bool HasQuarantine(string path)
+    {
+        return RunXattr($"-p com.apple.quarantine \"{path}\"").exitCode == 0;
+    }
+
+    private static (int exitCode, string output) RunXattr(string arguments)
+    {
+        using var process = Process.Start(new ProcessStartInfo("/usr/bin/xattr", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        })!;
+
+        var output = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output);
+    }
+}

--- a/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
+++ b/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
@@ -51,6 +51,17 @@ internal static class ExecutableFileSwap
                 File.SetUnixFileMode(temporaryPath, ExecutableMode);
             }
 
+            // On macOS the execute bit alone is not enough. A GenHub that was itself
+            // downloaded carries com.apple.quarantine, and macOS propagates that to the
+            // files it writes — so the engine binary lands quarantined and Gatekeeper
+            // refuses to run it. The user sees GenHub start normally and the game fail,
+            // which is a hard failure to attribute. Clearing it here, on the private copy
+            // GenHub just created, keeps that invisible to them.
+            //
+            // Cleared before the swap for the same reason the mode is: the destination is
+            // never observable in a half-prepared state.
+            MacOSNativeMethods.TryClearQuarantine(temporaryPath);
+
             File.Move(temporaryPath, targetPath, overwrite: true);
         }
         catch

--- a/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
+++ b/GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs
@@ -36,7 +36,13 @@ internal static class ExecutableFileSwap
     /// Swaps the file at <paramref name="targetPath"/> for an executable private copy.
     /// </summary>
     /// <param name="targetPath">The absolute path of the workspace file.</param>
-    internal static void MakeExecutable(string targetPath)
+    /// <returns>
+    /// <c>true</c> when the resulting file is known not to be quarantined. <c>false</c>
+    /// means the file is executable but macOS may still refuse to run it, which callers
+    /// should report — it is the difference between a working profile and a game that
+    /// will not start for a reason nothing else explains.
+    /// </returns>
+    internal static bool MakeExecutable(string targetPath)
     {
         var temporaryPath = targetPath + TemporaryMarker + Guid.NewGuid().ToString("N");
 
@@ -60,9 +66,15 @@ internal static class ExecutableFileSwap
             //
             // Cleared before the swap for the same reason the mode is: the destination is
             // never observable in a half-prepared state.
-            MacOSNativeMethods.TryClearQuarantine(temporaryPath);
+            var quarantineCleared = MacOSNativeMethods.TryClearQuarantine(temporaryPath);
 
             File.Move(temporaryPath, targetPath, overwrite: true);
+
+            // Not an exception: the file is materialized and correct, and failing the
+            // whole swap would be worse than a file that needs one manual command. The
+            // caller logs it so the cause is recoverable from the logs when a launch is
+            // later refused.
+            return quarantineCleared;
         }
         catch
         {

--- a/GenHub/GenHub/Features/Workspace/MacOSNativeMethods.cs
+++ b/GenHub/GenHub/Features/Workspace/MacOSNativeMethods.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GenHub.Features.Workspace;
+
+/// <summary>
+/// The libc calls GenHub needs on macOS only.
+/// <para>
+/// Separate from <see cref="UnixNativeMethods"/> by design. That type is restricted to
+/// functions whose signatures are identical on Linux and macOS; <c>removexattr</c> is
+/// not one of them, because macOS takes a trailing <c>options</c> argument that Linux
+/// does not. Declaring it there would be wrong on Linux in a way the compiler cannot
+/// catch.
+/// </para>
+/// </summary>
+internal static partial class MacOSNativeMethods
+{
+    /// <summary>
+    /// The extended attribute macOS sets on files that arrived from an untrusted source.
+    /// Gatekeeper refuses to execute anything carrying it until the user approves.
+    /// </summary>
+    private const string QuarantineAttribute = "com.apple.quarantine";
+
+    /// <summary>Act on the symlink itself rather than its target.</summary>
+    private const int XattrNoFollow = 0x0001;
+
+    /// <summary>The attribute was not present, POSIX <c>ENOATTR</c> on macOS.</summary>
+    private const int ENOATTR = 93;
+
+    /// <summary>
+    /// Removes the quarantine attribute from a file, if it carries one.
+    /// </summary>
+    /// <param name="path">The absolute path of the file to clear.</param>
+    /// <returns>
+    /// <c>true</c> when the file is known not to be quarantined afterwards — either the
+    /// attribute was removed or it was never there. <c>false</c> when the attribute could
+    /// not be removed, which leaves the file executable-but-blocked.
+    /// </returns>
+    /// <remarks>
+    /// Returns <c>true</c> unchanged on every non-macOS platform: no other system has this
+    /// attribute, so there is nothing to clear and nothing to report.
+    /// </remarks>
+    internal static bool TryClearQuarantine(string path)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return true;
+        }
+
+        // Follow symlinks is wrong here: the workspace entry is what has to be runnable,
+        // and clearing a link target would touch a file this workspace may not own.
+        if (RemoveExtendedAttribute(path, QuarantineAttribute, XattrNoFollow) == 0)
+        {
+            return true;
+        }
+
+        // Nothing to remove is the common case and not a failure — most files are never
+        // quarantined, and a build run from a developer machine never is.
+        return Marshal.GetLastPInvokeError() == ENOATTR;
+    }
+
+    [LibraryImport("libc", EntryPoint = "removexattr", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int RemoveExtendedAttribute(string path, string name, int options);
+}

--- a/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs
@@ -644,7 +644,16 @@ public abstract class WorkspaceStrategyBase<T>(
             // A delete-then-move sequence would expose both of those states. The second
             // is only papered over later — validation can restore a lost execute bit on
             // the entry point, but not on any other executable the manifest names.
-            await Task.Run(() => ExecutableFileSwap.MakeExecutable(targetPath), cancellationToken);
+            var quarantineCleared = await Task.Run(
+                () => ExecutableFileSwap.MakeExecutable(targetPath),
+                cancellationToken);
+            if (!quarantineCleared)
+            {
+                Logger.LogWarning(
+                    "Could not clear the macOS quarantine attribute from {RelativePath}; " +
+                    "macOS may refuse to launch it until it is cleared manually",
+                    file.RelativePath);
+            }
 
             Logger.LogDebug("Marked {RelativePath} executable on a workspace-owned copy", file.RelativePath);
         }

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -360,7 +360,16 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
 
         try
         {
-            await Task.Run(() => ExecutableFileSwap.MakeExecutable(executablePath), cancellationToken);
+            var quarantineCleared = await Task.Run(
+                () => ExecutableFileSwap.MakeExecutable(executablePath),
+                cancellationToken);
+            if (!quarantineCleared)
+            {
+                logger.LogWarning(
+                    "Could not clear the macOS quarantine attribute from workspace entry point {ExecutablePath}; " +
+                    "macOS may refuse to launch it until it is cleared manually",
+                    executablePath);
+            }
         }
         catch (Exception ex)
         {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,29 @@ Launcher for C&C: Generals and Zero Hour with patch management and mod support
 - [ ] Comprehensive mod support with easy installation
 - [ ] Compatibility fixes for Windows 10/11
 
+## Installing on macOS
+
+GenHub is not signed with an Apple Developer ID, so macOS quarantines it after
+download and Gatekeeper refuses to open it. Clear the quarantine attribute once,
+before the first launch:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/GenHub.app
+```
+
+You can instead open **System Settings → Privacy & Security**, find the blocked-app
+notice after a failed launch attempt, and choose **Open Anyway**. The Control-click →
+*Open* shortcut no longer works for unsigned apps; Apple removed it in macOS 15.
+
+Prefer the command. macOS propagates quarantine from a quarantined application to the
+files it writes, and if GenHub is still marked when it first runs, that can reach the
+game files it prepares. GenHub clears the attribute from the game executables it
+materializes, so the game itself launches either way — but clearing it on the app up
+front avoids the situation entirely.
+
+None of this applies to a build you compiled yourself. Quarantine is only attached to
+downloaded files.
+
 ## Documentation
 
 For detailed documentation and guides, visit our [Wiki](https://generalshub.netlify.app/wiki/).


### PR DESCRIPTION
## Summary

Makes an unsigned macOS build usable without an Apple Developer ID, by removing the
quarantine attribute from the game executables GenHub materializes and documenting the
one manual step users need for the app itself.

Addresses the practical half of #322. See "Scope" below — this does not close it.

## Why not signing

Notarization needs a Developer ID Application certificate, which needs a paid Apple
Developer Program membership. That is not being purchased, so the notarization half of
#322 is unreachable and no amount of build work substitutes for it.

What can be fixed without Apple is the part users actually hit. #322's two acceptance
criteria are that GenHub opens, and that the game binary launches. Only the first needs
a certificate.

## The failure this fixes

macOS propagates `com.apple.quarantine` from a quarantined application to the files it
writes. A downloaded GenHub therefore materializes a quarantined engine binary, and
Gatekeeper refuses to execute it — so GenHub starts normally and the game does not,
which is close to undiagnosable from the user's side.

`ExecutableFileSwap` already creates a private copy of each workspace executable and
sets its execute bit. Clearing the attribute at that same point costs one call and
keeps the whole problem invisible: GenHub removes it from a file GenHub just created,
after the user has already approved GenHub.

## Implementation

- `MacOSNativeMethods.TryClearQuarantine` wraps `removexattr(2)`, and is a no-op
  returning success on every other platform.
- It is a separate type from `UnixNativeMethods` deliberately. That type documents
  itself as holding only signatures identical on Linux and macOS, and `removexattr` is
  not one — macOS takes a trailing `options` argument that Linux does not, so a shared
  declaration would be wrong on Linux in a way the compiler cannot catch.
- `XATTR_NOFOLLOW` is passed: the workspace entry is what has to run, and following a
  symlink could clear an attribute on a file this workspace does not own.
- A missing attribute (`ENOATTR`) reports success. Most files are never quarantined,
  and a locally built GenHub never is.
- Cleared before the atomic swap, for the same reason the mode is: the destination is
  never observable in a half-prepared state.

## README

Adds a macOS install section. It leads with
`xattr -dr com.apple.quarantine /Applications/GenHub.app` rather than **Open Anyway**,
and notes that the Control-click → *Open* shortcut stopped working in macOS 15.

## Testing

`dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj -c Release`
— 1,540 passed, 0 failed. `dotnet build GenHub/GenHub.Linux/GenHub.Linux.csproj -c Release`
— passed, which is what covers the non-macOS path.

The three new tests are real rather than mocked: they apply a genuine
`com.apple.quarantine` through `/usr/bin/xattr`, assert the fixture starts out
quarantined, and then assert the production path clears it — so they prove the P/Invoke
works against what macOS itself considers quarantine. They no-op off macOS.

## Scope

**This does not close #322.** Its acceptance criteria require notarization to pass and
be reproducible in CI, which cannot happen without a Developer ID. #322 needs rescoping
or closing as not-planned, and #327's Alpha 5 definition of done — "the three PRs land
and #322 notarization passes — at that point there is a distributable macOS build" —
needs rewording, because there is no distributable macOS build in the Gatekeeper sense.

Two things remain unverified and need a real download-and-run on a clean machine:
whether **Open Anyway** removes the attribute or merely records an approval, and
whether quarantine reaches any shared libraries the native client loads. This change
makes the executable case robust regardless of the first answer.

The signing and notarization pipeline is not abandoned, only unmerged: it lives on
`feat/macos-signing-notarization` with inside-out signing verified end-to-end under an
ad-hoc identity, ready if a Developer ID is ever purchased.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes macOS quarantine metadata while preparing private executable copies and documents the manual application-level quarantine workaround.
- Adds a macOS-specific `removexattr` wrapper with non-macOS no-op behavior.
- Propagates quarantine-clear status to workspace preparation and validation callers.
- Adds platform-aware integration tests for quarantine removal and executable swapping.
- Documents installation steps for unsigned macOS builds.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not yet appear safe to merge because failure to clear quarantine still allows workspace preparation and validation to succeed before the game launch is blocked.

The previously reported failure remains: both current callers only log a false quarantine-clear result, and WorkspaceValidator subsequently returns success, leaving the quarantined entry point reachable by the launch path.

**Files Needing Attention:** GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs, GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs, GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Workspace/ExecutableFileSwap.cs | Prepares the temporary executable, attempts quarantine removal, atomically publishes it, and returns the removal status. |
| GenHub/GenHub/Features/Workspace/MacOSNativeMethods.cs | Adds the macOS `removexattr` interop wrapper and treats an absent quarantine attribute as success. |
| GenHub/GenHub/Features/Workspace/Strategies/WorkspaceStrategyBase.cs | Captures quarantine-clear status during manifest file materialization and emits a warning when clearing fails. |
| GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs | Reapplies executable preparation during entry-point validation and records quarantine-clear failures in logs. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/QuarantineClearingTests.cs | Adds platform-aware tests covering present and absent quarantine attributes and the complete executable swap. |
| README.md | Documents the required quarantine-removal step and alternative macOS approval flow. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(macos): report quarantine-clearing f..."](https://github.com/community-outpost/genhub/commit/584d167b987c7f47a66650bed3b9ac3706e52883) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49783489)</sub>

**Context used:**

- Knowledge Base — [Workspace Assembly](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/workspace-assembly.md)

<!-- /greptile_comment -->