### PR TITLE
fix(settings): write the declared TheSuperHackers defaults to settings.json

### DIFF
--- a/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
@@ -44,4 +44,46 @@ public static class GameSettingsTheSuperHackersConstants
     /// Default font size for system time display.
     /// </summary>
     public const int DefaultSystemTimeFontSize = 8;
+
+    /// <summary>
+    /// Default for whether player observer mode is enabled.
+    /// Matches the engine fallback in OptionPreferences::getPlayerObserverEnabled.
+    /// </summary>
+    public const bool DefaultPlayerObserverEnabled = true;
+
+    /// <summary>
+    /// Default for cursor capture in fullscreen game.
+    /// Included in the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInFullscreenGame = true;
+
+    /// <summary>
+    /// Default for cursor capture in fullscreen menu.
+    /// Included in the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInFullscreenMenu = true;
+
+    /// <summary>
+    /// Default for cursor capture in windowed game.
+    /// Included in the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInWindowedGame = true;
+
+    /// <summary>
+    /// Default for cursor capture in windowed menu.
+    /// Absent from the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInWindowedMenu = false;
+
+    /// <summary>
+    /// Default for screen edge scrolling in a fullscreen app.
+    /// The engine's ScreenEdgeScrollMode_Default is exactly this flag.
+    /// </summary>
+    public const bool DefaultScreenEdgeScrollEnabledInFullscreenApp = true;
+
+    /// <summary>
+    /// Default for screen edge scrolling in a windowed app.
+    /// Absent from the engine's ScreenEdgeScrollMode_Default.
+    /// </summary>
+    public const bool DefaultScreenEdgeScrollEnabledInWindowedApp = false;
 }

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -209,17 +209,17 @@ public static class GameSettingsMapper
         settings.ArchiveReplays = profile.TshArchiveReplays ?? false;
         settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
         settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
-        settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? false;
+        settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled;
         settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
         settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
         settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
         settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
-        settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? false;
-        settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? false;
-        settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? false;
-        settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu ?? false;
-        settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp ?? false;
-        settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp ?? false;
+        settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame;
+        settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu;
+        settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame;
+        settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu;
+        settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp;
+        settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -210,10 +210,10 @@ public static class GameSettingsMapper
         settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
         settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
         settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? false;
-        settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? 12;
-        settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? 12;
-        settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? 12;
-        settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? -100;
+        settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
+        settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
+        settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
+        settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
         settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? false;
         settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? false;
         settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? false;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -138,4 +138,102 @@ public class GameSettingsMapperTests
         Assert.Equal(22, settings.RenderFpsFontSize);
         Assert.Equal(23, settings.ResolutionFontAdjustment);
     }
