### PR TITLE
fix(content): propagate cancellation from SuperHackers reconciler acquisition (backport of #357)

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -251,9 +251,52 @@ public class ContentOrchestratorTests
             _manifestPoolMock.Object,
             _installationServiceMock.Object,
             _installationCasPoolServiceMock.Object);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => orchestrator.SearchAsync(new ContentSearchQuery()));
+            () => orchestrator.SearchAsync(new ContentSearchQuery(), cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that a provider timing out on its own token does not abort the aggregate search,
+    /// since <see cref="TaskCanceledException"/> is also raised by HttpClient timeouts.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_WhenProviderTimesOut_KeepsResultsFromOtherProviders()
+    {
+        var timingOutProviderMock = new Mock<IContentProvider>();
+        timingOutProviderMock.Setup(provider => provider.IsEnabled).Returns(true);
+        timingOutProviderMock.Setup(provider => provider.SourceName).Returns("SlowProvider");
+        timingOutProviderMock
+            .Setup(provider => provider.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout"));
+
+        var healthyProviderMock = new Mock<IContentProvider>();
+        healthyProviderMock.Setup(provider => provider.IsEnabled).Returns(true);
+        healthyProviderMock.Setup(provider => provider.SourceName).Returns("FastProvider");
+        healthyProviderMock
+            .Setup(provider => provider.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+                [new ContentSearchResult { Id = "fast.mod", Name = "Fast Mod" }]));
+
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [timingOutProviderMock.Object, healthyProviderMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+
+        var result = await orchestrator.SearchAsync(new ContentSearchQuery());
+
+        Assert.True(result.Success);
+        Assert.Single(result.Data ?? []);
+        Assert.Contains(result.Data ?? [], searchResult => searchResult.Id == "fast.mod");
     }
 
     /// <summary>
@@ -288,9 +331,49 @@ public class ContentOrchestratorTests
             _manifestPoolMock.Object,
             _installationServiceMock.Object,
             _installationCasPoolServiceMock.Object);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => orchestrator.AcquireContentAsync(searchResult));
