### PR TITLE
feat(content): forward-port GenLauncher file normalization from alpha-4 (#288)

### DIFF
--- a/GenHub/GenHub.Core/Constants/GenLauncherConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GenLauncherConstants.cs
@@ -1,0 +1,47 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Constants for GenLauncher file normalization.
+/// </summary>
+public static class GenLauncherConstants
+{
+    /// <summary>
+    /// GenLauncher Replace suffix - appended to original game files when temporarily disabled.
+    /// </summary>
+    public const string ReplaceSuffix = ".GLR";
+
+    /// <summary>
+    /// GenLauncher Original File suffix - backup suffix for original files before modification.
+    /// </summary>
+    public const string OriginalFileSuffix = ".GOF";
+
+    /// <summary>
+    /// GenLauncher Temp Copy suffix - temporary folder suffix for version copies.
+    /// </summary>
+    public const string TempCopySuffix = ".GLTC";
+
+    /// <summary>
+    /// GenLauncher scrambled .big file extension.
+    /// </summary>
+    public const string GibExtension = ".gib";
+
+    /// <summary>
+    /// Standard .big file extension.
+    /// </summary>
+    public const string BigExtension = ".big";
+
+    /// <summary>
+    /// All GenLauncher suffixes that should be removed during normalization.
+    /// </summary>
+    public static readonly string[] AllSuffixes =
+    [
+        ReplaceSuffix,
+        OriginalFileSuffix,
+        TempCopySuffix,
+    ];
+
+    /// <summary>
+    /// Session key for "do not ask again" preference for normalization dialog.
+    /// </summary>
+    public const string NormalizationDialogSessionKey = "genlauncher.normalization.skip";
+}

--- a/GenHub/GenHub.Core/Constants/GenLauncherConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GenLauncherConstants.cs
@@ -31,6 +31,11 @@ public static class GenLauncherConstants
     public const string BigExtension = ".big";
 
     /// <summary>
+    /// Session key for "do not ask again" preference for normalization dialog.
+    /// </summary>
+    public const string NormalizationDialogSessionKey = "genlauncher.normalization.skip";
+
+    /// <summary>
     /// All GenLauncher suffixes that should be removed during normalization.
     /// </summary>
     public static readonly string[] AllSuffixes =
@@ -39,9 +44,4 @@ public static class GenLauncherConstants
         OriginalFileSuffix,
         TempCopySuffix,
     ];