+
+    /// <summary>
+    /// Verifies that a profile with no cursor capture, edge scroll or observer toggles set
+    /// falls back to the declared defaults.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetToggles_UsesDeclaredDefaults()
+    {
+        // Arrange - seed each toggle inverted, so a missing assignment fails
+        var profile = new GameProfile();
+        var settings = new GeneralsOnlineSettings
+        {
+            PlayerObserverEnabled = false,
+            CursorCaptureEnabledInFullscreenGame = false,
+            CursorCaptureEnabledInFullscreenMenu = false,
+            CursorCaptureEnabledInWindowedGame = false,
+            CursorCaptureEnabledInWindowedMenu = true,
+            ScreenEdgeScrollEnabledInFullscreenApp = false,
+            ScreenEdgeScrollEnabledInWindowedApp = true,
+        };
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled, settings.PlayerObserverEnabled);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame, settings.CursorCaptureEnabledInFullscreenGame);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu, settings.CursorCaptureEnabledInFullscreenMenu);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame, settings.CursorCaptureEnabledInWindowedGame);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu, settings.CursorCaptureEnabledInWindowedMenu);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp, settings.ScreenEdgeScrollEnabledInFullscreenApp);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp, settings.ScreenEdgeScrollEnabledInWindowedApp);
+    }
+
+    /// <summary>
+    /// Verifies that the toggle fallbacks match the values declared on the settings model itself.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetToggles_MatchesModelDefaults()
+    {
+        // Arrange - seed each toggle inverted, so a missing assignment fails
+        var profile = new GameProfile();
+        var expected = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings
+        {
+            PlayerObserverEnabled = false,
+            CursorCaptureEnabledInFullscreenGame = false,
+            CursorCaptureEnabledInFullscreenMenu = false,
+            CursorCaptureEnabledInWindowedGame = false,
+            CursorCaptureEnabledInWindowedMenu = true,
+            ScreenEdgeScrollEnabledInFullscreenApp = false,
+            ScreenEdgeScrollEnabledInWindowedApp = true,
+        };
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(expected.PlayerObserverEnabled, settings.PlayerObserverEnabled);
+        Assert.Equal(expected.CursorCaptureEnabledInFullscreenGame, settings.CursorCaptureEnabledInFullscreenGame);
+        Assert.Equal(expected.CursorCaptureEnabledInFullscreenMenu, settings.CursorCaptureEnabledInFullscreenMenu);
+        Assert.Equal(expected.CursorCaptureEnabledInWindowedGame, settings.CursorCaptureEnabledInWindowedGame);
+        Assert.Equal(expected.CursorCaptureEnabledInWindowedMenu, settings.CursorCaptureEnabledInWindowedMenu);
+        Assert.Equal(expected.ScreenEdgeScrollEnabledInFullscreenApp, settings.ScreenEdgeScrollEnabledInFullscreenApp);
+        Assert.Equal(expected.ScreenEdgeScrollEnabledInWindowedApp, settings.ScreenEdgeScrollEnabledInWindowedApp);
+    }
+
+    /// <summary>
+    /// Verifies that explicit toggle values on the profile are written through unchanged.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_ExplicitToggles_ArePreserved()
+    {
+        // Arrange - every value is the opposite of its default
+        var profile = new GameProfile
+        {
+            TshPlayerObserverEnabled = false,
+            TshCursorCaptureEnabledInFullscreenGame = false,
+            TshCursorCaptureEnabledInFullscreenMenu = false,
+            TshCursorCaptureEnabledInWindowedGame = false,
+            TshCursorCaptureEnabledInWindowedMenu = true,
+            TshScreenEdgeScrollEnabledInFullscreenApp = false,
+            TshScreenEdgeScrollEnabledInWindowedApp = true,
+        };
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.False(settings.PlayerObserverEnabled);
+        Assert.False(settings.CursorCaptureEnabledInFullscreenGame);
+        Assert.False(settings.CursorCaptureEnabledInFullscreenMenu);
+        Assert.False(settings.CursorCaptureEnabledInWindowedGame);
+        Assert.True(settings.CursorCaptureEnabledInWindowedMenu);
+        Assert.False(settings.ScreenEdgeScrollEnabledInFullscreenApp);
+        Assert.True(settings.ScreenEdgeScrollEnabledInWindowedApp);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -66,9 +66,15 @@ public class GameSettingsMapperTests
     [Fact]
     public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_UsesDeclaredDefaults()
     {
-        // Arrange
+        // Arrange - seed with values the mapper must overwrite, so a missing assignment fails
         var profile = new GameProfile();
-        var settings = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings
+        {
+            SystemTimeFontSize = 99,
+            NetworkLatencyFontSize = 99,
+            RenderFpsFontSize = 99,
+            ResolutionFontAdjustment = 99,
+        };
 
         // Act
         GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
@@ -86,10 +92,16 @@ public class GameSettingsMapperTests
     [Fact]
     public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_MatchesModelDefaults()
     {
-        // Arrange
+        // Arrange - seed with values the mapper must overwrite, so a missing assignment fails
         var profile = new GameProfile();
         var expected = new GeneralsOnlineSettings();
-        var settings = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings
+        {
+            SystemTimeFontSize = 99,
+            NetworkLatencyFontSize = 99,
+            RenderFpsFontSize = 99,
+            ResolutionFontAdjustment = 99,
+        };
 
         // Act
         GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
@@ -113,6 +125,7 @@ public class GameSettingsMapperTests
             TshSystemTimeFontSize = 20,
             TshNetworkLatencyFontSize = 21,
             TshRenderFpsFontSize = 22,
+            TshResolutionFontAdjustment = 23,
         };
         var settings = new GeneralsOnlineSettings();
 
@@ -123,5 +136,6 @@ public class GameSettingsMapperTests
         Assert.Equal(20, settings.SystemTimeFontSize);
         Assert.Equal(21, settings.NetworkLatencyFontSize);
         Assert.Equal(22, settings.RenderFpsFontSize);
+        Assert.Equal(23, settings.ResolutionFontAdjustment);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -59,4 +59,69 @@ public class GameSettingsMapperTests
         // Assert
         Assert.Equal(expectedQuality, profile.VideoTextureQuality);
     }
+
+    /// <summary>
+    /// Verifies that a profile with no TheSuperHackers font sizes set falls back to the declared defaults.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_UsesDeclaredDefaults()
+    {
+        // Arrange
+        var profile = new GameProfile();
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize, settings.SystemTimeFontSize);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize, settings.NetworkLatencyFontSize);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize, settings.RenderFpsFontSize);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment, settings.ResolutionFontAdjustment);
+    }
+
+    /// <summary>
+    /// Verifies that the fallback defaults match the values declared on the settings model itself.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_MatchesModelDefaults()
+    {
+        // Arrange
+        var profile = new GameProfile();
+        var expected = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(expected.SystemTimeFontSize, settings.SystemTimeFontSize);
+        Assert.Equal(expected.NetworkLatencyFontSize, settings.NetworkLatencyFontSize);
+        Assert.Equal(expected.RenderFpsFontSize, settings.RenderFpsFontSize);
+        Assert.Equal(expected.ResolutionFontAdjustment, settings.ResolutionFontAdjustment);
+    }
+
+    /// <summary>
+    /// Verifies that explicit TheSuperHackers font sizes on the profile are written through unchanged.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_ExplicitFontSizes_ArePreserved()
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            TshSystemTimeFontSize = 20,
+            TshNetworkLatencyFontSize = 21,
+            TshRenderFpsFontSize = 22,
+        };
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(20, settings.SystemTimeFontSize);
+        Assert.Equal(21, settings.NetworkLatencyFontSize);
+        Assert.Equal(22, settings.RenderFpsFontSize);
+    }
 }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -286,16 +286,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _tshPlayerObserverEnabled;
 
     [ObservableProperty]