+            () => orchestrator.AcquireContentAsync(searchResult, progress: null, cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that a download timeout during acquisition is still reported as a failure result
+    /// rather than propagating as cancellation to the caller.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AcquireContentAsync_WhenProviderTimesOut_ReturnsFailure()
+    {
+        var searchResult = new ContentSearchResult
+        {
+            Id = "1.0.genhub.mod.test",
+            Name = "Test Mod",
+            ProviderName = "TestProvider",
+        };
+        var providerMock = new Mock<IContentProvider>();
+        providerMock.Setup(provider => provider.SourceName).Returns(searchResult.ProviderName);
+        providerMock
+            .Setup(provider => provider.GetValidatedContentAsync(searchResult.Id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout"));
+        _cacheMock
+            .Setup(cache => cache.GetAsync<ContentManifest>(searchResult.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ContentManifest?)null);
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [providerMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+
+        var result = await orchestrator.AcquireContentAsync(searchResult);
+
+        Assert.False(result.Success);
     }
 
     /// <summary>
@@ -341,8 +424,10 @@ public class ContentOrchestratorTests
         _manifestPoolMock
             .Setup(pool => pool.IsManifestAcquiredAsync(manifest.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+        using var cts = new CancellationTokenSource();
         _installationServiceMock
             .Setup(service => service.GetAllInstallationsAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => cts.Cancel())
             .ThrowsAsync(new OperationCanceledException());
         var orchestrator = new ContentOrchestrator(
             _loggerMock.Object,
@@ -356,6 +441,6 @@ public class ContentOrchestratorTests
             _installationCasPoolServiceMock.Object);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => orchestrator.AcquireContentAsync(searchResult));
+            () => orchestrator.AcquireContentAsync(searchResult, progress: null, cts.Token));
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -259,6 +259,38 @@ public class ContentOrchestratorTests
     }
 
     /// <summary>
+    /// Verifies that a cached search result cannot mask an already-cancelled caller.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_WhenCancelledBeforeCacheHit_PropagatesCancellation()
+    {
+        _cacheMock
+            .Setup(cache => cache.GetAsync<List<ContentSearchResult>>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ContentSearchResult { Id = "cached.mod", Name = "Cached Mod" }]);
+
+        var providerMock = new Mock<IContentProvider>();
+        providerMock.Setup(provider => provider.IsEnabled).Returns(true);
+        providerMock.Setup(provider => provider.SourceName).Returns("TestProvider");
+
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [providerMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => orchestrator.SearchAsync(new ContentSearchQuery(), cts.Token));
+    }
+
+    /// <summary>
     /// Verifies that a provider timing out on its own token does not abort the aggregate search,
     /// since <see cref="TaskCanceledException"/> is also raised by HttpClient timeouts.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -226,4 +226,136 @@ public class ContentOrchestratorTests
                 It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    /// <summary>
+    /// Verifies that provider cancellation escapes <see cref="ContentOrchestrator.SearchAsync"/>
+    /// instead of being aggregated into an empty success result.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_WhenProviderCancels_PropagatesCancellation()
+    {
+        var providerMock = new Mock<IContentProvider>();
+        providerMock.Setup(provider => provider.IsEnabled).Returns(true);
+        providerMock.Setup(provider => provider.SourceName).Returns("TestProvider");
+        providerMock
+            .Setup(provider => provider.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [providerMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => orchestrator.SearchAsync(new ContentSearchQuery()));
+    }
+
+    /// <summary>
+    /// Verifies that provider cancellation escapes <see cref="ContentOrchestrator.AcquireContentAsync"/>
+    /// instead of being converted into a failure result.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AcquireContentAsync_WhenProviderCancels_PropagatesCancellation()
+    {
+        var searchResult = new ContentSearchResult
+        {
+            Id = "1.0.genhub.mod.test",
+            Name = "Test Mod",
+            ProviderName = "TestProvider",
+        };
+        var providerMock = new Mock<IContentProvider>();
+        providerMock.Setup(provider => provider.SourceName).Returns(searchResult.ProviderName);
+        providerMock
+            .Setup(provider => provider.GetValidatedContentAsync(searchResult.Id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        _cacheMock
+            .Setup(cache => cache.GetAsync<ContentManifest>(searchResult.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ContentManifest?)null);
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [providerMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => orchestrator.AcquireContentAsync(searchResult));
+    }
+
+    /// <summary>
+    /// Verifies that cancellation during installation detection escapes GameClient acquisition
+    /// instead of being reported as an unusable CAS pool.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AcquireContentAsync_WhenInstallationDetectionCancels_PropagatesCancellation()
+    {
+        var searchResult = new ContentSearchResult
+        {
+            Id = "1.0.genhub.gameclient.test",
+            Name = "Test Client",
+            ProviderName = "TestProvider",
+        };
+        var manifest = new ContentManifest
+        {
+            Id = searchResult.Id,
+            Name = searchResult.Name,
+            ContentType = ContentType.GameClient,
+        };
+        var providerMock = new Mock<IContentProvider>();
+        providerMock.Setup(provider => provider.SourceName).Returns(searchResult.ProviderName);
+        providerMock
+            .Setup(provider => provider.GetValidatedContentAsync(searchResult.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
+        providerMock
+            .Setup(provider => provider.PrepareContentAsync(
+                manifest,
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
+        _cacheMock
+            .Setup(cache => cache.GetAsync<ContentManifest>(manifest.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ContentManifest?)null);
+        _contentValidatorMock
+            .Setup(validator => validator.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(manifest.Id, []));
+        _contentValidatorMock
+            .Setup(validator => validator.ValidateAllAsync(
+                It.IsAny<string>(),
+                manifest,
+                It.IsAny<IProgress<ValidationProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(manifest.Id, []));
+        _manifestPoolMock
+            .Setup(pool => pool.IsManifestAcquiredAsync(manifest.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+        _installationServiceMock
+            .Setup(service => service.GetAllInstallationsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [providerMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => orchestrator.AcquireContentAsync(searchResult));
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
@@ -198,4 +198,46 @@ public class CommunityOutpostProfileReconcilerTests
         Assert.False(result.Success);
         Assert.Contains("server unavailable", result.FirstError, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Propagates cancellation from acquisition instead of surfacing it as a generic download failure.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellation()
+    {
+        const string latestVersion = "2.0.0";
+
+        _updateServiceMock
+            .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "1.0.0"));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(CommunityOutpostConstants.PublisherType, true);
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _manifestPoolMock
+            .Setup(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([]));
+
+        _contentOrchestratorMock
+            .Setup(x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new ContentSearchResult { Name = "Community Patch", Version = latestVersion },
+            ]));
+
+        _contentOrchestratorMock
+            .Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        using var cts = new CancellationTokenSource();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _reconciler.CheckAndReconcileIfNeededAsync("profile1", cts.Token));
+
+        _notificationServiceMock.Verify(
+            x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -139,4 +139,45 @@ public class GeneralsOnlineProfileReconcilerTests
             Times.Never,
             "Local manifest should not be removed during reconciliation");
     }
+
+    /// <summary>
+    /// Propagates cancellation from acquisition instead of surfacing it as a generic download failure.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellation()
+    {
+        // Arrange
+        string latestVersion = "0.0.99";
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "0.0.1"));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(GeneralsOnlineConstants.PublisherType, true);
+        _userSettingsServiceMock.Setup(x => x.Get())
+            .Returns(settings);
+
+        _manifestPoolMock.Setup(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([]));
+
+        _contentOrchestratorMock.Setup(
+                x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new() { Name = "New GO Version", Version = latestVersion },
+            ]));
+
+        _contentOrchestratorMock.Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        using var cts = new CancellationTokenSource();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _reconciler.CheckAndReconcileIfNeededAsync("profile1", cts.Token));
+
+        _notificationServiceMock.Verify(
+            x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
@@ -199,4 +199,46 @@ public class SuperHackersProfileReconcilerTests
         Assert.False(result.Success);
         Assert.Contains("download timed out", result.FirstError, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Propagates cancellation from acquisition instead of surfacing it as a generic download failure.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellation()
+    {
+        const string latestVersion = "2.0.0";
+
+        _updateServiceMock
+            .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "1.0.0"));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(PublisherTypeConstants.TheSuperHackers, true);
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _manifestPoolMock
+            .Setup(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([]));
+
+        _contentOrchestratorMock
+            .Setup(x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new ContentSearchResult { Name = "SuperHackers", Version = latestVersion },
+            ]));
+
+        _contentOrchestratorMock
+            .Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        using var cts = new CancellationTokenSource();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _reconciler.CheckAndReconcileIfNeededAsync("profile1", cts.Token));
+
+        _notificationServiceMock.Verify(
+            x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
@@ -241,4 +241,50 @@ public class SuperHackersProfileReconcilerTests
             x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Never);
     }
+
+    /// <summary>
+    /// Treats an acquisition failure raised while shutting down as cancellation, covering the
+    /// pipeline layers that convert <see cref="OperationCanceledException"/> into a failed result
+    /// before it can reach the reconciler as an exception.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_AcquireFailsWhileCancelled_PropagatesCancellation()
+    {
+        const string latestVersion = "2.0.0";
+
+        _updateServiceMock
+            .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "1.0.0"));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(PublisherTypeConstants.TheSuperHackers, true);
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _manifestPoolMock
+            .Setup(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([]));
+
+        _contentOrchestratorMock
+            .Setup(x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new ContentSearchResult { Name = "SuperHackers", Version = latestVersion },
+            ]));
+
+        using var cts = new CancellationTokenSource();
+
+        _contentOrchestratorMock
+            .Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => cts.Cancel())
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateFailure(
+                "Content acquisition failed: The operation was canceled."));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _reconciler.CheckAndReconcileIfNeededAsync("profile1", cts.Token));
+
+        _notificationServiceMock.Verify(
+            x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/ProfileLauncherFacadeCancellationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/ProfileLauncherFacadeCancellationTests.cs
@@ -1,0 +1,84 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GameProfiles;
+using GenHub.Core.Interfaces.GameSettings;
+using GenHub.Core.Interfaces.Launching;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Interfaces.Workspace;
+using GenHub.Features.GameProfiles.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GenHub.Tests.Core.Features.GameProfiles.Services;
+
+/// <summary>
+/// Tests that <see cref="ProfileLauncherFacade"/> preserves cancellation rather than reporting it
+/// as a launch failure.
+/// </summary>
+public class ProfileLauncherFacadeCancellationTests
+{
+    private readonly Mock<IGameProfileManager> _profileManagerMock = new();
+
+    /// <summary>
+    /// Verifies that cancelling the launch token propagates instead of being logged and returned
+    /// as a generic "Failed to launch profile" result.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_WhenCancelled_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        _profileManagerMock
+            .Setup(manager => manager.GetProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var facade = CreateFacade();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => facade.LaunchProfileAsync("profile1", cancellationToken: cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that a timeout raised on some other token is still reported as a launch failure,
+    /// since HttpClient timeouts also surface as <see cref="TaskCanceledException"/>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_WhenDependencyTimesOut_ReturnsFailure()
+    {
+        _profileManagerMock
+            .Setup(manager => manager.GetProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout"));
+
+        var facade = CreateFacade();
+
+        var result = await facade.LaunchProfileAsync("profile1");
+
+        Assert.True(result.Failed);
+    }
+
+    private ProfileLauncherFacade CreateFacade() => new(
+        _profileManagerMock.Object,
+        Mock.Of<IGameLauncher>(),
+        Mock.Of<IWorkspaceManager>(),
+        Mock.Of<ILaunchRegistry>(),
+        Mock.Of<IContentManifestPool>(),
+        Mock.Of<IGameInstallationService>(),
+        Mock.Of<IDependencyResolver>(),
+        Mock.Of<ICasService>(),
+        Mock.Of<IGameSettingsService>(),
+        Mock.Of<IStorageLocationService>(),
+        Mock.Of<INotificationService>(),
+        Mock.Of<IPublisherReconcilerRegistry>(),
+        Mock.Of<IConfigurationProviderService>(),
+        Mock.Of<IGameProcessManager>(),
+        Mock.Of<ISymlinkCapabilityProvider>(),
+        Mock.Of<ILogger<ProfileLauncherFacade>>());
+}

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
@@ -311,6 +311,10 @@ public class CommunityOutpostProfileReconciler(
 
             var searchResult = await contentOrchestrator.SearchAsync(query, cancellationToken);
 
+            // Layers beneath the orchestrator still report cancellation as a failed result, so a
+            // failure raised while shutting down must not be surfaced as a real acquisition error.
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (!searchResult.Success || searchResult.Data == null || !searchResult.Data.Any())
             {
                 return OperationResult<List<ContentManifest>>.CreateFailure(
@@ -320,6 +324,7 @@ public class CommunityOutpostProfileReconciler(
             foreach (var result in searchResult.Data)
             {
                 var acquireOp = await contentOrchestrator.AcquireContentAsync(result, progress: null, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!acquireOp.Success)
                 {
                     logger.LogError(

--- a/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
@@ -102,6 +102,9 @@ public class ContentOrchestrator : IContentOrchestrator
             return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure("Take must be between 1 and 1000");
         }
 
+        // Checked before the cache lookup so a cache hit cannot mask an already-cancelled caller.
+        cancellationToken.ThrowIfCancellationRequested();
+
         _logger.LogDebug("Starting orchestrated content search with query: {SearchTerm}, ContentType: {ContentType}", query.SearchTerm, query.ContentType);
 
         // Check cache first

--- a/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
@@ -169,7 +169,9 @@ public class ContentOrchestrator : IContentOrchestrator
                         _logger.LogWarning("Provider {ProviderName} failed: {Error}", provider.SourceName, result.FirstError);
                     }
                 }
-                catch (OperationCanceledException)
+                // Filtered on the caller's token: a provider timing out on its own token raises
+                // TaskCanceledException too, and must not abort the other providers' results.
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw;
                 }
@@ -597,7 +599,7 @@ public class ContentOrchestrator : IContentOrchestrator
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -716,7 +718,7 @@ public class ContentOrchestrator : IContentOrchestrator
             var installations = installationsResult.Data.ToList();
             return await _installationCasPoolService.EnsurePoolPathAsync(installations, cancellationToken);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }

--- a/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
@@ -169,6 +169,10 @@ public class ContentOrchestrator : IContentOrchestrator
                         _logger.LogWarning("Provider {ProviderName} failed: {Error}", provider.SourceName, result.FirstError);
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Search failed for provider: {ProviderName}", provider.SourceName);
@@ -180,6 +184,10 @@ public class ContentOrchestrator : IContentOrchestrator
             });
 
         await Task.WhenAll(searchTasksAsync);
+
+        // A provider that handled cancellation internally reports it as a failed result rather
+        // than an exception, which would otherwise surface here as an empty successful search.
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Apply orchestrator-level sorting and pagination
         var sortedResults = ApplySorting(allResults, query.SortOrder)
@@ -589,6 +597,10 @@ public class ContentOrchestrator : IContentOrchestrator
                 }
             }
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to acquire content {ContentId}", searchResult.Id);
@@ -703,6 +715,10 @@ public class ContentOrchestrator : IContentOrchestrator
 
             var installations = installationsResult.Data.ToList();
             return await _installationCasPoolService.EnsurePoolPathAsync(installations, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -450,6 +450,10 @@ public class GeneralsOnlineProfileReconciler(
                 allResults.AddRange(mapPackResult.Data);
             }
 
+            // Layers beneath the orchestrator still report cancellation as a failed result, so a
+            // failure raised while shutting down must not be surfaced as a real acquisition error.
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (allResults.Count == 0)
             {
                 return OperationResult<List<ContentManifest>>.CreateFailure(
@@ -459,6 +463,7 @@ public class GeneralsOnlineProfileReconciler(
             foreach (var result in allResults)
             {
                 var acquireOp = await contentOrchestrator.AcquireContentAsync(result, progress: null, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!acquireOp.Success)
                 {
                     logger.LogError(

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -427,6 +427,7 @@ public class GeneralsOnlineProfileReconciler(
             };
 
             var clientResult = await contentOrchestrator.SearchAsync(clientQuery, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Search for Map Packs (required dependency)
             var mapPackQuery = new ContentSearchQuery

--- a/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
@@ -320,6 +320,10 @@ public class SuperHackersProfileReconciler(
 
             var searchResult = await contentOrchestrator.SearchAsync(query, cancellationToken);
 
+            // Layers beneath the orchestrator still report cancellation as a failed result, so a
+            // failure raised while shutting down must not be surfaced as a real acquisition error.
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (!searchResult.Success || searchResult.Data == null || !searchResult.Data.Any())
             {
                  return OperationResult<List<ContentManifest>>.CreateFailure(
@@ -329,6 +333,7 @@ public class SuperHackersProfileReconciler(
             foreach (var result in searchResult.Data)
             {
                 var acquireOp = await contentOrchestrator.AcquireContentAsync(result, progress: null, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!acquireOp.Success)
                 {
                     logger.LogError(

--- a/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
@@ -356,6 +356,10 @@ public class SuperHackersProfileReconciler(
 
             return OperationResult<List<ContentManifest>>.CreateSuccess(newManifests);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "[SH Reconciler] Failed to acquire latest version");

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -592,6 +592,10 @@ public class ProfileLauncherFacade(
 
             return ProfileOperationResult<GameLaunchInfo>.CreateSuccess(launchInfo);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to launch profile {ProfileId}", profileId);


### PR DESCRIPTION
Backport of #357 to `release/alpha-4`. Cherry-picked cleanly; no conflicts.

`SuperHackersProfileReconciler.AcquireLatestVersionAsync` caught `OperationCanceledException` in its generic `catch (Exception)` handler, logged it as an error, and returned a generic failure result. Both sibling reconcilers guard the same handler with `catch (OperationCanceledException) { throw; }`; SuperHackers did not.

Because the inner handler is nested inside the method's outer `catch (OperationCanceledException) { throw; }`, that outer guard was unreachable for any cancellation originating during acquisition. The caller then surfaced `ShowError("SuperHackers Update Failed", ...)` at `NotificationDurations.Critical`, so a clean shutdown or user-cancelled reconciliation produced a spurious critical error toast and a bogus `LogError` instead of propagating the cancel.

Alpha 4 carries the bug, so it is in scope for the release branch. Introduced in #261.

## Testing
- `ProfileReconcilerTests` on the alpha-4 base: 14/14 pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport consistently propagates caller cancellation through content search, acquisition, publisher reconciliation, and profile launch while preserving dependency-local timeouts as ordinary failures.
- Adds caller-token-aware cancellation handling in `ContentOrchestrator`.
- Adds reconciliation-boundary cancellation checks for Community Outpost, Generals Online, and SuperHackers.
- Preserves cancellation through `ProfileLauncherFacade`.
- Adds regression coverage for swallowed cancellation, cached searches, installation detection, and provider-local timeouts.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported cancellation paths now propagate caller cancellation while provider-local timeouts retain their normal failure behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs | Correctly distinguishes caller cancellation from provider-local timeouts across cached search, provider fan-out, acquisition, and installation-path preparation. |
| GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs | Cancellation is now recovered from both thrown exceptions and failed results before acquisition errors are logged or notified. |
| GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs | Adds cancellation checks after search and acquisition before entering ordinary failure handling. |
| GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs | Adds cancellation checks around the two-search aggregation and each acquisition without disrupting normal timeout failures. |
| GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs | Propagates cancellation only when the facade’s caller token is cancelled, retaining dependency-local timeout translation. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs | Covers caller cancellation, cache hits, provider-local timeouts, and cancellation during installation detection. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/ProfileLauncherFacadeCancellationTests.cs | Verifies caller cancellation propagation and preservation of dependency-local timeout behavior. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI
    participant Facade as ProfileLauncherFacade
    participant Reconciler
    participant Orchestrator as ContentOrchestrator
    participant Provider

    UI->>Facade: LaunchProfileAsync(token)
    Facade->>Reconciler: CheckAndReconcileIfNeededAsync(token)
    Reconciler->>Orchestrator: SearchAsync / AcquireContentAsync(token)
    Orchestrator->>Provider: Search / acquire(token)

    alt Caller token cancelled
        Provider-->>Orchestrator: OCE or failed result
        Orchestrator-->>Reconciler: OCE or failed result
        Reconciler->>Reconciler: ThrowIfCancellationRequested()
        Reconciler-->>Facade: OperationCanceledException
        Facade-->>UI: Propagate cancellation
    else Provider-local timeout
        Provider-->>Orchestrator: TaskCanceledException
        Orchestrator-->>Reconciler: Normal failure result
        Reconciler-->>Facade: Reconciliation failure
    end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(content): observe cancellation on ca..."](https://github.com/community-outpost/genhub/commit/8632991cc6609a6368305119cfd87866b625157b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51177911)</sub>

**Context used:**

- Knowledge Base — [Content Acquisition Pipeline](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-acquisition-pipeline.md)
- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)

<!-- /greptile_comment -->