### PR TITLE
fix(settings): write the declared TheSuperHackers defaults to settings.json (backport of #356)

### DIFF
--- a/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
@@ -44,4 +44,46 @@ public static class GameSettingsTheSuperHackersConstants
     /// Default font size for system time display.
     /// </summary>
     public const int DefaultSystemTimeFontSize = 8;
+
+    /// <summary>
+    /// Default for whether player observer mode is enabled.
+    /// Matches the engine fallback in OptionPreferences::getPlayerObserverEnabled.
+    /// </summary>
+    public const bool DefaultPlayerObserverEnabled = true;
+
+    /// <summary>
+    /// Default for cursor capture in fullscreen game.
+    /// Included in the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInFullscreenGame = true;
+
+    /// <summary>
+    /// Default for cursor capture in fullscreen menu.
+    /// Included in the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInFullscreenMenu = true;
+
+    /// <summary>
+    /// Default for cursor capture in windowed game.
+    /// Included in the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInWindowedGame = true;
+
+    /// <summary>
+    /// Default for cursor capture in windowed menu.
+    /// Absent from the engine's CursorCaptureMode_Default mask.
+    /// </summary>
+    public const bool DefaultCursorCaptureEnabledInWindowedMenu = false;
+
+    /// <summary>
+    /// Default for screen edge scrolling in a fullscreen app.
+    /// The engine's ScreenEdgeScrollMode_Default is exactly this flag.
+    /// </summary>
+    public const bool DefaultScreenEdgeScrollEnabledInFullscreenApp = true;
+
+    /// <summary>
+    /// Default for screen edge scrolling in a windowed app.
+    /// Absent from the engine's ScreenEdgeScrollMode_Default.
+    /// </summary>
+    public const bool DefaultScreenEdgeScrollEnabledInWindowedApp = false;
 }

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -209,17 +209,17 @@ public static class GameSettingsMapper
         settings.ArchiveReplays = profile.TshArchiveReplays ?? false;
         settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
         settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
-        settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? false;
+        settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled;
         settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
         settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
         settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
         settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
-        settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? false;
-        settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? false;
-        settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? false;
-        settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu ?? false;
-        settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp ?? false;
-        settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp ?? false;
+        settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame;
+        settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu;
+        settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame;
+        settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu;
+        settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp;
+        settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -210,10 +210,10 @@ public static class GameSettingsMapper
         settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
         settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
         settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? false;
-        settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? 12;
-        settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? 12;
-        settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? 12;
-        settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? -100;
+        settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
+        settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
+        settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
+        settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
         settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? false;
         settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? false;
         settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? false;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -138,4 +138,102 @@ public class GameSettingsMapperTests
         Assert.Equal(22, settings.RenderFpsFontSize);
         Assert.Equal(23, settings.ResolutionFontAdjustment);
     }
