### PR TITLE
fix(generalsonline): forward-port Easy Anti-Cheat launch support from alpha 4

### DIFF
--- a/GenHub/GenHub.Core/Constants/GameClientConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameClientConstants.cs
@@ -69,6 +69,15 @@ public static class GameClientConstants
     /// <summary>GeneralsOnline default client executable name.</summary>
     public const string GeneralsOnlineDefaultExecutable = "generalsonlinezh.exe";
 
+    /// <summary>
+    /// Easy Anti-Cheat bootstrapper shipped since GeneralsOnline 060526_QFE1. It launches the
+    /// binary named by <c>EasyAntiCheat/Settings.json</c> and is the supported launch target.
+    /// </summary>
+    public const string GeneralsOnlineEacLauncherExecutable = "EAC_LaunchGeneralsOnline.exe";
+
+    /// <summary>Epic Online Services Easy Anti-Cheat installer shipped in the GeneralsOnline portable.</summary>
+    public const string GeneralsOnlineEacSetupExecutable = "EasyAntiCheat_EOS_Setup.exe";
+
     /// <summary>Display name for GeneralsOnline 60Hz variant.</summary>
     public const string GeneralsOnline60HzDisplayName = "GeneralsOnline 60Hz";
 
@@ -180,12 +189,19 @@ public static class GameClientConstants
     ];
 
     /// <summary>
-    /// List of GeneralsOnline executable names to detect.
-    /// Only includes 30Hz and 60Hz variants as these are the primary clients.
-    /// GeneralsOnline provides auto-updated clients for Command &amp; Conquer Generals and Zero Hour.
+    /// The GeneralsOnline executable names that are supported launch entry points.
+    /// Since 060526_QFE1 the Easy Anti-Cheat bootstrapper starts the binary named by
+    /// <c>EasyAntiCheat/Settings.json</c>; older packages launch the 60Hz binary directly.
+    /// <c>GeneralsOnlineZH.exe</c> ships alongside both but is not wrapped, so it is workspace
+    /// content rather than an entry point.
     /// </summary>
+    /// <remarks>
+    /// Membership only. When both are present the bootstrapper wins, but that precedence is
+    /// expressed in the resolving code rather than by the order of this list.
+    /// </remarks>
     public static readonly IReadOnlyList<string> GeneralsOnlineExecutableNames =
     [
+        GeneralsOnlineEacLauncherExecutable,
         GeneralsOnline60HzExecutable,
     ];
 

--- a/GenHub/GenHub.Core/Constants/ProcessConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ProcessConstants.cs
@@ -82,4 +82,29 @@ public static class ProcessConstants
     /// Threshold in seconds to consider a process exit as "early" or "immediate".
     /// </summary>
     public const double EarlyExitThresholdSeconds = 10.0;
+
+    /// <summary>
+    /// How long to wait for a launcher's expected child process to appear. Measured spawn latency
+    /// for the Easy Anti-Cheat bootstrapper is well under two seconds. Must not exceed
+    /// <see cref="EarlyExitThresholdSeconds"/>, which bounds how old an adoptable process may be.
+    /// </summary>
+    public const int SpawnedChildDiscoveryTimeoutMs = 10_000;
+
+    /// <summary>
+    /// Interval in milliseconds between polls for a launcher's expected child process.
+    /// </summary>
+    public const int SpawnedChildPollIntervalMs = 100;
+
+    /// <summary>
+    /// How long to wait for an abandoned launcher to exit after it is killed. The launcher is
+    /// already being torn down on a cancelled launch, so this only bounds the cleanup.
+    /// </summary>
+    public const int AbandonedLauncherKillWaitMs = 2_000;
+
+    /// <summary>
+    /// How long to keep polling for the expected child after the launcher itself exits cleanly.
+    /// Covers the race between the child being spawned and becoming enumerable, without waiting
+    /// out <see cref="SpawnedChildDiscoveryTimeoutMs"/> once the launcher is known to be gone.
+    /// </summary>
+    public const int LauncherExitGracePeriodMs = 1_000;
 }

--- a/GenHub/GenHub.Core/Helpers/GameProcessSelector.cs
+++ b/GenHub/GenHub.Core/Helpers/GameProcessSelector.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GenHub.Core.Constants;
+using GenHub.Core.Models.Launching;
+
+namespace GenHub.Core.Helpers;
+
+/// <summary>
+/// Decides which running process is the game a launch spawned.
+/// </summary>
+public static class GameProcessSelector
+{
+    /// <summary>
+    /// Selects the process matching <paramref name="processName"/> that this launch spawned.
+    /// </summary>
+    /// <param name="candidates">The processes currently observed on the machine.</param>
+    /// <param name="processName">The expected process name, without extension.</param>
+    /// <param name="workingDirectory">The directory the game must run from, or <see langword="null"/> to skip the check.</param>
+    /// <param name="now">The current time, used to apply the recency window.</param>
+    /// <returns>The selected candidate, or <see langword="null"/> when none qualifies.</returns>
+    public static GameProcessCandidate? SelectSpawnedGameProcess(
+        IEnumerable<GameProcessCandidate> candidates,
+        string processName,
+        string? workingDirectory,
+        DateTime now)
+    {
+        var matches = candidates
+            .Where(candidate => candidate.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+            .Where(candidate => (now - candidate.StartTime).TotalSeconds < ProcessConstants.EarlyExitThresholdSeconds);
+
+        // Residence is required whenever a working directory is known, including for a lone match:
+        // a same-named process elsewhere on the machine is somebody else's.
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            matches = matches.Where(candidate => ResidesIn(candidate, workingDirectory));
+        }
+
+        return matches
+            .OrderByDescending(candidate => candidate.StartTime)
+            .FirstOrDefault();
+    }
+
+    private static bool ResidesIn(GameProcessCandidate candidate, string workingDirectory)
+    {
+        if (candidate.ExecutablePath is null)
+        {
+            return false;
+        }
+
+        var directory = Path.GetDirectoryName(candidate.ExecutablePath);
+        return directory != null && Normalize(directory).Equals(Normalize(workingDirectory), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Normalize(string path)
+    {
+        // MainModule.FileName is always absolute and fully resolved, while the configured working
+        // directory is neither guaranteed. Canonicalize first so a relative spelling or a "."
+        // segment does not read as a different directory and abandon an adoptable process.
+        try
+        {
+            path = Path.GetFullPath(path);
+        }
+        catch (Exception)
+        {
+            // A malformed path compares on its original spelling rather than aborting the scan.
+        }
+
+        return path
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/')
+            .TrimEnd('/');
+    }
+}

--- a/GenHub/GenHub.Core/Helpers/LaunchEntryPointResolver.cs
+++ b/GenHub/GenHub.Core/Helpers/LaunchEntryPointResolver.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using GenHub.Core.Constants;
+
+namespace GenHub.Core.Helpers;
+
+/// <summary>
+/// Relates a launch entry point to the process that ends up owning the game session.
+/// </summary>
+public static class LaunchEntryPointResolver
+{
+    /// <summary>
+    /// Resolves the process that <paramref name="executablePath"/> is expected to spawn and hand
+    /// the session to.
+    /// </summary>
+    /// <param name="executablePath">The executable being launched.</param>
+    /// <returns>
+    /// The expected child process name without extension, or <see langword="null"/> when the
+    /// launched executable is itself the game.
+    /// </returns>
+    public static string? ResolveExpectedChildProcessName(string? executablePath)
+    {
+        if (string.IsNullOrEmpty(executablePath))
+        {
+            return null;
+        }
+
+        var fileName = Path.GetFileName(executablePath);
+        if (fileName.Equals(GameClientConstants.GeneralsOnlineEacLauncherExecutable, StringComparison.OrdinalIgnoreCase))
+        {
+            return Path.GetFileNameWithoutExtension(GameClientConstants.GeneralsOnline60HzExecutable);
+        }
+
+        return null;
+    }
+}

--- a/GenHub/GenHub.Core/Models/Launching/GameLaunchConfiguration.cs
+++ b/GenHub/GenHub.Core/Models/Launching/GameLaunchConfiguration.cs
@@ -20,4 +20,19 @@ public class GameLaunchConfiguration
 
     /// <summary>Gets or sets the timeout for waiting.</summary>
     public TimeSpan? Timeout { get; set; }
+
+    /// <summary>
+    /// Gets or sets the process name, without extension, that <see cref="ExecutablePath"/> is
+    /// expected to spawn and hand the session to — the Easy Anti-Cheat bootstrapper being the
+    /// case that needs it. Leave <see langword="null"/> when the started executable *is* the game;
+    /// tracking then follows the started process as before.
+    /// </summary>
+    public string? ExpectedChildProcessName { get; set; }
+
+    /// <summary>
+    /// Gets or sets how long to wait for <see cref="ExpectedChildProcessName"/> to appear before
+    /// failing the launch. Defaults to
+    /// <see cref="GenHub.Core.Constants.ProcessConstants.SpawnedChildDiscoveryTimeoutMs"/>.
+    /// </summary>
+    public TimeSpan? ExpectedChildDiscoveryTimeout { get; set; }
 }

--- a/GenHub/GenHub.Core/Models/Launching/GameProcessCandidate.cs
+++ b/GenHub/GenHub.Core/Models/Launching/GameProcessCandidate.cs
@@ -1,0 +1,15 @@
+namespace GenHub.Core.Models.Launching;
+
+/// <summary>
+/// A running process reduced to the facts needed to decide whether it is the game a launch spawned.
+/// Keeps the selection policy free of <see cref="System.Diagnostics.Process"/> so it can be tested.
+/// </summary>
+/// <param name="ProcessId">The operating system process identifier.</param>
+/// <param name="ProcessName">The process name, without extension.</param>
+/// <param name="StartTime">When the process started.</param>
+/// <param name="ExecutablePath">The full image path, or <see langword="null"/> when it cannot be read.</param>
+public sealed record GameProcessCandidate(
+    int ProcessId,
+    string ProcessName,
+    DateTime StartTime,
+    string? ExecutablePath);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Constants/GameClientHashRegistryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Constants/GameClientHashRegistryTests.cs
@@ -83,6 +83,18 @@ public class GameClientHashRegistryTests
     }
 
     /// <summary>
