### PR TITLE
fix(generalsonline): set PublisherType and isolate identifier failures (backport of #366)

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
@@ -393,6 +393,61 @@ public class GameClientDetectorTests : IDisposable
         Assert.Equal(wrapperPath, only.ExecutablePath);
         Assert.Equal(GameType.ZeroHour, only.GameType);
         Assert.Equal(GameClientConstants.GeneralsOnline60HzDisplayName, only.Name);
+
+        // IsPublisherClient turns on PublisherType alone. Without it the client reads as a base
+        // retail install, so version resolution treats it as the base game and the launcher UI
+        // never sees a publisher client.
+        Assert.Equal(PublisherTypeConstants.GeneralsOnline, only.PublisherType);
+        Assert.True(only.IsPublisherClient);
+    }
+
+    /// <summary>
+    /// One misbehaving identifier must not take the rest down with it. The caller's handler
+    /// swallows anything thrown here and returns null, so an escaping exception would drop the
+    /// executable entirely rather than falling through to the identifiers after it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ScanDirectoryForGameClientsAsync_WhenAnIdentifierThrows_StillTriesTheRest()
+    {
+        var gameDir = Path.Combine(_tempDirectory, "GeneralsOnline");
+        Directory.CreateDirectory(gameDir);
+        var wrapperPath = Path.Combine(gameDir, GameClientConstants.GeneralsOnlineEacLauncherExecutable);
+        await File.WriteAllTextAsync(wrapperPath, "dummy content");
+
+        _hashProviderMock.Setup(x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("unknown_hash_12345");
+
+        var manifestBuilderMock = new Mock<IContentManifestBuilder>();
+        manifestBuilderMock.Setup(x => x.Build())
+            .Returns(new ContentManifest { Id = ManifestId.Create("1.0.generalsonline.gameclient.generals-generalsonline-60hz") });
+
+        _manifestGenerationServiceMock.Setup(x => x.CreateGameClientManifestAsync(
+                It.IsAny<string>(), It.IsAny<GameType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PublisherInfo?>()))
+            .ReturnsAsync(manifestBuilderMock.Object);
+
+        _contentManifestPoolMock.Setup(x => x.AddManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<string>(), It.IsAny<IProgress<ContentStorageProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Throws from CanIdentify, which is the probe that runs before Identify.
+        var throwingIdentifier = new Mock<IGameClientIdentifier>();
+        throwingIdentifier.Setup(x => x.PublisherId).Returns("throwing");
+        throwingIdentifier.Setup(x => x.CanIdentify(It.IsAny<string>())).Throws(new InvalidOperationException("boom"));
+
+        var detector = new GameClientDetector(
+            _manifestGenerationServiceMock.Object,
+            _contentManifestPoolMock.Object,
+            _hashProviderMock.Object,
+            _hashRegistryMock.Object,
+            [throwingIdentifier.Object, new GeneralsOnlineClientIdentifier()],
+            NullLogger<GameClientDetector>.Instance);
+
+        var result = await detector.ScanDirectoryForGameClientsAsync(_tempDirectory);
+
+        Assert.True(result.Success);
+        var only = Assert.Single(result.Items);
+        Assert.Equal(GameType.ZeroHour, only.GameType);
+        Assert.Equal(GameClientConstants.GeneralsOnline60HzDisplayName, only.Name);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -313,13 +313,15 @@ public class GameClientDetector(
     {
         foreach (var identifier in gameClientIdentifiers)
         {
-            if (!identifier.CanIdentify(executablePath))
-            {
-                continue;
-            }
-
             try
             {
+                // Inside the try: a throwing identifier must not stop the ones after it, and
+                // the caller's handler would swallow the executable entirely.
+                if (!identifier.CanIdentify(executablePath))
+                {
+                    continue;
+                }
+
                 var identification = identifier.Identify(executablePath);
                 if (identification == null)
                 {
@@ -342,6 +344,11 @@ public class GameClientDetector(
                     WorkingDirectory = workingDirectory,
                     InstallationId = string.Empty,
                     SourceType = ContentType.GameClient,
+
+                    // IsPublisherClient turns on this alone. Without it the client reads as a
+                    // base retail install, so version resolution picks it as the base game and
+                    // the launcher UI does not see a publisher client at all.
+                    PublisherType = identification.PublisherId,
                 };
             }
             catch (Exception ex)


### PR DESCRIPTION
Backport of the two `GameClientDetector` fixes from #366 to `release/alpha-4`. Both defects shipped
to this branch in #343 and alpha 4 has not been cut yet, so they are cheap to fix now and awkward
afterwards.

## Problem

**`PublisherType` was never set on an identified client.** This is not a cosmetic omission —
`GameClient.IsPublisherClient` keys on `PublisherType` alone:

```csharp
public bool IsPublisherClient =>
    !string.IsNullOrEmpty(PublisherType) &&
    !string.Equals(PublisherType, "Retail Installation", StringComparison.OrdinalIgnoreCase);
```

So a GeneralsOnline client resolved through `IdentifyPublisherClient` read as a retail install.
`GameInstallationService` selects the base game client with `!c.IsPublisherClient`, making the
GeneralsOnline client eligible as the *base game* for version resolution, and
`GameProfileLauncherViewModel` tests `Any(c => c.IsPublisherClient)`, so the launcher UI did not
see a publisher client at all.

**`CanIdentify` ran outside the try block.** A throwing identifier escaped to
`DetectGameClientFromExecutableAsync`'s handler, which returns null — dropping the executable
entirely rather than falling through to the identifiers after it.

## Change

- Set `PublisherType` from `identification.PublisherId`, matching what
  `DetectPublisherClientsFromLocalFilesAsync` already does.
- Move `CanIdentify` inside the existing try so one bad identifier cannot take the rest down.

## Scope

Deliberately narrow. #366 also hardens `GameProcessManager` (whitespace guard alignment, and
guarding `HasExited`/`ExitCode` in the polling loop), but those changes sit against the launcher
stderr diagnostics that exist on `development` and not here, so they conflict. They are defensive
hardening rather than active defects, and resolving conflicts by hand in a release candidate is not
worth the risk. They arrive on `development` via #366 and can follow later if wanted.

`#367` (CAS-symlinked bootstrapper monitors the launcher's hash) is present on this branch too and
is deliberately not addressed here — it needs its own scope and testing.

## Testing

`GenHub.Tests.Core` 1563 passed / 0 failed, launch tests excluded and `GGC_NO_AUDIO=1` set. Both
fixes are mutation-verified on #366: reverting either fails its own test.

**Correction (post-merge):** this section originally claimed no CI runs against `release/alpha-4` at
all. That is wrong, and the distinction matters.

`ci.yml`'s `pull_request` trigger filters on the *base* branch (`[main, development]`), so a PR
**into** `release/alpha-4` — this one — does get no pre-merge CI. But #335 is an open PR from
`release/alpha-4` → `main`, so merging here pushes that branch, updates #335's head, and fires the
workflow with base `main`. CI duly ran on the merge commit `cb5f36e9` and passed on Windows, Linux
and macOS.

So changes land here unverified and are validated moments later through #335 — a narrow gap, not an
absent one. Worth noting that the safety net depends on #335 staying open: once it merges or closes,
pushes to `release/alpha-4` are covered by neither trigger.

The identical changes are also green on Windows, Linux and macOS CI on #366.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport corrects publisher classification and isolates failures from individual game-client identifiers.
- Assigns the identified publisher ID to `GameClient.PublisherType`.
- Moves `CanIdentify` into the per-identifier exception boundary so later identifiers still run.
- Adds regression coverage for publisher classification and identifier failure isolation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with both narrowly scoped fixes covered by targeted regression tests.

The changed detection path now preserves publisher identity and continues to subsequent identifiers after a probe failure, while current identifier contracts and implementations support both behaviors.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/GameClients/GameClientDetector.cs | Correctly propagates publisher metadata and contains identifier probe failures without introducing a concrete regression. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs | Adds focused regression assertions for publisher-client classification and fallback after a throwing identifier. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(generalsonline): set PublisherType a..."](https://github.com/community-outpost/genhub/commit/de16311e0d1cfe785092424a029ba6b963ce8831) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51458725)</sub>

**Context used:**

- Knowledge Base — [Game Detection: Installations and Client Identification](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/game-detection.md)

<!-- /greptile_comment -->