+
+    /// <summary>
+    /// Verifies that a profile with no cursor capture, edge scroll or observer toggles set
+    /// falls back to the declared defaults.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetToggles_UsesDeclaredDefaults()
+    {
+        // Arrange - seed each toggle inverted, so a missing assignment fails
+        var profile = new GameProfile();
+        var settings = new GeneralsOnlineSettings
+        {
+            PlayerObserverEnabled = false,
+            CursorCaptureEnabledInFullscreenGame = false,
+            CursorCaptureEnabledInFullscreenMenu = false,
+            CursorCaptureEnabledInWindowedGame = false,
+            CursorCaptureEnabledInWindowedMenu = true,
+            ScreenEdgeScrollEnabledInFullscreenApp = false,
+            ScreenEdgeScrollEnabledInWindowedApp = true,
+        };
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled, settings.PlayerObserverEnabled);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame, settings.CursorCaptureEnabledInFullscreenGame);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu, settings.CursorCaptureEnabledInFullscreenMenu);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame, settings.CursorCaptureEnabledInWindowedGame);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu, settings.CursorCaptureEnabledInWindowedMenu);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp, settings.ScreenEdgeScrollEnabledInFullscreenApp);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp, settings.ScreenEdgeScrollEnabledInWindowedApp);
+    }
+
+    /// <summary>
+    /// Verifies that the toggle fallbacks match the values declared on the settings model itself.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetToggles_MatchesModelDefaults()
+    {
+        // Arrange - seed each toggle inverted, so a missing assignment fails
+        var profile = new GameProfile();
+        var expected = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings
+        {
+            PlayerObserverEnabled = false,
+            CursorCaptureEnabledInFullscreenGame = false,
+            CursorCaptureEnabledInFullscreenMenu = false,
+            CursorCaptureEnabledInWindowedGame = false,
+            CursorCaptureEnabledInWindowedMenu = true,
+            ScreenEdgeScrollEnabledInFullscreenApp = false,
+            ScreenEdgeScrollEnabledInWindowedApp = true,
+        };
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(expected.PlayerObserverEnabled, settings.PlayerObserverEnabled);
+        Assert.Equal(expected.CursorCaptureEnabledInFullscreenGame, settings.CursorCaptureEnabledInFullscreenGame);
+        Assert.Equal(expected.CursorCaptureEnabledInFullscreenMenu, settings.CursorCaptureEnabledInFullscreenMenu);
+        Assert.Equal(expected.CursorCaptureEnabledInWindowedGame, settings.CursorCaptureEnabledInWindowedGame);
+        Assert.Equal(expected.CursorCaptureEnabledInWindowedMenu, settings.CursorCaptureEnabledInWindowedMenu);
+        Assert.Equal(expected.ScreenEdgeScrollEnabledInFullscreenApp, settings.ScreenEdgeScrollEnabledInFullscreenApp);
+        Assert.Equal(expected.ScreenEdgeScrollEnabledInWindowedApp, settings.ScreenEdgeScrollEnabledInWindowedApp);
+    }
+
+    /// <summary>
+    /// Verifies that explicit toggle values on the profile are written through unchanged.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_ExplicitToggles_ArePreserved()
+    {
+        // Arrange - every value is the opposite of its default
+        var profile = new GameProfile
+        {
+            TshPlayerObserverEnabled = false,
+            TshCursorCaptureEnabledInFullscreenGame = false,
+            TshCursorCaptureEnabledInFullscreenMenu = false,
+            TshCursorCaptureEnabledInWindowedGame = false,
+            TshCursorCaptureEnabledInWindowedMenu = true,
+            TshScreenEdgeScrollEnabledInFullscreenApp = false,
+            TshScreenEdgeScrollEnabledInWindowedApp = true,
+        };
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.False(settings.PlayerObserverEnabled);
+        Assert.False(settings.CursorCaptureEnabledInFullscreenGame);
+        Assert.False(settings.CursorCaptureEnabledInFullscreenMenu);
+        Assert.False(settings.CursorCaptureEnabledInWindowedGame);
+        Assert.True(settings.CursorCaptureEnabledInWindowedMenu);
+        Assert.False(settings.ScreenEdgeScrollEnabledInFullscreenApp);
+        Assert.True(settings.ScreenEdgeScrollEnabledInWindowedApp);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -66,9 +66,15 @@ public class GameSettingsMapperTests
     [Fact]
     public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_UsesDeclaredDefaults()
     {
-        // Arrange
+        // Arrange - seed with values the mapper must overwrite, so a missing assignment fails
         var profile = new GameProfile();
-        var settings = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings
+        {
+            SystemTimeFontSize = 99,
+            NetworkLatencyFontSize = 99,
+            RenderFpsFontSize = 99,
+            ResolutionFontAdjustment = 99,
+        };
 
         // Act
         GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
@@ -86,10 +92,16 @@ public class GameSettingsMapperTests
     [Fact]
     public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_MatchesModelDefaults()
     {
-        // Arrange
+        // Arrange - seed with values the mapper must overwrite, so a missing assignment fails
         var profile = new GameProfile();
         var expected = new GeneralsOnlineSettings();
-        var settings = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings
+        {
+            SystemTimeFontSize = 99,
+            NetworkLatencyFontSize = 99,
+            RenderFpsFontSize = 99,
+            ResolutionFontAdjustment = 99,
+        };
 
         // Act
         GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
@@ -113,6 +125,7 @@ public class GameSettingsMapperTests
             TshSystemTimeFontSize = 20,
             TshNetworkLatencyFontSize = 21,
             TshRenderFpsFontSize = 22,
+            TshResolutionFontAdjustment = 23,
         };
         var settings = new GeneralsOnlineSettings();
 
@@ -123,5 +136,6 @@ public class GameSettingsMapperTests
         Assert.Equal(20, settings.SystemTimeFontSize);
         Assert.Equal(21, settings.NetworkLatencyFontSize);
         Assert.Equal(22, settings.RenderFpsFontSize);
+        Assert.Equal(23, settings.ResolutionFontAdjustment);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -59,4 +59,69 @@ public class GameSettingsMapperTests
         // Assert
         Assert.Equal(expectedQuality, profile.VideoTextureQuality);
     }
+
+    /// <summary>
+    /// Verifies that a profile with no TheSuperHackers font sizes set falls back to the declared defaults.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_UsesDeclaredDefaults()
+    {
+        // Arrange
+        var profile = new GameProfile();
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize, settings.SystemTimeFontSize);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize, settings.NetworkLatencyFontSize);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize, settings.RenderFpsFontSize);
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment, settings.ResolutionFontAdjustment);
+    }
+
+    /// <summary>
+    /// Verifies that the fallback defaults match the values declared on the settings model itself.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_MatchesModelDefaults()
+    {
+        // Arrange
+        var profile = new GameProfile();
+        var expected = new GeneralsOnlineSettings();
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(expected.SystemTimeFontSize, settings.SystemTimeFontSize);
+        Assert.Equal(expected.NetworkLatencyFontSize, settings.NetworkLatencyFontSize);
+        Assert.Equal(expected.RenderFpsFontSize, settings.RenderFpsFontSize);
+        Assert.Equal(expected.ResolutionFontAdjustment, settings.ResolutionFontAdjustment);
+    }
+
+    /// <summary>
+    /// Verifies that explicit TheSuperHackers font sizes on the profile are written through unchanged.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_ExplicitFontSizes_ArePreserved()
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            TshSystemTimeFontSize = 20,
+            TshNetworkLatencyFontSize = 21,
+            TshRenderFpsFontSize = 22,
+        };
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(20, settings.SystemTimeFontSize);
+        Assert.Equal(21, settings.NetworkLatencyFontSize);
+        Assert.Equal(22, settings.RenderFpsFontSize);
+    }
 }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -286,16 +286,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _tshPlayerObserverEnabled;
 
     [ObservableProperty]