+    /// Since 060526_QFE1 the GeneralsOnline portable launches through the Easy Anti-Cheat
+    /// bootstrapper, so directory scans have to recognise it as a client executable.
+    /// </summary>
+    [Fact]
+    public void PossibleExecutableNames_IncludeTheGeneralsOnlineAntiCheatBootstrapper()
+    {
+        Assert.Contains(
+            _registry.PossibleExecutableNames,
+            name => name.Equals(GameClientConstants.GeneralsOnlineEacLauncherExecutable, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
     /// Verifies that GameClientInfo.Validate() works correctly.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineClientIdentifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineClientIdentifierTests.cs
@@ -1,0 +1,55 @@
+using GenHub.Core.Constants;
+using GenHub.Features.Content.Services.GeneralsOnline;
+
+namespace GenHub.Tests.Core.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Tests for <see cref="GeneralsOnlineClientIdentifier"/> across the pre- and post-EAC layouts.
+/// </summary>
+public class GeneralsOnlineClientIdentifierTests
+{
+    /// <summary>
+    /// The Easy Anti-Cheat bootstrapper is the supported entry point, so publisher discovery
+    /// must recognise it.
+    /// </summary>
+    [Fact]
+    public void Identify_EacLauncher_ReturnsSixtyHertzClient()
+    {
+        var identifier = new GeneralsOnlineClientIdentifier();
+        var path = Path.Combine("C:", "GO", GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+
+        Assert.True(identifier.CanIdentify(path));
+
+        var identification = identifier.Identify(path);
+
+        Assert.NotNull(identification);
+        Assert.Equal(GameClientConstants.GeneralsOnline60HzDisplayName, identification!.DisplayName);
+    }
+
+    /// <summary>
+    /// Pre-EAC packages ship the 60Hz binary as the entry point and must still be recognised.
+    /// </summary>
+    [Fact]
+    public void Identify_SixtyHertzExecutable_ReturnsSixtyHertzClient()
+    {
+        var identifier = new GeneralsOnlineClientIdentifier();
+        var path = Path.Combine("C:", "GO", GameClientConstants.GeneralsOnline60HzExecutable);
+
+        Assert.True(identifier.CanIdentify(path));
+        Assert.NotNull(identifier.Identify(path));
+    }
+
+    /// <summary>
+    /// Easy Anti-Cheat wraps only the 60Hz binary. The ordinary client binary ships alongside it
+    /// as workspace content and is not a supported entry point.
+    /// </summary>
+    [Fact]
+    public void Identify_DefaultExecutable_IsNotRecognised()
+    {
+        var identifier = new GeneralsOnlineClientIdentifier();
+        var path = Path.Combine("C:", "GO", GameClientConstants.GeneralsOnlineDefaultExecutable);
+
+        Assert.False(identifier.CanIdentify(path));
+        Assert.Null(identifier.Identify(path));
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
@@ -1,0 +1,186 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Providers;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Features.Content.Services.GeneralsOnline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Tests covering the Easy Anti-Cheat era layout of the Generals Online portable,
+/// where <c>EAC_LaunchGeneralsOnline.exe</c> wraps the game binary named by
+/// <c>EasyAntiCheat/Settings.json</c>.
+/// </summary>
+public class GeneralsOnlineManifestFactoryEacTests : IDisposable
+{
+    private readonly string _extractedDirectory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeneralsOnlineManifestFactoryEacTests"/> class.
+    /// </summary>
+    public GeneralsOnlineManifestFactoryEacTests()
+    {
+        _extractedDirectory = Path.Combine(Path.GetTempPath(), $"genhub-eac-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_extractedDirectory);
+    }
+
+    /// <summary>
+    /// The EAC bootstrapper is the launch target, so it must be the file carrying
+    /// <see cref="ManifestFile.IsExecutable"/> in the game client manifest.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_MarksWrapperAsExecutable()
+    {
+        WriteEacPortableLayout();
+
+        var gameClient = await CreateGameClientManifestAsync();
+
+        var executables = gameClient.Files.Where(file => file.IsExecutable).ToList();
+        var executable = Assert.Single(executables);
+        Assert.Equal(
+            GameClientConstants.GeneralsOnlineEacLauncherExecutable,
+            Path.GetFileName(executable.RelativePath),
+            ignoreCase: true);
+    }
+
+    /// <summary>
+    /// Easy Anti-Cheat launches the binary named by its settings file, so the wrapped
+    /// game binary must remain in the workspace as a non-launch file. Dropping it
+    /// leaves the bootstrapper with nothing to start.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_RetainsWrappedBinaryAsWorkspaceFile()
+    {
+        WriteEacPortableLayout();
+
+        var gameClient = await CreateGameClientManifestAsync();
+
+        var wrapped = gameClient.Files.SingleOrDefault(file =>
+            Path.GetFileName(file.RelativePath)
+                .Equals(GameClientConstants.GeneralsOnline60HzExecutable, StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(wrapped);
+        Assert.False(wrapped!.IsExecutable);
+    }
+
+    /// <summary>
+    /// The portable also ships a non-60Hz binary. Easy Anti-Cheat wraps only the binary named
+    /// by its settings file, so the other one stays as plain workspace content.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_RetainsDefaultBinaryAsWorkspaceFile()
+    {
+        WriteEacPortableLayout();
+
+        var gameClient = await CreateGameClientManifestAsync();
+
+        var defaultBinary = gameClient.Files.SingleOrDefault(file =>
+            Path.GetFileName(file.RelativePath)
+                .Equals(GameClientConstants.GeneralsOnlineDefaultExecutable, StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(defaultBinary);
+        Assert.False(defaultBinary!.IsExecutable);
+    }
+
+    /// <summary>
+    /// Only the bootstrapper at the archive root is the supported entry point. A nested file
+    /// that merely shares its name must not divert the launch target away from the real client.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_NestedWrapperName_DoesNotBecomeLaunchTarget()
+    {
+        WriteFile(GameClientConstants.GeneralsOnline60HzExecutable);
+        WriteFile(Path.Combine("tools", GameClientConstants.GeneralsOnlineEacLauncherExecutable));
+
+        var gameClient = await CreateGameClientManifestAsync();
+
+        var executables = gameClient.Files.Where(file => file.IsExecutable).ToList();
+        var executable = Assert.Single(executables);
+        Assert.Equal(
+            GameClientConstants.GeneralsOnline60HzExecutable,
+            executable.RelativePath,
+            ignoreCase: true);
+    }
+
+    /// <summary>
+    /// Pre-EAC portables ship no bootstrapper, so the 60Hz binary stays the launch target.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_PreEacLayout_MarksSixtyHertzBinaryAsExecutable()
+    {
+        WriteFile(GameClientConstants.GeneralsOnline60HzExecutable);
+        WriteFile("libcurl.dll");
+
+        var gameClient = await CreateGameClientManifestAsync();
+
+        var executables = gameClient.Files.Where(file => file.IsExecutable).ToList();
+        var executable = Assert.Single(executables);
+        Assert.Equal(
+            GameClientConstants.GeneralsOnline60HzExecutable,
+            Path.GetFileName(executable.RelativePath),
+            ignoreCase: true);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        if (Directory.Exists(_extractedDirectory))
+        {
+            Directory.Delete(_extractedDirectory, recursive: true);
+        }
+    }
+
+    private static ContentManifest CreateOriginalManifest() => new()
+    {
+        Id = "1.605261.generalsonline.gameclient.60hz",
+        Name = "GeneralsOnline",
+        Version = "060526_QFE1",
+        ContentType = ContentType.GameClient,
+        TargetGame = GameType.ZeroHour,
+        Publisher = new PublisherInfo
+        {
+            Name = "GeneralsOnline",
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        },
+    };
+
+    private void WriteEacPortableLayout()
+    {
+        WriteFile(GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+        WriteFile(GameClientConstants.GeneralsOnlineEacSetupExecutable);
+        WriteFile(GameClientConstants.GeneralsOnline60HzExecutable);
+        WriteFile(GameClientConstants.GeneralsOnlineDefaultExecutable);
+        WriteFile(Path.Combine("EasyAntiCheat", "Settings.json"));
+        WriteFile("EOSSDK-Win32-Shipping.dll");
+    }
+
+    private void WriteFile(string relativePath)
+    {
+        var fullPath = Path.Combine(_extractedDirectory, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, relativePath);
+    }
+
+    private async Task<ContentManifest> CreateGameClientManifestAsync()
+    {
+        var providerLoader = new Mock<IProviderDefinitionLoader>();
+        var factory = new GeneralsOnlineManifestFactory(
+            NullLogger<GeneralsOnlineManifestFactory>.Instance,
+            providerLoader.Object);
+
+        var manifests = await factory.CreateManifestsFromExtractedContentAsync(
+            CreateOriginalManifest(),
+            _extractedDirectory);
+
+        return manifests.Single(manifest => manifest.ContentType == ContentType.GameClient);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
@@ -393,6 +393,61 @@ public class GameClientDetectorTests : IDisposable
         Assert.Equal(wrapperPath, only.ExecutablePath);
         Assert.Equal(GameType.ZeroHour, only.GameType);
         Assert.Equal(GameClientConstants.GeneralsOnline60HzDisplayName, only.Name);
+
+        // IsPublisherClient turns on PublisherType alone. Without it the client reads as a base
+        // retail install, so version resolution treats it as the base game and the launcher UI
+        // never sees a publisher client.
+        Assert.Equal(PublisherTypeConstants.GeneralsOnline, only.PublisherType);
+        Assert.True(only.IsPublisherClient);
+    }
+
+    /// <summary>
+    /// One misbehaving identifier must not take the rest down with it. The caller's handler
+    /// swallows anything thrown here and returns null, so an escaping exception would drop the
+    /// executable entirely rather than falling through to the identifiers after it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ScanDirectoryForGameClientsAsync_WhenAnIdentifierThrows_StillTriesTheRest()
+    {
+        var gameDir = Path.Combine(_tempDirectory, "GeneralsOnline");
+        Directory.CreateDirectory(gameDir);
+        var wrapperPath = Path.Combine(gameDir, GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+        await File.WriteAllTextAsync(wrapperPath, "dummy content");
+
+        _hashProviderMock.Setup(x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("unknown_hash_12345");
+
+        var manifestBuilderMock = new Mock<IContentManifestBuilder>();
+        manifestBuilderMock.Setup(x => x.Build())
+            .Returns(new ContentManifest { Id = ManifestId.Create("1.0.generalsonline.gameclient.generals-generalsonline-60hz") });
+
+        _manifestGenerationServiceMock.Setup(x => x.CreateGameClientManifestAsync(
+                It.IsAny<string>(), It.IsAny<GameType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PublisherInfo?>()))
+            .ReturnsAsync(manifestBuilderMock.Object);
+
+        _contentManifestPoolMock.Setup(x => x.AddManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<string>(), It.IsAny<IProgress<ContentStorageProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Throws from CanIdentify, which is the probe that runs before Identify.
+        var throwingIdentifier = new Mock<IGameClientIdentifier>();
+        throwingIdentifier.Setup(x => x.PublisherId).Returns("throwing");
+        throwingIdentifier.Setup(x => x.CanIdentify(It.IsAny<string>())).Throws(new InvalidOperationException("boom"));
+
+        var detector = new GameClientDetector(
+            _manifestGenerationServiceMock.Object,
+            _contentManifestPoolMock.Object,
+            _hashProviderMock.Object,
+            _hashRegistryMock.Object,
+            [throwingIdentifier.Object, new GeneralsOnlineClientIdentifier()],
+            NullLogger<GameClientDetector>.Instance);
+
+        var result = await detector.ScanDirectoryForGameClientsAsync(_tempDirectory);
+
+        Assert.True(result.Success);
+        var only = Assert.Single(result.Items);
+        Assert.Equal(GameType.ZeroHour, only.GameType);
+        Assert.Equal(GameClientConstants.GeneralsOnline60HzDisplayName, only.Name);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
@@ -8,6 +8,7 @@ using GenHub.Core.Models.GameClients;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
+using GenHub.Features.Content.Services.GeneralsOnline;
 using GenHub.Features.GameClients;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -19,7 +20,13 @@ namespace GenHub.Tests.Core.Features.GameClients;
 /// </summary>
 public class GameClientDetectorTests : IDisposable
 {
-    private static readonly IReadOnlyList<string> PossibleExecutableNames = [GameClientConstants.GeneralsExecutable, GameClientConstants.GeneralsOnline60HzExecutable];
+    private static readonly IReadOnlyList<string> PossibleExecutableNames =
+    [
+        GameClientConstants.GeneralsExecutable,
+        GameClientConstants.GeneralsOnlineEacLauncherExecutable,
+        GameClientConstants.GeneralsOnline60HzExecutable,
+    ];
+
     private readonly Mock<IManifestGenerationService> _manifestGenerationServiceMock;
     private readonly Mock<IContentManifestPool> _contentManifestPoolMock;
     private readonly Mock<IFileHashProvider> _hashProviderMock;
@@ -306,6 +313,123 @@ public class GameClientDetectorTests : IDisposable
     }
 
     /// <summary>
+    /// A GeneralsOnline directory holds both the Easy Anti-Cheat bootstrapper and the binary it
+    /// wraps. A scan must report the installation once, through the bootstrapper.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ScanDirectoryForGameClientsAsync_WithEacLauncherBesideSixtyHertz_FindsOnlyWrapper()
+    {
+        var gameDir = Path.Combine(_tempDirectory, "GeneralsOnline");
+        Directory.CreateDirectory(gameDir);
+        var wrapperPath = Path.Combine(gameDir, GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+        var sixtyHertzPath = Path.Combine(gameDir, GameClientConstants.GeneralsOnline60HzExecutable);
+        await File.WriteAllTextAsync(wrapperPath, "dummy content");
+        await File.WriteAllTextAsync(sixtyHertzPath, "dummy content");
+
+        _hashProviderMock.Setup(x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("unknown_hash_12345");
+
+        var manifestBuilderMock = new Mock<IContentManifestBuilder>();
+        manifestBuilderMock.Setup(x => x.Build())
+            .Returns(new ContentManifest { Id = ManifestId.Create("1.0.genhub.gameclient.unknownclient") });
+
+        _manifestGenerationServiceMock.Setup(x => x.CreateGameClientManifestAsync(
+                It.IsAny<string>(), It.IsAny<GameType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PublisherInfo?>()))
+            .ReturnsAsync(manifestBuilderMock.Object);
+
+        _contentManifestPoolMock.Setup(x => x.AddManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<string>(), It.IsAny<IProgress<ContentStorageProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var result = await _detector.ScanDirectoryForGameClientsAsync(_tempDirectory);
+
+        Assert.True(result.Success);
+        var only = Assert.Single(result.Items);
+        Assert.Equal(wrapperPath, only.ExecutablePath);
+    }
+
+    /// <summary>
+    /// The bootstrapper is absent from the retail hash registry by definition, so an unrecognized
+    /// hash must fall through to the publisher identifier rather than to the generic entry. A
+    /// GeneralsOnline client reported as GameType.Generals never matches the Zero Hour launch
+    /// path, which is what writes settings.json.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ScanDirectoryForGameClientsAsync_WithEacLauncherAndUnknownHash_ClassifiesAsZeroHourGeneralsOnline()
+    {
+        var gameDir = Path.Combine(_tempDirectory, "GeneralsOnline");
+        Directory.CreateDirectory(gameDir);
+        var wrapperPath = Path.Combine(gameDir, GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+        await File.WriteAllTextAsync(wrapperPath, "dummy content");
+
+        _hashProviderMock.Setup(x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("unknown_hash_12345");
+
+        var manifestBuilderMock = new Mock<IContentManifestBuilder>();
+        manifestBuilderMock.Setup(x => x.Build())
+            .Returns(new ContentManifest { Id = ManifestId.Create("1.0.generalsonline.gameclient.generals-generalsonline-60hz") });
+
+        _manifestGenerationServiceMock.Setup(x => x.CreateGameClientManifestAsync(
+                It.IsAny<string>(), It.IsAny<GameType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PublisherInfo?>()))
+            .ReturnsAsync(manifestBuilderMock.Object);
+
+        _contentManifestPoolMock.Setup(x => x.AddManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<string>(), It.IsAny<IProgress<ContentStorageProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // The production identifier, so this pins real classification rather than a mock's answer.
+        var detector = new GameClientDetector(
+            _manifestGenerationServiceMock.Object,
+            _contentManifestPoolMock.Object,
+            _hashProviderMock.Object,
+            _hashRegistryMock.Object,
+            [new GeneralsOnlineClientIdentifier()],
+            NullLogger<GameClientDetector>.Instance);
+
+        var result = await detector.ScanDirectoryForGameClientsAsync(_tempDirectory);
+
+        Assert.True(result.Success);
+        var only = Assert.Single(result.Items);
+        Assert.Equal(wrapperPath, only.ExecutablePath);
+        Assert.Equal(GameType.ZeroHour, only.GameType);
+        Assert.Equal(GameClientConstants.GeneralsOnline60HzDisplayName, only.Name);
+    }
+
+    /// <summary>
+    /// Portables predating 060526_QFE1 ship no bootstrapper, so the wrapped binary stays the
+    /// entry point rather than being filtered out with it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ScanDirectoryForGameClientsAsync_WithoutEacLauncher_FindsSixtyHertzClient()
+    {
+        var gameDir = Path.Combine(_tempDirectory, "GeneralsOnlinePreEac");
+        Directory.CreateDirectory(gameDir);
+        var sixtyHertzPath = Path.Combine(gameDir, GameClientConstants.GeneralsOnline60HzExecutable);
+        await File.WriteAllTextAsync(sixtyHertzPath, "dummy content");
+
+        _hashProviderMock.Setup(x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("unknown_hash_12345");
+
+        var manifestBuilderMock = new Mock<IContentManifestBuilder>();
+        manifestBuilderMock.Setup(x => x.Build())
+            .Returns(new ContentManifest { Id = ManifestId.Create("1.0.genhub.gameclient.unknownclient") });
+
+        _manifestGenerationServiceMock.Setup(x => x.CreateGameClientManifestAsync(
+                It.IsAny<string>(), It.IsAny<GameType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PublisherInfo?>()))
+            .ReturnsAsync(manifestBuilderMock.Object);
+
+        _contentManifestPoolMock.Setup(x => x.AddManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<string>(), It.IsAny<IProgress<ContentStorageProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var result = await _detector.ScanDirectoryForGameClientsAsync(_tempDirectory);
+
+        Assert.True(result.Success);
+        var only = Assert.Single(result.Items);
+        Assert.Equal(sixtyHertzPath, only.ExecutablePath);
+    }
+
+    /// <summary>
     /// Tests that DetectGameClientsFromInstallationsAsync detects GeneralsOnline 60Hz client.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
@@ -401,6 +525,59 @@ public class GameClientDetectorTests : IDisposable
         Assert.Equal(generalsOnlineExePath, generalsOnlineClient.ExecutablePath);
 
         Assert.Contains("60Hz", generalsOnlineClient.Name);
+    }
+
+    /// <summary>
+    /// Since 060526_QFE1 the Easy Anti-Cheat bootstrapper ships beside the binary it wraps.
+    /// Detection must yield a single client pointing at the bootstrapper, not one client per
+    /// recognised executable name.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DetectGameClientsFromInstallationsAsync_WithEacLauncherBesideSixtyHertz_DetectsOnlyWrapper()
+    {
+        var identifierMock = new Mock<IGameClientIdentifier>();
+        identifierMock.Setup(x => x.PublisherId).Returns(PublisherTypeConstants.GeneralsOnline);
+        identifierMock.Setup(x => x.CanIdentify(It.IsAny<string>())).Returns(false);
+
+        var detector = new GameClientDetector(
+            _manifestGenerationServiceMock.Object,
+            _contentManifestPoolMock.Object,
+            _hashProviderMock.Object,
+            _hashRegistryMock.Object,
+            [identifierMock.Object],
+            NullLogger<GameClientDetector>.Instance);
+
+        var zeroHourPath = Path.Combine(_tempDirectory, "ZeroHourEac");
+        Directory.CreateDirectory(zeroHourPath);
+
+        var wrapperPath = Path.Combine(zeroHourPath, GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+        var sixtyHertzPath = Path.Combine(zeroHourPath, GameClientConstants.GeneralsOnline60HzExecutable);
+        await File.WriteAllTextAsync(wrapperPath, "dummy content");
+        await File.WriteAllTextAsync(sixtyHertzPath, "dummy content");
+
+        var installation = new GameInstallation("C:\\TestInstallEac", GameInstallationType.Steam)
+        {
+            HasZeroHour = true,
+            ZeroHourPath = zeroHourPath,
+        };
+
+        _hashProviderMock.Setup(x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("any_hash");
+
+        _contentManifestPoolMock
+            .Setup(x => x.AddManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<string>(), It.IsAny<IProgress<ContentStorageProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var result = await detector.DetectGameClientsFromInstallationsAsync([installation]);
+
+        Assert.True(result.Success);
+        var generalsOnlineClients = result.Items
+            .Where(client => client.Name.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var only = Assert.Single(generalsOnlineClients);
+        Assert.Equal(wrapperPath, only.ExecutablePath);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProcessManagerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProcessManagerTests.cs
@@ -23,6 +23,210 @@ public class GameProcessManagerTests
     }
 
     /// <summary>
+    /// A process that was just started successfully is running, and the returned information has
+    /// to say so — consumers read <see cref="GameProcessInfo.IsRunning"/> to decide launch state.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task StartProcessAsync_WithLiveProcess_ReportsItAsRunning()
+    {
+        using var harness = LauncherHarness.Create(spawnChild: false);
+
+        var config = new GameLaunchConfiguration
+        {
+            ExecutablePath = harness.LauncherPath,
+            WorkingDirectory = harness.WorkingDirectory,
+        };
+
+        var result = await _processManager.StartProcessAsync(config);
+
+        Assert.True(result.Success, string.Join(", ", result.Errors));
+        Assert.True(result.Data!.IsRunning);
+
+        await _processManager.TerminateProcessAsync(result.Data.ProcessId);
+    }
+
+    /// <summary>
+    /// Launch state is re-read through <see cref="GameProcessManager.GetProcessInfoAsync"/> after
+    /// the launch returns, so that path has to report running state too — not just the one that
+    /// started the process.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetProcessInfoAsync_ForALiveProcess_ReportsItAsRunning()
+    {
+        using var harness = LauncherHarness.Create(spawnChild: false);
+
+        var config = new GameLaunchConfiguration
+        {
+            ExecutablePath = harness.LauncherPath,
+            WorkingDirectory = harness.WorkingDirectory,
+        };
+
+        var started = await _processManager.StartProcessAsync(config);
+        Assert.True(started.Success, string.Join(", ", started.Errors));
+
+        var info = await _processManager.GetProcessInfoAsync(started.Data!.ProcessId);
+
+        Assert.True(info.Success, string.Join(", ", info.Errors));
+        Assert.True(info.Data!.IsRunning);
+
+        await _processManager.TerminateProcessAsync(started.Data.ProcessId);
+    }
+
+    /// <summary>
+    /// The Easy Anti-Cheat bootstrapper spawns the game and then keeps running for about a minute.
+    /// Tracking must follow the spawned child and must not wait for the launcher to exit first.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task StartProcessAsync_WithExpectedChild_TracksTheChildWhileTheLauncherStillRuns()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            // Process.GetProcessesByName does not enumerate these processes on macOS, so adoption
+            // cannot be observed there. The behaviour is Windows-only in practice.
+            return;
+        }
+
+        using var harness = LauncherHarness.Create();
+
+        var config = new GameLaunchConfiguration
+        {
+            ExecutablePath = harness.LauncherPath,
+            WorkingDirectory = harness.WorkingDirectory,
+            ExpectedChildProcessName = LauncherHarness.ChildProcessName,
+        };
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var result = await _processManager.StartProcessAsync(config);
+        stopwatch.Stop();
+
+        Assert.True(result.Success, string.Join(", ", result.Errors));
+        Assert.NotNull(result.Data);
+        Assert.Equal(LauncherHarness.ChildProcessName, result.Data!.ProcessName);
+
+        // The launcher outlives this call by design; returning quickly proves tracking did not
+        // wait for it to exit, which is what made the real bootstrapper untrackable.
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(LauncherHarness.LauncherLifetimeSeconds / 2.0),
+            $"tracking took {stopwatch.Elapsed}, so it waited for the launcher");
+
+        await _processManager.TerminateProcessAsync(result.Data.ProcessId);
+    }
+
+    /// <summary>
+    /// When a child is expected but never appears, the launch fails rather than silently falling
+    /// back to tracking the launcher — which would report the game as running when it is not.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task StartProcessAsync_WithExpectedChildThatNeverAppears_FailsInsteadOfTrackingTheLauncher()
+    {
+        using var harness = LauncherHarness.Create(spawnChild: false);
+
+        var config = new GameLaunchConfiguration
+        {
+            ExecutablePath = harness.LauncherPath,
+            WorkingDirectory = harness.WorkingDirectory,
+            ExpectedChildProcessName = LauncherHarness.ChildProcessName,
+            ExpectedChildDiscoveryTimeout = TimeSpan.FromMilliseconds(750),
+        };
+
+        var result = await _processManager.StartProcessAsync(config);
+
+        Assert.False(result.Success);
+        Assert.Contains(LauncherHarness.ChildProcessName, string.Join(", ", result.Errors));
+    }
+
+    /// <summary>
+    /// A bootstrapper that bails without launching the game exits with code 0, so the exit code
+    /// alone cannot distinguish it from success. Once the launcher is gone no child is coming, and
+    /// waiting out the full discovery timeout only delays the failure behind a misleading message.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task StartProcessAsync_WhenLauncherExitsCleanlyWithoutChild_FailsWithoutWaitingOutTheTimeout()
+    {
+        using var harness = LauncherHarness.Create(spawnChild: false, exitImmediately: true, stderrMessage: null);
+
+        var config = new GameLaunchConfiguration
+        {
+            ExecutablePath = harness.LauncherPath,
+            WorkingDirectory = harness.WorkingDirectory,
+            ExpectedChildProcessName = LauncherHarness.ChildProcessName,
+            ExpectedChildDiscoveryTimeout = TimeSpan.FromSeconds(10),
+        };
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var result = await _processManager.StartProcessAsync(config);
+        stopwatch.Stop();
+
+        Assert.False(result.Success);
+        Assert.Contains("without starting", string.Join(", ", result.Errors));
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Expected a fast failure once the launcher exited, but it took {stopwatch.Elapsed}.");
+    }
+
+    /// <summary>
+    /// The clean-exit failure and the stderr diagnostics are complementary and belong together:
+    /// this path fires only once the launcher has provably exited, which is exactly the condition
+    /// AppendLauncherErrors requires before draining is safe. So the message that says the game
+    /// never started can also carry the bootstrapper's own explanation of why.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task StartProcessAsync_WhenLauncherExitsCleanlyWithoutChild_ReportsItsStderr()
+    {
+        const string complaint = "EasyAntiCheat_is_not_installed";
+        using var harness = LauncherHarness.Create(spawnChild: false, exitImmediately: true, stderrMessage: complaint);
+
+        var config = new GameLaunchConfiguration
+        {
+            ExecutablePath = harness.LauncherPath,
+            WorkingDirectory = harness.WorkingDirectory,
+            ExpectedChildProcessName = LauncherHarness.ChildProcessName,
+            ExpectedChildDiscoveryTimeout = TimeSpan.FromSeconds(10),
+        };
+
+        var result = await _processManager.StartProcessAsync(config);
+
+        Assert.False(result.Success);
+
+        var errors = string.Join(", ", result.Errors);
+        Assert.Contains("without starting", errors);
+        Assert.Contains(complaint, errors);
+    }
+
+    /// <summary>
+    /// A cancelled adoption must surface as cancellation rather than a generic start failure.
+    /// Swallowing it disagrees with TerminateProcessAsync, which rethrows, and prevents
+    /// GameLauncher.LaunchProfileAsync from reaching its own cancellation branch.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task StartProcessAsync_WhenAdoptionIsCancelled_PropagatesCancellation()
+    {
+        using var harness = LauncherHarness.Create(spawnChild: false);
+
+        var config = new GameLaunchConfiguration
+        {
+            ExecutablePath = harness.LauncherPath,
+            WorkingDirectory = harness.WorkingDirectory,
+            ExpectedChildProcessName = LauncherHarness.ChildProcessName,
+
+            // Long enough that the timeout cannot be what ends the wait.
+            ExpectedChildDiscoveryTimeout = TimeSpan.FromSeconds(30),
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _processManager.StartProcessAsync(config, cts.Token));
+    }
+
+    /// <summary>
     /// Tests that StartProcessAsync handles invalid executable path.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -146,6 +350,187 @@ public class GameProcessManagerTests
         finally
         {
             File.Delete(tempExe);
+        }
+    }
+
+    /// <summary>
+    /// A disposable stand-in for the Easy Anti-Cheat bootstrapper: a launcher that outlives the
+    /// call which starts it, optionally spawning a distinctly named child inside the working
+    /// directory. Uses copies of real long-running system binaries so the child has a process name
+    /// of its own, which is what selection keys on.
+    /// </summary>
+    private sealed class LauncherHarness : IDisposable
+    {
+        /// <summary>The process name the spawned child reports.</summary>
+        public const string ChildProcessName = "genhubchild";
+
+        /// <summary>How long the launcher keeps running after it spawns the child.</summary>
+        public const int LauncherLifetimeSeconds = 20;
+
+        /// <summary>File the launcher writes its own PID into, so Dispose can stop it.</summary>
+        private const string LauncherPidFileName = "launcher.pid";
+
+        private LauncherHarness(string workingDirectory, string launcherPath)
+        {
+            WorkingDirectory = workingDirectory;
+            LauncherPath = launcherPath;
+        }
+
+        /// <summary>Gets the directory the launcher and child run from.</summary>
+        public string WorkingDirectory { get; }
+
+        /// <summary>Gets the path of the launcher to start.</summary>
+        public string LauncherPath { get; }
+
+        /// <summary>Creates a harness, optionally spawning a child.</summary>
+        /// <param name="spawnChild">Whether the launcher should spawn the child.</param>
+        /// <param name="exitImmediately">Whether the launcher should exit cleanly instead of staying alive.</param>
+        /// <param name="stderrMessage">A line the launcher writes to stderr before doing anything else.</param>
+        /// <returns>The created harness.</returns>
+        public static LauncherHarness Create(bool spawnChild = true, bool exitImmediately = false, string? stderrMessage = null)
+        {
+            var workingDirectory = Path.Combine(Path.GetTempPath(), "genhub-launcher-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(workingDirectory);
+
+            var childPath = Path.Combine(workingDirectory, OperatingSystem.IsWindows() ? ChildProcessName + ".exe" : ChildProcessName);
+            File.Copy(LongRunningSystemBinary(), childPath);
+
+            string launcherPath;
+            string script;
+            if (OperatingSystem.IsWindows())
+            {
+                launcherPath = Path.Combine(workingDirectory, "genhublauncher.bat");
+                var spawn = spawnChild ? $"start \"\" /b \"{childPath}\" -n {LauncherLifetimeSeconds + 1} 127.0.0.1 >nul\n" : string.Empty;
+
+                // Leave the working directory afterwards: a batch host holds its current directory
+                // open, which would defeat the cleanup delete for the launcher's whole lifetime.
+                var linger = exitImmediately ? string.Empty : $"ping -n {LauncherLifetimeSeconds + 1} 127.0.0.1 >nul\n";
+                var complain = stderrMessage is null ? string.Empty : $"echo {stderrMessage} 1>&2\n";
+                script = $"@echo off\n{complain}{spawn}cd /d \"%TEMP%\"\n{linger}";
+            }
+            else
+            {
+                launcherPath = Path.Combine(workingDirectory, "genhublauncher.sh");
+                var spawn = spawnChild ? $"\"{childPath}\" {LauncherLifetimeSeconds} &\n" : string.Empty;
+                var linger = exitImmediately ? string.Empty : $"sleep {LauncherLifetimeSeconds}\n";
+                var complain = stderrMessage is null ? string.Empty : $"echo \"{stderrMessage}\" >&2\n";
+
+                // The harness does not start the launcher, so it cannot learn the PID by itself.
+                script = $"#!/bin/bash\necho $$ > \"{Path.Combine(workingDirectory, LauncherPidFileName)}\"\n{complain}{spawn}{linger}";
+            }
+
+            File.WriteAllText(launcherPath, script);
+            MakeExecutable(launcherPath);
+            MakeExecutable(childPath);
+
+            return new LauncherHarness(workingDirectory, launcherPath);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            KillLauncher();
+
+            foreach (var process in System.Diagnostics.Process.GetProcessesByName(ChildProcessName))
+            {
+                try
+                {
+                    if (GetImagePath(process)?.StartsWith(WorkingDirectory, StringComparison.OrdinalIgnoreCase) == true)
+                    {
+                        process.Kill(entireProcessTree: true);
+                        process.WaitForExit(2000);
+                    }
+                }
+                catch
+                {
+                    // Best effort - the process may already be gone.
+                }
+                finally
+                {
+                    process.Dispose();
+                }
+            }
+
+            DeleteWorkingDirectory();
+        }
+
+        /// <summary>
+        /// Stops the launcher so it does not outlive the test by <see cref="LauncherLifetimeSeconds"/>.
+        /// </summary>
+        private void KillLauncher()
+        {
+            var pidFile = Path.Combine(WorkingDirectory, LauncherPidFileName);
+
+            try
+            {
+                if (!File.Exists(pidFile) || !int.TryParse(File.ReadAllText(pidFile).Trim(), out var launcherId))
+                {
+                    return;
+                }
+
+                using var launcher = System.Diagnostics.Process.GetProcessById(launcherId);
+                launcher.Kill(entireProcessTree: true);
+                launcher.WaitForExit(2000);
+            }
+            catch
+            {
+                // Best effort - the launcher may have exited, or never recorded a PID.
+            }
+        }
+
+        private void DeleteWorkingDirectory()
+        {
+            // A killed process can hold a handle for a moment after it stops, so retry rather than
+            // leaking the directory for the rest of the run.
+            for (var attempt = 0; attempt < 5; attempt++)
+            {
+                try
+                {
+                    Directory.Delete(WorkingDirectory, recursive: true);
+                    return;
+                }
+                catch when (attempt < 4)
+                {
+                    Thread.Sleep(100);
+                }
+                catch
+                {
+                    // Best effort.
+                }
+            }
+        }
+
+        private static string? GetImagePath(System.Diagnostics.Process process)
+        {
+            try
+            {
+                return process.MainModule?.FileName;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string LongRunningSystemBinary()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "PING.EXE");
+            }
+
+            return File.Exists("/bin/sleep") ? "/bin/sleep" : "/usr/bin/sleep";
+        }
+
+        private static void MakeExecutable(string path)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            using var chmod = System.Diagnostics.Process.Start("chmod", ["+x", path]);
+            chmod?.WaitForExit();
         }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProcessManagerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProcessManagerTests.cs
@@ -402,11 +402,16 @@ public class GameProcessManagerTests
                 launcherPath = Path.Combine(workingDirectory, "genhublauncher.bat");
                 var spawn = spawnChild ? $"start \"\" /b \"{childPath}\" -n {LauncherLifetimeSeconds + 1} 127.0.0.1 >nul\n" : string.Empty;
 
+                // Batch has no $$. PowerShell's own parent is the batch host, so it can report the
+                // PID the harness needs. If PowerShell is unavailable the loop simply writes
+                // nothing and Dispose falls back to leaving the launcher alone.
+                var recordPid = $"for /f %%p in ('powershell -NoProfile -Command \"(Get-Process -Id $PID).Parent.Id\"') do @echo %%p> \"{Path.Combine(workingDirectory, LauncherPidFileName)}\"\n";
+
                 // Leave the working directory afterwards: a batch host holds its current directory
                 // open, which would defeat the cleanup delete for the launcher's whole lifetime.
                 var linger = exitImmediately ? string.Empty : $"ping -n {LauncherLifetimeSeconds + 1} 127.0.0.1 >nul\n";
                 var complain = stderrMessage is null ? string.Empty : $"echo {stderrMessage} 1>&2\n";
-                script = $"@echo off\n{complain}{spawn}cd /d \"%TEMP%\"\n{linger}";
+                script = $"@echo off\n{recordPid}{complain}{spawn}cd /d \"%TEMP%\"\n{linger}";
             }
             else
             {
@@ -415,7 +420,7 @@ public class GameProcessManagerTests
                 var linger = exitImmediately ? string.Empty : $"sleep {LauncherLifetimeSeconds}\n";
                 var complain = stderrMessage is null ? string.Empty : $"echo \"{stderrMessage}\" >&2\n";
 
-                // The harness does not start the launcher, so it cannot learn the PID by itself.
+                // The harness does not start the launcher, so the launcher reports its own PID.
                 script = $"#!/bin/bash\necho $$ > \"{Path.Combine(workingDirectory, LauncherPidFileName)}\"\n{complain}{spawn}{linger}";
             }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameProcessSelectorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameProcessSelectorTests.cs
@@ -1,0 +1,161 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
+using GenHub.Core.Models.Launching;
+
+namespace GenHub.Tests.Core.Helpers;
+
+/// <summary>
+/// Unit tests for <see cref="GameProcessSelector"/>.
+/// </summary>
+public class GameProcessSelectorTests
+{
+    private static readonly DateTime Now = new(2026, 7, 31, 12, 0, 0, DateTimeKind.Utc);
+
+    // Native separators on both platforms: a real workspace path never mixes them, and comparing
+    // like-for-like is what the non-separator tests are meant to exercise.
+    private static readonly string Workspace = Path.Combine(Path.GetTempPath(), "genhub-workspace", "generalsonline");
+
+    /// <summary>
+    /// The spawned game is identified by the name the caller expects, not by the launcher's name.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_MatchesTheExpectedNameCaseInsensitively()
+    {
+        var candidates = new[]
+        {
+            Candidate(1, "EAC_LaunchGeneralsOnline", Now.AddSeconds(-2), Workspace),
+            Candidate(2, "GENERALSONLINEZH_60", Now.AddSeconds(-1), Workspace),
+        };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(candidates, "generalsonlinezh_60", Workspace, Now);
+
+        Assert.NotNull(selected);
+        Assert.Equal(2, selected.ProcessId);
+    }
+
+    /// <summary>
+    /// A same-named process that predates the launch is somebody else's, not the child we spawned.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_RejectsCandidatesStartedBeforeTheRecencyWindow()
+    {
+        var stale = Now.AddSeconds(-(ProcessConstants.EarlyExitThresholdSeconds + 1));
+        var candidates = new[] { Candidate(1, "GeneralsOnlineZH_60", stale, Workspace) };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(candidates, "GeneralsOnlineZH_60", Workspace, Now);
+
+        Assert.Null(selected);
+    }
+
+    /// <summary>
+    /// Workspace residence must be required even when only one candidate matches the name — a lone
+    /// same-named process anywhere on the machine used to be accepted unconditionally.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_RejectsALoneCandidateOutsideTheWorkingDirectory()
+    {
+        var candidates = new[] { Candidate(1, "GeneralsOnlineZH_60", Now, "/somewhere/else") };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(candidates, "GeneralsOnlineZH_60", Workspace, Now);
+
+        Assert.Null(selected);
+    }
+
+    /// <summary>
+    /// Residence cannot be proven for a process whose image path is unreadable, so it is not
+    /// accepted while a working directory is being enforced.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_RejectsCandidatesWithAnUnknownExecutablePath()
+    {
+        var candidates = new[] { new GameProcessCandidate(1, "GeneralsOnlineZH_60", Now, null) };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(candidates, "GeneralsOnlineZH_60", Workspace, Now);
+
+        Assert.Null(selected);
+    }
+
+    /// <summary>
+    /// With no working directory to enforce, name and recency are the only available evidence.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_WithoutAWorkingDirectory_AcceptsOnNameAndRecency()
+    {
+        var candidates = new[] { new GameProcessCandidate(1, "GeneralsOnlineZH_60", Now, null) };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(candidates, "GeneralsOnlineZH_60", null, Now);
+
+        Assert.NotNull(selected);
+        Assert.Equal(1, selected.ProcessId);
+    }
+
+    /// <summary>
+    /// When several qualify, the newest is the one this launch just spawned.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_PrefersTheMostRecentlyStartedCandidate()
+    {
+        var candidates = new[]
+        {
+            Candidate(1, "GeneralsOnlineZH_60", Now.AddSeconds(-5), Workspace),
+            Candidate(2, "GeneralsOnlineZH_60", Now.AddSeconds(-1), Workspace),
+            Candidate(3, "GeneralsOnlineZH_60", Now.AddSeconds(-3), Workspace),
+        };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(candidates, "GeneralsOnlineZH_60", Workspace, Now);
+
+        Assert.NotNull(selected);
+        Assert.Equal(2, selected.ProcessId);
+    }
+
+    /// <summary>
+    /// A trailing separator on the working directory is a formatting difference, not a mismatch.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_IgnoresTrailingSeparatorsOnTheWorkingDirectory()
+    {
+        var candidates = new[] { Candidate(1, "GeneralsOnlineZH_60", Now, Workspace) };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(
+            candidates, "GeneralsOnlineZH_60", Workspace + Path.DirectorySeparatorChar, Now);
+
+        Assert.NotNull(selected);
+        Assert.Equal(1, selected.ProcessId);
+    }
+
+    /// <summary>
+    /// Separator style is a spelling difference, not a location difference. Windows accepts both
+    /// forms, so a working directory and a process image path can legitimately disagree on which
+    /// one they use and still name the same directory. Only discriminating on Windows: elsewhere
+    /// both separator constants are '/', and a backslash is a legal file name character that must
+    /// not be treated as a separator.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_IgnoresSeparatorStyleWhenComparingResidence()
+    {
+        var candidates = new[] { Candidate(1, "GeneralsOnlineZH_60", Now, Workspace) };
+        var alternateSpelling = Workspace.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(
+            candidates, "GeneralsOnlineZH_60", alternateSpelling, Now);
+
+        Assert.NotNull(selected);
+        Assert.Equal(1, selected.ProcessId);
+    }
+
+    /// <summary>
+    /// Nothing matching the expected name means no adoption.
+    /// </summary>
+    [Fact]
+    public void SelectSpawnedGameProcess_WithNoNameMatch_ReturnsNull()
+    {
+        var candidates = new[] { Candidate(1, "EAC_LaunchGeneralsOnline", Now, Workspace) };
+
+        var selected = GameProcessSelector.SelectSpawnedGameProcess(candidates, "GeneralsOnlineZH_60", Workspace, Now);
+
+        Assert.Null(selected);
+    }
+
+    private static GameProcessCandidate Candidate(int id, string name, DateTime startTime, string directory) =>
+        new(id, name, startTime, Path.Combine(directory, name + ".exe"));
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/LaunchEntryPointResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/LaunchEntryPointResolverTests.cs
@@ -1,0 +1,74 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
+
+namespace GenHub.Tests.Core.Helpers;
+
+/// <summary>
+/// Unit tests for <see cref="LaunchEntryPointResolver"/>.
+/// </summary>
+public class LaunchEntryPointResolverTests
+{
+    /// <summary>
+    /// The Easy Anti-Cheat bootstrapper starts the 60Hz client and keeps running, so tracking has
+    /// to be told which process the session actually moves to.
+    /// </summary>
+    [Fact]
+    public void ResolveExpectedChildProcessName_ForTheAntiCheatBootstrapper_ReturnsTheSixtyHertzClient()
+    {
+        var path = Path.Combine("/workspace", GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+
+        var child = LaunchEntryPointResolver.ResolveExpectedChildProcessName(path);
+
+        Assert.Equal(
+            Path.GetFileNameWithoutExtension(GameClientConstants.GeneralsOnline60HzExecutable),
+            child);
+    }
+
+    /// <summary>
+    /// The bootstrapper ships with mixed-case naming; matching must not depend on it.
+    /// </summary>
+    [Fact]
+    public void ResolveExpectedChildProcessName_MatchesTheBootstrapperCaseInsensitively()
+    {
+        var path = Path.Combine("/workspace", GameClientConstants.GeneralsOnlineEacLauncherExecutable.ToUpperInvariant());
+
+        var child = LaunchEntryPointResolver.ResolveExpectedChildProcessName(path);
+
+        Assert.NotNull(child);
+    }
+
+    /// <summary>
+    /// A pre-EAC portable launches the game directly — there is no child to wait for, and claiming
+    /// one would make every legacy launch fail.
+    /// </summary>
+    [Fact]
+    public void ResolveExpectedChildProcessName_ForTheSixtyHertzClientItself_ReturnsNull()
+    {
+        var path = Path.Combine("/workspace", GameClientConstants.GeneralsOnline60HzExecutable);
+
+        Assert.Null(LaunchEntryPointResolver.ResolveExpectedChildProcessName(path));
+    }
+
+    /// <summary>
+    /// Every other client launches its own executable and is unaffected.
+    /// </summary>
+    [Fact]
+    public void ResolveExpectedChildProcessName_ForAnOrdinaryExecutable_ReturnsNull()
+    {
+        var path = Path.Combine("/workspace", GameClientConstants.GeneralsExecutable);
+
+        Assert.Null(LaunchEntryPointResolver.ResolveExpectedChildProcessName(path));
+    }
+
+    /// <summary>
+    /// A missing path resolves to no expectation rather than throwing.
+    /// </summary>
+    /// <param name="path">The path under test.</param>
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ResolveExpectedChildProcessName_WithoutAPath_ReturnsNull(string? path)
+    {
+        Assert.Null(LaunchEntryPointResolver.ResolveExpectedChildProcessName(path));
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineClientIdentifier.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineClientIdentifier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.GameClients;
 using GenHub.Core.Models.Enums;
@@ -16,18 +17,12 @@ public class GeneralsOnlineClientIdentifier : IGameClientIdentifier
     public string PublisherId => PublisherTypeConstants.GeneralsOnline;
 
     /// <inheritdoc/>
-    public bool CanIdentify(string executablePath)
-    {
-        var fileName = Path.GetFileName(executablePath);
-        return fileName.Equals(GameClientConstants.GeneralsOnline60HzExecutable, StringComparison.OrdinalIgnoreCase);
-    }
+    public bool CanIdentify(string executablePath) => IsSupportedEntryPoint(Path.GetFileName(executablePath));
 
     /// <inheritdoc/>
     public GameClientIdentification? Identify(string executablePath)
     {
-        var fileName = Path.GetFileName(executablePath);
-
-        if (!fileName.Equals(GameClientConstants.GeneralsOnline60HzExecutable, StringComparison.OrdinalIgnoreCase))
+        if (!IsSupportedEntryPoint(Path.GetFileName(executablePath)))
         {
             return null;
         }
@@ -39,4 +34,13 @@ public class GeneralsOnlineClientIdentifier : IGameClientIdentifier
             gameType: GameType.ZeroHour,
             localVersion: null); // Don't fetch from web during detection!
     }
+
+    /// <summary>
+    /// Determines whether a file name is a supported Generals Online entry point. Since
+    /// 060526_QFE1 that is the Easy Anti-Cheat bootstrapper; older packages launch the 60Hz
+    /// binary directly. <c>GeneralsOnlineZH.exe</c> ships alongside both but is not wrapped by
+    /// Easy Anti-Cheat, so it is workspace content rather than an entry point.
+    /// </summary>
+    private static bool IsSupportedEntryPoint(string fileName) =>
+        GameClientConstants.GeneralsOnlineExecutableNames.Contains(fileName, StringComparer.OrdinalIgnoreCase);
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -197,6 +197,16 @@ public class GeneralsOnlineManifestFactory(
 
     private static int ParseVersionForManifestId(string version) => GameVersionHelper.GetGeneralsOnlineManifestIdComponent(version);
 
+    /// <summary>
+    /// Determines whether a manifest-relative path is the named file at the archive root.
+    /// Nested files that merely share the name are not the published entry point.
+    /// </summary>
+    private static bool IsArchiveRootFile(string relativePath, string fileName) =>
+        string.Equals(
+            relativePath.Replace('\\', '/').TrimStart('/'),
+            fileName,
+            StringComparison.OrdinalIgnoreCase);
+
     private static ManifestFile CreateMapManifestFile(string relativePath, FileInfo fileInfo, string hash)
     {
         // For maps, the relative path should be relative to the Maps directory
@@ -464,11 +474,18 @@ public class GeneralsOnlineManifestFactory(
             {
                 // Game client manifest: include executables, shared files, AND map files
                 // Map files are included with UserMapsDirectory install target so they install to Documents
-                var targetExecutable = GameClientConstants.GeneralsOnline60HzExecutable;
+                // Since 060526_QFE1 the portable ships an Easy Anti-Cheat bootstrapper that starts the
+                // binary named by EasyAntiCheat/Settings.json. When present it is the only launch target;
+                // the wrapped binary stays in the workspace as ordinary content for EAC to start.
+                var hasEacLauncher = filesWithHashes.Any(file =>
+                    !file.IsMap && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacLauncherExecutable));
+
+                var targetExecutable = hasEacLauncher
+                    ? GameClientConstants.GeneralsOnlineEacLauncherExecutable
+                    : GameClientConstants.GeneralsOnline60HzExecutable;
 
                 foreach (var (relativePath, fileInfo, hash, isMap) in filesWithHashes)
                 {
-                    var fileName = Path.GetFileName(relativePath);
                     var isExecutable = false;
 
                     // Skip map files in GameClient manifests - they belong in the MapPack manifest
@@ -477,13 +494,9 @@ public class GeneralsOnlineManifestFactory(
                         continue;
                     }
 
-                    if (string.Equals(fileName, targetExecutable, StringComparison.OrdinalIgnoreCase))
+                    if (IsArchiveRootFile(relativePath, targetExecutable))
                     {
                         isExecutable = true;
-                    }
-                    else if (string.Equals(fileName, GameClientConstants.GeneralsOnline60HzExecutable, StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
                     }
 
                     manifestFiles.Add(new ManifestFile

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -313,13 +313,15 @@ public class GameClientDetector(
     {
         foreach (var identifier in gameClientIdentifiers)
         {
-            if (!identifier.CanIdentify(executablePath))
-            {
-                continue;
-            }
-
             try
             {
+                // Inside the try: a throwing identifier must not stop the ones after it, and
+                // the caller's handler would swallow the executable entirely.
+                if (!identifier.CanIdentify(executablePath))
+                {
+                    continue;
+                }
+
                 var identification = identifier.Identify(executablePath);
                 if (identification == null)
                 {
@@ -342,6 +344,11 @@ public class GameClientDetector(
                     WorkingDirectory = workingDirectory,
                     InstallationId = string.Empty,
                     SourceType = ContentType.GameClient,
+
+                    // IsPublisherClient turns on this alone. Without it the client reads as a
+                    // base retail install, so version resolution picks it as the base game and
+                    // the launcher UI does not see a publisher client at all.
+                    PublisherType = identification.PublisherId,
                 };
             }
             catch (Exception ex)

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -171,6 +171,53 @@ public class GameClientDetector(
     }
 
     /// <summary>
+    /// Resolves the single supported Generals Online entry point among one directory's file names.
+    /// The Easy Anti-Cheat bootstrapper takes precedence because it starts the binary named by
+    /// <c>EasyAntiCheat/Settings.json</c>; the bare 60Hz binary is the pre-EAC fallback.
+    /// </summary>
+    /// <param name="fileNames">The file names present in a single directory.</param>
+    /// <returns>The entry point name as it appears on disk, or <see langword="null"/> when none is present.</returns>
+    private static string? ResolveGeneralsOnlineEntryPoint(IEnumerable<string> fileNames)
+    {
+        string? sixtyHertz = null;
+
+        foreach (var fileName in fileNames)
+        {
+            if (fileName.Equals(GameClientConstants.GeneralsOnlineEacLauncherExecutable, StringComparison.OrdinalIgnoreCase))
+            {
+                return fileName;
+            }
+
+            if (fileName.Equals(GameClientConstants.GeneralsOnline60HzExecutable, StringComparison.OrdinalIgnoreCase))
+            {
+                sixtyHertz = fileName;
+            }
+        }
+
+        return sixtyHertz;
+    }
+
+    /// <summary>
+    /// Resolves the single supported Generals Online entry point in a directory. Names are matched
+    /// against the directory listing rather than composed from constants, so the package's own
+    /// casing resolves on case-sensitive file systems.
+    /// </summary>
+    /// <param name="directory">The directory to inspect.</param>
+    /// <returns>The entry point name, or <see langword="null"/> when none is present.</returns>
+    private static string? ResolveGeneralsOnlineEntryPoint(string directory)
+    {
+        try
+        {
+            return ResolveGeneralsOnlineEntryPoint(
+                Directory.EnumerateFiles(directory).Select(Path.GetFileName).OfType<string>());
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Detects a game client from a specific executable file using hash analysis.
     /// </summary>
     /// <param name="executablePath">The path to the executable file.</param>
@@ -224,6 +271,17 @@ public class GameClientDetector(
                 };
             }
 
+            // A publisher entry point is absent from the retail hash registry by definition, so an
+            // unrecognized hash means "not retail" rather than "unidentifiable". Ask the publisher
+            // identifiers before falling back, otherwise the GeneralsOnline anti-cheat bootstrapper
+            // is reported as Unknown Game with GameType.Generals and never matches the Zero Hour
+            // launch path.
+            var identifiedClient = IdentifyPublisherClient(executablePath, workingDirectory);
+            if (identifiedClient != null)
+            {
+                return identifiedClient;
+            }
+
             // If hash is not recognized, create a generic entry for manual identification
             logger.LogDebug("Unknown game executable found at {ExecutablePath} with hash {Hash}", executablePath, hash);
             return new GameClient
@@ -243,6 +301,60 @@ public class GameClientDetector(
             logger.LogWarning(ex, "Failed to analyze executable {ExecutablePath}", executablePath);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Classifies an executable through the registered publisher identifiers.
+    /// </summary>
+    /// <param name="executablePath">The path to the executable file.</param>
+    /// <param name="workingDirectory">The working directory for the game client.</param>
+    /// <returns>A GameClient if a publisher recognizes the executable, otherwise null.</returns>
+    private GameClient? IdentifyPublisherClient(string executablePath, string workingDirectory)
+    {
+        foreach (var identifier in gameClientIdentifiers)
+        {
+            if (!identifier.CanIdentify(executablePath))
+            {
+                continue;
+            }
+
+            try
+            {
+                var identification = identifier.Identify(executablePath);
+                if (identification == null)
+                {
+                    continue;
+                }
+
+                logger.LogInformation(
+                    "Identified {PublisherId} client {DisplayName} at {ExecutablePath}",
+                    identification.PublisherId,
+                    identification.DisplayName,
+                    executablePath);
+
+                return new GameClient
+                {
+                    Name = identification.DisplayName,
+                    Id = string.Empty, // Will be set by manifest generation
+                    Version = identification.LocalVersion ?? GameClientConstants.UnknownVersion,
+                    ExecutablePath = executablePath,
+                    GameType = identification.GameType,
+                    WorkingDirectory = workingDirectory,
+                    InstallationId = string.Empty,
+                    SourceType = ContentType.GameClient,
+                };
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Publisher identifier {PublisherId} failed for {ExecutablePath}",
+                    identifier.PublisherId,
+                    executablePath);
+            }
+        }
+
+        return null;
     }
 
     private async Task GenerateClientManifestAndSetIdAsync(GameClient gameClient, string clientPath, GameInstallation? installation, GameType gameType)
@@ -623,7 +735,6 @@ public class GameClientDetector(
     /// </summary>
     /// <param name="installation">The game installation to scan.</param>
     /// <param name="gameType">The type of game (Generals or ZeroHour).</param>
-
     /// <returns>A list of detected GeneralsOnline game clients.</returns>
     /// <remarks>
     /// GeneralsOnline executables are auto-updated by the GeneralsOnline launcher,
@@ -645,34 +756,20 @@ public class GameClientDetector(
         // GeneralsOnline clients auto-update, so we use a fixed version string
         const string generalsOnlineVersion = GameClientConstants.UnknownVersion;
 
-        var generalsOnlineExecutables = GameClientConstants.GeneralsOnlineExecutableNames;
+        // Exactly one entry point per installation. Since 060526_QFE1 the Easy Anti-Cheat
+        // bootstrapper wraps the 60Hz binary and both ship side by side, so detecting each
+        // recognised name in turn would surface the same client twice.
+        var executableName = ResolveGeneralsOnlineEntryPoint(installationPath);
 
-        foreach (var executableName in generalsOnlineExecutables)
+        if (executableName is not null)
         {
             var executablePath = Path.Combine(installationPath, executableName);
 
-            if (!File.Exists(executablePath))
-            {
-                continue;
-            }
-
             try
             {
-                // Determine the variant name from the executable
-                var variantName = executableName switch
-                {
-                    GameClientConstants.GeneralsOnline60HzExecutable => GameClientConstants.GeneralsOnline60HzDisplayName,
-                    _ => null, // Skip unknown variants
-                };
-
-                // Skip if variant is not recognized
-                if (variantName == null)
-                {
-                    logger.LogDebug(
-                        "Skipping unrecognized GeneralsOnline executable: {ExecutableName}",
-                        executableName);
-                    continue;
-                }
+                // Both supported entry points start the 60Hz client: the bootstrapper launches
+                // the binary named by EasyAntiCheat/Settings.json, and pre-EAC packages run it directly.
+                var variantName = GameClientConstants.GeneralsOnline60HzDisplayName;
 
                 logger.LogInformation(
                     "Detected GeneralsOnline client: {VariantName} at {ExecutablePath}",
@@ -880,12 +977,27 @@ public class GameClientDetector(
             try
             {
                 // Process files in current directory
-                foreach (var file in Directory.EnumerateFiles(currentDir))
+                var files = Directory.EnumerateFiles(currentDir).ToList();
+                var generalsOnlineEntryPoint = ResolveGeneralsOnlineEntryPoint(
+                    files.Select(Path.GetFileName).OfType<string>());
+
+                foreach (var file in files)
                 {
-                    if (hashRegistry.PossibleExecutableNames.Contains(Path.GetFileName(file), StringComparer.OrdinalIgnoreCase))
+                    var fileName = Path.GetFileName(file);
+                    if (!hashRegistry.PossibleExecutableNames.Contains(fileName, StringComparer.OrdinalIgnoreCase))
                     {
-                        results.Add(file);
+                        continue;
                     }
+
+                    // A GeneralsOnline directory holds several supported entry points but is one
+                    // client, so only the resolved entry point counts.
+                    if (GameClientConstants.GeneralsOnlineExecutableNames.Contains(fileName, StringComparer.OrdinalIgnoreCase)
+                        && !fileName.Equals(generalsOnlineEntryPoint, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    results.Add(file);
                 }
 
                 // Enqueue subdirectories if not excluded

--- a/GenHub/GenHub/Features/GameClients/GameClientHashRegistry.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientHashRegistry.cs
@@ -56,6 +56,7 @@ public class GameClientHashRegistry : IGameClientHashRegistry
             // Publisher clients
             GameClientConstants.SuperHackersGeneralsExecutable,
             GameClientConstants.SuperHackersZeroHourExecutable,
+            GameClientConstants.GeneralsOnlineEacLauncherExecutable,
             GameClientConstants.GeneralsOnline60HzExecutable,
         ];
 

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Models.Events;
@@ -220,6 +221,15 @@ public class GameProcessManager(
                 logger.LogDebug(ex, "[Process] Could not capture stderr for process {ProcessId}", process.Id);
             }
 
+            // A launcher that hands the session to another binary is tracked through that binary.
+            // Poll for it independently of the launcher's own lifetime: the Easy Anti-Cheat
+            // bootstrapper outlives the game's startup by about a minute, so waiting for it to
+            // exit first never finds the game.
+            if (!string.IsNullOrWhiteSpace(configuration.ExpectedChildProcessName))
+            {
+                return await AdoptExpectedChildProcessAsync(process, configuration, workingDirectory, capturedErrors, cancellationToken);
+            }
+
             // Check if process exited immediately (launcher pattern)
             // Only apply delay if we need to detect a spawned process
             if (!isBatchFile)
@@ -248,7 +258,10 @@ public class GameProcessManager(
                             "[Process] Launcher process {ProcessId} exited with code 0 - attempting to find spawned game process",
                             process.Id);
 
-                        var executableName = Path.GetFileNameWithoutExtension(configuration.ExecutablePath);
+                        // A bootstrapper hands the session to a differently-named binary, so the
+                        // name to adopt comes from the caller — never from the path we started.
+                        var executableName = configuration.ExpectedChildProcessName
+                            ?? Path.GetFileNameWithoutExtension(configuration.ExecutablePath);
                         var spawnedProcess = FindSpawnedGameProcess(executableName, configuration.WorkingDirectory ?? Path.GetDirectoryName(configuration.ExecutablePath)!);
 
                         if (spawnedProcess != null)
@@ -273,28 +286,7 @@ public class GameProcessManager(
                                 logger.LogWarning(ex, "Failed to enable raising events for spawned process {ProcessId}", spawnedProcess.Id);
                             }
 
-                            GameProcessInfo spawnedProcessInfo;
-                            try
-                            {
-                                spawnedProcessInfo = new GameProcessInfo
-                                {
-                                    ProcessId = spawnedProcess.Id,
-                                    ProcessName = spawnedProcess.ProcessName,
-                                    StartTime = spawnedProcess.StartTime,
-                                    ExecutablePath = GetProcessExecutablePath(spawnedProcess),
-                                };
-                            }
-                            catch (Exception ex)
-                            {
-                                logger.LogWarning(ex, "Failed to get process information for {ProcessId}, using minimal info", spawnedProcess.Id);
-                                spawnedProcessInfo = new GameProcessInfo
-                                {
-                                    ProcessId = spawnedProcess.Id,
-                                    ProcessName = GameClientConstants.UnknownVersion,
-                                    StartTime = DateTime.Now,
-                                    ExecutablePath = configuration.ExecutablePath,
-                                };
-                            }
+                            var spawnedProcessInfo = BuildProcessInfo(spawnedProcess, configuration.ExecutablePath);
 
                             logger.LogInformation("Started game process {ProcessId} for executable {ExecutablePath}", spawnedProcess.Id, configuration.ExecutablePath);
                             return OperationResult<GameProcessInfo>.CreateSuccess(spawnedProcessInfo);
@@ -371,31 +363,17 @@ public class GameProcessManager(
                 logger.LogWarning(ex, "Failed to enable raising events for process {ProcessId}, process cleanup may not work properly", process.Id);
             }
 
-            GameProcessInfo processInfo;
-            try
-            {
-                processInfo = new GameProcessInfo
-                {
-                    ProcessId = process.Id,
-                    ProcessName = process.ProcessName,
-                    StartTime = process.StartTime,
-                    ExecutablePath = GetProcessExecutablePath(process),
-                };
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to get process information for {ProcessId}, using minimal info", process.Id);
-                processInfo = new GameProcessInfo
-                {
-                    ProcessId = process.Id,
-                    ProcessName = GameClientConstants.UnknownVersion,
-                    StartTime = DateTime.Now,
-                    ExecutablePath = configuration.ExecutablePath,
-                };
-            }
+            var processInfo = BuildProcessInfo(process, configuration.ExecutablePath);
 
             logger.LogInformation("Started game process {ProcessId} for executable {ExecutablePath}", process.Id, configuration.ExecutablePath);
             return OperationResult<GameProcessInfo>.CreateSuccess(processInfo);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // A cancelled launch is not a start failure. Reporting it as one hides the reason from
+            // the caller and bypasses GameLauncher.LaunchProfileAsync's cancellation handling.
+            logger.LogInformation("Start of {ExecutablePath} was cancelled", configuration.ExecutablePath);
+            throw;
         }
         catch (Exception ex)
         {
@@ -512,6 +490,7 @@ public class GameProcessManager(
                     ProcessName = process.ProcessName,
                     StartTime = process.StartTime,
                     ExecutablePath = GetProcessExecutablePath(process),
+                    IsRunning = IsStillRunning(process),
                 };
 
                 return Task.FromResult(OperationResult<GameProcessInfo>.CreateSuccess(processInfo));
@@ -532,6 +511,7 @@ public class GameProcessManager(
                     ProcessName = process.ProcessName,
                     StartTime = process.StartTime,
                     ExecutablePath = GetProcessExecutablePath(process),
+                    IsRunning = IsStillRunning(process),
                 };
 
                 return Task.FromResult(OperationResult<GameProcessInfo>.CreateSuccess(processInfo));
@@ -568,6 +548,7 @@ public class GameProcessManager(
                             ProcessName = process.ProcessName,
                             StartTime = process.StartTime,
                             ExecutablePath = GetProcessExecutablePath(process),
+                            IsRunning = IsStillRunning(process),
                         };
                         activeProcesses.Add(processInfo);
                     }
@@ -654,13 +635,14 @@ public class GameProcessManager(
                     logger.LogWarning(ex, "Failed to enable raising events for discovered process {ProcessId}", process.Id);
                 }
 
-                return OperationResult<GameProcessInfo>.CreateSuccess(new GameProcessInfo
-                {
-                    ProcessId = process.Id,
-                    ProcessName = process.ProcessName,
-                    StartTime = process.StartTime,
-                    ExecutablePath = GetProcessExecutablePath(process),
-                });
+                // BuildProcessInfo assigns the fallback to GameProcessInfo.ExecutablePath, which
+                // GameLauncher persists. Passing the directory alone would store a folder where a
+                // file path is expected, so rebuild the executable path from what we were given.
+                var fallbackExecutable = Path.Combine(
+                    workingDirectory,
+                    OperatingSystem.IsWindows() ? processName + ".exe" : processName);
+
+                return OperationResult<GameProcessInfo>.CreateSuccess(BuildProcessInfo(process, fallbackExecutable));
             }
 
             await Task.Delay(DelayMs, cancellationToken);
@@ -747,6 +729,23 @@ public class GameProcessManager(
         logger.LogInformation("GameProcessManager disposed");
     }
 
+    /// <summary>
+    /// Reports whether a process is still running, treating an unreadable process as not running.
+    /// </summary>
+    /// <param name="process">The process to check.</param>
+    /// <returns><see langword="true"/> when the process is known to be running.</returns>
+    private static bool IsStillRunning(Process process)
+    {
+        try
+        {
+            return !process.HasExited;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static string GetProcessExecutablePath(Process process)
     {
         try
@@ -824,6 +823,202 @@ public class GameProcessManager(
     }
 
     /// <summary>
+    /// Waits for a launcher to spawn the process named by
+    /// <see cref="GameLaunchConfiguration.ExpectedChildProcessName"/> and tracks that process
+    /// instead of the launcher. The launcher's own exit is never treated as the game exiting.
+    /// </summary>
+    /// <param name="launcher">The process that was started.</param>
+    /// <param name="configuration">The launch configuration.</param>
+    /// <param name="workingDirectory">The directory the game must run from.</param>
+    /// <param name="capturedErrors">
+    /// The launcher's captured stderr, quoted in the failure messages so a bootstrapper
+    /// that refuses to start the game can say why.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The adopted child process, or a failure describing why none was adopted.</returns>
+    private async Task<OperationResult<GameProcessInfo>> AdoptExpectedChildProcessAsync(
+        Process launcher,
+        GameLaunchConfiguration configuration,
+        string workingDirectory,
+        BoundedErrorBuffer capturedErrors,
+        CancellationToken cancellationToken)
+    {
+        var expectedName = configuration.ExpectedChildProcessName!;
+        var timeout = configuration.ExpectedChildDiscoveryTimeout
+            ?? TimeSpan.FromMilliseconds(ProcessConstants.SpawnedChildDiscoveryTimeoutMs);
+        var deadline = DateTime.UtcNow + timeout;
+        var gracePeriod = TimeSpan.FromMilliseconds(ProcessConstants.LauncherExitGracePeriodMs);
+        DateTime? launcherExitedAt = null;
+
+        logger.LogInformation(
+            "[Process] Waiting up to {TimeoutMs}ms for launcher {LauncherId} to start {ExpectedName}",
+            (int)timeout.TotalMilliseconds,
+            launcher.Id,
+            expectedName);
+
+        try
+        {
+            while (true)
+            {
+                var child = FindSpawnedGameProcess(expectedName, workingDirectory);
+                if (child != null)
+                {
+                    _managedProcesses[child.Id] = child;
+
+                    try
+                    {
+                        child.EnableRaisingEvents = true;
+                        child.Exited += OnProcessExited;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Failed to enable raising events for adopted process {ProcessId}", child.Id);
+                    }
+
+                    logger.LogInformation(
+                        "[Process] Adopted game process {ProcessId} ({ExpectedName}); launcher {LauncherId} is no longer tracked and its exit is ignored",
+                        child.Id,
+                        expectedName,
+                        launcher.Id);
+
+                    return OperationResult<GameProcessInfo>.CreateSuccess(BuildProcessInfo(child, configuration.ExecutablePath));
+                }
+
+                // A launcher that fails outright will never produce a child - do not wait it out.
+                if (launcher.HasExited && launcher.ExitCode != ProcessConstants.ExitCodeSuccess)
+                {
+                    logger.LogError(
+                        "[Process] Launcher {LauncherId} exited with code {ExitCode} before starting {ExpectedName}",
+                        launcher.Id,
+                        launcher.ExitCode,
+                        expectedName);
+                    return OperationResult<GameProcessInfo>.CreateFailure(
+                        AppendLauncherErrors(
+                            $"Launcher exited with code {launcher.ExitCode} before starting {expectedName}.",
+                            launcher,
+                            capturedErrors));
+                }
+
+                // A clean exit with no child is still a failure - the bootstrapper bailing without
+                // launching the game looks identical to success from the exit code alone. Allow a
+                // short grace period for the spawn-then-enumerate race, then stop: once the
+                // launcher is gone a child will not appear, and waiting out the full discovery
+                // timeout only delays the failure and reports a misleading timeout as the cause.
+                if (launcher.HasExited)
+                {
+                    launcherExitedAt ??= DateTime.UtcNow;
+
+                    if (DateTime.UtcNow - launcherExitedAt.Value >= gracePeriod)
+                    {
+                        logger.LogError(
+                            "[Process] Launcher {LauncherId} exited cleanly without starting {ExpectedName}",
+                            launcher.Id,
+                            expectedName);
+                        // The launcher has provably exited here, so the drain is safe and this
+                        // message carries the complete stderr rather than a partial snapshot.
+                        return OperationResult<GameProcessInfo>.CreateFailure(
+                            AppendLauncherErrors(
+                                $"Launcher exited without starting {expectedName}.",
+                                launcher,
+                                capturedErrors));
+                    }
+                }
+
+                if (DateTime.UtcNow >= deadline)
+                {
+                    logger.LogError(
+                        "[Process] Launcher {LauncherId} did not start {ExpectedName} within {TimeoutMs}ms",
+                        launcher.Id,
+                        expectedName,
+                        (int)timeout.TotalMilliseconds);
+                    return OperationResult<GameProcessInfo>.CreateFailure(
+                        AppendLauncherErrors(
+                            $"Launcher did not start {expectedName} within {timeout.TotalSeconds:0.#}s.",
+                            launcher,
+                            capturedErrors));
+                }
+
+                await Task.Delay(ProcessConstants.SpawnedChildPollIntervalMs, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Matches TerminateProcessAsync, and lets GameLauncher.LaunchProfileAsync reach its
+            // own cancellation branch instead of reporting a generic start failure.
+            logger.LogInformation(
+                "[Process] Adoption of {ExpectedName} was cancelled; terminating launcher {LauncherId}",
+                expectedName,
+                launcher.Id);
+
+            TerminateAbandonedLauncher(launcher);
+            throw;
+        }
+        finally
+        {
+            // Releases our handle only; the launcher keeps running and owns its own lifetime.
+            launcher.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Kills a launcher whose child was never adopted. Without this a cancelled launch leaves the
+    /// bootstrapper running with no tracked process and no handle for the caller to reach it.
+    /// </summary>
+    /// <param name="launcher">The launcher to terminate.</param>
+    private void TerminateAbandonedLauncher(Process launcher)
+    {
+        try
+        {
+            if (launcher.HasExited)
+            {
+                return;
+            }
+
+            // The child may already exist but not yet be discoverable, so take the tree with it.
+            launcher.Kill(entireProcessTree: true);
+            launcher.WaitForExit(ProcessConstants.AbandonedLauncherKillWaitMs);
+        }
+        catch (Exception ex)
+        {
+            // The caller is already unwinding a cancellation; cleanup failure must not mask it.
+            logger.LogWarning(ex, "[Process] Failed to terminate abandoned launcher {LauncherId}", launcher.Id);
+        }
+    }
+
+    /// <summary>
+    /// Builds process information, falling back to minimal details when the process cannot be read.
+    /// </summary>
+    /// <param name="process">The process to describe.</param>
+    /// <param name="fallbackExecutablePath">Path to report when the process cannot be inspected.</param>
+    /// <returns>The process information.</returns>
+    private GameProcessInfo BuildProcessInfo(Process process, string fallbackExecutablePath)
+    {
+        try
+        {
+            return new GameProcessInfo
+            {
+                ProcessId = process.Id,
+                ProcessName = process.ProcessName,
+                StartTime = process.StartTime,
+                ExecutablePath = GetProcessExecutablePath(process),
+                IsRunning = IsStillRunning(process),
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to get process information for {ProcessId}, using minimal info", process.Id);
+            return new GameProcessInfo
+            {
+                ProcessId = process.Id,
+                ProcessName = GameClientConstants.UnknownVersion,
+                StartTime = DateTime.Now,
+                ExecutablePath = fallbackExecutablePath,
+                IsRunning = IsStillRunning(process),
+            };
+        }
+    }
+
+    /// <summary>
     /// Finds a spawned game process by executable name and working directory.
     /// Used when a launcher executable spawns the actual game and exits.
     /// </summary>
@@ -832,69 +1027,116 @@ public class GameProcessManager(
     /// <returns>The spawned process if found, null otherwise.</returns>
     private Process? FindSpawnedGameProcess(string executableName, string workingDirectory)
     {
+        Process[] processes;
         try
         {
-            var processes = Process.GetProcessesByName(executableName)
-                .Where(p =>
-                {
-                    try
-                    {
-                        // Verify process was started within last 10 seconds
-                        return (DateTime.Now - p.StartTime).TotalSeconds < ProcessConstants.EarlyExitThresholdSeconds;
-                    }
-                    catch
-                    {
-                        return false;
-                    }
-                })
-                .ToArray();
-            if (processes.Length == 0)
-            {
-                return null;
-            }
-
-            // If multiple processes exist, try to find one with matching working directory
-            if (processes.Length > 1 && !string.IsNullOrEmpty(workingDirectory))
-            {
-                foreach (var proc in processes)
-                {
-                    try
-                    {
-                        var procPath = proc.MainModule?.FileName;
-                        if (procPath != null && Path.GetDirectoryName(procPath)?.Equals(workingDirectory, StringComparison.OrdinalIgnoreCase) == true)
-                        {
-                            // Dispose other processes we're not using
-                            foreach (var otherProc in processes.Where(p => p.Id != proc.Id))
-                            {
-                                otherProc.Dispose();
-                            }
-
-                            return proc;
-                        }
-                    }
-                    catch
-                    {
-                        // Cannot access process info, continue
-                    }
-                }
-            }
-
-            // Return the first (or only) process found
-            var result = processes.First();
-
-            // Dispose other processes
-            foreach (var proc in processes.Skip(1))
-            {
-                proc.Dispose();
-            }
-
-            return result;
+            processes = Process.GetProcessesByName(executableName);
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to find spawned game process for {ExecutableName}", executableName);
             return null;
         }
+
+        try
+        {
+            var candidates = new List<GameProcessCandidate>();
+            foreach (var process in processes)
+            {
+                try
+                {
+                    var executablePath = GetProcessExecutablePath(process);
+                    candidates.Add(new GameProcessCandidate(
+                        process.Id,
+                        process.ProcessName,
+                        process.StartTime,
+                        string.IsNullOrEmpty(executablePath) ? null : executablePath));
+                }
+                catch (Exception ex)
+                {
+                    // A process that cannot be inspected cannot be shown to be ours.
+                    logger.LogDebug(ex, "Skipping uninspectable process {ProcessId}", process.Id);
+                }
+            }
+
+            var selected = GameProcessSelector.SelectSpawnedGameProcess(
+                candidates, executableName, workingDirectory, DateTime.Now);
+
+            if (selected == null)
+            {
+                foreach (var process in processes)
+                {
+                    process.Dispose();
+                }
+
+                return null;
+            }
+
+            var match = processes.First(process => process.Id == selected.ProcessId);
+            foreach (var other in processes.Where(process => process.Id != selected.ProcessId))
+            {
+                other.Dispose();
+            }
+
+            return match;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to find spawned game process for {ExecutableName}", executableName);
+            foreach (var process in processes)
+            {
+                process.Dispose();
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Appends whatever the launcher wrote to stderr to a failure message.
+    /// </summary>
+    /// <param name="message">The failure message describing what was expected.</param>
+    /// <param name="launcher">The launcher process whose stderr was captured.</param>
+    /// <param name="capturedErrors">The buffer receiving the launcher's stderr lines.</param>
+    /// <returns>The message, with the captured tail appended when there is one.</returns>
+    /// <remarks>
+    /// Without this the adoption failures say only that the game never appeared, which is
+    /// the symptom rather than the cause. A bootstrapper that refuses to start the game —
+    /// a missing Easy Anti-Cheat installation being the expected case — explains itself on
+    /// stderr, and that explanation is the only thing that makes the failure actionable.
+    /// </remarks>
+    private string AppendLauncherErrors(string message, Process launcher, BoundedErrorBuffer capturedErrors)
+    {
+        // Only drain once the launcher has exited. Draining waits on the stderr handlers,
+        // which requires the untimed WaitForExit — and on the discovery-timeout path the
+        // bootstrapper is still running and outlives game startup by about a minute, so
+        // waiting there would stall the failure long past the timeout it is reporting.
+        // A live launcher contributes whatever has already arrived instead.
+        // Broad by intent, matching DrainStandardError below. HasExited throws
+        // InvalidOperationException with no handle and Win32Exception when the exit code
+        // cannot be read — the latter being a plausible result for the hard-crashing
+        // launcher this method exists to report on. Letting either escape would turn a
+        // failure result into a thrown exception on the path describing that failure.
+        var launcherExited = false;
+        try
+        {
+            launcherExited = launcher.HasExited;
+        }
+        catch (Exception ex)
+        {
+            // No launcher property is read here: Id throws once the process is disposed,
+            // which is one of the states that lands in this catch to begin with.
+            logger.LogDebug(ex, "[Process] Could not determine whether the launcher had exited");
+        }
+
+        if (launcherExited)
+        {
+            DrainStandardError(launcher, capturedErrors);
+        }
+
+        var detail = capturedErrors.ToString();
+
+        return string.IsNullOrWhiteSpace(detail) ? message : $"{message} {detail}";
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -260,8 +260,11 @@ public class GameProcessManager(
 
                         // A bootstrapper hands the session to a differently-named binary, so the
                         // name to adopt comes from the caller — never from the path we started.
-                        var executableName = configuration.ExpectedChildProcessName
-                            ?? Path.GetFileNameWithoutExtension(configuration.ExecutablePath);
+                        // Same emptiness test as the adoption guard above: `??` would accept a
+                        // whitespace-only name that skipped adoption, then match no process.
+                        var executableName = !string.IsNullOrWhiteSpace(configuration.ExpectedChildProcessName)
+                            ? configuration.ExpectedChildProcessName
+                            : Path.GetFileNameWithoutExtension(configuration.ExecutablePath);
                         var spawnedProcess = FindSpawnedGameProcess(executableName, configuration.WorkingDirectory ?? Path.GetDirectoryName(configuration.ExecutablePath)!);
 
                         if (spawnedProcess != null)
@@ -884,17 +887,19 @@ public class GameProcessManager(
                     return OperationResult<GameProcessInfo>.CreateSuccess(BuildProcessInfo(child, configuration.ExecutablePath));
                 }
 
+                var (launcherExited, launcherExitCode) = ReadLauncherExit(launcher);
+
                 // A launcher that fails outright will never produce a child - do not wait it out.
-                if (launcher.HasExited && launcher.ExitCode != ProcessConstants.ExitCodeSuccess)
+                if (launcherExited && launcherExitCode is int exitCode && exitCode != ProcessConstants.ExitCodeSuccess)
                 {
                     logger.LogError(
                         "[Process] Launcher {LauncherId} exited with code {ExitCode} before starting {ExpectedName}",
                         launcher.Id,
-                        launcher.ExitCode,
+                        exitCode,
                         expectedName);
                     return OperationResult<GameProcessInfo>.CreateFailure(
                         AppendLauncherErrors(
-                            $"Launcher exited with code {launcher.ExitCode} before starting {expectedName}.",
+                            $"Launcher exited with code {exitCode} before starting {expectedName}.",
                             launcher,
                             capturedErrors));
                 }
@@ -904,7 +909,7 @@ public class GameProcessManager(
                 // short grace period for the spawn-then-enumerate race, then stop: once the
                 // launcher is gone a child will not appear, and waiting out the full discovery
                 // timeout only delays the failure and reports a misleading timeout as the cause.
-                if (launcher.HasExited)
+                if (launcherExited)
                 {
                     launcherExitedAt ??= DateTime.UtcNow;
 
@@ -1089,6 +1094,49 @@ public class GameProcessManager(
             }
 
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads a launcher's exit state without throwing.
+    /// </summary>
+    /// <param name="launcher">The launcher to inspect.</param>
+    /// <returns>
+    /// Whether the launcher has exited, and its exit code when that could be read.
+    /// </returns>
+    /// <remarks>
+    /// <see cref="Process.HasExited"/> and <see cref="Process.ExitCode"/> throw
+    /// <see cref="InvalidOperationException"/> with no handle and
+    /// <see cref="System.ComponentModel.Win32Exception"/> when the code cannot be read — both
+    /// plausible for the hard-crashing launcher this loop exists to report on. Letting either
+    /// escape would replace the launcher diagnosis with a generic start failure.
+    /// An unreadable state is reported as still running, so the loop keeps polling to its
+    /// deadline rather than concluding anything from a failed probe.
+    /// </remarks>
+    private (bool Exited, int? ExitCode) ReadLauncherExit(Process launcher)
+    {
+        try
+        {
+            if (!launcher.HasExited)
+            {
+                return (false, null);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "[Process] Could not determine whether the launcher had exited");
+            return (false, null);
+        }
+
+        try
+        {
+            return (true, launcher.ExitCode);
+        }
+        catch (Exception ex)
+        {
+            // Exited, but the code is unavailable. The clean-exit path still applies.
+            logger.LogDebug(ex, "[Process] Could not read the launcher's exit code");
+            return (true, null);
         }
     }
 

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -1192,6 +1192,10 @@ public class GameLauncher(
                 WorkingDirectory = workspaceInfo.WorkspacePath,
                 Arguments = arguments,
                 EnvironmentVariables = BuildEnvironmentVariables(profile.EnvironmentVariables, installation),
+
+                // Null for every client that launches its own executable; set only where a
+                // bootstrapper hands the session to a differently-named binary.
+                ExpectedChildProcessName = LaunchEntryPointResolver.ResolveExpectedChildProcessName(finalExecutablePath),
             };
 
             // Before spawn, so a misconfigured root is reported with the path named. The
@@ -1261,6 +1265,15 @@ public class GameLauncher(
                     // This is because Windows reports the symlink target hash as the process name
                     gameProcessName = executableFileForMonitor.Hash;
                     logger.LogInformation("[GameLauncher] Monitoring for CAS symlinked process with hash: {Hash}", gameProcessName);
+
+                    if (!string.IsNullOrEmpty(launchConfig.ExpectedChildProcessName))
+                    {
+                        // The hash names the entry point, not the binary it hands the session to,
+                        // and the child's own hash is not available here.
+                        logger.LogWarning(
+                            "[GameLauncher] Launching {Entry} through a bootstrapper under CAS symlinking; monitoring may track the wrong process",
+                            Path.GetFileName(finalExecutablePath));
+                    }
                 }
                 else
                 {
@@ -1269,6 +1282,14 @@ public class GameLauncher(
                     gameProcessName = executableFileForMonitor != null
                         ? Path.GetFileNameWithoutExtension(executableFileForMonitor.RelativePath)
                         : Path.GetFileNameWithoutExtension(finalExecutablePath);
+
+                    // The monitored name is derived from the entry point, which may be a
+                    // bootstrapper that exits ownership to another binary.
+                    if (!string.IsNullOrEmpty(launchConfig.ExpectedChildProcessName))
+                    {
+                        gameProcessName = launchConfig.ExpectedChildProcessName;
+                    }
+
                     logger.LogInformation("[GameLauncher] Monitoring for process: {ProcessName}", gameProcessName);
                 }
 


### PR DESCRIPTION
Forward-ports Easy Anti-Cheat launch support to `development`, which has none of it. Replaces the
unopened `port/generalsonline-eac-launch` branch.

## Why this branch and not that one

#343 merged to `release/alpha-4` as squash commit `3c5fe60c`, and `development` never received it.
`port/generalsonline-eac-launch` was pushed to carry it across but no PR was ever opened, and the
two lineages then diverged in both directions:

- `release/alpha-4` gained five review-pass fixes the port branch lacks — publisher-identifier
  classification, cancellation propagation with launcher termination, fail-fast on a childless
  launcher exit, path canonicalization before residence comparison, and an executable fallback path.
- The port branch gained three commits `release/alpha-4` lacks — `144f9847`, `2c1616f8`, `ed81fa98`
  — which extend the launcher stderr capture into the adoption path.

These are complementary, not rival implementations, so this is the union of both.

This branch is cut from `development` rather than `release/alpha-4` because the stderr machinery
(`BoundedErrorBuffer`, `DrainStandardError`, `RedirectStandardError`) comes from development
ancestry and is absent from the release branch — the three commits extend it rather than introduce
it. Cherry-picking them onto a release-based branch would not compile.

## What it does

- Cherry-picks `3c5fe60c`, the exact reviewed and Windows-validated release artifact.
- Resolves the two conflicts: keeps development's stderr capture and places the expected-child
  branch after it; keeps `BuildEnvironmentVariables(...)` and adds `ExpectedChildProcessName`.
- Applies the net diagnostics delta from the three port commits: threads `capturedErrors` into
  `AdoptExpectedChildProcessAsync`, adds `AppendLauncherErrors`, guards draining on a
  broadly-caught `HasExited`, and wraps all three adoption failure messages.

Cancellation stays an exception path rather than becoming a fourth failure message.

## Note on the combined path

The clean-exit failure and the stderr diagnostics reinforce each other. That failure fires only
after the launcher has provably exited, which is exactly the condition `AppendLauncherErrors`
requires before draining is safe — so unlike the discovery-timeout path, it can report the
launcher's complete stderr rather than a partial snapshot. A bootstrapper that bails because Easy
Anti-Cheat is not installed now says so.

The three port commits shipped no tests. Added
`StartProcessAsync_WhenLauncherExitsCleanlyWithoutChild_ReportsItsStderr`, which asserts the
message carries both the childless-exit text and the launcher's stderr. Verified by mutation:
dropping the `AppendLauncherErrors` wrapper fails it.

## Testing

`GenHub.Tests.Core` 1603 passed / 0 failed; both projects build with 0 errors. macOS only — CI will
cover Windows and Linux on this base, which it could not do for #343.

Nothing else from the port branch is lost: comparing content rather than commit messages, its other
12 commits are fully subsumed by `3c5fe60c`. `port/generalsonline-eac-launch` should be retired
once this lands.

## Known gaps, tracked separately

- #364 — the discovery-timeout path still leaves a live launcher running untracked
- #365 — the clean-exit grace period can be preempted by a shorter discovery timeout

Both are inherited from `3c5fe60c` and are present in `release/alpha-4`; neither is introduced here.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR forward-ports GeneralsOnline Easy Anti-Cheat launch support and associated diagnostics to the development branch.
- Recognizes the EAC bootstrapper during client detection and manifest generation.
- Adds expected-child process adoption, launcher cleanup, and stderr-enriched failures.
- Adds focused tests for detection, manifest selection, process adoption, cancellation, and launcher failures.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the outstanding Steam CAS/SymlinkOnly path can report an EAC launch as failed while the game is running.

The CAS/SymlinkOnly Steam branch still passes the executable hash to process discovery and merely logs when an expected child is configured, so the previously reported child-monitoring failure remains.

**Files Needing Attention:** GenHub/GenHub/Features/Launching/GameLauncher.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Launching/GameLauncher.cs | Wires EAC child-process expectations into launch configuration and Steam process discovery. |
| GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs | Adds expected-child adoption, cancellation cleanup, launcher-exit handling, and stderr diagnostics. |
| GenHub/GenHub/Features/GameClients/GameClientDetector.cs | Improves GeneralsOnline publisher classification and isolates failures from individual client identifiers. |
| GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs | Selects the EAC bootstrapper as the launch entry point while retaining wrapped binaries as workspace content. |
| GenHub/GenHub.Core/Helpers/GameProcessSelector.cs | Adds name, recency, and canonicalized-directory filtering for spawned game-process candidates. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Detect GeneralsOnline client] --> B[Select EAC bootstrapper]
    B --> C[Prepare profile workspace]
    C --> D{Steam launch?}
    D -- No --> E[Start bootstrapper]
    E --> F[Adopt expected game child]
    D -- Yes --> G[Launch through Steam]
    G --> H[Discover running game process]
    F --> I[Register child PID]
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(launching): harden publisher classif..."](https://github.com/community-outpost/genhub/commit/3ae107a32ac85e24ced2613bbaed821bce507c70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51443951)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Game Detection: Installations and Client Identification](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-detection.md)
- Knowledge Base — [Content Acquisition Pipeline](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-acquisition-pipeline.md)
- Knowledge Base — [Game Profiles and Launching](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-profiles-launching.md)
</details>

<!-- /greptile_comment -->