-    private int _tshSystemTimeFontSize = 12;
+    private int _tshSystemTimeFontSize = GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
 
     [ObservableProperty]
-    private int _tshNetworkLatencyFontSize = 12;
+    private int _tshNetworkLatencyFontSize = GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
 
     [ObservableProperty]
-    private int _tshRenderFpsFontSize = 12;
+    private int _tshRenderFpsFontSize = GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
 
     [ObservableProperty]
-    private int _tshResolutionFontAdjustment = -100;
+    private int _tshResolutionFontAdjustment = GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
 
     [ObservableProperty]
     private bool _tshCursorCaptureEnabledInFullscreenGame;

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -283,7 +283,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _tshShowMoneyPerMinute;
 
     [ObservableProperty]
-    private bool _tshPlayerObserverEnabled;
+    private bool _tshPlayerObserverEnabled = GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled;
 
     [ObservableProperty]
     private int _tshSystemTimeFontSize = GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
@@ -298,22 +298,22 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private int _tshResolutionFontAdjustment = GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInFullscreenGame;
+    private bool _tshCursorCaptureEnabledInFullscreenGame = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInFullscreenMenu;
+    private bool _tshCursorCaptureEnabledInFullscreenMenu = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInWindowedGame;
+    private bool _tshCursorCaptureEnabledInWindowedGame = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInWindowedMenu;
+    private bool _tshCursorCaptureEnabledInWindowedMenu = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu;
 
     [ObservableProperty]
-    private bool _tshScreenEdgeScrollEnabledInFullscreenApp;
+    private bool _tshScreenEdgeScrollEnabledInFullscreenApp = GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp;
 
     [ObservableProperty]
-    private bool _tshScreenEdgeScrollEnabledInWindowedApp;
+    private bool _tshScreenEdgeScrollEnabledInWindowedApp = GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
 
     [ObservableProperty]
     private int _tshMoneyTransactionVolume = 50;


### PR DESCRIPTION
## Problem

`GameSettingsMapper.ApplyToGeneralsOnlineSettings` fell back to hardcoded literals that disagreed with both the declared model defaults and the game engine. `GameLauncher.ApplyGeneralsOnlineSettingsAsync` runs on every Zero Hour launch and builds a **fresh** `GeneralsOnlineSettings` before mapping, so any profile that never set these got the wrong value written to settings.json on every launch.

Eight settings were affected. Verified against the engine source:

| Setting | Engine | Was | Now |
|---|---|---|---|
| `SystemTimeFontSize` | `8` | `?? 12` | `8` |
| `NetworkLatencyFontSize` | `8` | `?? 12` | `8` |
| `RenderFpsFontSize` | `8` | `?? 12` | `8` |
| `PlayerObserverEnabled` | `TRUE` | `?? false` | `true` |
| `CursorCaptureEnabledInFullscreenGame` | in default mask | `?? false` | `true` |
| `CursorCaptureEnabledInFullscreenMenu` | in default mask | `?? false` | `true` |
| `CursorCaptureEnabledInWindowedGame` | in default mask | `?? false` | `true` |
| `ScreenEdgeScrollEnabledInFullscreenApp` | in default mask | `?? false` | `true` |