-    private int _tshSystemTimeFontSize = 12;
+    private int _tshSystemTimeFontSize = GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
 
     [ObservableProperty]
-    private int _tshNetworkLatencyFontSize = 12;
+    private int _tshNetworkLatencyFontSize = GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
 
     [ObservableProperty]
-    private int _tshRenderFpsFontSize = 12;
+    private int _tshRenderFpsFontSize = GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
 
     [ObservableProperty]
-    private int _tshResolutionFontAdjustment = -100;
+    private int _tshResolutionFontAdjustment = GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
 
     [ObservableProperty]
     private bool _tshCursorCaptureEnabledInFullscreenGame;

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -283,7 +283,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _tshShowMoneyPerMinute;
 
     [ObservableProperty]
-    private bool _tshPlayerObserverEnabled;
+    private bool _tshPlayerObserverEnabled = GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled;
 
     [ObservableProperty]
     private int _tshSystemTimeFontSize = GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
@@ -298,22 +298,22 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private int _tshResolutionFontAdjustment = GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInFullscreenGame;
+    private bool _tshCursorCaptureEnabledInFullscreenGame = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInFullscreenMenu;
+    private bool _tshCursorCaptureEnabledInFullscreenMenu = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInWindowedGame;
+    private bool _tshCursorCaptureEnabledInWindowedGame = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame;
 
     [ObservableProperty]
-    private bool _tshCursorCaptureEnabledInWindowedMenu;
+    private bool _tshCursorCaptureEnabledInWindowedMenu = GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu;
 
     [ObservableProperty]
-    private bool _tshScreenEdgeScrollEnabledInFullscreenApp;
+    private bool _tshScreenEdgeScrollEnabledInFullscreenApp = GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp;
 
     [ObservableProperty]
-    private bool _tshScreenEdgeScrollEnabledInWindowedApp;
+    private bool _tshScreenEdgeScrollEnabledInWindowedApp = GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
 
     [ObservableProperty]
     private int _tshMoneyTransactionVolume = 50;


