### PR TITLE
ci: build release branches explicitly instead of relying on an open release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,22 @@ on:
     branches: [main, development, 'release/**']
   workflow_dispatch:
 
-# Keyed on branch name rather than PR number so that a push and a pull request describing the
-# same branch share a group. A release branch is normally the head of an open release PR, so
-# without this every push to it would start a second full matrix under a different key.
-# Feature branches are unaffected: they match no push filter, so only their PR run exists.
+# A release branch is normally the head of an open release PR, so a push to it would otherwise
+# start a second full matrix under a different key. Same-repository pull requests therefore share
+# a group with pushes describing the same branch, and collapse.
+#
+# Only same-repository heads are keyed by branch name. A fork's head ref is contributor-controlled,
+# so keying on it unconditionally would let a fork branch named `development`, `main` or
+# `release/*` land in a protected branch's group — and because cancel-in-progress is on for pull
+# requests, each push to that PR would cancel the protected branch's running CI. Fork pull requests
+# fall back to github.ref_name, which is `<pr-number>/merge` and therefore unique per PR.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.pull_request.head.ref
+        || github.ref_name
+    }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,16 @@ permissions:
   pull-requests: write
 
 on:
+  # release/** is covered explicitly rather than incidentally. A release branch is only built
+  # today because an open release PR happens to point at main, which makes its head a pull_request
+  # head — so coverage disappears the moment that PR merges or closes.
   push:
-    branches: [ main, development]
+    branches: [ main, development, 'release/**' ]
+
+  # Filters on the base branch, so without release/** a PR *into* a release branch gets no
+  # pre-merge CI at all. That is how #343 and #368 merged unbuilt.
   pull_request:
-    branches: [ main, development]
+    branches: [ main, development, 'release/**' ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,20 @@ on:
   # today because an open release PR happens to point at main, which makes its head a pull_request
   # head — so coverage disappears the moment that PR merges or closes.
   push:
-    branches: [ main, development, 'release/**' ]
+    branches: [main, development, 'release/**']
 
   # Filters on the base branch, so without release/** a PR *into* a release branch gets no
   # pre-merge CI at all. That is how #343 and #368 merged unbuilt.
   pull_request:
-    branches: [ main, development, 'release/**' ]
+    branches: [main, development, 'release/**']
   workflow_dispatch:
 
+# Keyed on branch name rather than PR number so that a push and a pull request describing the
+# same branch share a group. A release branch is normally the head of an open release PR, so
+# without this every push to it would start a second full matrix under a different key.
+# Feature branches are unaffected: they match no push filter, so only their PR run exists.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
## Problem

`release/**` appears in neither trigger, so release branches are built only by accident.

Pushes to `release/alpha-4` do currently produce CI runs — but only because #335 is an open PR from
`release/alpha-4` → `main`. Each push updates that PR's head, which fires the `pull_request`
workflow with base `main`. All four merge commits on that branch have green runs for this reason.

That coverage vanishes the moment #335 merges or closes. Any future release branch worked before
its release PR exists gets nothing at all.

The `pull_request` trigger filters on the **base** branch, which is the sharper edge: a PR *into* a
release branch matches neither `main` nor `development`, so it gets **no pre-merge CI**. #343 and
#368 both merged to `release/alpha-4` without a single build or test job having run against them.
Both turned out fine, but that was luck rather than process.

## Change

Add `release/**` to both triggers.

- **push** — makes release-branch coverage intentional and independent of any open PR.
- **pull_request** — gives PRs targeting a release branch pre-merge CI, closing the gap #343 and
  #368 went through.

I extended this past the `push` trigger deliberately: adding only `push` would leave the specific
hole that actually bit us open, since that one is on the `pull_request` side. Easy to drop the
second line if you want the narrower change.

## Concurrency

Adding `release/**` to `push` would otherwise have duplicated CI, and on this repo that is not
hypothetical: `release/alpha-4` is the head of open PR #335, so every merge into it would start a
push run *and* a pull-request run under different keys.

The group was `github.event.pull_request.number || github.ref` — `GenHub CI-refs/heads/release/alpha-4`
versus `GenHub CI-335`, so neither cancelled the other. It is now keyed on branch name,
`github.event.pull_request.head.ref || github.ref_name`, so both resolve to `release/alpha-4`,
share a group, and collapse. The pull-request run survives, which is the one that gates #335.

Feature branches are unaffected — they match no push filter, so only their PR run exists. Pushes to
`development` key on `development` while PRs into it key on their own head, so those do not collide.

**Fork safety.** Keying on `head.ref` alone would have been contributor-controlled: a fork branch
named `main`, `development` or `release/*` would land in a protected branch's group, and because
`cancel-in-progress` is on for pull requests, each push to that PR would cancel the protected
branch's running CI. That needs no malice — people commonly work on `main` or `development` in
their own fork. Only **same-repository** heads are keyed by branch name; fork pull requests fall
back to `github.ref_name`, which is `<pr-number>/merge` and unique per PR.

## Notes

No other job definitions touched — only the trigger lists and the concurrency key. The `concurrency` group already keys on
`github.event.pull_request.number || github.ref`, so release-branch runs cancel and queue correctly
without further change.

Verified the file still parses and all 5 jobs load. Beyond that this is self-testing: if the
triggers are wrong, this PR does not build.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR explicitly enables CI for pushes and pull requests involving release branches and revises concurrency grouping to distinguish same-repository heads from fork pull requests.
- Adds `release/**` to both push and pull-request branch filters.
- Groups same-repository runs by branch while giving fork pull requests PR-specific groups.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds explicit release-branch triggers and repository-aware concurrency grouping. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: key concurrency on fork-safe identit..."](https://github.com/community-outpost/genhub/commit/74fa6863013b8fa6a1dd8840bc79b4fa6ac3f52f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51591514)</sub>

<!-- /greptile_comment -->