-
-    /// <summary>
-    /// Session key for "do not ask again" preference for normalization dialog.
-    /// </summary>
-    public const string NormalizationDialogSessionKey = "genlauncher.normalization.skip";
 }

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Result of GenLauncher file detection.
+/// </summary>
+public class GenLauncherDetectionResult
+{
+    /// <summary>
+    /// Whether any GenLauncher files were detected.
+    /// </summary>
+    public bool HasGenLauncherFiles { get; set; }
+
+    /// <summary>
+    /// List of .gib files found.
+    /// </summary>
+    public List<string> GibFiles { get; set; } = [];
+
+    /// <summary>
+    /// List of files with .GLR suffix.
+    /// </summary>
+    public List<string> GlrFiles { get; set; } = [];
+
+    /// <summary>
+    /// List of files with .GOF suffix.
+    /// </summary>
+    public List<string> GofFiles { get; set; } = [];
+
+    /// <summary>
+    /// List of files with .GLTC suffix.
+    /// </summary>
+    public List<string> GltcFiles { get; set; } = [];
+
+    /// <summary>
+    /// List of symbolic links detected.
+    /// </summary>
+    public List<string> SymbolicLinks { get; set; } = [];
+
+    /// <summary>
+    /// Total count of affected files.
+    /// </summary>
+    public int TotalAffectedFiles =>
+        GibFiles.Count + GlrFiles.Count + GofFiles.Count + GltcFiles.Count + SymbolicLinks.Count;
+
+    /// <summary>
+    /// Gets a user-friendly summary of detected files.
+    /// </summary>
+    /// <returns>Summary string.</returns>
+    public string GetSummary()
+    {
+        var parts = new List<string>();
+        if (GibFiles.Count > 0)
+        {
+            parts.Add($"{GibFiles.Count} .gib file(s)");
+        }
+
+        if (GlrFiles.Count > 0)
+        {
+            parts.Add($"{GlrFiles.Count} .GLR file(s)");
+        }
+
+        if (GofFiles.Count > 0)
+        {
+            parts.Add($"{GofFiles.Count} .GOF file(s)");
+        }
+
+        if (GltcFiles.Count > 0)
+        {
+            parts.Add($"{GltcFiles.Count} .GLTC file(s)");
+        }
+
+        if (SymbolicLinks.Count > 0)
+        {
+            parts.Add($"{SymbolicLinks.Count} symbolic link(s)");
+        }
+
+        return parts.Count > 0 ? string.Join(", ", parts) : "No GenLauncher files detected";
+    }
+}

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
@@ -8,37 +8,37 @@ namespace GenHub.Core.Interfaces.Content;
 public class GenLauncherDetectionResult
 {
     /// <summary>
-    /// Whether any GenLauncher files were detected.
+    /// Gets or sets a value indicating whether any GenLauncher files were detected.
     /// </summary>
     public bool HasGenLauncherFiles { get; set; }
 
     /// <summary>
-    /// List of .gib files found.
+    /// Gets or sets the list of .gib files found.
     /// </summary>
     public List<string> GibFiles { get; set; } = [];
 
     /// <summary>
-    /// List of files with .GLR suffix.
+    /// Gets or sets the list of files with .GLR suffix.
     /// </summary>
     public List<string> GlrFiles { get; set; } = [];
 
     /// <summary>
-    /// List of files with .GOF suffix.
+    /// Gets or sets the list of files with .GOF suffix.
     /// </summary>
     public List<string> GofFiles { get; set; } = [];
 
     /// <summary>
-    /// List of files with .GLTC suffix.
+    /// Gets or sets the list of files with .GLTC suffix.
     /// </summary>
     public List<string> GltcFiles { get; set; } = [];
 
     /// <summary>
-    /// List of symbolic links detected.
+    /// Gets or sets the list of symbolic links detected.
     /// </summary>
     public List<string> SymbolicLinks { get; set; } = [];
 
     /// <summary>
-    /// Total count of affected files.
+    /// Gets the total count of affected files.
     /// </summary>
     public int TotalAffectedFiles =>
         GibFiles.Count + GlrFiles.Count + GofFiles.Count + GltcFiles.Count + SymbolicLinks.Count;

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using GenHub.Core.Constants;
 
 namespace GenHub.Core.Interfaces.Content;
 
@@ -52,22 +53,22 @@ public class GenLauncherDetectionResult
         var parts = new List<string>();
         if (GibFiles.Count > 0)
         {
-            parts.Add($"{GibFiles.Count} .gib file(s)");
+            parts.Add($"{GibFiles.Count} {GenLauncherConstants.GibExtension} file(s)");
         }
 
         if (GlrFiles.Count > 0)
         {
-            parts.Add($"{GlrFiles.Count} .GLR file(s)");
+            parts.Add($"{GlrFiles.Count} {GenLauncherConstants.ReplaceSuffix} file(s)");
         }
 
         if (GofFiles.Count > 0)
         {
-            parts.Add($"{GofFiles.Count} .GOF file(s)");
+            parts.Add($"{GofFiles.Count} {GenLauncherConstants.OriginalFileSuffix} file(s)");
         }
 
         if (GltcFiles.Count > 0)
         {
-            parts.Add($"{GltcFiles.Count} .GLTC file(s)");
+            parts.Add($"{GltcFiles.Count} {GenLauncherConstants.TempCopySuffix} file(s)");
         }
 
         if (SymbolicLinks.Count > 0)

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Result of GenLauncher file normalization.
+/// </summary>
+public class GenLauncherNormalizationResult
+{
+    /// <summary>
+    /// Number of files successfully normalized.
+    /// </summary>
+    public int NormalizedCount { get; set; }
+
+    /// <summary>
+    /// Number of symbolic links removed.
+    /// </summary>
+    public int SymbolicLinksRemoved { get; set; }
+
+    /// <summary>
+    /// List of files that failed to normalize.
+    /// </summary>
+    public List<string> FailedFiles { get; set; } = [];
+
+    /// <summary>
+    /// Whether normalization was fully successful.
+    /// </summary>
+    public bool IsFullySuccessful => FailedFiles.Count == 0;
+}

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
@@ -8,22 +8,22 @@ namespace GenHub.Core.Interfaces.Content;
 public class GenLauncherNormalizationResult
 {
     /// <summary>
-    /// Number of files successfully normalized.
+    /// Gets or sets the number of files successfully normalized.
     /// </summary>
     public int NormalizedCount { get; set; }
 
     /// <summary>
-    /// Number of symbolic links removed.
+    /// Gets or sets the number of symbolic links removed.
     /// </summary>
     public int SymbolicLinksRemoved { get; set; }
 
     /// <summary>
-    /// List of files that failed to normalize.
+    /// Gets or sets the list of files that failed to normalize.
     /// </summary>
     public List<string> FailedFiles { get; set; } = [];
 
     /// <summary>
-    /// Whether normalization was fully successful.
+    /// Gets a value indicating whether normalization was fully successful.
     /// </summary>
     public bool IsFullySuccessful => FailedFiles.Count == 0;
 }

--- a/GenHub/GenHub.Core/Interfaces/Content/IGenLauncherNormalizationService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IGenLauncherNormalizationService.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Service for detecting and normalizing GenLauncher file modifications.
+/// </summary>
+public interface IGenLauncherNormalizationService
+{
+    /// <summary>
+    /// Detects GenLauncher files (.gib, .GLR, .GOF, .GLTC) in the specified directory.
+    /// </summary>
+    /// <param name="directoryPath">The directory to scan.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Detection result with list of affected files.</returns>
+    Task<GenLauncherDetectionResult> DetectGenLauncherFilesAsync(string directoryPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Normalizes GenLauncher files in the specified directory.
+    /// Converts .gib to .big and removes .GLR, .GOF, .GLTC suffixes.
+    /// </summary>
+    /// <param name="directoryPath">The directory containing files to normalize.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result with normalization details.</returns>
+    Task<OperationResult<GenLauncherNormalizationResult>> NormalizeFilesAsync(
+        string directoryPath,
+        CancellationToken cancellationToken = default);
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
@@ -50,6 +50,8 @@ public class GameProfileLauncherViewModelTests
                 null,
                 new Mock<IContentStorageService>().Object,
                 null, // ILocalContentService
+                null, // IGenLauncherNormalizationService
+                null, // IDialogService
                 NullLogger<GameProfileSettingsViewModel>.Instance,
                 NullLogger<GameSettingsViewModel>.Instance),
             new Mock<IProfileEditorFacade>().Object,
@@ -94,6 +96,8 @@ public class GameProfileLauncherViewModelTests
                 null,
                 new Mock<IContentStorageService>().Object,
                 null, // ILocalContentService
+                null, // IGenLauncherNormalizationService
+                null, // IDialogService
                 NullLogger<GameProfileSettingsViewModel>.Instance,
                 NullLogger<GameSettingsViewModel>.Instance),
             new Mock<IProfileEditorFacade>().Object,
@@ -358,6 +362,8 @@ public class GameProfileLauncherViewModelTests
                 null,
                 new Mock<IContentStorageService>().Object,
                 null, // ILocalContentService
+                null, // IGenLauncherNormalizationService
+                null, // IDialogService
                 NullLogger<GameProfileSettingsViewModel>.Instance,
                 NullLogger<GameSettingsViewModel>.Instance),
             new Mock<IProfileEditorFacade>().Object,

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -52,6 +52,8 @@ public class GameProfileSettingsViewModelDependencyTests
             _mockManifestPool.Object,
             null, // IContentStorageService
             null, // ILocalContentService
+            null, // IGenLauncherNormalizationService
+            null, // IDialogService
             NullLogger<GameProfileSettingsViewModel>.Instance,
             NullLogger<GameSettingsViewModel>.Instance);
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
@@ -82,6 +82,8 @@ public class GameProfileSettingsViewModelTests
             null, // IContentManifestPool
             null, // IContentStorageService
             null, // ILocalContentService
+            null, // IGenLauncherNormalizationService
+            null, // IDialogService
             nullLogger,
             gameSettingsLogger);
 
@@ -141,6 +143,8 @@ public class GameProfileSettingsViewModelTests
             null, // IContentManifestPool
             null, // IContentStorageService
             null, // ILocalContentService
+            null, // IGenLauncherNormalizationService
+            null, // IDialogService
             nullLogger,
             gameSettingsLogger);
 
@@ -228,6 +232,8 @@ public class GameProfileSettingsViewModelTests
             mockManifestPool.Object,
             null, // IContentStorageService
             null, // ILocalContentService
+            null, // IGenLauncherNormalizationService
+            null, // IDialogService
             logger,
             NullLogger<GameSettingsViewModel>.Instance);
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
@@ -326,6 +326,8 @@ public class MainViewModelTests
             null, // IContentManifestPool
             null, // IContentStorageService
             null, // ILocalContentService
+            null, // IGenLauncherNormalizationService
+            null, // IDialogService
             NullLogger<GameProfileSettingsViewModel>.Instance,
             NullLogger<GameSettingsViewModel>.Instance);
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
@@ -7,6 +7,7 @@ using GenHub.Core.Utilities;
 using GenHub.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Xunit.Abstractions;
 
 namespace GenHub.Tests.Core.Infrastructure.Services;
 
@@ -17,12 +18,15 @@ public class GenLauncherNormalizationServiceTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly GenLauncherNormalizationService _service;
+    private readonly ITestOutputHelper _testOutput;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GenLauncherNormalizationServiceTests"/> class.
     /// </summary>