### PR DESCRIPTION
Full backport of #356 to `release/alpha-4`. All three commits cherry-picked cleanly with no conflicts; the resulting diff is byte-for-byte identical to #356.

## Why this matters for alpha 4

Alpha 4 has not shipped and `release/alpha-4` carries the bug, so without this the release goes out writing wrong defaults on every Zero Hour launch.

`GameLauncher.ApplyGeneralsOnlineSettingsAsync` builds a **fresh** `GeneralsOnlineSettings` before mapping, so any profile that never set these got the wrong value written to settings.json every time. Verified against the engine source:

| Setting | Engine | Was | Now |
|---|---|---|---|
| `SystemTimeFontSize` | `8` | `?? 12` | `8` |
| `NetworkLatencyFontSize` | `8` | `?? 12` | `8` |
| `RenderFpsFontSize` | `8` | `?? 12` | `8` |
| `PlayerObserverEnabled` | `TRUE` | `?? false` | `true` |
| `CursorCaptureEnabledInFullscreenGame` | in default mask | `?? false` | `true` |
| `CursorCaptureEnabledInFullscreenMenu` | in default mask | `?? false` | `true` |
| `CursorCaptureEnabledInWindowedGame` | in default mask | `?? false` | `true` |
| `ScreenEdgeScrollEnabledInFullscreenApp` | in default mask | `?? false` | `true` |

```cpp
m_systemTimeFontSize = 8;  m_renderFpsFontSize = 8;  m_networkLatencyFontSize = 8;

CursorCaptureMode_Default = EnabledInWindowedGame | EnabledInFullscreenGame | EnabledInFullscreenMenu
ScreenEdgeScrollMode_Default = ScreenEdgeScrollMode_EnabledInFullscreenApp
```

The cursor capture and edge scroll entries are input behaviour, not cosmetics: every launch was disabling cursor capture and fullscreen edge scrolling for profiles that never touched them.

## Note on verification

**Correction (post-merge):** this originally claimed no CI runs against `release/alpha-4` at all. That is wrong. `ci.yml`'s `pull_request` trigger filters on the *base* branch (`[main, development]`), so a PR **into** `release/alpha-4` gets no **pre-merge** CI — but #335 is an open PR from `release/alpha-4` → `main`, so merging pushes that branch, updates #335's head, and fires the workflow with base `main`. CI ran on this PR's merge commit `90588361` and passed. The gap is pre-merge only, and it depends on #335 staying open.

Everything below was run locally on this branch before merging:

- `GameSettingsMapperTests` 13/13 pass; `GenHub.csproj` builds.
- Test targets are seeded with sentinel values (inverted for booleans) so a missing or reverted mapper assignment fails rather than passing on the constructor default. Verified by mutation: restoring `?? false` on `CursorCaptureEnabledInFullscreenGame` fails both toggle tests; deleting the `SystemTimeFontSize` assignment fails all three numeric tests.

Worth merging with room to spare before the release is cut rather than against the deadline, given CI cannot check it before merge.

See #356 for the full root-cause history.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport centralizes TheSuperHackers settings defaults and updates mapper, ViewModel, and test coverage to use them.
- Adds named constants for font-size, observer, cursor-capture, and edge-scroll defaults.
- Applies those constants when mapping nullable profile settings into `settings.json`.
- Aligns ViewModel initialization with the declared constants.
- Adds mapper tests for unset and explicit font-size and toggle values.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no eligible blocking failure remains in the available follow-up review context.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs | Declares centralized defaults for TheSuperHackers font sizes and behavioral toggles. |
| GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs | Replaces literal settings fallbacks with the centralized constants. |
| GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs | Initializes TheSuperHackers settings fields from the same constants used by the mapper. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs | Adds sentinel-based coverage for unset defaults and explicit profile values. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    C[TheSuperHackers default constants] --> VM[GameSettingsViewModel defaults]
    C --> M[GameSettingsMapper fallbacks]
    P[Nullable GameProfile settings] --> M
    M --> S[GeneralsOnlineSettings]
    S --> J[settings.json]
    T[Mapper tests] --> M
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(settings): align TheSuperHackers cur..."](https://github.com/community-outpost/genhub/commit/3bfd014eba9a9606121718b5bc3330bbd5f85579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51181624)</sub>

**Context used:**

- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)

<!-- /greptile_comment -->