Engine references — `GlobalData.cpp` for the font sizes, `OptionPreferences.cpp` for the observer fallback, and the bitmask constants these resolve through:

```cpp
m_systemTimeFontSize = 8;  m_renderFpsFontSize = 8;  m_networkLatencyFontSize = 8;

CursorCaptureMode_Default = EnabledInWindowedGame | EnabledInFullscreenGame | EnabledInFullscreenMenu
ScreenEdgeScrollMode_Default = ScreenEdgeScrollMode_EnabledInFullscreenApp
```

`CursorCaptureEnabledInWindowedMenu` and `ScreenEdgeScrollEnabledInWindowedApp` are absent from those masks, so their existing `?? false` was already correct — they are now expressed through constants for consistency rather than changed.

The cursor capture and edge scroll entries are input behaviour, not cosmetics: every launch was disabling cursor capture and fullscreen edge scrolling for profiles that never touched them.

## Cause

#208 established the correct defaults across the model, constants and view model. #227 bumped the **view model** font sizes to `12`. #247 then added this mapper using `?? 12` and `?? false` — matching the drifted view model rather than the model defaults, despite the block comment saying "use null-coalescing with model defaults". Nothing tested any of it, so the drift went unnoticed.

## Change

- Mapper and `GameSettingsViewModel` both source every TSH default from `GameSettingsTheSuperHackersConstants`, so the UI cannot offer one value while the launcher writes another.
- Boolean defaults added to that constants class, each documented with the engine construct it derives from.
- `ResolutionFontAdjustment` switched to its constant; same value (`-100`), no behaviour change.
- Tests cover fallbacks-match-constants, fallbacks-match-model, and explicit-values-pass-through, for both the numeric and boolean groups.

Note: these constants previously had no references anywhere. They are also duplicated verbatim in `TheSuperHackersConstants.cs` (identical content, different class name) — left alone here, worth deleting separately.

## Testing

- `GameSettingsMapperTests` 13/13 pass; full `GenHub.Tests.Core` 1541 passed / 2 failed, both failures (`NativeLaunchDiagnosticsTests`, `RetailArchiveRootTests`) reproducing unchanged on clean `development` as macOS environment failures.
- Test targets are seeded with sentinel values (inverted for booleans) so a missing or reverted mapper assignment fails rather than passing on the constructor default. Verified by mutation: restoring `?? false` on `CursorCaptureEnabledInFullscreenGame` fails both toggle tests; deleting the `SystemTimeFontSize` assignment fails all three numeric tests.

## Related

#359 backports this change to `release/alpha-4` **in full** — all three commits, diff byte-for-byte identical to this PR. That includes the behavioural defaults (observer, cursor capture, edge scroll), not just the font sizes.

Including them is deliberate: every value in the table above is verified against the engine source, and `release/alpha-4` carries the bug, so shipping alpha 4 without them means releasing a launcher that disables cursor capture and fullscreen edge scrolling on every Zero Hour launch. Note that `ci.yml` triggers only on `main` and `development`, so no build or test job runs against that base — see #359 for the local verification.

`MoneyTransactionVolume` still uses `?? 50` while the model declares `0`. The engine derives it from `AudioSettings` at runtime rather than a literal, so it needs someone familiar with the audio INI data to settle. Left untouched.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns TheSuperHackers settings written at launch and displayed in the profile editor with the declared model and engine defaults.
- Replaces mapper fallback literals with centralized constants.
- Aligns font-size, observer, cursor-capture, and edge-scroll defaults across the mapper and view model.
- Adds tests covering unset defaults, model alignment, and explicit-value preservation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs | Adds named defaults for observer, cursor-capture, and edge-scroll settings consistent with the settings model. |
| GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs | Replaces divergent literal fallbacks with the centralized TheSuperHackers defaults while preserving explicit profile values. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs | Adds coverage for fallback defaults, model-default consistency, and explicit font and toggle values. |
| GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs | Aligns initial editor values with the same centralized defaults used by launch-time mapping. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(settings): align TheSuperHackers cur..."](https://github.com/community-outpost/genhub/commit/9f11b57421c261de03a6b6759d0e2398c15cbb34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51175583)</sub>

**Context used:**

- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)

<!-- /greptile_comment -->