-    public GenLauncherNormalizationServiceTests()
+    /// <param name="testOutput">The test output helper.</param>
+    public GenLauncherNormalizationServiceTests(ITestOutputHelper testOutput)
     {
+        _testOutput = testOutput;
         _tempDir = Path.Combine(Path.GetTempPath(), "GenHubTests", Guid.NewGuid().ToString());
         Directory.CreateDirectory(_tempDir);
         _service = new GenLauncherNormalizationService(new Mock<ILogger<GenLauncherNormalizationService>>().Object);
@@ -186,6 +190,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     {
         if (!TryCreateFileSymlink(out var skipReason))
         {
+            _testOutput.WriteLine($"Not exercised: file symbolic links are unavailable here ({skipReason}).");
             return;
         }
 
@@ -211,6 +216,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     {
         if (!TryCreateFileSymlink(out var skipReason))
         {
+            _testOutput.WriteLine($"Not exercised: file symbolic links are unavailable here ({skipReason}).");
             return;
         }
 
@@ -234,6 +240,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     {
         if (!TryCreateDirectorySymlink(out var skipReason))
         {
+            _testOutput.WriteLine($"Not exercised: directory symbolic links are unavailable here ({skipReason}).");
             return;
         }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
@@ -1,0 +1,358 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GenHub.Tests.Core.Infrastructure.Services;
+
+/// <summary>
+/// Tests for <see cref="GenLauncherNormalizationService"/>.
+/// </summary>
+public class GenLauncherNormalizationServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly GenLauncherNormalizationService _service;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenLauncherNormalizationServiceTests"/> class.
+    /// </summary>
+    public GenLauncherNormalizationServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "GenHubTests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+        _service = new GenLauncherNormalizationService(new Mock<ILogger<GenLauncherNormalizationService>>().Object);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, true);
+            }
+        }
+        catch
+        {
+            // Allowed to fail during cleanup
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Tests that .gib files are converted to .big.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_ConvertsGibToBig()
+    {
+        var gibPath = Path.Combine(_tempDir, "data.gib");
+        await File.WriteAllTextAsync(gibPath, "gib-content");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.NormalizedCount);
+        Assert.False(File.Exists(gibPath));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "data.big")));
+    }
+
+    /// <summary>
+    /// Tests that GenLauncher suffixes are removed from files.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_RemovesSuffixes()
+    {
+        var glrPath = Path.Combine(_tempDir, "sound.wav.GLR");
+        var gofPath = Path.Combine(_tempDir, "texture.tga.GOF");
+        var gltcPath = Path.Combine(_tempDir, "map.map.GLTC");
+        await File.WriteAllTextAsync(glrPath, "a");
+        await File.WriteAllTextAsync(gofPath, "b");
+        await File.WriteAllTextAsync(gltcPath, "c");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(3, result.Data.NormalizedCount);
+        Assert.True(File.Exists(Path.Combine(_tempDir, "sound.wav")));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "texture.tga")));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "map.map")));
+    }
+
+    /// <summary>
+    /// Tests that files with both a .gib extension and a GenLauncher suffix are fully normalized.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_ConvertsGibWithSuffixToBig()
+    {
+        var sourcePath = Path.Combine(_tempDir, "sound.gib.GLR");
+        await File.WriteAllTextAsync(sourcePath, "gib-content");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Data.NormalizedCount);
+        Assert.False(File.Exists(sourcePath));
+        Assert.False(File.Exists(Path.Combine(_tempDir, "sound.gib")));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "sound.big")));
+    }
+
+    /// <summary>
+    /// Tests that normalization skips moves when the destination already exists.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_SkipsWhenDestinationExists()
+    {
+        var gibPath = Path.Combine(_tempDir, "data.gib");
+        var bigPath = Path.Combine(_tempDir, "data.big");
+        await File.WriteAllTextAsync(gibPath, "gib-content");
+        await File.WriteAllTextAsync(bigPath, "existing-big");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.Data.NormalizedCount);
+        Assert.False(result.Data.IsFullySuccessful);
+        Assert.Contains(gibPath, result.Data.FailedFiles);
+        Assert.True(File.Exists(gibPath));
+        Assert.Equal("existing-big", await File.ReadAllTextAsync(bigPath));
+    }
+
+    /// <summary>
+    /// Tests that directory with .GLTC suffix is detected, renamed, and contents preserved.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_DetectsAndRenamesSuffixDirectory_PreservingContents()
+    {
+        var gltcDir = Path.Combine(_tempDir, "Maps.GLTC");
+        Directory.CreateDirectory(gltcDir);
+        var mapPath = Path.Combine(gltcDir, "map1.map");
+        var gibPath = Path.Combine(gltcDir, "map2.gib");
+        await File.WriteAllTextAsync(mapPath, "map-content");
+        await File.WriteAllTextAsync(gibPath, "gib-content");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Data.NormalizedCount);
+        var targetDir = Path.Combine(_tempDir, "Maps");
+        Assert.True(Directory.Exists(targetDir));
+        Assert.False(Directory.Exists(gltcDir));
+        Assert.True(File.Exists(Path.Combine(targetDir, "map1.map")));
+        Assert.True(File.Exists(Path.Combine(targetDir, "map2.big")));
+    }
+
+    /// <summary>
+    /// Tests that directory suffix normalization skips when destination directory already exists.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_SkipsDirectorySuffixRemoval_WhenDestinationExists()
+    {
+        var gltcDir = Path.Combine(_tempDir, "Maps.GLTC");
+        Directory.CreateDirectory(gltcDir);
+        await File.WriteAllTextAsync(Path.Combine(gltcDir, "map1.map"), "map-content");
+
+        var existingTargetDir = Path.Combine(_tempDir, "Maps");
+        Directory.CreateDirectory(existingTargetDir);
+        await File.WriteAllTextAsync(Path.Combine(existingTargetDir, "existing.txt"), "existing-content");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.False(result.Data.IsFullySuccessful);
+        Assert.Contains(gltcDir, result.Data.FailedFiles);
+        Assert.True(Directory.Exists(gltcDir));
+        Assert.True(Directory.Exists(existingTargetDir));
+    }
+
+    /// <summary>
+    /// Tests that file symbolic links are removed during normalization.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_RemovesFileSymlink()
+    {
+        if (!TryCreateFileSymlink(out var skipReason))
+        {
+            return;
+        }
+
+        var targetPath = Path.Combine(_tempDir, "target.txt");
+        var linkPath = Path.Combine(_tempDir, "link.txt");
+        await File.WriteAllTextAsync(targetPath, "target-content");
+        File.CreateSymbolicLink(linkPath, targetPath);
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.SymbolicLinksRemoved);
+        Assert.False(File.Exists(linkPath));
+        Assert.True(File.Exists(targetPath));
+    }
+
+    /// <summary>
+    /// Tests that dangling file symbolic links are removed during normalization.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_RemovesDanglingFileSymlink()
+    {
+        if (!TryCreateFileSymlink(out var skipReason))
+        {
+            return;
+        }
+
+        var targetPath = Path.Combine(_tempDir, "nonexistent-target.txt");
+        var linkPath = Path.Combine(_tempDir, "dangling-link.txt");
+        File.CreateSymbolicLink(linkPath, targetPath);
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.SymbolicLinksRemoved);
+        Assert.False(File.Exists(linkPath));
+    }
+
+    /// <summary>
+    /// Tests that dangling directory symbolic links are removed during normalization.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_RemovesDanglingDirectorySymlink()
+    {
+        if (!TryCreateDirectorySymlink(out var skipReason))
+        {
+            return;
+        }
+
+        var targetPath = Path.Combine(_tempDir, "nonexistent-dir-target");
+        var linkPath = Path.Combine(_tempDir, "dangling-dir-link");
+        Directory.CreateSymbolicLink(linkPath, targetPath);
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.SymbolicLinksRemoved);
+        Assert.False(Directory.Exists(linkPath));
+    }
+
+    /// <summary>
+    /// Tests that normalization honors cancellation.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_HonorsCancellation()
+    {
+        var gibPath = Path.Combine(_tempDir, "data.gib");
+        await File.WriteAllTextAsync(gibPath, "gib-content");
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _service.NormalizeFilesAsync(_tempDir, cts.Token));
+
+        Assert.True(File.Exists(gibPath));
+    }
+
+    /// <summary>
+    /// Tests that detection reports GenLauncher files in nested directories.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task DetectGenLauncherFilesAsync_FindsNestedFiles()
+    {
+        var nestedDir = Path.Combine(_tempDir, "mods", "audio");
+        Directory.CreateDirectory(nestedDir);
+        await File.WriteAllTextAsync(Path.Combine(nestedDir, "clip.gib"), "gib");
+
+        var detection = await _service.DetectGenLauncherFilesAsync(_tempDir);
+
+        Assert.True(detection.HasGenLauncherFiles);
+        Assert.Single(detection.GibFiles);
+    }
+
+    private bool TryCreateFileSymlink(out string? skipReason)
+    {
+        skipReason = null;
+
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            skipReason = "Unsupported operating system.";
+            return false;
+        }
+
+        try
+        {
+            var probeTarget = Path.Combine(_tempDir, "probe-target.txt");
+            var probeLink = Path.Combine(_tempDir, "probe-link.txt");
+            File.WriteAllText(probeTarget, "probe");
+            File.CreateSymbolicLink(probeLink, probeTarget);
+            File.Delete(probeLink);
+            File.Delete(probeTarget);
+            return true;
+        }
+        catch (IOException ex) when (ex.Message.Contains("privilege", StringComparison.OrdinalIgnoreCase))
+        {
+            skipReason = ex.Message;
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            skipReason = ex.Message;
+            return false;
+        }
+        catch (PlatformNotSupportedException ex)
+        {
+            skipReason = ex.Message;
+            return false;
+        }
+    }
+
+    private bool TryCreateDirectorySymlink(out string? skipReason)
+    {
+        skipReason = null;
+
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            skipReason = "Unsupported operating system.";
+            return false;
+        }
+
+        try
+        {
+            var probeTarget = Path.Combine(_tempDir, "probe-dir-target");
+            var probeLink = Path.Combine(_tempDir, "probe-dir-link");
+            Directory.CreateDirectory(probeTarget);
+            Directory.CreateSymbolicLink(probeLink, probeTarget);
+            Directory.Delete(probeLink);
+            Directory.Delete(probeTarget);
+            return true;
+        }
+        catch (IOException ex) when (ex.Message.Contains("privilege", StringComparison.OrdinalIgnoreCase))
+        {
+            skipReason = ex.Message;
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            skipReason = ex.Message;
+            return false;
+        }
+        catch (PlatformNotSupportedException ex)
+        {
+            skipReason = ex.Message;
+            return false;
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Utilities;
 using GenHub.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -280,6 +282,37 @@ public class GenLauncherNormalizationServiceTests : IDisposable
 
         Assert.True(detection.HasGenLauncherFiles);
         Assert.Single(detection.GibFiles);
+    }
+
+    /// <summary>
+    /// A native game binary has no extension, so GenLauncher's suffix hides it from
+    /// <see cref="ExecutableFileClassifier"/>: the name ends in <c>.GOF</c>, which is
+    /// neither a library nor a runnable extension, so the magic bytes are never read.
+    /// Stripping the suffix is what restores the extensionless shape that classification
+    /// by content depends on, which makes the ordering in the import flow load-bearing.
+    /// </summary>
+    /// <param name="header">Native executable magic bytes to write to the file.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01 })]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 })]
+    public async Task NormalizeFilesAsync_UnmasksNativeBinaryForMagicByteClassification(byte[] header)
+    {
+        var suffixedPath = Path.Combine(_tempDir, "generals" + GenLauncherConstants.OriginalFileSuffix);
+        await File.WriteAllBytesAsync(suffixedPath, header);
+
+        Assert.False(ExecutableFileClassifier.RequiresExecutePermission("generals.GOF", suffixedPath));
+        Assert.False(ExecutableFileClassifier.IsLegacyLaunchCandidate("generals.GOF", suffixedPath));
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        var normalizedPath = Path.Combine(_tempDir, "generals");
+        Assert.False(File.Exists(suffixedPath));
+        Assert.True(File.Exists(normalizedPath));
+
+        Assert.True(ExecutableFileClassifier.RequiresExecutePermission("generals", normalizedPath));
+        Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("generals", normalizedPath));
     }
 
     private bool TryCreateFileSymlink(out string? skipReason)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -398,8 +398,8 @@ public partial class AddLocalContentViewModel(
                         var normalizationPrompt =
                             $"This content contains GenLauncher-modified files:\n\n{detectionResult.GetSummary()}\n\nWould you like to normalize these files to standard format?\n\n" +
                             "This will:\n" +
-                            "• Convert .gib files to .big\n" +
-                            "• Remove .GLR, .GOF, .GLTC suffixes\n" +
+                            $"• Convert {GenLauncherConstants.GibExtension} files to {GenLauncherConstants.BigExtension}\n" +
+                            $"• Remove {string.Join(", ", GenLauncherConstants.AllSuffixes)} suffixes\n" +
                             "• Remove symbolic links";
 
                         var shouldNormalize = await dialogService.ShowConfirmationAsync(

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -395,13 +395,16 @@ public partial class AddLocalContentViewModel(
                     {
                         logger?.LogInformation("GenLauncher files detected: {Summary}", detectionResult.GetSummary());
 
-                        var shouldNormalize = await dialogService.ShowConfirmationAsync(
-                            "GenLauncher Files Detected",
+                        var normalizationPrompt =
                             $"This content contains GenLauncher-modified files:\n\n{detectionResult.GetSummary()}\n\nWould you like to normalize these files to standard format?\n\n" +
                             "This will:\n" +
                             "• Convert .gib files to .big\n" +
                             "• Remove .GLR, .GOF, .GLTC suffixes\n" +
-                            "• Remove symbolic links",
+                            "• Remove symbolic links";
+
+                        var shouldNormalize = await dialogService.ShowConfirmationAsync(
+                            "GenLauncher Files Detected",
+                            normalizationPrompt,
                             "Normalize",
                             "Skip",
                             sessionKey: GenLauncherConstants.NormalizationDialogSessionKey);

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Enums;
 using Microsoft.Extensions.Logging;
@@ -19,10 +21,14 @@ namespace GenHub.Features.GameProfiles.ViewModels;
 /// </summary>
 /// <param name="localContentService">Service for handling local content operations.</param>
 /// <param name="contentStorageService">Service for content storage operations.</param>
+/// <param name="genLauncherNormalizationService">Service for GenLauncher file normalization.</param>
+/// <param name="dialogService">Service for showing dialogs.</param>
 /// <param name="logger">Logger instance.</param>
 public partial class AddLocalContentViewModel(
     ILocalContentService localContentService,
     IContentStorageService? contentStorageService,
+    IGenLauncherNormalizationService? genLauncherNormalizationService,
+    IDialogService? dialogService,
     ILogger<AddLocalContentViewModel>? logger = null) : ObservableObject
 {
     /// <summary>
@@ -369,8 +375,102 @@ public partial class AddLocalContentViewModel(
             // Auto-organization: If we have .map files at the root level, move them into subdirectories
             CreateMapFoldersIfNeeded();
 
+            // Detect and normalize GenLauncher files
+            _cts ??= new CancellationTokenSource();
+            if (_cts.IsCancellationRequested)
+            {
+                _cts.Dispose();
+                _cts = new CancellationTokenSource();
+            }
+
+            var cancellationToken = _cts.Token;
+            var normalizationSetStatus = false;
+            try
+            {
+                if (genLauncherNormalizationService != null && dialogService != null)
+                {
+                    var detectionResult = await genLauncherNormalizationService.DetectGenLauncherFilesAsync(_stagingPath, cancellationToken);
+
+                    if (detectionResult.HasGenLauncherFiles)
+                    {
+                        logger?.LogInformation("GenLauncher files detected: {Summary}", detectionResult.GetSummary());
+
+                        var shouldNormalize = await dialogService.ShowConfirmationAsync(
+                            "GenLauncher Files Detected",
+                            $"This content contains GenLauncher-modified files:\n\n{detectionResult.GetSummary()}\n\nWould you like to normalize these files to standard format?\n\n" +
+                            "This will:\n" +
+                            "• Convert .gib files to .big\n" +
+                            "• Remove .GLR, .GOF, .GLTC suffixes\n" +
+                            "• Remove symbolic links",
+                            "Normalize",
+                            "Skip",
+                            sessionKey: GenLauncherConstants.NormalizationDialogSessionKey);
+
+                        if (shouldNormalize)
+                        {
+                            StatusMessage = "Normalizing GenLauncher files...";
+                            logger?.LogInformation("User confirmed normalization");
+
+                            var normalizationResult = await genLauncherNormalizationService.NormalizeFilesAsync(
+                                _stagingPath,
+                                cancellationToken);
+
+                            if (normalizationResult.Success)
+                            {
+                                var result = normalizationResult.Data;
+                                StatusMessage = result.IsFullySuccessful
+                                    ? $"Normalized {result.NormalizedCount} file(s). Import successful."
+                                    : $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
+                                normalizationSetStatus = true;
+                                logger?.LogInformation(
+                                    "Normalization completed: {NormalizedCount} files, {SymlinksRemoved} symlinks removed",
+                                    result.NormalizedCount,
+                                    result.SymbolicLinksRemoved);
+
+                                if (!result.IsFullySuccessful)
+                                {
+                                    logger?.LogWarning(
+                                        "Some files failed to normalize: {FailedFiles}",
+                                        string.Join(", ", result.FailedFiles));
+                                }
+                            }
+                            else
+                            {
+                                StatusMessage = $"Normalization warning: {normalizationResult.FirstError}. Import will continue.";
+                                normalizationSetStatus = true;
+                                logger?.LogWarning("Normalization failed: {Error}", normalizationResult.FirstError);
+                            }
+                        }
+                        else
+                        {
+                            logger?.LogInformation("User skipped normalization");
+                            StatusMessage = "Import successful (GenLauncher files not normalized).";
+                            normalizationSetStatus = true;
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                logger?.LogInformation("GenLauncher detection/normalization was cancelled");
+                StatusMessage = "Import cancelled.";
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Error during GenLauncher detection/normalization");
+                StatusMessage = "Import successful (normalization check failed).";
+                normalizationSetStatus = true;
+            }
+
             await RefreshStagingTreeAsync();
-            StatusMessage = "Import successful.";
+
+            // Only set generic message if normalization didn't set a specific one
+            if (!normalizationSetStatus)
+            {
+                StatusMessage = "Import successful.";
+            }
+
             Validate();
         }
         catch (Exception ex)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoAddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoAddLocalContentViewModel.cs
@@ -29,7 +29,7 @@ public partial class DemoAddLocalContentViewModel : AddLocalContentViewModel
         IContentStorageService? contentStorageService,
         INotificationService? notificationService,
         ILogger<AddLocalContentViewModel>? logger = null)
-        : base(localContentService ?? new MockLocalContentService(), contentStorageService, logger)
+        : base(localContentService ?? new MockLocalContentService(), contentStorageService, null, null, logger)
     {
         _notificationService = notificationService;
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoGameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoGameProfileSettingsViewModel.cs
@@ -34,6 +34,8 @@ public partial class DemoGameProfileSettingsViewModel : GameProfileSettingsViewM
     /// <param name="manifestPool">The content manifest pool.</param>
     /// <param name="contentStorageService">The content storage service.</param>
     /// <param name="localContentService">The local content service.</param>
+    /// <param name="genLauncherNormalizationService">The GenLauncher normalization service.</param>
+    /// <param name="dialogService">The dialog service.</param>
     /// <param name="logger">The logger for this view model.</param>
     /// <param name="gameSettingsLogger">The logger for the game settings view model.</param>
     public DemoGameProfileSettingsViewModel(
@@ -46,6 +48,8 @@ public partial class DemoGameProfileSettingsViewModel : GameProfileSettingsViewM
         IContentManifestPool? manifestPool,
         IContentStorageService? contentStorageService,
         ILocalContentService? localContentService,
+        IGenLauncherNormalizationService? genLauncherNormalizationService,
+        IDialogService? dialogService,
         ILogger<GameProfileSettingsViewModel>? logger,
         ILogger<GameSettingsViewModel>? gameSettingsLogger)
         : base(
@@ -58,6 +62,8 @@ public partial class DemoGameProfileSettingsViewModel : GameProfileSettingsViewM
             manifestPool,
             contentStorageService,
             localContentService,
+            genLauncherNormalizationService,
+            dialogService,
             logger,
             gameSettingsLogger)
     {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -668,7 +668,12 @@ public partial class GameProfileSettingsViewModel
 
             if (dialogOwner == null) return;
 
-            var vm = new AddLocalContentViewModel(_localContentService, _contentStorageService, null);
+            var vm = new AddLocalContentViewModel(
+                _localContentService,
+                _contentStorageService,
+                _genLauncherNormalizationService,
+                _dialogService,
+                null);
             var window = new Views.AddLocalContentWindow
             {
                 DataContext = vm,
@@ -724,7 +729,12 @@ public partial class GameProfileSettingsViewModel
 
             if (owner == null) return;
 
-            var vm = new AddLocalContentViewModel(_localContentService, _contentStorageService, null);
+            var vm = new AddLocalContentViewModel(
+                _localContentService,
+                _contentStorageService,
+                _genLauncherNormalizationService,
+                _dialogService,
+                null);
             await vm.LoadFromManifestAsync(contentItem);
 
             var window = new Views.AddLocalContentWindow

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -147,6 +147,8 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
     private readonly IContentManifestPool? _manifestPool;
     private readonly IContentStorageService? _contentStorageService;
     private readonly ILocalContentService? _localContentService;
+    private readonly IGenLauncherNormalizationService? _genLauncherNormalizationService;
+    private readonly IDialogService? _dialogService;
     private readonly ILogger<GameProfileSettingsViewModel>? _logger;
     private readonly ILogger<GameSettingsViewModel>? _gameSettingsLogger;
 
@@ -182,6 +184,8 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
     /// <param name="manifestPool">The manifest pool.</param>
     /// <param name="contentStorageService">The content storage service.</param>
     /// <param name="localContentService">The local content service.</param>
+    /// <param name="genLauncherNormalizationService">The GenLauncher normalization service.</param>
+    /// <param name="dialogService">The dialog service.</param>
     /// <param name="logger">The logger for this view model.</param>
     /// <param name="gameSettingsLogger">The logger for the game settings view model.</param>
     public GameProfileSettingsViewModel(
@@ -194,6 +198,8 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         IContentManifestPool? manifestPool,
         IContentStorageService? contentStorageService,
         ILocalContentService? localContentService,
+        IGenLauncherNormalizationService? genLauncherNormalizationService,
+        IDialogService? dialogService,
         ILogger<GameProfileSettingsViewModel>? logger,
         ILogger<GameSettingsViewModel>? gameSettingsLogger)
     {
@@ -206,6 +212,8 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         _manifestPool = manifestPool;
         _contentStorageService = contentStorageService;
         _localContentService = localContentService;
+        _genLauncherNormalizationService = genLauncherNormalizationService;
+        _dialogService = dialogService;
         _logger = logger;
         _gameSettingsLogger = gameSettingsLogger;
 

--- a/GenHub/GenHub/Features/Info/ViewModels/DemoViewModelFactory.cs
+++ b/GenHub/GenHub/Features/Info/ViewModels/DemoViewModelFactory.cs
@@ -317,7 +317,7 @@ public static class DemoViewModelFactory
         var mockService = new MockLocalContentService();
         var mockLogger = new MockLogger<AddLocalContentViewModel>();
 
-        return new AddLocalContentViewModel(mockService, null, mockLogger);
+        return new AddLocalContentViewModel(mockService, null, null, null, mockLogger);
     }
 
     /// <summary>
@@ -359,6 +359,8 @@ public static class DemoViewModelFactory
             mockManifests,
             mockStorage,
             mockLocalContent,
+            null, // genLauncherNormalizationService
+            null, // dialogService
             mockLogger,
             mockSettingsLogger)
         {
@@ -401,6 +403,8 @@ public static class DemoViewModelFactory
             mockManifests,
             mockStorage,
             mockLocalContent,
+            null, // genLauncherNormalizationService
+            null, // dialogService
             mockLogger,
             mockSettingsLogger)
         {
@@ -446,6 +450,8 @@ public static class DemoViewModelFactory
                 mockManifests,
                 mockStorage,
                 mockLocalContent,
+                null, // genLauncherNormalizationService
+                null, // dialogService
                 mockLogger,
                 mockSettingsLogger)
             {
@@ -475,6 +481,8 @@ public static class DemoViewModelFactory
                 new MockContentManifestPool(),
                 new MockContentStorageService(),
                 new MockLocalContentService(),
+                null, // genLauncherNormalizationService
+                null, // dialogService
                 mockLogger,
                 mockSettingsLogger)
              {

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -25,6 +25,7 @@ using GenHub.Features.Downloads.ViewModels;
 using GenHub.Features.GitHub.Services;
 using GenHub.Features.Manifest;
 using GenHub.Features.Storage.Services;
+using GenHub.Infrastructure.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
@@ -147,6 +148,9 @@ public static class ContentPipelineModule
 
         // Register Unified Content Reconciliation Service
         services.AddScoped<IContentReconciliationService, ContentReconciliationService>();
+
+        // Register GenLauncher normalization service
+        services.AddSingleton<IGenLauncherNormalizationService, GenLauncherNormalizationService>();
 
         // Reconciliation infrastructure
         services.AddScoped<IContentReconciliationOrchestrator, ContentReconciliationOrchestrator>();

--- a/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
+++ b/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
@@ -42,13 +42,15 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
 
         try
         {
-            await Task.Run(() =>
-            {
-                // Manual recursion to avoid following directory symlinks
-                ScanDirectory(directoryPath, result, cancellationToken);
+            await Task.Run(
+                () =>
+                {
+                    // Manual recursion to avoid following directory symlinks
+                    ScanDirectory(directoryPath, result, cancellationToken);
 
-                result.HasGenLauncherFiles = result.TotalAffectedFiles > 0;
-            }, cancellationToken).ConfigureAwait(false);
+                    result.HasGenLauncherFiles = result.TotalAffectedFiles > 0;
+                },
+                cancellationToken).ConfigureAwait(false);
 
             logger.LogInformation(
                 "Detection complete. Found {TotalCount} GenLauncher files: {Summary}",

--- a/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
+++ b/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Results;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Infrastructure.Services;
+
+/// <summary>
+/// Service for detecting and normalizing GenLauncher file modifications.
+/// </summary>
+/// <param name="logger">Logger instance.</param>
+public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationService> logger) : IGenLauncherNormalizationService
+{
+    private static readonly HashSet<string> GibExtensions = [GenLauncherConstants.GibExtension];
+    private static readonly HashSet<string> SuffixesToRemove =
+    [
+        GenLauncherConstants.ReplaceSuffix,
+        GenLauncherConstants.OriginalFileSuffix,
+        GenLauncherConstants.TempCopySuffix,
+    ];
+
+    /// <inheritdoc/>
+    public async Task<GenLauncherDetectionResult> DetectGenLauncherFilesAsync(string directoryPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPath, nameof(directoryPath));
+
+        logger.LogInformation("Detecting GenLauncher files in directory: {DirectoryPath}", directoryPath);
+
+        var result = new GenLauncherDetectionResult();
+
+        if (!Directory.Exists(directoryPath))
+        {
+            logger.LogWarning("Directory does not exist: {DirectoryPath}", directoryPath);
+            return result;
+        }
+
+        try
+        {
+            await Task.Run(() =>
+            {
+                // Manual recursion to avoid following directory symlinks
+                ScanDirectory(directoryPath, result, cancellationToken);
+
+                result.HasGenLauncherFiles = result.TotalAffectedFiles > 0;
+            }, cancellationToken).ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Detection complete. Found {TotalCount} GenLauncher files: {Summary}",
+                result.TotalAffectedFiles,
+                result.GetSummary());
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error detecting GenLauncher files in directory: {DirectoryPath}", directoryPath);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<OperationResult<GenLauncherNormalizationResult>> NormalizeFilesAsync(
+        string directoryPath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPath, nameof(directoryPath));
+
+        logger.LogInformation("Starting GenLauncher file normalization in directory: {DirectoryPath}", directoryPath);
+
+        if (!Directory.Exists(directoryPath))
+        {
+            logger.LogError("Directory does not exist: {DirectoryPath}", directoryPath);
+            return OperationResult<GenLauncherNormalizationResult>.CreateFailure($"Directory does not exist: {directoryPath}");
+        }
+
+        var result = new GenLauncherNormalizationResult();
+
+        try
+        {
+            // First, detect all files that need normalization
+            var detection = await DetectGenLauncherFilesAsync(directoryPath, cancellationToken).ConfigureAwait(false);
+
+            if (!detection.HasGenLauncherFiles)
+            {
+                logger.LogInformation("No GenLauncher files detected. Nothing to normalize.");
+                return OperationResult<GenLauncherNormalizationResult>.CreateSuccess(result);
+            }
+
+            // Remove symbolic links (both files and directories, including dangling links)
+            foreach (var symlink in detection.SymbolicLinks)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    var attributes = File.GetAttributes(symlink);
+
+                    // Check if it's a directory symlink using reparse-point metadata rather than target existence
+                    if (attributes.HasFlag(FileAttributes.Directory))
+                    {
+                        Directory.Delete(symlink);
+                        result.SymbolicLinksRemoved++;
+                        logger.LogInformation("Removed directory symbolic link: {DirectoryPath}", symlink);
+                    }
+                    else
+                    {
+                        File.Delete(symlink);
+                        result.SymbolicLinksRemoved++;
+                        logger.LogInformation("Removed file symbolic link: {FilePath}", symlink);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to remove symbolic link: {FilePath}", symlink);
+                    result.FailedFiles.Add(symlink);
+                }
+            }
+
+            // Remove suffixes from .GLR, .GOF, .GLTC files and directories.
+            var suffixItems = detection.GlrFiles
+                .Concat(detection.GofFiles)
+                .Concat(detection.GltcFiles)
+                .ToList();
+
+            // Process files first, then directories (deepest path first to handle nested suffix directories cleanly)
+            var suffixFiles = suffixItems.Where(File.Exists).ToList();
+            var suffixDirectories = suffixItems.Where(Directory.Exists).OrderByDescending(d => d.Length).ToList();
+
+            foreach (var suffixFile in suffixFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    var normalizedName = RemoveSuffix(suffixFile);
+                    if (normalizedName != suffixFile)
+                    {
+                        // Check if destination exists (file or directory) - skip to avoid data loss
+                        if (File.Exists(normalizedName) || Directory.Exists(normalizedName))
+                        {
+                            logger.LogWarning(
+                                "Skipping suffix removal for {OriginalFile}: target {NormalizedFile} already exists. Manual resolution required.",
+                                suffixFile,
+                                normalizedName);
+                            result.FailedFiles.Add(suffixFile);
+                            continue;
+                        }
+
+                        File.Move(suffixFile, normalizedName);
+                        result.NormalizedCount++;
+                        logger.LogInformation("Normalized {OriginalFile} to {NormalizedFile}", suffixFile, normalizedName);
+
+                        if (Path.GetExtension(normalizedName).Equals(GenLauncherConstants.GibExtension, StringComparison.OrdinalIgnoreCase))
+                        {
+                            TryConvertGibToBig(normalizedName, result);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to normalize file: {FilePath}", suffixFile);
+                    result.FailedFiles.Add(suffixFile);
+                }
+            }
+
+            // Convert standalone .gib files to .big before directory moves so file paths remain valid during conversion
+            foreach (var gibFile in detection.GibFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                TryConvertGibToBig(gibFile, result);
+            }
+
+            // Normalize matching directories after file conversions
+            foreach (var suffixDir in suffixDirectories)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    var normalizedName = RemoveSuffix(suffixDir);
+                    if (normalizedName != suffixDir)
+                    {
+                        // Check if destination exists (directory or file) - skip to avoid data loss
+                        if (Directory.Exists(normalizedName) || File.Exists(normalizedName))
+                        {
+                            logger.LogWarning(
+                                "Skipping suffix removal for directory {OriginalDir}: target {NormalizedDir} already exists. Manual resolution required.",
+                                suffixDir,
+                                normalizedName);
+                            result.FailedFiles.Add(suffixDir);
+                            continue;
+                        }
+
+                        Directory.Move(suffixDir, normalizedName);
+                        result.NormalizedCount++;
+                        logger.LogInformation("Normalized directory {OriginalDir} to {NormalizedDir}", suffixDir, normalizedName);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to normalize directory: {DirectoryPath}", suffixDir);
+                    result.FailedFiles.Add(suffixDir);
+                }
+            }
+
+            logger.LogInformation(
+                "Normalization complete. Normalized: {NormalizedCount}, Symlinks removed: {SymlinksRemoved}, Failed: {FailedCount}",
+                result.NormalizedCount,
+                result.SymbolicLinksRemoved,
+                result.FailedFiles.Count);
+
+            return OperationResult<GenLauncherNormalizationResult>.CreateSuccess(result);
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogWarning("Normalization operation was cancelled.");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error during GenLauncher file normalization in directory: {DirectoryPath}", directoryPath);
+            return OperationResult<GenLauncherNormalizationResult>.CreateFailure($"Normalization failed: {ex.Message}");
+        }
+    }
+
+    private static string RemoveSuffix(string filePath)
+    {
+        var fileName = Path.GetFileName(filePath);
+        var directory = Path.GetDirectoryName(filePath) ?? string.Empty;
+
+        foreach (var suffix in SuffixesToRemove)
+        {
+            if (fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                var newFileName = fileName[..^suffix.Length];
+                return Path.Combine(directory, newFileName);
+            }
+        }
+
+        return filePath;
+    }
+
+    private void ScanDirectory(string directoryPath, GenLauncherDetectionResult result, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Scan files in current directory only (non-recursive)
+        try
+        {
+            foreach (var file in Directory.EnumerateFiles(directoryPath, "*.*", SearchOption.TopDirectoryOnly))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    var fileInfo = new FileInfo(file);
+
+                    // Check for symbolic links
+                    if (fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        result.SymbolicLinks.Add(file);
+                        logger.LogDebug("Detected symbolic link: {FilePath}", file);
+                        continue;
+                    }
+
+                    var fileName = fileInfo.Name;
+                    var extension = fileInfo.Extension.ToLowerInvariant();
+
+                    // Check for .gib files
+                    if (GibExtensions.Contains(extension))
+                    {
+                        result.GibFiles.Add(file);
+                        logger.LogDebug("Detected .gib file: {FilePath}", file);
+                    }
+
+                    // Check for suffix files
+                    if (fileName.EndsWith(GenLauncherConstants.ReplaceSuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GlrFiles.Add(file);
+                        logger.LogDebug("Detected .GLR file: {FilePath}", file);
+                    }
+                    else if (fileName.EndsWith(GenLauncherConstants.OriginalFileSuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GofFiles.Add(file);
+                        logger.LogDebug("Detected .GOF file: {FilePath}", file);
+                    }
+                    else if (fileName.EndsWith(GenLauncherConstants.TempCopySuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GltcFiles.Add(file);
+                        logger.LogDebug("Detected .GLTC file: {FilePath}", file);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to inspect file during detection: {FilePath}", file);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to enumerate files in directory: {DirectoryPath}", directoryPath);
+        }
+
+        // Scan subdirectories (non-recursive, manual control)
+        try
+        {
+            foreach (var directory in Directory.EnumerateDirectories(directoryPath, "*", SearchOption.TopDirectoryOnly))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    var dirInfo = new DirectoryInfo(directory);
+
+                    // Check if it's a directory symlink
+                    if (dirInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        result.SymbolicLinks.Add(directory);
+                        logger.LogDebug("Detected directory symbolic link: {DirectoryPath}", directory);
+
+                        // Don't recurse into symlinked directories
+                        continue;
+                    }
+
+                    var dirName = dirInfo.Name;
+                    if (dirName.EndsWith(GenLauncherConstants.ReplaceSuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GlrFiles.Add(directory);
+                        logger.LogDebug("Detected .GLR directory: {DirectoryPath}", directory);
+                    }
+                    else if (dirName.EndsWith(GenLauncherConstants.OriginalFileSuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GofFiles.Add(directory);
+                        logger.LogDebug("Detected .GOF directory: {DirectoryPath}", directory);
+                    }
+                    else if (dirName.EndsWith(GenLauncherConstants.TempCopySuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GltcFiles.Add(directory);
+                        logger.LogDebug("Detected .GLTC directory: {DirectoryPath}", directory);
+                    }
+
+                    // Recurse into normal directories
+                    ScanDirectory(directory, result, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to process subdirectory during detection: {DirectoryPath}", directory);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to enumerate subdirectories in directory: {DirectoryPath}", directoryPath);
+        }
+    }
+
+    private void TryConvertGibToBig(string gibFile, GenLauncherNormalizationResult result)
+    {
+        if (!File.Exists(gibFile))
+        {
+            return;
+        }
+
+        try
+        {
+            var bigFile = Path.ChangeExtension(gibFile, GenLauncherConstants.BigExtension);
+
+            // Check if destination exists - skip to avoid data loss
+            if (File.Exists(bigFile))
+            {
+                logger.LogWarning(
+                    "Skipping .gib → .big conversion for {GibFile}: target {BigFile} already exists. Manual resolution required.",
+                    gibFile,
+                    bigFile);
+                result.FailedFiles.Add(gibFile);
+                return;
+            }
+
+            File.Move(gibFile, bigFile);
+            result.NormalizedCount++;
+            logger.LogInformation("Converted {GibFile} to {BigFile}", gibFile, bigFile);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to convert .gib file: {FilePath}", gibFile);
+            result.FailedFiles.Add(gibFile);
+        }
+    }
+}


### PR DESCRIPTION
Forward-ports GenLauncher file normalization (#288) from `release/alpha-4` to `development`.

#288 landed only on `release/alpha-4` and was never forward-ported, so `GenLauncherConstants`, `IGenLauncherNormalizationService`, `GenLauncherNormalizationService` and its tests are absent from `development`. Without this, the release merge would put ~800 lines into `main` that have never been compiled or tested against the two subsystems they overlap: magic-byte executable classification (#339) and atomic workspace materialization (#338).

### Commits

1. **Forward-port** — the six GenLauncher files are byte-identical to `release/alpha-4`. Everything else is constructor threading through `AddLocalContentViewModel`, `GameProfileSettingsViewModel`, the demo view models, and the DI registration in `ContentPipelineModule`.
2. **StyleCop** — the ported files carried 15 analyzer warnings (SA1623, SA1203, SA1116/1117, SA1118). Doc-comment and formatting only, no behaviour change.
3. **Test** — new coverage for the interaction with #339.

### Interaction with the subsystems it overlaps

Normalization runs against the temp staging directory during import, before manifest generation and well before workspace materialization.

- **#339 magic-byte classification** — these compose, and the ordering is load-bearing. A native game binary has no extension, so GenLauncher's suffix hides it: `generals.GOF` has extension `.GOF`, which is neither a library nor a runnable extension, so the magic bytes are never read and it classifies as non-executable. Stripping the suffix restores the extensionless shape that content-based classification depends on. The new `NormalizeFilesAsync_UnmasksNativeBinaryForMagicByteClassification` theory asserts both sides of that flip for Mach-O and ELF headers, so it fails if either subsystem regresses.
- **#338 atomic materialization** — no contact. It operates on the workspace downstream of the manifest/CAS; normalization only ever touches the staging directory, and its symlink removal is confined there.

### Verification

- `GenHub.Tests.Core` — 1550 passed, 0 failed (baseline on `development` is 1537; +11 ported, +2 new)
- `GenHub.Tests.MacOS` — 3 passed, including the composition root's `ValidateOnBuild` and the shrink-only `ValidateScopes` ratchet from #337, which the new singleton registration has to satisfy
- `GenHub.Tests.Linux` and `GenHub.MacOS.slnf` — build clean, 0 errors
- Clean rebuild adds no new analyzer warnings (2 before, same 2 after)

`GenHub.Tests.Windows` was not built locally — it fails `NETSDK1100` on macOS, identically on unmodified `development`. Left to CI.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR forward-ports GenLauncher staging-file normalization and integrates it into local-content import and profile settings.
- Adds detection and normalization contracts, result models, constants, and the filesystem implementation.
- Threads the service through view models and registers it in the content pipeline.
- Adds normalization and executable-classification interaction tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs | Adds recursive detection and normalization of GenLauncher-modified files in staging directories. |
| GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs | Integrates detection and optional normalization into the local-content import workflow. |
| GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs | Applies normalization before importing profile-local content. |
| GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs | Registers the normalization service with the application dependency container. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs | Covers suffix conversion, symlink handling, conflicts, cancellation, and executable-classification composition. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Import["Import local content"] --> Stage["Temporary staging directory"]
    Stage --> Detect["Detect GenLauncher suffixes, .gib files, and symlinks"]
    Detect --> Normalize["Normalize files and remove staging symlinks"]
    Normalize --> Classify["Classify executable content"]
    Classify --> Manifest["Generate manifest and store content"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(content): report why symbolic-link ..."](https://github.com/community-outpost/genhub/commit/cbd743483ea830fb9ec2137e2d3f99a844f7309c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51156322)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Content Manifest System](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-manifest-system.md)
- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)
- Knowledge Base — [App Shell and Dependency Injection](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/app-shell-and-di.md)
</details>

<!-- /greptile_comment -->