### PR TITLE
feat(generalsonline): create distinct ContentManifest for GeneralsOnlineGameData data patch

### DIFF
--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -138,5 +138,5 @@ public static class GeneralsOnlineConstants
     /// <summary>
     /// Default tags for GameData patch manifests.
     /// </summary>
-    public static readonly string[] GameDataTags = ["patch", "generalsonline", "gamedata"];
+    public static readonly string[] GameDataTags = ["patch", "generalsonline"];
 }

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -103,7 +103,7 @@ public static class GeneralsOnlineConstants
     public const string GameDataDisplayName = "GeneralsOnline Game Data";
 
     /// <summary>Description for GeneralsOnlineGameData data patch.</summary>
-    public const string GameDataDescription = "Game data patch for GeneralsOnline containing splash screens and map cache configuration.";
+    public const string GameDataDescription = "Game data patch for GeneralsOnline containing community balance and core INI configuration.";
 
     /// <summary>Subdirectory within the portable ZIP containing maps.</summary>
     public const string MapsSubdirectory = "Maps";

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -87,6 +87,9 @@ public static class GeneralsOnlineConstants
     /// <summary>Manifest name suffix for QuickMatch MapPack.</summary>
     public const string QuickMatchMapPackSuffix = "quickmatch-maps";
 
+    /// <summary>Manifest name suffix for GeneralsOnlineGameData data patch.</summary>
+    public const string GameDataPatchSuffix = "gamedata";
+
     /// <summary>The default tick rate variant suffix.</summary>
     public const string DefaultVariantSuffix = Variant60HzSuffix;
 
@@ -96,8 +99,17 @@ public static class GeneralsOnlineConstants
     /// <summary>Description for QuickMatch MapPack.</summary>
     public const string QuickMatchMapPackDescription = "Official map pack required for GeneralsOnline QuickMatch multiplayer. Contains competitively balanced maps.";
 
+    /// <summary>Display name for GeneralsOnlineGameData data patch.</summary>
+    public const string GameDataDisplayName = "GeneralsOnline Game Data";
+
+    /// <summary>Description for GeneralsOnlineGameData data patch.</summary>
+    public const string GameDataDescription = "Game data patch for GeneralsOnline containing splash screens and map cache configuration.";
+
     /// <summary>Subdirectory within the portable ZIP containing maps.</summary>
     public const string MapsSubdirectory = "Maps";
+
+    /// <summary>Subdirectory within the portable ZIP containing GeneralsOnline game data.</summary>
+    public const string GameDataSubdirectory = "GeneralsOnlineGameData";
 
     // ===== Component Identifiers =====
 
@@ -122,4 +134,9 @@ public static class GeneralsOnlineConstants
     /// Default tags for MapPack manifests.
     /// </summary>
     public static readonly string[] MapPackTags = ["mappack", "generalsonline", "quickmatch", "competitive"];
+
+    /// <summary>
+    /// Default tags for GameData patch manifests.
+    /// </summary>
+    public static readonly string[] GameDataTags = ["patch", "generalsonline", "gamedata"];
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Providers;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Providers;
+using GenHub.Core.Models.Results;
+using GenHub.Features.Content.Services.GeneralsOnline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Unit tests for <see cref="GeneralsOnlineDeliverer"/>.
+/// </summary>
+public class GeneralsOnlineDelivererTests : IDisposable
+{
+    private readonly Mock<IDownloadService> _downloadServiceMock;
+    private readonly Mock<IContentManifestPool> _manifestPoolMock;
+    private readonly Mock<IProviderDefinitionLoader> _providerLoaderMock;
+    private readonly GeneralsOnlineManifestFactory _manifestFactory;
+    private readonly GeneralsOnlineDeliverer _deliverer;
+    private readonly string _tempDir;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeneralsOnlineDelivererTests"/> class.
+    /// </summary>
+    public GeneralsOnlineDelivererTests()
+    {
+        _downloadServiceMock = new Mock<IDownloadService>();
+        _manifestPoolMock = new Mock<IContentManifestPool>();
+        _providerLoaderMock = new Mock<IProviderDefinitionLoader>();
+
+        _providerLoaderMock
+            .Setup(l => l.GetProvider(PublisherTypeConstants.GeneralsOnline))
+            .Returns(new ProviderDefinition
+            {
+                ProviderId = PublisherTypeConstants.GeneralsOnline,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+                Endpoints = new ProviderEndpoints
+                {
+                    WebsiteUrl = "https://example.com/go",
+                },
+            });
+
+        _manifestFactory = new GeneralsOnlineManifestFactory(
+            NullLogger<GeneralsOnlineManifestFactory>.Instance,
+            _providerLoaderMock.Object);
+
+        _deliverer = new GeneralsOnlineDeliverer(
+            _downloadServiceMock.Object,
+            _manifestPoolMock.Object,
+            _manifestFactory,
+            NullLogger<GeneralsOnlineDeliverer>.Instance);
+
+        _tempDir = Path.Combine(Path.GetTempPath(), "GenHub_GODelivererTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Cleans up test artifacts.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Verifies CanDeliver returns true for GeneralsOnline manifests with zip downloads.
+    /// </summary>
+    [Fact]
+    public void CanDeliver_ValidGeneralsOnlineManifest_ReturnsTrue()
+    {
+        var manifest = new ContentManifest
+        {
+            Publisher = new PublisherInfo
+            {
+                Name = GeneralsOnlineConstants.PublisherName,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+            },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline_101525_QFE5.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        Assert.True(_deliverer.CanDeliver(manifest));
+    }
+
+    /// <summary>
+    /// Verifies CanDeliver returns false for other publishers.
+    /// </summary>
+    [Fact]
+    public void CanDeliver_OtherPublisher_ReturnsFalse()
+    {
+        var manifest = new ContentManifest
+        {
+            Publisher = new PublisherInfo { PublisherType = "other-publisher" },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/other.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        Assert.False(_deliverer.CanDeliver(manifest));
+    }
+
+    /// <summary>
+    /// Verifies DeliverContentAsync fails when any manifest registration in pool fails.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_WhenManifestRegistrationFails_ReturnsFailure()
+    {
+        // Arrange
+        var zipPath = Path.Combine(_tempDir, "test.zip");
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write("fake content");
+        }
+
+        _downloadServiceMock
+            .Setup(d => d.DownloadFileAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) =>
+            {
+                File.Copy(zipPath, path, true);
+            })
+            .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline_101525_QFE5.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        // First manifest registration succeeds, second fails
+        var callCount = 0;
+        _manifestPoolMock
+            .Setup(p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? OperationResult<bool>.CreateSuccess(true)
+                    : OperationResult<bool>.CreateFailure("Simulated pool registration failure");
+            });
+
+        // Act
+        var targetDir = Path.Combine(_tempDir, "delivery");
+        Directory.CreateDirectory(targetDir);
+        var result = await _deliverer.DeliverContentAsync(manifest, targetDir, null, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Simulated pool registration failure", result.FirstError);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -134,6 +134,32 @@ public class GeneralsOnlineDelivererTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies CanDeliver returns false for GeneralsOnline manifests without a ZIP download URL.
+    /// </summary>
+    [Fact]
+    public void CanDeliver_ManifestWithoutZipFile_ReturnsFalse()
+    {
+        var manifest = new ContentManifest
+        {
+            Publisher = new PublisherInfo
+            {
+                Name = GeneralsOnlineConstants.PublisherName,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+            },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline.exe",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        Assert.False(_deliverer.CanDeliver(manifest));
+    }
+
+    /// <summary>
     /// Verifies DeliverContentAsync fails when any manifest registration in pool fails.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
@@ -164,10 +190,7 @@ public class GeneralsOnlineDelivererTests : IDisposable
                 It.IsAny<string?>(),
                 It.IsAny<IProgress<DownloadProgress>?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) =>
-            {
-                File.Copy(zipPath, path, true);
-            })
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) => File.Copy(zipPath, path, true))
             .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
 
         var manifest = new ContentManifest
@@ -222,10 +245,14 @@ public class GeneralsOnlineDelivererTests : IDisposable
         // Verifies that earlier successfully registered manifest was rolled back
         _manifestPoolMock.Verify(
             p => p.RemoveManifestAsync(
-                It.IsAny<ManifestId>(),
+                It.Is<ManifestId>(id => id.Value == manifest.Id.Value),
                 false,
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // Temp artifacts should be cleaned up on failure
+        Assert.False(File.Exists(Path.Combine(targetDir, "GeneralsOnline.zip")));
+        Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
     }
 
     /// <summary>
@@ -260,10 +287,7 @@ public class GeneralsOnlineDelivererTests : IDisposable
                 It.IsAny<string?>(),
                 It.IsAny<IProgress<DownloadProgress>?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) =>
-            {
-                File.Copy(zipPath, path, true);
-            })
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) => File.Copy(zipPath, path, true))
             .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
 
         var manifest = new ContentManifest
@@ -321,7 +345,8 @@ public class GeneralsOnlineDelivererTests : IDisposable
         Assert.True(File.Exists(Path.Combine(targetDir, "generalsonlinezh_60.exe")));
         Assert.True(File.Exists(Path.Combine(targetDir, "GeneralsOnlineGameData", "500_900_CommunityPatch_CoreINI.big")));
 
-        // Temporary extracted directory was cleaned up
+        // Downloaded ZIP and temporary extracted directory were cleaned up
+        Assert.False(File.Exists(Path.Combine(targetDir, "GeneralsOnline.zip")));
         Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
     }
 
@@ -356,10 +381,7 @@ public class GeneralsOnlineDelivererTests : IDisposable
                 It.IsAny<string?>(),
                 It.IsAny<IProgress<DownloadProgress>?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) =>
-            {
-                File.Copy(zipPath, path, true);
-            })
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) => File.Copy(zipPath, path, true))
             .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
 
         var manifest = new ContentManifest
@@ -412,9 +434,195 @@ public class GeneralsOnlineDelivererTests : IDisposable
         // First manifest was rolled back
         _manifestPoolMock.Verify(
             p => p.RemoveManifestAsync(
-                It.IsAny<ManifestId>(),
-                It.IsAny<bool>(),
+                It.Is<ManifestId>(id => id.Value == manifest.Id.Value),
+                false,
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // Temp artifacts should be cleaned up on failure
+        Assert.False(File.Exists(Path.Combine(targetDir, "GeneralsOnline.zip")));
+        Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
+    }
+
+    /// <summary>
+    /// Verifies that already-acquired manifests are skipped during registration.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_ManifestAlreadyAcquired_SkipsRegistration()
+    {
+        // Arrange
+        var zipPath = Path.Combine(_tempDir, "already_acquired.zip");
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
+            using (var writer = new StreamWriter(entry.Open()))
+            {
+                writer.Write("fake content");
+            }
+
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
+            using (var writer = new StreamWriter(gameDataEntry.Open()))
+            {
+                writer.Write("fake big content");
+            }
+        }
+
+        _downloadServiceMock
+            .Setup(d => d.DownloadFileAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) => File.Copy(zipPath, path, true))
+            .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline_101525_QFE5.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        // First manifest is already acquired, second is not
+        _manifestPoolMock
+            .SetupSequence(p => p.IsManifestAcquiredAsync(It.IsAny<ManifestId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+
+        _manifestPoolMock
+            .Setup(p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        var targetDir = Path.Combine(_tempDir, "already_acquired_delivery");
+        Directory.CreateDirectory(targetDir);
+        var result = await _deliverer.DeliverContentAsync(manifest, targetDir, null, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+
+        // AddManifestAsync called only once (for the unacquired Patch manifest, skipping GameClient)
+        _manifestPoolMock.Verify(
+            p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that cancellation during manifest registration triggers rollback, cleans temp artifacts, and rethrows OperationCanceledException.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_CancellationDuringRegistration_RollsBackAndRethrows()
+    {
+        // Arrange
+        var zipPath = Path.Combine(_tempDir, "cancel_test.zip");
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
+            using (var writer = new StreamWriter(entry.Open()))
+            {
+                writer.Write("fake content");
+            }
+
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
+            using (var writer = new StreamWriter(gameDataEntry.Open()))
+            {
+                writer.Write("fake big content");
+            }
+        }
+
+        _downloadServiceMock
+            .Setup(d => d.DownloadFileAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) => File.Copy(zipPath, path, true))
+            .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline_101525_QFE5.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        using var cts = new CancellationTokenSource();
+
+        var callCount = 0;
+        _manifestPoolMock
+            .Setup(p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return OperationResult<bool>.CreateSuccess(true);
+                }
+
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            });
+
+        _manifestPoolMock
+            .Setup(p => p.RemoveManifestAsync(
+                It.IsAny<ManifestId>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act & Assert
+        var targetDir = Path.Combine(_tempDir, "cancel_delivery");
+        Directory.CreateDirectory(targetDir);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _deliverer.DeliverContentAsync(manifest, targetDir, null, cts.Token));
+
+        // Rollback was invoked for the earlier registered manifest
+        _manifestPoolMock.Verify(
+            p => p.RemoveManifestAsync(
+                It.Is<ManifestId>(id => id.Value == manifest.Id.Value),
+                false,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Temp artifacts were cleaned up
+        Assert.False(File.Exists(Path.Combine(targetDir, "GeneralsOnline.zip")));
+        Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -55,6 +55,10 @@ public class GeneralsOnlineDelivererTests : IDisposable
                 },
             });
 
+        _manifestPoolMock
+            .Setup(p => p.IsManifestAcquiredAsync(It.IsAny<ManifestId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false));
+
         _manifestFactory = new GeneralsOnlineManifestFactory(
             NullLogger<GeneralsOnlineManifestFactory>.Instance,
             _providerLoaderMock.Object);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -142,8 +142,16 @@ public class GeneralsOnlineDelivererTests : IDisposable
         using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
         {
             var entry = archive.CreateEntry("generalsonlinezh_60.exe");
-            using var writer = new StreamWriter(entry.Open());
-            writer.Write("fake content");
+            using (var writer = new StreamWriter(entry.Open()))
+            {
+                writer.Write("fake content");
+            }
+
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/splash.bmp");
+            using (var writer = new StreamWriter(gameDataEntry.Open()))
+            {
+                writer.Write("fake splash");
+            }
         }
 
         _downloadServiceMock

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -200,6 +200,13 @@ public class GeneralsOnlineDelivererTests : IDisposable
                     : OperationResult<bool>.CreateFailure("Simulated pool registration failure");
             });
 
+        _manifestPoolMock
+            .Setup(p => p.RemoveManifestAsync(
+                It.IsAny<ManifestId>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
         // Act
         var targetDir = Path.Combine(_tempDir, "delivery");
         Directory.CreateDirectory(targetDir);
@@ -208,5 +215,102 @@ public class GeneralsOnlineDelivererTests : IDisposable
         // Assert
         Assert.False(result.Success);
         Assert.Contains("Simulated pool registration failure", result.FirstError);
+
+        // Verifies that earlier successfully registered manifest was rolled back
+        _manifestPoolMock.Verify(
+            p => p.RemoveManifestAsync(
+                It.IsAny<ManifestId>(),
+                false,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies the happy path of DeliverContentAsync: all manifests register,
+    /// files are moved to target directory, and temporary extraction directory is cleaned up.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_HappyPath_RegistersAllManifestsAndCleansUp()
+    {
+        // Arrange
+        var zipPath = Path.Combine(_tempDir, "happy_test.zip");
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
+            using (var writer = new StreamWriter(entry.Open()))
+            {
+                writer.Write("fake content");
+            }
+
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/splash.bmp");
+            using (var writer = new StreamWriter(gameDataEntry.Open()))
+            {
+                writer.Write("fake splash");
+            }
+        }
+
+        _downloadServiceMock
+            .Setup(d => d.DownloadFileAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) =>
+            {
+                File.Copy(zipPath, path, true);
+            })
+            .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline_101525_QFE5.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        _manifestPoolMock
+            .Setup(p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        var targetDir = Path.Combine(_tempDir, "happy_delivery");
+        Directory.CreateDirectory(targetDir);
+        var result = await _deliverer.DeliverContentAsync(manifest, targetDir, null, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+
+        // Multiple manifests were registered in pool (GameClient and GameData Patch)
+        _manifestPoolMock.Verify(
+            p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
+
+        // Files were moved to target directory
+        Assert.True(File.Exists(Path.Combine(targetDir, "generalsonlinezh_60.exe")));
+        Assert.True(File.Exists(Path.Combine(targetDir, "GeneralsOnlineGameData", "splash.bmp")));
+
+        // Temporary extracted directory was cleaned up
+        Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -301,14 +301,22 @@ public class GeneralsOnlineDelivererTests : IDisposable
         Assert.True(result.Success);
         Assert.NotNull(result.Data);
 
-        // Multiple manifests were registered in pool (GameClient and GameData Patch)
+        // Exactly 2 manifests were registered in pool (GameClient and GameData Patch; empty MapPack is skipped)
         _manifestPoolMock.Verify(
             p => p.AddManifestAsync(
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
                 It.IsAny<IProgress<ContentStorageProgress>?>(),
                 It.IsAny<CancellationToken>()),
-            Times.AtLeast(2));
+            Times.Exactly(2));
+
+        // Rollback was never invoked on the happy path
+        _manifestPoolMock.Verify(
+            p => p.RemoveManifestAsync(
+                It.IsAny<ManifestId>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
 
         // Files were moved to target directory
         Assert.True(File.Exists(Path.Combine(targetDir, "generalsonlinezh_60.exe")));

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -325,4 +325,97 @@ public class GeneralsOnlineDelivererTests : IDisposable
         // Temporary extracted directory was cleaned up
         Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
     }
+
+    /// <summary>
+    /// Verifies that if manifest acquisition check fails, rollback is triggered and failure is returned.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_CheckAcquisitionFails_RollsBackAndReturnsFailure()
+    {
+        // Arrange
+        var zipPath = Path.Combine(_tempDir, "check_fail.zip");
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+        {
+            var exeEntry = archive.CreateEntry("generalsonlinezh_60.exe");
+            using (var writer = new StreamWriter(exeEntry.Open()))
+            {
+                writer.Write("fake exe");
+            }
+
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/splash.bmp");
+            using (var writer = new StreamWriter(gameDataEntry.Open()))
+            {
+                writer.Write("fake splash");
+            }
+        }
+
+        _downloadServiceMock
+            .Setup(d => d.DownloadFileAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) =>
+            {
+                File.Copy(zipPath, path, true);
+            })
+            .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline_101525_QFE5.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                },
+            ],
+        };
+
+        // First check succeeds, second check fails
+        _manifestPoolMock
+            .SetupSequence(p => p.IsManifestAcquiredAsync(It.IsAny<ManifestId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(false))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("CAS index corrupted"));
+
+        _manifestPoolMock
+            .Setup(p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        _manifestPoolMock
+            .Setup(p => p.RemoveManifestAsync(
+                It.IsAny<ManifestId>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        var targetDir = Path.Combine(_tempDir, "check_fail_delivery");
+        Directory.CreateDirectory(targetDir);
+        var result = await _deliverer.DeliverContentAsync(manifest, targetDir, null, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Failed to check manifest acquisition status", result.FirstError);
+
+        // First manifest was rolled back
+        _manifestPoolMock.Verify(
+            p => p.RemoveManifestAsync(
+                It.IsAny<ManifestId>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -151,10 +151,10 @@ public class GeneralsOnlineDelivererTests : IDisposable
                 writer.Write("fake content");
             }
 
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/splash.bmp");
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
             using (var writer = new StreamWriter(gameDataEntry.Open()))
             {
-                writer.Write("fake splash");
+                writer.Write("fake big content");
             }
         }
 
@@ -247,10 +247,10 @@ public class GeneralsOnlineDelivererTests : IDisposable
                 writer.Write("fake content");
             }
 
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/splash.bmp");
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
             using (var writer = new StreamWriter(gameDataEntry.Open()))
             {
-                writer.Write("fake splash");
+                writer.Write("fake big content");
             }
         }
 
@@ -320,7 +320,7 @@ public class GeneralsOnlineDelivererTests : IDisposable
 
         // Files were moved to target directory
         Assert.True(File.Exists(Path.Combine(targetDir, "generalsonlinezh_60.exe")));
-        Assert.True(File.Exists(Path.Combine(targetDir, "GeneralsOnlineGameData", "splash.bmp")));
+        Assert.True(File.Exists(Path.Combine(targetDir, "GeneralsOnlineGameData", "500_900_CommunityPatch_CoreINI.big")));
 
         // Temporary extracted directory was cleaned up
         Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
@@ -343,10 +343,10 @@ public class GeneralsOnlineDelivererTests : IDisposable
                 writer.Write("fake exe");
             }
 
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/splash.bmp");
+            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
             using (var writer = new StreamWriter(gameDataEntry.Open()))
             {
-                writer.Write("fake splash");
+                writer.Write("fake big content");
             }
         }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -164,24 +164,11 @@ public class GeneralsOnlineDelivererTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DeliverContentAsync_WhenManifestRegistrationFails_ReturnsFailure()
+    public async Task DeliverContentAsync_WhenManifestRegistrationFails_ReturnsFailureAsync()
     {
         // Arrange
         var zipPath = Path.Combine(_tempDir, "test.zip");
-        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
-        {
-            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
-            using (var writer = new StreamWriter(entry.Open()))
-            {
-                writer.Write("fake content");
-            }
-
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
-            using (var writer = new StreamWriter(gameDataEntry.Open()))
-            {
-                writer.Write("fake big content");
-            }
-        }
+        CreateTestZip(zipPath);
 
         _downloadServiceMock
             .Setup(d => d.DownloadFileAsync(
@@ -261,24 +248,11 @@ public class GeneralsOnlineDelivererTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DeliverContentAsync_HappyPath_RegistersAllManifestsAndCleansUp()
+    public async Task DeliverContentAsync_HappyPath_RegistersAllManifestsAndCleansUpAsync()
     {
         // Arrange
         var zipPath = Path.Combine(_tempDir, "happy_test.zip");
-        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
-        {
-            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
-            using (var writer = new StreamWriter(entry.Open()))
-            {
-                writer.Write("fake content");
-            }
-
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
-            using (var writer = new StreamWriter(gameDataEntry.Open()))
-            {
-                writer.Write("fake big content");
-            }
-        }
+        CreateTestZip(zipPath);
 
         _downloadServiceMock
             .Setup(d => d.DownloadFileAsync(
@@ -355,24 +329,11 @@ public class GeneralsOnlineDelivererTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task DeliverContentAsync_CheckAcquisitionFails_RollsBackAndReturnsFailure()
+    public async Task DeliverContentAsync_CheckAcquisitionFails_RollsBackAndReturnsFailureAsync()
     {
         // Arrange
         var zipPath = Path.Combine(_tempDir, "check_fail.zip");
-        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
-        {
-            var exeEntry = archive.CreateEntry("generalsonlinezh_60.exe");
-            using (var writer = new StreamWriter(exeEntry.Open()))
-            {
-                writer.Write("fake exe");
-            }
-
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
-            using (var writer = new StreamWriter(gameDataEntry.Open()))
-            {
-                writer.Write("fake big content");
-            }
-        }
+        CreateTestZip(zipPath);
 
         _downloadServiceMock
             .Setup(d => d.DownloadFileAsync(
@@ -449,24 +410,11 @@ public class GeneralsOnlineDelivererTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DeliverContentAsync_ManifestAlreadyAcquired_SkipsRegistration()
+    public async Task DeliverContentAsync_ManifestAlreadyAcquired_SkipsRegistrationAsync()
     {
         // Arrange
         var zipPath = Path.Combine(_tempDir, "already_acquired.zip");
-        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
-        {
-            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
-            using (var writer = new StreamWriter(entry.Open()))
-            {
-                writer.Write("fake content");
-            }
-
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
-            using (var writer = new StreamWriter(gameDataEntry.Open()))
-            {
-                writer.Write("fake big content");
-            }
-        }
+        CreateTestZip(zipPath);
 
         _downloadServiceMock
             .Setup(d => d.DownloadFileAsync(
@@ -532,24 +480,11 @@ public class GeneralsOnlineDelivererTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DeliverContentAsync_CancellationDuringRegistration_RollsBackAndRethrows()
+    public async Task DeliverContentAsync_CancellationDuringRegistration_RollsBackAndRethrowsAsync()
     {
         // Arrange
         var zipPath = Path.Combine(_tempDir, "cancel_test.zip");
-        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
-        {
-            var entry = archive.CreateEntry("generalsonlinezh_60.exe");
-            using (var writer = new StreamWriter(entry.Open()))
-            {
-                writer.Write("fake content");
-            }
-
-            var gameDataEntry = archive.CreateEntry("GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big");
-            using (var writer = new StreamWriter(gameDataEntry.Open()))
-            {
-                writer.Write("fake big content");
-            }
-        }
+        CreateTestZip(zipPath);
 
         _downloadServiceMock
             .Setup(d => d.DownloadFileAsync(
@@ -624,5 +559,19 @@ public class GeneralsOnlineDelivererTests : IDisposable
         // Temp artifacts were cleaned up
         Assert.False(File.Exists(Path.Combine(targetDir, "GeneralsOnline.zip")));
         Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
+    }
+
+    private static void CreateTestZip(string zipPath)
+    {
+        using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+        CreateEntryWithText(archive, "generalsonlinezh_60.exe", "fake content");
+        CreateEntryWithText(archive, "GeneralsOnlineGameData/500_900_CommunityPatch_CoreINI.big", "fake big content");
+    }
+
+    private static void CreateEntryWithText(ZipArchive archive, string entryName, string content)
+    {
+        var entry = archive.CreateEntry(entryName);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(content);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -281,17 +281,69 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
         // Act
         var manifests = await _factory.CreateManifestsFromExtractedContentAsync(originalManifest, _tempDir, CancellationToken.None);
 
-        var gameClient = manifests.First(m => m.ContentType == ContentType.GameClient);
-        var mapPack = manifests.First(m => m.ContentType == ContentType.MapPack);
-        var gameDataPatch = manifests.First(m => m.ContentType == ContentType.Patch);
-
-        // Assert - MapPack and GameData patch must not contain sibling files
-        Assert.Empty(mapPack.Files);
-        Assert.Empty(gameDataPatch.Files);
+        // Assert - MapPack and GameData patch are omitted because they have 0 files
+        Assert.Single(manifests);
+        var gameClient = manifests.Single();
+        Assert.Equal(ContentType.GameClient, gameClient.ContentType);
+        Assert.DoesNotContain(manifests, m => m.ContentType == ContentType.MapPack);
+        Assert.DoesNotContain(manifests, m => m.ContentType == ContentType.Patch);
 
         // Assert - GameClient must contain the sibling files as workspace files
         Assert.Contains(gameClient.Files, f => f.RelativePath.Contains("Maps_backup"));
         Assert.Contains(gameClient.Files, f => f.RelativePath.Contains("GeneralsOnlineGameData_backup"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="GeneralsOnlineManifestFactory.CreateManifestsFromExtractedContentAsync"/> throws
+    /// <see cref="OperationCanceledException"/> when passed a cancelled token.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_PreCancelledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var originalManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _factory.CreateManifestsFromExtractedContentAsync(originalManifest, _tempDir, cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that GameData patch metadata tags do not contain duplicate tags.
+    /// </summary>
+    [Fact]
+    public void CreateManifests_GameDataPatchTags_HasNoDuplicateTags()
+    {
+        // Arrange
+        var release = new GeneralsOnlineRelease
+        {
+            Version = "101525_QFE5",
+            ReleaseDate = DateTime.UtcNow,
+            PortableUrl = "https://example.com/test.zip",
+        };
+
+        // Act
+        var manifests = _factory.CreateManifests(release);
+        var gameDataPatch = manifests.First(m => m.ContentType == ContentType.Patch);
+
+        // Assert
+        var tags = gameDataPatch.Metadata?.Tags ?? [];
+        var distinctTags = tags.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        Assert.Equal(distinctTags.Count, tags.Count);
+        Assert.Contains("gamedata", tags);
+        Assert.Contains("patch", tags);
+        Assert.Contains("generalsonline", tags);
     }
 
     /// <summary>
@@ -311,12 +363,13 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
         var builder = new GeneralsOnlineDependencyBuilder();
         var patchManifest = new ContentManifest
         {
+            Version = "101525_QFE5",
             ContentType = ContentType.Patch,
             Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
         };
         var resolvedDeps = builder.GetDependencies(patchManifest);
         Assert.Equal(2, resolvedDeps.Count);
         Assert.Contains(resolvedDeps, d => d.DependencyType == ContentType.GameInstallation);
-        Assert.Contains(resolvedDeps, d => d.DependencyType == ContentType.GameClient);
+        Assert.Contains(resolvedDeps, d => d.DependencyType == ContentType.GameClient && d.Id.Value.Contains("1015255"));
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -144,7 +144,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
 
         Assert.NotNull(zhDepInPatch);
         Assert.NotNull(clientDepInPatch);
-        Assert.Contains(GeneralsOnlineConstants.Variant60HzSuffix, clientDepInPatch.Id.Value);
+        Assert.Equal(gameClient.Id.Value, clientDepInPatch.Id.Value);
         Assert.False(clientDepInPatch.IsOptional);
         Assert.True(clientDepInPatch.StrictPublisher);
         Assert.Equal(PublisherTypeConstants.GeneralsOnline, clientDepInPatch.PublisherType);
@@ -347,18 +347,49 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that <see cref="GeneralsOnlineManifestFactory.CreateManifestsFromExtractedContentAsync"/> throws
+    /// <see cref="InvalidDataException"/> when the GameClient manifest has zero files.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_EmptyGameClient_ThrowsInvalidDataException()
+    {
+        // Arrange: Only create map files, no GameClient files
+        var mapsDir = Path.Combine(_tempDir, GeneralsOnlineConstants.MapsSubdirectory, "TestMap");
+        Directory.CreateDirectory(mapsDir);
+        File.WriteAllText(Path.Combine(mapsDir, "TestMap.map"), "fake map");
+
+        var originalManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            _factory.CreateManifestsFromExtractedContentAsync(originalManifest, _tempDir, CancellationToken.None));
+    }
+
+    /// <summary>
     /// Verifies <see cref="GeneralsOnlineDependencyBuilder"/> directly returns the expected GameData dependencies.
     /// </summary>
     [Fact]
     public void DependencyBuilder_GetDependenciesForGameData_ReturnsExpectedDependencies()
     {
+        // Arrange
+        var expectedClientId = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz");
+
         // Act
         var dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesForGameData(1015255);
 
         // Assert
         Assert.Equal(2, dependencies.Count);
         Assert.Contains(dependencies, d => d.DependencyType == ContentType.GameInstallation);
-        Assert.Contains(dependencies, d => d.DependencyType == ContentType.GameClient && d.Id.Value.Contains("60hz"));
+        var clientDep = dependencies.First(d => d.DependencyType == ContentType.GameClient);
+        Assert.Equal(expectedClientId.Value, clientDep.Id.Value);
 
         var builder = new GeneralsOnlineDependencyBuilder();
         var patchManifest = new ContentManifest
@@ -370,6 +401,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
         var resolvedDeps = builder.GetDependencies(patchManifest);
         Assert.Equal(2, resolvedDeps.Count);
         Assert.Contains(resolvedDeps, d => d.DependencyType == ContentType.GameInstallation);
-        Assert.Contains(resolvedDeps, d => d.DependencyType == ContentType.GameClient && d.Id.Value.Contains("1015255"));
+        var resolvedClientDep = resolvedDeps.First(d => d.DependencyType == ContentType.GameClient);
+        Assert.Equal(expectedClientId.Value, resolvedClientDep.Id.Value);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -252,6 +252,49 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that directories with names starting with "Maps" or "GeneralsOnlineGameData" (e.g. Maps_backup, GeneralsOnlineGameData_backup)
+    /// are not misclassified as Maps or GeneralsOnlineGameData.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_SiblingDirectories_AreNotMisclassified()
+    {
+        // Arrange
+        var siblingMapDir = Path.Combine(_tempDir, "Maps_backup");
+        Directory.CreateDirectory(siblingMapDir);
+        File.WriteAllText(Path.Combine(siblingMapDir, "backup.map"), "fake map backup");
+
+        var siblingGameDataDir = Path.Combine(_tempDir, "GeneralsOnlineGameData_backup");
+        Directory.CreateDirectory(siblingGameDataDir);
+        File.WriteAllText(Path.Combine(siblingGameDataDir, "backup.ini"), "fake ini backup");
+
+        var originalManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Metadata = new ContentMetadata { ReleaseDate = DateTime.UtcNow },
+        };
+
+        // Act
+        var manifests = await _factory.CreateManifestsFromExtractedContentAsync(originalManifest, _tempDir, CancellationToken.None);
+
+        var gameClient = manifests.First(m => m.ContentType == ContentType.GameClient);
+        var mapPack = manifests.First(m => m.ContentType == ContentType.MapPack);
+        var gameDataPatch = manifests.First(m => m.ContentType == ContentType.Patch);
+
+        // Assert - MapPack and GameData patch must not contain sibling files
+        Assert.Empty(mapPack.Files);
+        Assert.Empty(gameDataPatch.Files);
+
+        // Assert - GameClient must contain the sibling files as workspace files
+        Assert.Contains(gameClient.Files, f => f.RelativePath.Contains("Maps_backup"));
+        Assert.Contains(gameClient.Files, f => f.RelativePath.Contains("GeneralsOnlineGameData_backup"));
+    }
+
+    /// <summary>
     /// Verifies <see cref="GeneralsOnlineDependencyBuilder"/> directly returns the expected GameData dependencies.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -198,10 +198,8 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
 
         var gameDataDir = Path.Combine(_tempDir, GeneralsOnlineConstants.GameDataSubdirectory);
         Directory.CreateDirectory(gameDataDir);
-        var splashPath = Path.Combine(gameDataDir, "GOSplash.bmp");
-        var mapCachePath = Path.Combine(gameDataDir, "MapCacheGO.ini");
-        File.WriteAllText(splashPath, "fake splash bmp");
-        File.WriteAllText(mapCachePath, "fake mapcache ini");
+        var bigPath = Path.Combine(gameDataDir, "500_900_CommunityPatch_CoreINI.big");
+        File.WriteAllText(bigPath, "fake big content");
 
         var originalManifest = new ContentManifest
         {
@@ -239,7 +237,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
         Assert.False(mapFile.RelativePath.StartsWith("Maps", StringComparison.OrdinalIgnoreCase));
 
         // Check GameData patch files
-        Assert.Equal(2, gameDataPatch.Files.Count);
+        Assert.Single(gameDataPatch.Files);
         Assert.All(gameDataPatch.Files, f =>
         {
             Assert.Equal(ContentInstallTarget.Workspace, f.InstallTarget);
@@ -247,8 +245,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
             Assert.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory, f.RelativePath, StringComparison.OrdinalIgnoreCase);
             Assert.NotEmpty(f.Hash);
         });
-        Assert.Contains(gameDataPatch.Files, f => f.RelativePath.EndsWith("GOSplash.bmp", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(gameDataPatch.Files, f => f.RelativePath.EndsWith("MapCacheGO.ini", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(gameDataPatch.Files, f => f.RelativePath.EndsWith("500_900_CommunityPatch_CoreINI.big", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Providers;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GeneralsOnline;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Providers;
+using GenHub.Features.Content.Services.GeneralsOnline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Unit tests for <see cref="GeneralsOnlineManifestFactory"/> and related dependency creation.
+/// </summary>
+public class GeneralsOnlineManifestFactoryTests : IDisposable
+{
+    private readonly Mock<IProviderDefinitionLoader> _providerLoaderMock;
+    private readonly GeneralsOnlineManifestFactory _factory;
+    private readonly string _tempDir;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeneralsOnlineManifestFactoryTests"/> class.
+    /// </summary>
+    public GeneralsOnlineManifestFactoryTests()
+    {
+        _providerLoaderMock = new Mock<IProviderDefinitionLoader>();
+        _providerLoaderMock
+            .Setup(l => l.GetProvider(PublisherTypeConstants.GeneralsOnline))
+            .Returns(new ProviderDefinition
+            {
+                ProviderId = PublisherTypeConstants.GeneralsOnline,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+                Description = "Community multiplayer for Generals Zero Hour",
+                DefaultTags = ["multiplayer", "online"],
+                Endpoints = new ProviderEndpoints
+                {
+                    WebsiteUrl = "https://example.com/go",
+                },
+            });
+
+        _factory = new GeneralsOnlineManifestFactory(
+            NullLogger<GeneralsOnlineManifestFactory>.Instance,
+            _providerLoaderMock.Object);
+
+        _tempDir = Path.Combine(Path.GetTempPath(), "GenHub_GOTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Cleans up temporary test directory.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="GeneralsOnlineManifestFactory.CreateManifests"/> generates 3 manifests:
+    /// 60Hz GameClient, QuickMatch MapPack, and GeneralsOnlineGameData data patch.
+    /// </summary>
+    [Fact]
+    public void CreateManifests_GeneratesThreeManifests_IncludingGameDataPatch()
+    {
+        // Arrange
+        var release = new GeneralsOnlineRelease
+        {
+            Version = "101525_QFE5",
+            ReleaseDate = DateTime.UtcNow,
+            PortableUrl = "https://example.com/GeneralsOnline_portable_101525_QFE5.zip",
+            PortableSize = 1048576,
+            Changelog = "https://example.com/changelog",
+        };
+
+        // Act
+        var manifests = _factory.CreateManifests(release);
+
+        // Assert
+        Assert.Equal(3, manifests.Count);
+
+        var gameClient = manifests.FirstOrDefault(m => m.ContentType == ContentType.GameClient);
+        var mapPack = manifests.FirstOrDefault(m => m.ContentType == ContentType.MapPack);
+        var gameDataPatch = manifests.FirstOrDefault(m => m.ContentType == ContentType.Patch);
+
+        Assert.NotNull(gameClient);
+        Assert.NotNull(mapPack);
+        Assert.NotNull(gameDataPatch);
+
+        // Verify GameClient manifest
+        Assert.Contains(GeneralsOnlineConstants.Variant60HzSuffix, gameClient.Id.Value);
+        Assert.Equal(GameType.ZeroHour, gameClient.TargetGame);
+        Assert.Equal(GameClientConstants.GeneralsOnline60HzDisplayName, gameClient.Name);
+
+        // Verify MapPack manifest
+        Assert.Contains("quickmatchmaps", mapPack.Id.Value);
+        Assert.Equal(GameType.ZeroHour, mapPack.TargetGame);
+        Assert.Equal(GeneralsOnlineConstants.QuickMatchMapPackDisplayName, mapPack.Name);
+
+        // Verify GameData Patch manifest
+        Assert.Contains(GeneralsOnlineConstants.GameDataPatchSuffix, gameDataPatch.Id.Value);
+        Assert.Equal(ContentType.Patch, gameDataPatch.ContentType);
+        Assert.Equal(GameType.ZeroHour, gameDataPatch.TargetGame);
+        Assert.Equal(GeneralsOnlineConstants.GameDataDisplayName, gameDataPatch.Name);
+        Assert.Equal(GeneralsOnlineConstants.GameDataDescription, gameDataPatch.Metadata?.Description);
+        Assert.Contains(GeneralsOnlineVariantTags.TagGameData, gameDataPatch.Metadata?.Tags ?? []);
+    }
+
+    /// <summary>
+    /// Verifies that the GameData patch depends on the 60Hz GameClient and Zero Hour,
+    /// while the 60Hz GameClient does not depend on the GameData patch (making GameData patch optional).
+    /// </summary>
+    [Fact]
+    public void Dependencies_GameDataPatch_DependsOn60HzGameClientAndZeroHour_WhileGameClientDoesNotDependOnGameData()
+    {
+        // Arrange
+        var release = new GeneralsOnlineRelease
+        {
+            Version = "101525_QFE5",
+            ReleaseDate = DateTime.UtcNow,
+            PortableUrl = "https://example.com/test.zip",
+        };
+
+        // Act
+        var manifests = _factory.CreateManifests(release);
+        var gameClient = manifests.First(m => m.ContentType == ContentType.GameClient);
+        var gameDataPatch = manifests.First(m => m.ContentType == ContentType.Patch);
+
+        // Assert - GameData patch has dependencies on Zero Hour and 60Hz GameClient
+        Assert.NotEmpty(gameDataPatch.Dependencies);
+        var zhDepInPatch = gameDataPatch.Dependencies.FirstOrDefault(d => d.DependencyType == ContentType.GameInstallation);
+        var clientDepInPatch = gameDataPatch.Dependencies.FirstOrDefault(d => d.DependencyType == ContentType.GameClient);
+
+        Assert.NotNull(zhDepInPatch);
+        Assert.NotNull(clientDepInPatch);
+        Assert.Contains(GeneralsOnlineConstants.Variant60HzSuffix, clientDepInPatch.Id.Value);
+        Assert.False(clientDepInPatch.IsOptional);
+        Assert.True(clientDepInPatch.StrictPublisher);
+        Assert.Equal(PublisherTypeConstants.GeneralsOnline, clientDepInPatch.PublisherType);
+
+        // Assert - GameClient dependencies do NOT include Patch dependency
+        Assert.DoesNotContain(gameClient.Dependencies, d => d.DependencyType == ContentType.Patch);
+        Assert.DoesNotContain(gameClient.Dependencies, d => d.Id.Value.Contains(GeneralsOnlineConstants.GameDataPatchSuffix));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="GeneralsOnlineManifestFactory.CanHandle"/> returns true for GameClient, MapPack, and Patch.
+    /// </summary>
+    [Fact]
+    public void CanHandle_WithValidManifestTypes_ReturnsTrue()
+    {
+        // Arrange
+        var publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline };
+
+        var clientManifest = new ContentManifest { ContentType = ContentType.GameClient, Publisher = publisher };
+        var mapPackManifest = new ContentManifest { ContentType = ContentType.MapPack, Publisher = publisher };
+        var patchManifest = new ContentManifest { ContentType = ContentType.Patch, Publisher = publisher };
+        var otherPublisherManifest = new ContentManifest { ContentType = ContentType.Patch, Publisher = new PublisherInfo { PublisherType = "other" } };
+        var otherTypeManifest = new ContentManifest { ContentType = ContentType.Mod, Publisher = publisher };
+
+        // Act & Assert
+        Assert.True(_factory.CanHandle(clientManifest));
+        Assert.True(_factory.CanHandle(mapPackManifest));
+        Assert.True(_factory.CanHandle(patchManifest));
+        Assert.False(_factory.CanHandle(otherPublisherManifest));
+        Assert.False(_factory.CanHandle(otherTypeManifest));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="GeneralsOnlineManifestFactory.CreateManifestsFromExtractedContentAsync"/> separates files
+    /// correctly among GameClient, MapPack, and GameData Patch manifests.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the test execution.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_SeparatesFilesCorrectly()
+    {
+        // Arrange: Create simulated extracted directory structure
+        var exePath = Path.Combine(_tempDir, GameClientConstants.GeneralsOnline60HzExecutable);
+        var dllPath = Path.Combine(_tempDir, "GameNetworkingSockets.dll");
+        File.WriteAllText(exePath, "fake exe content");
+        File.WriteAllText(dllPath, "fake dll content");
+
+        var mapsDir = Path.Combine(_tempDir, GeneralsOnlineConstants.MapsSubdirectory, "Tournament Desert");
+        Directory.CreateDirectory(mapsDir);
+        var mapFilePath = Path.Combine(mapsDir, "Tournament Desert.map");
+        File.WriteAllText(mapFilePath, "fake map content");
+
+        var gameDataDir = Path.Combine(_tempDir, GeneralsOnlineConstants.GameDataSubdirectory);
+        Directory.CreateDirectory(gameDataDir);
+        var splashPath = Path.Combine(gameDataDir, "GOSplash.bmp");
+        var mapCachePath = Path.Combine(gameDataDir, "MapCacheGO.ini");
+        File.WriteAllText(splashPath, "fake splash bmp");
+        File.WriteAllText(mapCachePath, "fake mapcache ini");
+
+        var originalManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Metadata = new ContentMetadata { ReleaseDate = DateTime.UtcNow },
+        };
+
+        // Act
+        var manifests = await _factory.CreateManifestsFromExtractedContentAsync(originalManifest, _tempDir, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(3, manifests.Count);
+
+        var gameClient = manifests.First(m => m.ContentType == ContentType.GameClient);
+        var mapPack = manifests.First(m => m.ContentType == ContentType.MapPack);
+        var gameDataPatch = manifests.First(m => m.ContentType == ContentType.Patch);
+
+        // Check GameClient files
+        Assert.Equal(2, gameClient.Files.Count);
+        Assert.Contains(gameClient.Files, f => f.RelativePath == GameClientConstants.GeneralsOnline60HzExecutable && f.IsExecutable && f.InstallTarget == ContentInstallTarget.Workspace);
+        Assert.Contains(gameClient.Files, f => f.RelativePath == "GameNetworkingSockets.dll" && !f.IsExecutable && f.InstallTarget == ContentInstallTarget.Workspace);
+        Assert.DoesNotContain(gameClient.Files, f => f.RelativePath.Contains("Maps"));
+        Assert.DoesNotContain(gameClient.Files, f => f.RelativePath.Contains("GeneralsOnlineGameData"));
+
+        // Check MapPack files
+        Assert.Single(mapPack.Files);
+        var mapFile = mapPack.Files[0];
+        Assert.Equal(ContentInstallTarget.UserMapsDirectory, mapFile.InstallTarget);
+        Assert.False(mapFile.IsExecutable);
+        Assert.EndsWith(".map", mapFile.RelativePath, StringComparison.OrdinalIgnoreCase);
+        Assert.False(mapFile.RelativePath.StartsWith("Maps", StringComparison.OrdinalIgnoreCase));
+
+        // Check GameData patch files
+        Assert.Equal(2, gameDataPatch.Files.Count);
+        Assert.All(gameDataPatch.Files, f =>
+        {
+            Assert.Equal(ContentInstallTarget.Workspace, f.InstallTarget);
+            Assert.False(f.IsExecutable);
+            Assert.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory, f.RelativePath, StringComparison.OrdinalIgnoreCase);
+            Assert.NotEmpty(f.Hash);
+        });
+        Assert.Contains(gameDataPatch.Files, f => f.RelativePath.EndsWith("GOSplash.bmp", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(gameDataPatch.Files, f => f.RelativePath.EndsWith("MapCacheGO.ini", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Verifies <see cref="GeneralsOnlineDependencyBuilder"/> directly returns the expected GameData dependencies.
+    /// </summary>
+    [Fact]
+    public void DependencyBuilder_GetDependenciesForGameData_ReturnsExpectedDependencies()
+    {
+        // Act
+        var dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesForGameData(1015255);
+
+        // Assert
+        Assert.Equal(2, dependencies.Count);
+        Assert.Contains(dependencies, d => d.DependencyType == ContentType.GameInstallation);
+        Assert.Contains(dependencies, d => d.DependencyType == ContentType.GameClient && d.Id.Value.Contains("60hz"));
+
+        var builder = new GeneralsOnlineDependencyBuilder();
+        var patchManifest = new ContentManifest
+        {
+            ContentType = ContentType.Patch,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+        };
+        var resolvedDeps = builder.GetDependencies(patchManifest);
+        Assert.Equal(2, resolvedDeps.Count);
+        Assert.Contains(resolvedDeps, d => d.DependencyType == ContentType.GameInstallation);
+        Assert.Contains(resolvedDeps, d => d.DependencyType == ContentType.GameClient);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -17,6 +17,7 @@ using GenHub.Features.Content.Services.GeneralsOnline;
 using GenHub.Tests.Core.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
 
 namespace GenHub.Tests.Core.Features.Content.Services.GeneralsOnline;
 
@@ -179,5 +180,97 @@ public class GeneralsOnlineProfileReconcilerTests
         _notificationServiceMock.Verify(
             x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that old and new GameData patch manifests are recognized by variant and included in reconciliation mapping.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_WithGameDataPatchManifest_MapsAndReconcilesGameDataPatch()
+    {
+        // Arrange
+        const string oldVersion = "101524";
+        const string newVersion = "101525";
+
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(newVersion, oldVersion));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(GeneralsOnlineConstants.PublisherType, true);
+        _userSettingsServiceMock.Setup(x => x.Get())
+            .Returns(settings);
+
+        var oldClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101524.generalsonline.gameclient.60hz"),
+            Version = oldVersion,
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        var oldPatchManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101524.generalsonline.patch.gamedata"),
+            Version = oldVersion,
+            ContentType = ContentType.Patch,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+            Metadata = new ContentMetadata { Tags = ["gamedata", "patch", "generalsonline"] },
+        };
+
+        var newClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101525.generalsonline.gameclient.60hz"),
+            Version = newVersion,
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        var newPatchManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101525.generalsonline.patch.gamedata"),
+            Version = newVersion,
+            ContentType = ContentType.Patch,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+            Metadata = new ContentMetadata { Tags = ["gamedata", "patch", "generalsonline"] },
+        };
+
+        _manifestPoolMock.SetupSequence(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, oldPatchManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, oldPatchManifest, newClientManifest, newPatchManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, oldPatchManifest, newClientManifest, newPatchManifest]));
+
+        _contentOrchestratorMock.Setup(
+                x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new() { Name = "New GO Version", Version = newVersion },
+            ]));
+
+        _contentOrchestratorMock.Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(newClientManifest));
+
+        IReadOnlyDictionary<string, string>? capturedMapping = null;
+        _reconciliationServiceMock
+            .Setup(x => x.OrchestrateBulkUpdateAsync(
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyDictionary<string, string>, bool, CancellationToken>((mapping, createNew, token) =>
+            {
+                capturedMapping = mapping;
+            })
+            .ReturnsAsync(OperationResult<ReconciliationResult>.CreateSuccess(new ReconciliationResult(1, 0)));
+
+        // Act
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync("profile1", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success, $"Reconciliation failed: {result.FirstError}");
+        Assert.NotNull(capturedMapping);
+        Assert.True(capturedMapping.ContainsKey(oldClientManifest.Id.Value));
+        Assert.Equal(newClientManifest.Id.Value, capturedMapping[oldClientManifest.Id.Value]);
+        Assert.True(capturedMapping.ContainsKey(oldPatchManifest.Id.Value));
+        Assert.Equal(newPatchManifest.Id.Value, capturedMapping[oldPatchManifest.Id.Value]);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -237,7 +237,6 @@ public class GeneralsOnlineProfileReconcilerTests
 
         _manifestPoolMock.SetupSequence(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, oldPatchManifest]))
-            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, oldPatchManifest, newClientManifest, newPatchManifest]))
             .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, oldPatchManifest, newClientManifest, newPatchManifest]));
 
         _contentOrchestratorMock.Setup(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -271,5 +271,11 @@ public class GeneralsOnlineProfileReconcilerTests
         Assert.Equal(newClientManifest.Id.Value, capturedMapping[oldClientManifest.Id.Value]);
         Assert.True(capturedMapping.ContainsKey(oldPatchManifest.Id.Value));
         Assert.Equal(newPatchManifest.Id.Value, capturedMapping[oldPatchManifest.Id.Value]);
+
+        _reconciliationServiceMock.Verify(
+            x => x.OrchestrateBulkRemovalAsync(
+                It.Is<IEnumerable<ManifestId>>(ids => ids.Contains(oldClientManifest.Id) && ids.Contains(oldPatchManifest.Id)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -187,7 +187,7 @@ public class GeneralsOnlineProfileReconcilerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_WithGameDataPatchManifest_MapsAndReconcilesGameDataPatch()
+    public async Task CheckAndReconcileIfNeededAsync_WithGameDataPatchManifest_MapsAndReconcilesGameDataPatchAsync()
     {
         // Arrange
         const string oldVersion = "101524";
@@ -198,6 +198,7 @@ public class GeneralsOnlineProfileReconcilerTests
 
         var settings = new UserSettings();
         settings.SetAutoUpdatePreference(GeneralsOnlineConstants.PublisherType, true);
+        settings.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType).DeleteOldVersions = true;
         _userSettingsServiceMock.Setup(x => x.Get())
             .Returns(settings);
 
@@ -255,10 +256,7 @@ public class GeneralsOnlineProfileReconcilerTests
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyDictionary<string, string>, bool, CancellationToken>((mapping, createNew, token) =>
-            {
-                capturedMapping = mapping;
-            })
+            .Callback<IReadOnlyDictionary<string, string>, bool, CancellationToken>((mapping, createNew, token) => capturedMapping = mapping)
             .ReturnsAsync(OperationResult<ReconciliationResult>.CreateSuccess(new ReconciliationResult(1, 0)));
 
         // Act

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -81,7 +81,7 @@ public class GeneralsOnlineProfileReconcilerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CheckAndReconcile_ShouldIgnore_LocalManifests()
+    public async Task CheckAndReconcile_ShouldIgnore_LocalManifestsAsync()
     {
         // Arrange
         string latestVersion = "0.0.99";
@@ -146,7 +146,7 @@ public class GeneralsOnlineProfileReconcilerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellation()
+    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellationAsync()
     {
         // Arrange
         string latestVersion = "0.0.99";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
@@ -46,7 +46,7 @@ public class StderrCaptureRaceTests
         // by its value, which produces `/bin/sh -c <script>`.
         var script =
             $"echo {HeadLine} >&2; " +
-            "for i in $(seq 1 200); do echo noise-$i >&2; done; " +
+            "for i in $(seq 1 50); do echo noise-$i >&2; done; " +
             $"echo {TailLine} >&2; " +
             "exit 3";
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
@@ -35,7 +35,7 @@ public class StderrCaptureRaceTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task StartProcessAsync_WithImmediateFailure_CapturesBothEndsOfStderr()
+    public async Task StartProcessAsync_WithImmediateFailure_CapturesBothEndsOfStderrAsync()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -51,26 +51,19 @@ public class StderrCaptureRaceTests
             $"echo {TailLine} >&2; " +
             "exit 3";
 
-        var manager = new GameProcessManager(Mock.Of<ILogger<GameProcessManager>>());
-        try
+        using var manager = new GameProcessManager(Mock.Of<ILogger<GameProcessManager>>());
+        var result = await manager.StartProcessAsync(new GameLaunchConfiguration
         {
-            var result = await manager.StartProcessAsync(new GameLaunchConfiguration
-            {
-                ExecutablePath = "/bin/sh",
-                Arguments = new Dictionary<string, string> { ["-c"] = script },
-                WorkingDirectory = Path.GetTempPath(),
-            });
+            ExecutablePath = "/bin/sh",
+            Arguments = new Dictionary<string, string> { ["-c"] = script },
+            WorkingDirectory = Path.GetTempPath(),
+        });
 
-            var reported = string.Join(" ", result.Errors);
+        var reported = string.Join(" ", result.Errors);
 
-            Assert.Contains("3", reported);
-            Assert.Contains(HeadLine, reported);
-            Assert.Contains(TailLine, reported);
-            Assert.DoesNotContain("noise-25", reported);
-        }
-        finally
-        {
-            manager.Dispose();
-        }
+        Assert.Contains("3", reported);
+        Assert.Contains(HeadLine, reported);
+        Assert.Contains(TailLine, reported);
+        Assert.DoesNotContain("noise-25", reported);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
@@ -66,6 +66,7 @@ public class StderrCaptureRaceTests
             Assert.Contains("3", reported);
             Assert.Contains(HeadLine, reported);
             Assert.Contains(TailLine, reported);
+            Assert.DoesNotContain("noise-25", reported);
         }
         finally
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/StderrCaptureRaceTests.cs
@@ -42,11 +42,12 @@ public class StderrCaptureRaceTests
             return;
         }
 
-        // Arguments are key/value pairs; a leading '-' key is emitted as a flag followed
-        // by its value, which produces `/bin/sh -c <script>`.
+        // 50 lines exceeds the 10 head + 20 tail (30 total) bounded error buffer capacity
+        // to verify middle line dropping without causing race conditions from heavy I/O in CI.
+        const int noiseLines = 50;
         var script =
             $"echo {HeadLine} >&2; " +
-            "for i in $(seq 1 50); do echo noise-$i >&2; done; " +
+            $"for i in $(seq 1 {noiseLines}); do echo noise-$i >&2; done; " +
             $"echo {TailLine} >&2; " +
             "exit 3";
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameInstallationValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameInstallationValidatorTests.cs
@@ -86,16 +86,13 @@ public class GameInstallationValidatorTests
             // Ensure the installation is properly fetched to have consistent state
             installation.Fetch();
 
-            // Use thread-safe collection for progress reports
-            var progressReports = new System.Collections.Concurrent.ConcurrentBag<ValidationProgress>();
-            var progress = new Progress<ValidationProgress>(p => progressReports.Add(p));
+            var progress = new SynchronousProgress<ValidationProgress>();
 
             // Act
             await _validator.ValidateAsync(installation, progress);
-            await Task.Delay(100); // Ensure all progress callbacks are processed
 
             // Assert
-            var reportsList = progressReports.ToList();
+            var reportsList = progress.Reports.ToList();
             Assert.True(reportsList.Count > 0, "Expected progress reports to be generated");
 
             // Find the final progress report (highest processed count)

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -196,6 +196,11 @@ public abstract class BaseContentProvider(
 
             return result;
         }
+        catch (OperationCanceledException)
+        {
+            Logger.LogInformation("Content preparation was canceled for manifest {ManifestId}", manifest.Id);
+            throw;
+        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to prepare content for manifest {ManifestId}", manifest.Id);

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -220,10 +220,14 @@ public class GeneralsOnlineDeliverer(
                         {
                             backupPath = targetPath + ".gh_bak_" + Guid.NewGuid().ToString("N");
                             File.Move(targetPath, backupPath);
+                            movedFiles.Add((targetPath, backupPath));
                         }
 
                         File.Move(file, targetPath, overwrite: true);
-                        movedFiles.Add((targetPath, backupPath));
+                        if (backupPath == null)
+                        {
+                            movedFiles.Add((targetPath, null));
+                        }
                     }
                 }
                 catch

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -43,7 +43,9 @@ public class GeneralsOnlineDeliverer(
     public bool CanDeliver(ContentManifest manifest)
     {
         // Can deliver if it's a Generals Online manifest with a portable ZIP URL
-        return manifest.Publisher?.Name?.Equals(GeneralsOnlineConstants.PublisherName, StringComparison.OrdinalIgnoreCase) == true &&
+        var isPublisher = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true ||
+                          manifest.Publisher?.Name?.Equals(GeneralsOnlineConstants.PublisherName, StringComparison.OrdinalIgnoreCase) == true;
+        return isPublisher &&
                manifest.Files.Any(f => f.DownloadUrl?.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase) == true);
     }
 
@@ -139,16 +141,17 @@ public class GeneralsOnlineDeliverer(
                 var addResult = await manifestPool.AddManifestAsync(manifest, extractPath, cancellationToken: cancellationToken);
                 if (!addResult.Success)
                 {
-                    logger.LogWarning(
+                    logger.LogError(
                         "Failed to register manifest {ManifestId} ({Name}): {Error}",
                         manifest.Id,
                         manifest.Name,
                         addResult.FirstError);
+
+                    return OperationResult<ContentManifest>.CreateFailure(
+                        $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}");
                 }
-                else
-                {
-                    logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
-                }
+
+                logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
             }
 
             var parentDir = Directory.GetParent(extractPath)?.FullName;

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -124,7 +124,7 @@ public class GeneralsOnlineDeliverer(
             }
 
             // Step 4: Register all variant manifests to CAS
-            // This ensures all files (including both executables and map pack) are stored before validation
+            // This ensures all files (including executables, map pack, and data patch) are stored before validation
             progress?.Report(new ContentAcquisitionProgress
             {
                 Phase = ContentAcquisitionPhase.Copying,
@@ -132,36 +132,23 @@ public class GeneralsOnlineDeliverer(
                 CurrentOperation = "Registering all variant manifests to content library",
             });
 
-            logger.LogInformation("Registering all variant manifests (60Hz, QuickMatch MapPack) in pool");
+            logger.LogInformation("Registering all variant manifests (60Hz, QuickMatch MapPack, GameData patch) in pool");
 
-            // Register 60Hz manifest
-            var hz60Manifest = manifests[0];
-            var add60Result = await manifestPool.AddManifestAsync(hz60Manifest, extractPath, cancellationToken: cancellationToken);
-            if (!add60Result.Success)
+            foreach (var manifest in manifests)
             {
-                logger.LogWarning(
-                    "Failed to register 60Hz manifest {ManifestId}: {Error}",
-                    hz60Manifest.Id,
-                    add60Result.FirstError);
-            }
-            else
-            {
-                logger.LogInformation("Successfully registered 60Hz manifest: {ManifestId}", hz60Manifest.Id);
-            }
-
-            // Register QuickMatch MapPack manifest
-            var mapPackManifest = manifests[1];
-            var addMapPackResult = await manifestPool.AddManifestAsync(mapPackManifest, extractPath, cancellationToken: cancellationToken);
-            if (!addMapPackResult.Success)
-            {
-                logger.LogWarning(
-                    "Failed to register QuickMatch MapPack manifest {ManifestId}: {Error}",
-                    mapPackManifest.Id,
-                    addMapPackResult.FirstError);
-            }
-            else
-            {
-                logger.LogInformation("Successfully registered QuickMatch MapPack manifest: {ManifestId}", mapPackManifest.Id);
+                var addResult = await manifestPool.AddManifestAsync(manifest, extractPath, cancellationToken: cancellationToken);
+                if (!addResult.Success)
+                {
+                    logger.LogWarning(
+                        "Failed to register manifest {ManifestId} ({Name}): {Error}",
+                        manifest.Id,
+                        manifest.Name,
+                        addResult.FirstError);
+                }
+                else
+                {
+                    logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
+                }
             }
 
             var parentDir = Directory.GetParent(extractPath)?.FullName;
@@ -209,7 +196,8 @@ public class GeneralsOnlineDeliverer(
 
             var primaryManifest = manifests[0];
             logger.LogInformation(
-                "Successfully delivered Generals Online content: 2 manifests created, all registered to pool");
+                "Successfully delivered Generals Online content: {Count} manifests created, all registered to pool",
+                manifests.Count);
 
             return OperationResult<ContentManifest>.CreateSuccess(primaryManifest);
         }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -135,10 +135,17 @@ public class GeneralsOnlineDeliverer(
                 CurrentOperation = "Registering all variant manifests to content library",
             });
 
-            var registeredManifests = new List<ContentManifest>();
+            var newlyRegisteredManifests = new List<ContentManifest>();
 
             foreach (var manifest in manifests)
             {
+                var isPreExisting = false;
+                var checkResult = await manifestPool.IsManifestAcquiredAsync(manifest.Id, cancellationToken: cancellationToken);
+                if (checkResult?.Success == true && checkResult.Data)
+                {
+                    isPreExisting = true;
+                }
+
                 var addResult = await manifestPool.AddManifestAsync(manifest, extractPath, cancellationToken: cancellationToken);
                 if (!addResult.Success)
                 {
@@ -148,12 +155,21 @@ public class GeneralsOnlineDeliverer(
                         manifest.Name,
                         addResult.FirstError);
 
-                    // Roll back previously registered manifests to prevent partial acquisition state
-                    foreach (var registeredManifest in registeredManifests)
+                    // Roll back newly registered manifests to prevent partial acquisition state
+                    var rollbackErrors = new List<string>();
+                    foreach (var registeredManifest in newlyRegisteredManifests)
                     {
                         try
                         {
-                            await manifestPool.RemoveManifestAsync(registeredManifest.Id, cancellationToken: cancellationToken);
+                            var removeResult = await manifestPool.RemoveManifestAsync(registeredManifest.Id, cancellationToken: CancellationToken.None);
+                            if (!removeResult.Success)
+                            {
+                                logger.LogWarning(
+                                    "Failed to rollback manifest {ManifestId} during delivery failure cleanup: {Error}",
+                                    registeredManifest.Id,
+                                    removeResult.FirstError);
+                                rollbackErrors.Add($"Rollback of manifest {registeredManifest.Id} failed: {removeResult.FirstError}");
+                            }
                         }
                         catch (Exception rollbackEx)
                         {
@@ -161,14 +177,24 @@ public class GeneralsOnlineDeliverer(
                                 rollbackEx,
                                 "Failed to rollback manifest {ManifestId} during delivery failure cleanup",
                                 registeredManifest.Id);
+                            rollbackErrors.Add($"Rollback exception for manifest {registeredManifest.Id}: {rollbackEx.Message}");
                         }
                     }
 
-                    return OperationResult<ContentManifest>.CreateFailure(
-                        $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}");
+                    var errorMessage = $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}";
+                    if (rollbackErrors.Count > 0)
+                    {
+                        errorMessage += $"; Rollback warnings: {string.Join("; ", rollbackErrors)}";
+                    }
+
+                    return OperationResult<ContentManifest>.CreateFailure(errorMessage);
                 }
 
-                registeredManifests.Add(manifest);
+                if (!isPreExisting)
+                {
+                    newlyRegisteredManifests.Add(manifest);
+                }
+
                 logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
             }
 
@@ -222,9 +248,14 @@ public class GeneralsOnlineDeliverer(
 
             return OperationResult<ContentManifest>.CreateSuccess(primaryManifest);
         }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("Generals Online content delivery was canceled for {Version}", packageManifest.Version);
+            throw;
+        }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to deliver Generals Online content");
+            logger.LogError(ex, "Failed to deliver Generals Online content for {Version}", packageManifest.Version);
             return OperationResult<ContentManifest>.CreateFailure($"Content delivery failed: {ex.Message}");
         }
     }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -58,6 +58,8 @@ public class GeneralsOnlineDeliverer(
         CancellationToken cancellationToken = default)
     {
         var newlyRegisteredManifests = new List<ContentManifest>();
+        string? zipPath = null;
+        string? extractPath = null;
 
         try
         {
@@ -70,7 +72,7 @@ public class GeneralsOnlineDeliverer(
                 return OperationResult<ContentManifest>.CreateFailure("No ZIP file found in manifest");
             }
 
-            var zipPath = Path.Combine(targetDirectory, "GeneralsOnline.zip");
+            zipPath = Path.Combine(targetDirectory, "GeneralsOnline.zip");
 
             progress?.Report(new ContentAcquisitionProgress
             {
@@ -90,12 +92,13 @@ public class GeneralsOnlineDeliverer(
 
             if (!downloadResult.Success)
             {
+                CleanupTempArtifacts(zipPath, extractPath, logger);
                 return OperationResult<ContentManifest>.CreateFailure(
                     $"Failed to download ZIP: {downloadResult.FirstError}");
             }
 
             // Step 2: Extract ZIP
-            var extractPath = Path.Combine(targetDirectory, "extracted");
+            extractPath = Path.Combine(targetDirectory, "extracted");
             Directory.CreateDirectory(extractPath);
 
             progress?.Report(new ContentAcquisitionProgress
@@ -124,6 +127,7 @@ public class GeneralsOnlineDeliverer(
             if (manifests.Count == 0)
             {
                 logger.LogError("No manifests could be created from extracted content");
+                CleanupTempArtifacts(zipPath, extractPath, logger);
                 return OperationResult<ContentManifest>.CreateFailure(
                     "Failed to create any variant manifests from extracted content");
             }
@@ -139,7 +143,27 @@ public class GeneralsOnlineDeliverer(
             foreach (var manifest in manifests)
             {
                 var checkResult = await manifestPool.IsManifestAcquiredAsync(manifest.Id, cancellationToken: cancellationToken);
-                if (checkResult?.Success == true && checkResult.Data)
+                if (!checkResult.Success)
+                {
+                    logger.LogError(
+                        "Failed to check acquisition status for manifest {ManifestId}: {Error}",
+                        manifest.Id,
+                        checkResult.FirstError);
+
+                    var rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
+                    newlyRegisteredManifests.Clear();
+                    CleanupTempArtifacts(zipPath, extractPath, logger);
+
+                    var errorMessage = $"Failed to check manifest acquisition status for {manifest.Id}: {checkResult.FirstError}";
+                    if (rollbackErrors.Count > 0)
+                    {
+                        errorMessage += $"; Rollback warnings: {string.Join("; ", rollbackErrors)}";
+                    }
+
+                    return OperationResult<ContentManifest>.CreateFailure(errorMessage);
+                }
+
+                if (checkResult.Data)
                 {
                     logger.LogInformation(
                         "Manifest {ManifestId} ({Name}) is already acquired in pool; skipping registration",
@@ -159,6 +183,7 @@ public class GeneralsOnlineDeliverer(
 
                     var rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
                     newlyRegisteredManifests.Clear();
+                    CleanupTempArtifacts(zipPath, extractPath, logger);
 
                     var errorMessage = $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}";
                     if (rollbackErrors.Count > 0)
@@ -173,21 +198,73 @@ public class GeneralsOnlineDeliverer(
                 logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
             }
 
+            var movedFiles = new List<(string TargetPath, string? BackupPath)>();
             var parentDir = Directory.GetParent(extractPath)?.FullName;
             if (parentDir != null)
             {
                 logger.LogInformation("Moving extracted files from {ExtractPath} to parent {ParentDir}", extractPath, parentDir);
-                foreach (var file in Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories))
+                try
                 {
-                    var relativePath = Path.GetRelativePath(extractPath, file);
-                    var targetPath = Path.Combine(parentDir, relativePath);
-                    var targetDir = Path.GetDirectoryName(targetPath);
-                    if (!string.IsNullOrEmpty(targetDir))
+                    foreach (var file in Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories))
                     {
-                        Directory.CreateDirectory(targetDir);
+                        var relativePath = Path.GetRelativePath(extractPath, file);
+                        var targetPath = Path.Combine(parentDir, relativePath);
+                        var targetDir = Path.GetDirectoryName(targetPath);
+                        if (!string.IsNullOrEmpty(targetDir))
+                        {
+                            Directory.CreateDirectory(targetDir);
+                        }
+
+                        string? backupPath = null;
+                        if (File.Exists(targetPath))
+                        {
+                            backupPath = targetPath + ".gh_bak_" + Guid.NewGuid().ToString("N");
+                            File.Move(targetPath, backupPath);
+                        }
+
+                        File.Move(file, targetPath, overwrite: true);
+                        movedFiles.Add((targetPath, backupPath));
+                    }
+                }
+                catch
+                {
+                    // Roll back moved files
+                    foreach (var (targetPath, backupPath) in movedFiles)
+                    {
+                        try
+                        {
+                            if (backupPath != null && File.Exists(backupPath))
+                            {
+                                File.Move(backupPath, targetPath, overwrite: true);
+                            }
+                            else if (File.Exists(targetPath))
+                            {
+                                File.Delete(targetPath);
+                            }
+                        }
+                        catch (Exception restoreEx)
+                        {
+                            logger.LogWarning(restoreEx, "Failed to restore target file {TargetPath} during rollback", targetPath);
+                        }
                     }
 
-                    File.Move(file, targetPath, overwrite: true);
+                    throw;
+                }
+
+                // Clean up backup files on success
+                foreach (var (_, backupPath) in movedFiles)
+                {
+                    if (backupPath != null && File.Exists(backupPath))
+                    {
+                        try
+                        {
+                            File.Delete(backupPath);
+                        }
+                        catch (Exception delEx)
+                        {
+                            logger.LogWarning(delEx, "Failed to delete backup file {BackupPath}", backupPath);
+                        }
+                    }
                 }
 
                 try
@@ -231,6 +308,7 @@ public class GeneralsOnlineDeliverer(
                 await RollbackManifestsAsync(newlyRegisteredManifests);
             }
 
+            CleanupTempArtifacts(zipPath, extractPath, logger);
             throw;
         }
         catch (Exception ex)
@@ -241,6 +319,8 @@ public class GeneralsOnlineDeliverer(
             {
                 rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
             }
+
+            CleanupTempArtifacts(zipPath, extractPath, logger);
 
             var errorMessage = $"Content delivery failed: {ex.Message}";
             if (rollbackErrors.Count > 0)
@@ -269,6 +349,33 @@ public class GeneralsOnlineDeliverer(
         {
             logger.LogError(ex, "Validation failed for Generals Online manifest {ManifestId}", manifest.Id);
             return Task.FromResult(OperationResult<bool>.CreateFailure($"Validation failed: {ex.Message}"));
+        }
+    }
+
+    private static void CleanupTempArtifacts(string? zipPath, string? extractPath, ILogger logger)
+    {
+        if (!string.IsNullOrEmpty(extractPath) && Directory.Exists(extractPath))
+        {
+            try
+            {
+                Directory.Delete(extractPath, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to clean up extracted directory {ExtractPath}", extractPath);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(zipPath) && File.Exists(zipPath))
+        {
+            try
+            {
+                File.Delete(zipPath);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to clean up ZIP file {ZipPath}", zipPath);
+            }
         }
     }
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -46,7 +46,7 @@ public class GeneralsOnlineDeliverer(
         // Can deliver if it's a Generals Online manifest with a portable ZIP URL
         var isPublisher = string.Equals(manifest.Publisher?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase);
         return isPublisher &&
-               manifest.Files.Any(f => f.DownloadUrl != null && f.DownloadUrl.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
+               manifest.Files.Any(f => f.DownloadUrl is { } url && url.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <inheritdoc />
@@ -65,7 +65,7 @@ public class GeneralsOnlineDeliverer(
             logger.LogInformation("Starting Generals Online content delivery for {Version}", packageManifest.Version);
 
             // Step 1: Download ZIP file
-            var zipFile = packageManifest.Files.FirstOrDefault(f => f.DownloadUrl != null && f.DownloadUrl.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
+            var zipFile = packageManifest.Files.FirstOrDefault(f => f.DownloadUrl is { } url && url.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
             if (zipFile == null)
             {
                 return OperationResult<ContentManifest>.CreateFailure("No ZIP file found in manifest");

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -57,6 +57,8 @@ public class GeneralsOnlineDeliverer(
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
+        var newlyRegisteredManifests = new List<ContentManifest>();
+
         try
         {
             logger.LogInformation("Starting Generals Online content delivery for {Version}", packageManifest.Version);
@@ -106,15 +108,14 @@ public class GeneralsOnlineDeliverer(
             logger.LogDebug("Extracting ZIP to {Path}", extractPath);
             ZipFile.ExtractToDirectory(zipPath, extractPath, overwriteFiles: true);
 
-            // Step 3: Create all variant manifests using the factory (30Hz, 60Hz GameClients + QuickMatch MapPack)
+            // Step 3: Create variant manifests from extracted files
             progress?.Report(new ContentAcquisitionProgress
             {
                 Phase = ContentAcquisitionPhase.Copying,
-                ProgressPercentage = 50,
-                CurrentOperation = "Creating manifests for all variants",
+                ProgressPercentage = 80,
+                CurrentOperation = "Generating variant manifests (60Hz, MapPack, and GameData Patch)",
             });
 
-            logger.LogInformation("Creating manifests for GeneralsOnline variants (60Hz, QuickMatch MapPack)");
             var manifests = await manifestFactory.CreateManifestsFromExtractedContentAsync(
                 packageManifest,
                 extractPath,
@@ -122,12 +123,12 @@ public class GeneralsOnlineDeliverer(
 
             if (manifests.Count == 0)
             {
+                logger.LogError("No manifests could be created from extracted content");
                 return OperationResult<ContentManifest>.CreateFailure(
-                    $"Got 0 Manifests");
+                    "Failed to create any variant manifests from extracted content");
             }
 
-            // Step 4: Register all variant manifests to CAS
-            // This ensures all files (including executables, map pack, and data patch) are stored before validation
+            // Step 4: Add all variant manifests to the ContentManifestPool
             progress?.Report(new ContentAcquisitionProgress
             {
                 Phase = ContentAcquisitionPhase.Copying,
@@ -135,15 +136,16 @@ public class GeneralsOnlineDeliverer(
                 CurrentOperation = "Registering all variant manifests to content library",
             });
 
-            var newlyRegisteredManifests = new List<ContentManifest>();
-
             foreach (var manifest in manifests)
             {
-                var isPreExisting = false;
                 var checkResult = await manifestPool.IsManifestAcquiredAsync(manifest.Id, cancellationToken: cancellationToken);
                 if (checkResult?.Success == true && checkResult.Data)
                 {
-                    isPreExisting = true;
+                    logger.LogInformation(
+                        "Manifest {ManifestId} ({Name}) is already acquired in pool; skipping registration",
+                        manifest.Id,
+                        manifest.Name);
+                    continue;
                 }
 
                 var addResult = await manifestPool.AddManifestAsync(manifest, extractPath, cancellationToken: cancellationToken);
@@ -155,31 +157,8 @@ public class GeneralsOnlineDeliverer(
                         manifest.Name,
                         addResult.FirstError);
 
-                    // Roll back newly registered manifests to prevent partial acquisition state
-                    var rollbackErrors = new List<string>();
-                    foreach (var registeredManifest in newlyRegisteredManifests)
-                    {
-                        try
-                        {
-                            var removeResult = await manifestPool.RemoveManifestAsync(registeredManifest.Id, cancellationToken: CancellationToken.None);
-                            if (!removeResult.Success)
-                            {
-                                logger.LogWarning(
-                                    "Failed to rollback manifest {ManifestId} during delivery failure cleanup: {Error}",
-                                    registeredManifest.Id,
-                                    removeResult.FirstError);
-                                rollbackErrors.Add($"Rollback of manifest {registeredManifest.Id} failed: {removeResult.FirstError}");
-                            }
-                        }
-                        catch (Exception rollbackEx)
-                        {
-                            logger.LogWarning(
-                                rollbackEx,
-                                "Failed to rollback manifest {ManifestId} during delivery failure cleanup",
-                                registeredManifest.Id);
-                            rollbackErrors.Add($"Rollback exception for manifest {registeredManifest.Id}: {rollbackEx.Message}");
-                        }
-                    }
+                    var rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
+                    newlyRegisteredManifests.Clear();
 
                     var errorMessage = $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}";
                     if (rollbackErrors.Count > 0)
@@ -190,11 +169,7 @@ public class GeneralsOnlineDeliverer(
                     return OperationResult<ContentManifest>.CreateFailure(errorMessage);
                 }
 
-                if (!isPreExisting)
-                {
-                    newlyRegisteredManifests.Add(manifest);
-                }
-
+                newlyRegisteredManifests.Add(manifest);
                 logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
             }
 
@@ -251,12 +226,29 @@ public class GeneralsOnlineDeliverer(
         catch (OperationCanceledException)
         {
             logger.LogInformation("Generals Online content delivery was canceled for {Version}", packageManifest.Version);
+            if (newlyRegisteredManifests.Count > 0)
+            {
+                await RollbackManifestsAsync(newlyRegisteredManifests);
+            }
+
             throw;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to deliver Generals Online content for {Version}", packageManifest.Version);
-            return OperationResult<ContentManifest>.CreateFailure($"Content delivery failed: {ex.Message}");
+            var rollbackErrors = new List<string>();
+            if (newlyRegisteredManifests.Count > 0)
+            {
+                rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
+            }
+
+            var errorMessage = $"Content delivery failed: {ex.Message}";
+            if (rollbackErrors.Count > 0)
+            {
+                errorMessage += $"; Rollback warnings: {string.Join("; ", rollbackErrors)}";
+            }
+
+            return OperationResult<ContentManifest>.CreateFailure(errorMessage);
         }
     }
 
@@ -278,5 +270,35 @@ public class GeneralsOnlineDeliverer(
             logger.LogError(ex, "Validation failed for Generals Online manifest {ManifestId}", manifest.Id);
             return Task.FromResult(OperationResult<bool>.CreateFailure($"Validation failed: {ex.Message}"));
         }
+    }
+
+    private async Task<List<string>> RollbackManifestsAsync(IReadOnlyList<ContentManifest> manifestsToRollback)
+    {
+        var rollbackErrors = new List<string>();
+        foreach (var registeredManifest in manifestsToRollback)
+        {
+            try
+            {
+                var removeResult = await manifestPool.RemoveManifestAsync(registeredManifest.Id, cancellationToken: CancellationToken.None);
+                if (!removeResult.Success)
+                {
+                    logger.LogWarning(
+                        "Failed to rollback manifest {ManifestId} during delivery failure cleanup: {Error}",
+                        registeredManifest.Id,
+                        removeResult.FirstError);
+                    rollbackErrors.Add($"Rollback of manifest {registeredManifest.Id} failed: {removeResult.FirstError}");
+                }
+            }
+            catch (Exception rollbackEx)
+            {
+                logger.LogWarning(
+                    rollbackEx,
+                    "Failed to rollback manifest {ManifestId} during delivery failure cleanup",
+                    registeredManifest.Id);
+                rollbackErrors.Add($"Rollback exception for manifest {registeredManifest.Id}: {rollbackEx.Message}");
+            }
+        }
+
+        return rollbackErrors;
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -44,8 +44,7 @@ public class GeneralsOnlineDeliverer(
     public bool CanDeliver(ContentManifest manifest)
     {
         // Can deliver if it's a Generals Online manifest with a portable ZIP URL
-        var isPublisher = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true ||
-                          manifest.Publisher?.Name?.Equals(GeneralsOnlineConstants.PublisherName, StringComparison.OrdinalIgnoreCase) == true;
+        var isPublisher = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true;
         return isPublisher &&
                manifest.Files.Any(f => f.DownloadUrl?.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase) == true);
     }
@@ -115,7 +114,7 @@ public class GeneralsOnlineDeliverer(
             progress?.Report(new ContentAcquisitionProgress
             {
                 Phase = ContentAcquisitionPhase.Copying,
-                ProgressPercentage = 80,
+                ProgressPercentage = 60,
                 CurrentOperation = "Generating variant manifests (60Hz, MapPack, and GameData Patch)",
             });
 
@@ -136,7 +135,7 @@ public class GeneralsOnlineDeliverer(
             progress?.Report(new ContentAcquisitionProgress
             {
                 Phase = ContentAcquisitionPhase.Copying,
-                ProgressPercentage = 90,
+                ProgressPercentage = 80,
                 CurrentOperation = "Registering all variant manifests to content library",
             });
 
@@ -230,8 +229,10 @@ public class GeneralsOnlineDeliverer(
                         }
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    logger.LogError(ex, "Failed to move extracted files from {ExtractPath} to parent {ParentDir}; rolling back moved files", extractPath, parentDir);
+
                     // Roll back moved files
                     foreach (var (targetPath, backupPath) in movedFiles)
                     {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -64,51 +64,13 @@ public class GeneralsOnlineDeliverer(
         {
             logger.LogInformation("Starting Generals Online content delivery for {Version}", packageManifest.Version);
 
-            // Step 1: Download ZIP file
-            var zipFile = packageManifest.Files.FirstOrDefault(f => f.DownloadUrl is { } url && url.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
-            if (zipFile == null)
-            {
-                return OperationResult<ContentManifest>.CreateFailure("No ZIP file found in manifest");
-            }
-
-            zipPath = Path.Combine(targetDirectory, "GeneralsOnline.zip");
-
-            progress?.Report(new ContentAcquisitionProgress
-            {
-                Phase = ContentAcquisitionPhase.Downloading,
-                ProgressPercentage = 10,
-                CurrentOperation = "Downloading Generals Online ZIP package",
-                CurrentFile = zipFile.RelativePath,
-            });
-
-            logger.LogDebug("Downloading ZIP from {Url} to {Path}", zipFile.DownloadUrl, zipPath);
-            var downloadResult = await downloadService.DownloadFileAsync(
-                new Uri(zipFile.DownloadUrl!),
-                zipPath,
-                expectedHash: null,
-                progress: null,
-                cancellationToken);
-
+            var downloadResult = await DownloadAndExtractPackageAsync(packageManifest, targetDirectory, progress, cancellationToken);
             if (!downloadResult.Success)
             {
-                CleanupTempArtifacts(zipPath, extractPath, logger);
-                return OperationResult<ContentManifest>.CreateFailure(
-                    $"Failed to download ZIP: {downloadResult.FirstError}");
+                return OperationResult<ContentManifest>.CreateFailure(downloadResult.FirstError ?? "Failed to download and extract package");
             }
 
-            // Step 2: Extract ZIP
-            extractPath = Path.Combine(targetDirectory, "extracted");
-            Directory.CreateDirectory(extractPath);
-
-            progress?.Report(new ContentAcquisitionProgress
-            {
-                Phase = ContentAcquisitionPhase.Extracting,
-                ProgressPercentage = 40,
-                CurrentOperation = "Extracting Generals Online files",
-            });
-
-            logger.LogDebug("Extracting ZIP to {Path}", extractPath);
-            ZipFile.ExtractToDirectory(zipPath, extractPath, overwriteFiles: true);
+            (zipPath, extractPath) = downloadResult.Data;
 
             // Step 3: Create variant manifests from extracted files
             progress?.Report(new ContentAcquisitionProgress
@@ -139,157 +101,15 @@ public class GeneralsOnlineDeliverer(
                 CurrentOperation = "Registering all variant manifests to content library",
             });
 
-            foreach (var manifest in manifests)
+            var registrationResult = await RegisterVariantManifestsAsync(manifests, extractPath, newlyRegisteredManifests, cancellationToken);
+            if (!registrationResult.Success)
             {
-                var checkResult = await manifestPool.IsManifestAcquiredAsync(manifest.Id, cancellationToken: cancellationToken);
-                if (!checkResult.Success)
-                {
-                    logger.LogError(
-                        "Failed to check acquisition status for manifest {ManifestId}: {Error}",
-                        manifest.Id,
-                        checkResult.FirstError);
-
-                    var rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
-                    newlyRegisteredManifests.Clear();
-                    CleanupTempArtifacts(zipPath, extractPath, logger);
-
-                    var errorMessage = $"Failed to check manifest acquisition status for {manifest.Id}: {checkResult.FirstError}";
-                    if (rollbackErrors.Count > 0)
-                    {
-                        errorMessage += $"; Rollback warnings: {string.Join("; ", rollbackErrors)}";
-                    }
-
-                    return OperationResult<ContentManifest>.CreateFailure(errorMessage);
-                }
-
-                if (checkResult.Data)
-                {
-                    logger.LogInformation(
-                        "Manifest {ManifestId} ({Name}) is already acquired in pool; skipping registration",
-                        manifest.Id,
-                        manifest.Name);
-                    continue;
-                }
-
-                var addResult = await manifestPool.AddManifestAsync(manifest, extractPath, cancellationToken: cancellationToken);
-                if (!addResult.Success)
-                {
-                    logger.LogError(
-                        "Failed to register manifest {ManifestId} ({Name}): {Error}",
-                        manifest.Id,
-                        manifest.Name,
-                        addResult.FirstError);
-
-                    var rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
-                    newlyRegisteredManifests.Clear();
-                    CleanupTempArtifacts(zipPath, extractPath, logger);
-
-                    var errorMessage = $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}";
-                    if (rollbackErrors.Count > 0)
-                    {
-                        errorMessage += $"; Rollback warnings: {string.Join("; ", rollbackErrors)}";
-                    }
-
-                    return OperationResult<ContentManifest>.CreateFailure(errorMessage);
-                }
-
-                newlyRegisteredManifests.Add(manifest);
-                logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
+                CleanupTempArtifacts(zipPath, extractPath, logger);
+                return OperationResult<ContentManifest>.CreateFailure(registrationResult.FirstError ?? "Failed to register variant manifests");
             }
 
-            var movedFiles = new List<(string TargetPath, string? BackupPath)>();
-            var parentDir = Directory.GetParent(extractPath)?.FullName;
-            if (parentDir != null)
-            {
-                logger.LogInformation("Moving extracted files from {ExtractPath} to parent {ParentDir}", extractPath, parentDir);
-                try
-                {
-                    foreach (var file in Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories))
-                    {
-                        var relativePath = Path.GetRelativePath(extractPath, file);
-                        var targetPath = Path.Combine(parentDir, relativePath);
-                        var targetDir = Path.GetDirectoryName(targetPath);
-                        if (!string.IsNullOrEmpty(targetDir))
-                        {
-                            Directory.CreateDirectory(targetDir);
-                        }
-
-                        string? backupPath = null;
-                        if (File.Exists(targetPath))
-                        {
-                            backupPath = targetPath + ".gh_bak_" + Guid.NewGuid().ToString("N");
-                            File.Move(targetPath, backupPath);
-                            movedFiles.Add((targetPath, backupPath));
-                        }
-
-                        File.Move(file, targetPath, overwrite: true);
-                        if (backupPath == null)
-                        {
-                            movedFiles.Add((targetPath, null));
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to move extracted files from {ExtractPath} to parent {ParentDir}; rolling back moved files", extractPath, parentDir);
-
-                    // Roll back moved files
-                    foreach (var (targetPath, backupPath) in movedFiles)
-                    {
-                        try
-                        {
-                            if (backupPath != null && File.Exists(backupPath))
-                            {
-                                File.Move(backupPath, targetPath, overwrite: true);
-                            }
-                            else if (File.Exists(targetPath))
-                            {
-                                File.Delete(targetPath);
-                            }
-                        }
-                        catch (Exception restoreEx)
-                        {
-                            logger.LogWarning(restoreEx, "Failed to restore target file {TargetPath} during rollback", targetPath);
-                        }
-                    }
-
-                    throw;
-                }
-
-                // Clean up backup files on success
-                foreach (var (_, backupPath) in movedFiles)
-                {
-                    if (backupPath != null && File.Exists(backupPath))
-                    {
-                        try
-                        {
-                            File.Delete(backupPath);
-                        }
-                        catch (Exception delEx)
-                        {
-                            logger.LogWarning(delEx, "Failed to delete backup file {BackupPath}", backupPath);
-                        }
-                    }
-                }
-
-                try
-                {
-                    Directory.Delete(extractPath, recursive: true);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "Failed to delete extracted directory {ExtractPath}", extractPath);
-                }
-            }
-
-            try
-            {
-                File.Delete(zipPath);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to delete ZIP file {ZipPath}", zipPath);
-            }
+            MoveExtractedFilesToTarget(extractPath);
+            DeleteZipSafe(zipPath);
 
             progress?.Report(new ContentAcquisitionProgress
             {
@@ -381,6 +201,224 @@ public class GeneralsOnlineDeliverer(
             {
                 logger.LogWarning(ex, "Failed to clean up ZIP file {ZipPath}", zipPath);
             }
+        }
+    }
+
+    private async Task<OperationResult<(string ZipPath, string ExtractPath)>> DownloadAndExtractPackageAsync(
+        ContentManifest packageManifest,
+        string targetDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var zipFile = packageManifest.Files.FirstOrDefault(f => f.DownloadUrl is { } url && url.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
+        if (zipFile == null)
+        {
+            return OperationResult<(string, string)>.CreateFailure("No ZIP file found in manifest");
+        }
+
+        var zipPath = Path.Combine(targetDirectory, "GeneralsOnline.zip");
+        progress?.Report(new ContentAcquisitionProgress
+        {
+            Phase = ContentAcquisitionPhase.Downloading,
+            ProgressPercentage = 10,
+            CurrentOperation = "Downloading Generals Online ZIP package",
+            CurrentFile = zipFile.RelativePath,
+        });
+
+        logger.LogDebug("Downloading ZIP from {Url} to {Path}", zipFile.DownloadUrl, zipPath);
+        var downloadResult = await downloadService.DownloadFileAsync(
+            new Uri(zipFile.DownloadUrl!),
+            zipPath,
+            expectedHash: null,
+            progress: null,
+            cancellationToken);
+
+        if (!downloadResult.Success)
+        {
+            CleanupTempArtifacts(zipPath, null, logger);
+            return OperationResult<(string, string)>.CreateFailure($"Failed to download ZIP: {downloadResult.FirstError}");
+        }
+
+        var extractPath = Path.Combine(targetDirectory, "extracted");
+        Directory.CreateDirectory(extractPath);
+
+        progress?.Report(new ContentAcquisitionProgress
+        {
+            Phase = ContentAcquisitionPhase.Extracting,
+            ProgressPercentage = 40,
+            CurrentOperation = "Extracting Generals Online files",
+        });
+
+        logger.LogDebug("Extracting ZIP to {Path}", extractPath);
+        ZipFile.ExtractToDirectory(zipPath, extractPath, overwriteFiles: true);
+
+        return OperationResult<(string, string)>.CreateSuccess((zipPath, extractPath));
+    }
+
+    private async Task<OperationResult> RegisterVariantManifestsAsync(
+        IReadOnlyList<ContentManifest> manifests,
+        string extractPath,
+        List<ContentManifest> newlyRegisteredManifests,
+        CancellationToken cancellationToken)
+    {
+        foreach (var manifest in manifests)
+        {
+            var checkResult = await manifestPool.IsManifestAcquiredAsync(manifest.Id, cancellationToken: cancellationToken);
+            if (!checkResult.Success)
+            {
+                logger.LogError("Failed to check acquisition status for manifest {ManifestId}: {Error}", manifest.Id, checkResult.FirstError);
+                var rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
+                newlyRegisteredManifests.Clear();
+
+                var errorMessage = $"Failed to check manifest acquisition status for {manifest.Id}: {checkResult.FirstError}";
+                if (rollbackErrors.Count > 0)
+                {
+                    errorMessage += $"; Rollback warnings: {string.Join("; ", rollbackErrors)}";
+                }
+
+                return OperationResult.CreateFailure(errorMessage);
+            }
+
+            if (checkResult.Data)
+            {
+                logger.LogInformation("Manifest {ManifestId} ({Name}) is already acquired in pool; skipping registration", manifest.Id, manifest.Name);
+                continue;
+            }
+
+            var addResult = await manifestPool.AddManifestAsync(manifest, extractPath, cancellationToken: cancellationToken);
+            if (!addResult.Success)
+            {
+                logger.LogError("Failed to register manifest {ManifestId} ({Name}): {Error}", manifest.Id, manifest.Name, addResult.FirstError);
+                var rollbackErrors = await RollbackManifestsAsync(newlyRegisteredManifests);
+                newlyRegisteredManifests.Clear();
+
+                var errorMessage = $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}";
+                if (rollbackErrors.Count > 0)
+                {
+                    errorMessage += $"; Rollback warnings: {string.Join("; ", rollbackErrors)}";
+                }
+
+                return OperationResult.CreateFailure(errorMessage);
+            }
+
+            newlyRegisteredManifests.Add(manifest);
+            logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
+        }
+
+        return OperationResult.CreateSuccess();
+    }
+
+    private void MoveExtractedFilesToTarget(string extractPath)
+    {
+        var parentDir = Directory.GetParent(extractPath)?.FullName;
+        if (parentDir == null)
+        {
+            return;
+        }
+
+        logger.LogInformation("Moving extracted files from {ExtractPath} to parent {ParentDir}", extractPath, parentDir);
+        var movedFiles = new List<(string TargetPath, string? BackupPath)>();
+
+        try
+        {
+            foreach (var file in Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories))
+            {
+                var relativePath = Path.GetRelativePath(extractPath, file);
+                var targetPath = Path.Combine(parentDir, relativePath);
+                var targetDir = Path.GetDirectoryName(targetPath);
+                if (!string.IsNullOrEmpty(targetDir))
+                {
+                    Directory.CreateDirectory(targetDir);
+                }
+
+                string? backupPath = null;
+                if (File.Exists(targetPath))
+                {
+                    backupPath = targetPath + ".gh_bak_" + Guid.NewGuid().ToString("N");
+                    File.Move(targetPath, backupPath);
+                    movedFiles.Add((targetPath, backupPath));
+                }
+
+                File.Move(file, targetPath, overwrite: true);
+                if (backupPath == null)
+                {
+                    movedFiles.Add((targetPath, null));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to move extracted files from {ExtractPath} to parent {ParentDir}; rolling back moved files", extractPath, parentDir);
+            RollbackMovedFiles(movedFiles);
+            throw;
+        }
+
+        CleanupBackupFiles(movedFiles);
+
+        try
+        {
+            Directory.Delete(extractPath, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete extracted directory {ExtractPath}", extractPath);
+        }
+    }
+
+    private void RollbackMovedFiles(List<(string TargetPath, string? BackupPath)> movedFiles)
+    {
+        foreach (var (targetPath, backupPath) in movedFiles)
+        {
+            try
+            {
+                if (backupPath != null && File.Exists(backupPath))
+                {
+                    File.Move(backupPath, targetPath, overwrite: true);
+                }
+                else if (File.Exists(targetPath))
+                {
+                    File.Delete(targetPath);
+                }
+            }
+            catch (Exception restoreEx)
+            {
+                logger.LogWarning(restoreEx, "Failed to restore target file {TargetPath} during rollback", targetPath);
+            }
+        }
+    }
+
+    private void CleanupBackupFiles(List<(string TargetPath, string? BackupPath)> movedFiles)
+    {
+        foreach (var (_, backupPath) in movedFiles)
+        {
+            if (backupPath != null && File.Exists(backupPath))
+            {
+                try
+                {
+                    File.Delete(backupPath);
+                }
+                catch (Exception delEx)
+                {
+                    logger.LogWarning(delEx, "Failed to delete backup file {BackupPath}", backupPath);
+                }
+            }
+        }
+    }
+
+    private void DeleteZipSafe(string? zipPath)
+    {
+        if (string.IsNullOrEmpty(zipPath) || !File.Exists(zipPath))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(zipPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete ZIP file {ZipPath}", zipPath);
         }
     }
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -44,9 +44,9 @@ public class GeneralsOnlineDeliverer(
     public bool CanDeliver(ContentManifest manifest)
     {
         // Can deliver if it's a Generals Online manifest with a portable ZIP URL
-        var isPublisher = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true;
+        var isPublisher = string.Equals(manifest.Publisher?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase);
         return isPublisher &&
-               manifest.Files.Any(f => f.DownloadUrl?.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase) == true);
+               manifest.Files.Any(f => f.DownloadUrl != null && f.DownloadUrl.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <inheritdoc />
@@ -65,7 +65,7 @@ public class GeneralsOnlineDeliverer(
             logger.LogInformation("Starting Generals Online content delivery for {Version}", packageManifest.Version);
 
             // Step 1: Download ZIP file
-            var zipFile = packageManifest.Files.FirstOrDefault(f => f.DownloadUrl?.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase) == true);
+            var zipFile = packageManifest.Files.FirstOrDefault(f => f.DownloadUrl != null && f.DownloadUrl.EndsWith(GeneralsOnlineConstants.PortableExtension, StringComparison.OrdinalIgnoreCase));
             if (zipFile == null)
             {
                 return OperationResult<ContentManifest>.CreateFailure("No ZIP file found in manifest");

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -134,7 +135,7 @@ public class GeneralsOnlineDeliverer(
                 CurrentOperation = "Registering all variant manifests to content library",
             });
 
-            logger.LogInformation("Registering all variant manifests (60Hz, QuickMatch MapPack, GameData patch) in pool");
+            var registeredManifests = new List<ContentManifest>();
 
             foreach (var manifest in manifests)
             {
@@ -147,10 +148,27 @@ public class GeneralsOnlineDeliverer(
                         manifest.Name,
                         addResult.FirstError);
 
+                    // Roll back previously registered manifests to prevent partial acquisition state
+                    foreach (var registeredManifest in registeredManifests)
+                    {
+                        try
+                        {
+                            await manifestPool.RemoveManifestAsync(registeredManifest.Id, cancellationToken: cancellationToken);
+                        }
+                        catch (Exception rollbackEx)
+                        {
+                            logger.LogWarning(
+                                rollbackEx,
+                                "Failed to rollback manifest {ManifestId} during delivery failure cleanup",
+                                registeredManifest.Id);
+                        }
+                    }
+
                     return OperationResult<ContentManifest>.CreateFailure(
                         $"Failed to register manifest {manifest.Id} ({manifest.Name}): {addResult.FirstError}");
                 }
 
+                registeredManifests.Add(manifest);
                 logger.LogInformation("Successfully registered manifest: {ManifestId} ({Name})", manifest.Id, manifest.Name);
             }
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDependencyBuilder.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDependencyBuilder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Services.Dependencies;
@@ -130,11 +131,25 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
     {
         var dependencies = new List<ContentDependency>();
 
+        var userVersion = 0;
+        if (!string.IsNullOrWhiteSpace(manifest.Version))
+        {
+            userVersion = GameVersionHelper.GetGeneralsOnlineManifestIdComponent(manifest.Version);
+        }
+        else if (!string.IsNullOrWhiteSpace(manifest.Id.Value))
+        {
+            var parts = manifest.Id.Value.Split('.');
+            if (parts.Length >= 2 && int.TryParse(parts[1], out var parsedVersion))
+            {
+                userVersion = parsedVersion;
+            }
+        }
+
         // All Generals Online game clients require Zero Hour 1.04 and the QuickMatch MapPack
         if (manifest.ContentType == ContentType.GameClient)
         {
             dependencies.Add(CreateZeroHourDependencyForGeneralsOnline());
-            dependencies.Add(CreateQuickMatchMapPackDependency());
+            dependencies.Add(CreateQuickMatchMapPackDependency(userVersion));
         }
         else if (manifest.ContentType == ContentType.MapPack)
         {
@@ -145,7 +160,7 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
         {
             // Data patch requires Zero Hour installation and GeneralsOnline GameClient
             dependencies.Add(CreateZeroHourDependencyForGeneralsOnline());
-            dependencies.Add(CreateGameClient60HzDependency());
+            dependencies.Add(CreateGameClient60HzDependency(userVersion));
         }
 
         return dependencies;

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDependencyBuilder.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDependencyBuilder.cs
@@ -25,10 +25,14 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
             Id = ManifestId.Create($"1.104.genhub.gameinstallation.zerohour"),
             Name = GameClientConstants.ZeroHourInstallationDependencyName,
             DependencyType = ContentType.GameInstallation,
-            MinVersion = ManifestConstants.ZeroHourManifestVersion, // "1.04"
+
+            // "1.04"
+            MinVersion = ManifestConstants.ZeroHourManifestVersion,
             InstallBehavior = DependencyInstallBehavior.RequireExisting,
             IsOptional = false,
-            StrictPublisher = false, // Any publisher's ZH installation will work
+
+            // Any publisher's ZH installation will work
+            StrictPublisher = false,
             CompatibleGameTypes = new List<GameType> { GameType.ZeroHour },
         };
     }
@@ -52,7 +56,9 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
             DependencyType = ContentType.MapPack,
             InstallBehavior = DependencyInstallBehavior.AutoInstall,
             IsOptional = false,
-            StrictPublisher = true, // Must be from GeneralsOnline publisher
+
+            // Must be from GeneralsOnline publisher
+            StrictPublisher = true,
             PublisherType = PublisherTypeConstants.GeneralsOnline,
             CompatibleGameTypes = new List<GameType> { GameType.ZeroHour },
         };
@@ -77,7 +83,9 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
             DependencyType = ContentType.GameClient,
             InstallBehavior = DependencyInstallBehavior.AutoInstall,
             IsOptional = false,
-            StrictPublisher = true, // Must be from GeneralsOnline publisher
+
+            // Must be from GeneralsOnline publisher
+            StrictPublisher = true,
             PublisherType = PublisherTypeConstants.GeneralsOnline,
             CompatibleGameTypes = new List<GameType> { GameType.ZeroHour },
         };

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDependencyBuilder.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDependencyBuilder.cs
@@ -59,6 +59,31 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
     }
 
     /// <summary>
+    /// Creates a dependency on the GeneralsOnline 60Hz GameClient.
+    /// This is required for GeneralsOnline data patches to work.
+    /// </summary>
+    /// <param name="version">Optional version constraint for the game client.</param>
+    /// <returns>A content dependency for the 60Hz GameClient.</returns>
+    public static ContentDependency CreateGameClient60HzDependency(int version = 0)
+    {
+        return new ContentDependency
+        {
+            Id = ManifestId.Create(ManifestIdGenerator.GeneratePublisherContentId(
+                PublisherTypeConstants.GeneralsOnline,
+                ContentType.GameClient,
+                GeneralsOnlineConstants.Variant60HzSuffix,
+                version)),
+            Name = $"{GameClientConstants.GeneralsOnline60HzDisplayName} (Required)",
+            DependencyType = ContentType.GameClient,
+            InstallBehavior = DependencyInstallBehavior.AutoInstall,
+            IsOptional = false,
+            StrictPublisher = true, // Must be from GeneralsOnline publisher
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+            CompatibleGameTypes = new List<GameType> { GameType.ZeroHour },
+        };
+    }
+
+    /// <summary>
     /// Gets the list of all dependencies for a Generals Online 60Hz variant.
     /// Includes Zero Hour installation and QuickMatch MapPack.
     /// </summary>
@@ -70,6 +95,21 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
         {
             CreateZeroHourDependencyForGeneralsOnline(),
             CreateQuickMatchMapPackDependency(mapPackVersion),
+        };
+    }
+
+    /// <summary>
+    /// Gets the list of dependencies for the GeneralsOnlineGameData data patch.
+    /// Includes Zero Hour installation and GeneralsOnline 60Hz GameClient.
+    /// </summary>
+    /// <param name="clientVersion">The version of the GameClient to depend on.</param>
+    /// <returns>List of dependencies for GameData data patch.</returns>
+    public static List<ContentDependency> GetDependenciesForGameData(int clientVersion = 0)
+    {
+        return new List<ContentDependency>
+        {
+            CreateZeroHourDependencyForGeneralsOnline(),
+            CreateGameClient60HzDependency(clientVersion),
         };
     }
 
@@ -92,6 +132,12 @@ public class GeneralsOnlineDependencyBuilder : BaseDependencyBuilder
         {
             // MapPacks only require Zero Hour installation
             dependencies.Add(CreateZeroHourDependencyForGeneralsOnline());
+        }
+        else if (manifest.ContentType == ContentType.Patch)
+        {
+            // Data patch requires Zero Hour installation and GeneralsOnline GameClient
+            dependencies.Add(CreateZeroHourDependencyForGeneralsOnline());
+            dependencies.Add(CreateGameClient60HzDependency());
         }
 
         return dependencies;

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
@@ -139,7 +139,7 @@ public class GeneralsOnlineJsonCatalogParser(
     /// </summary>
     private static GeneralsOnlineRelease CreateReleaseFromApiResponse(GeneralsOnlineApiResponse apiResponse)
     {
-        var versionDate = ParseVersionDate(apiResponse.Version) ?? DateTime.Now;
+        var versionDate = ParseVersionDate(apiResponse.Version) ?? DateTime.UtcNow;
 
         return new GeneralsOnlineRelease
         {
@@ -158,7 +158,7 @@ public class GeneralsOnlineJsonCatalogParser(
     /// </summary>
     private static GeneralsOnlineRelease CreateReleaseFromVersion(string version, ProviderDefinition provider)
     {
-        var versionDate = ParseVersionDate(version) ?? DateTime.Now;
+        var versionDate = ParseVersionDate(version) ?? DateTime.UtcNow;
         var releasesUrl = provider.Endpoints.GetEndpoint("releasesUrl");
 
         return new GeneralsOnlineRelease

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
@@ -194,11 +194,15 @@ public class GeneralsOnlineJsonCatalogParser(
                 return null;
             }
 
-            var month = int.Parse(datePart[..2]);
-            var day = int.Parse(datePart.Substring(2, 2));
-            var year = 2000 + int.Parse(datePart[4..]);
+            if (!int.TryParse(datePart[..2], out var month) ||
+                !int.TryParse(datePart.Substring(2, 2), out var day) ||
+                !int.TryParse(datePart[4..], out var yearSuffix))
+            {
+                return null;
+            }
 
-            return new DateTime(year, month, day);
+            var year = 2000 + yearSuffix;
+            return new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc);
         }
         catch
         {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -540,7 +540,7 @@ public class GeneralsOnlineManifestFactory(
             var isGameData = relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
                              relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
 
-            string hash;
+            var hash = string.Empty;
             using (var stream = File.OpenRead(filePath))
             {
                 var hashBytes = await SHA256.HashDataAsync(stream, cancellationToken);

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -684,7 +684,7 @@ public class GeneralsOnlineManifestFactory(
             {
                 if (m.Dependencies.Any(d => d.DependencyType == ContentType.MapPack))
                 {
-                    logger.LogInformation(
+                    logger.LogWarning(
                         "Removing MapPack dependency from manifest '{Name}' because MapPack was not found in archive",
                         m.Name);
                     m.Dependencies = m.Dependencies.Where(d => d.DependencyType != ContentType.MapPack).ToList();

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -131,7 +131,7 @@ public class GeneralsOnlineManifestFactory(
     /// <inheritdoc />
     public bool CanHandle(ContentManifest manifest)
     {
-        var publisherMatches = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true;
+        var publisherMatches = string.Equals(manifest.Publisher?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase);
         var isGameClient = manifest.ContentType == ContentType.GameClient;
         var isMapPack = manifest.ContentType == ContentType.MapPack;
         var isPatch = manifest.ContentType == ContentType.Patch;
@@ -186,8 +186,8 @@ public class GeneralsOnlineManifestFactory(
         var release = new GeneralsOnlineRelease
         {
             Version = GameClientConstants.AutoDetectedVersion,
-            VersionDate = DateTime.Now,
-            ReleaseDate = DateTime.Now,
+            VersionDate = DateTime.UtcNow,
+            ReleaseDate = DateTime.UtcNow,
             PortableUrl = string.Empty,
             PortableSize = 0,
             Changelog = string.Empty,
@@ -412,7 +412,7 @@ public class GeneralsOnlineManifestFactory(
         };
 
         // Create metadata template
-        var releaseDate = originalManifest.Metadata?.ReleaseDate ?? DateTime.Now;
+        var releaseDate = originalManifest.Metadata?.ReleaseDate ?? DateTime.UtcNow;
         var changelogUrl = originalManifest.Metadata?.ChangelogUrl;
 
         // Create 60Hz variant

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -104,13 +104,14 @@ public class GeneralsOnlineManifestFactory(
     }
 
     /// <summary>
-    /// Creates two content manifests from a GeneralsOnline release:
+    /// Creates content manifests from a GeneralsOnline release:
     /// - 60Hz game client variant
     /// - QuickMatch MapPack (required for multiplayer)
+    /// - GeneralsOnlineGameData data patch (optional patch, depends on 60Hz game client)
     /// This creates the initial manifests with download URLs.
     /// </summary>
     /// <param name="release">The GeneralsOnlineRelease to create the manifests from.</param>
-    /// <returns>A list containing two ContentManifest instances.</returns>
+    /// <returns>A list containing the ContentManifest instances.</returns>
     public List<ContentManifest> CreateManifests(GeneralsOnlineRelease release)
     {
         List<ContentManifest> manifests = [];
@@ -118,8 +119,11 @@ public class GeneralsOnlineManifestFactory(
         // Create manifest for 60Hz variant
         manifests.Add(CreateVariantManifest(release, GeneralsOnlineConstants.Variant60HzSuffix, GameClientConstants.GeneralsOnline60HzDisplayName));
 
-        // Create manifest for QuickMatch MapPack (required dependency for both variants)
+        // Create manifest for QuickMatch MapPack (required dependency for game client)
         manifests.Add(CreateQuickMatchMapPackManifest(release));
+
+        // Create manifest for GeneralsOnlineGameData data patch (optional patch, depends on 60Hz game client)
+        manifests.Add(CreateGameDataPatchManifest(release));
 
         return manifests;
     }
@@ -130,7 +134,8 @@ public class GeneralsOnlineManifestFactory(
         var publisherMatches = manifest.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true;
         var isGameClient = manifest.ContentType == ContentType.GameClient;
         var isMapPack = manifest.ContentType == ContentType.MapPack;
-        return publisherMatches && (isGameClient || isMapPack);
+        var isPatch = manifest.ContentType == ContentType.Patch;
+        return publisherMatches && (isGameClient || isMapPack || isPatch);
     }
 
     /// <inheritdoc />
@@ -141,7 +146,7 @@ public class GeneralsOnlineManifestFactory(
     {
         logger.LogInformation("Creating GeneralsOnline manifests from extracted content in: {Directory}", extractedDirectory);
 
-        // Create all variant manifests (30Hz, 60Hz, and QuickMatch MapPack) from extracted files
+        // Create all variant manifests (60Hz, QuickMatch MapPack, and GeneralsOnlineGameData data patch) from extracted files
         var manifests = CreateVariantManifestsFromOriginal(originalManifest);
 
         // Update manifests with extracted files (compute hashes, set file entries)
@@ -230,6 +235,20 @@ public class GeneralsOnlineManifestFactory(
         };
     }
 
+    private static ManifestFile CreateGameDataManifestFile(string relativePath, FileInfo fileInfo, string hash)
+    {
+        return new ManifestFile
+        {
+            RelativePath = relativePath,
+            Size = fileInfo.Length,
+            Hash = hash,
+            SourceType = ContentSourceType.ContentAddressable,
+            SourcePath = fileInfo.FullName,
+            InstallTarget = ContentInstallTarget.Workspace,
+            IsExecutable = false,
+        };
+    }
+
     /// <summary>
     /// Gets variant-specific tags for a given variant suffix.
     /// </summary>
@@ -247,7 +266,62 @@ public class GeneralsOnlineManifestFactory(
             return [GeneralsOnlineVariantTags.TagQuickMatchMaps];
         }
 
+        if (variantSuffix.Equals(GeneralsOnlineConstants.GameDataPatchSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return [GeneralsOnlineVariantTags.TagGameData];
+        }
+
         return [];
+    }
+
+    /// <summary>
+    /// Creates a content manifest for the GeneralsOnlineGameData data patch.
+    /// This manifest contains game data files (splash screens, map cache configuration).
+    /// </summary>
+    /// <param name="release">The Generals Online release information.</param>
+    /// <returns>A content manifest for the GeneralsOnlineGameData data patch.</returns>
+    public ContentManifest CreateGameDataPatchManifest(GeneralsOnlineRelease release)
+    {
+        var provider = providerLoader.GetProvider(PublisherTypeConstants.GeneralsOnline);
+        var websiteUrl = provider?.Endpoints.WebsiteUrl ?? GeneralsOnlineConstants.WebsiteUrl;
+        var supportUrl = provider?.Endpoints.GetEndpoint(ProviderEndpointConstants.SupportUrl) ?? GeneralsOnlineConstants.SupportUrl;
+        var downloadPageUrl = provider?.Endpoints.GetEndpoint(ProviderEndpointConstants.DownloadPageUrl) ?? GeneralsOnlineConstants.DownloadPageUrl;
+        var iconUrl = GeneralsOnlineConstants.LogoSource;
+        var userVersion = ParseVersionForManifestId(release.Version);
+        var manifestId = ManifestId.Create(ManifestIdGenerator.GeneratePublisherContentId(
+            PublisherTypeConstants.GeneralsOnline,
+            ContentType.Patch,
+            GeneralsOnlineConstants.GameDataPatchSuffix,
+            userVersion));
+
+        return new ContentManifest
+        {
+            Id = manifestId,
+            Name = GeneralsOnlineConstants.GameDataDisplayName,
+            Version = release.Version,
+            ContentType = ContentType.Patch,
+            TargetGame = GameType.ZeroHour,
+            Publisher = new PublisherInfo
+            {
+                Name = GeneralsOnlineConstants.PublisherName,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+                Website = websiteUrl,
+                SupportUrl = supportUrl,
+                ContentIndexUrl = downloadPageUrl,
+                UpdateCheckIntervalHours = GeneralsOnlineConstants.UpdateCheckIntervalHours,
+            },
+            Metadata = new ContentMetadata
+            {
+                Description = GeneralsOnlineConstants.GameDataDescription,
+                ReleaseDate = release.ReleaseDate,
+                IconUrl = iconUrl,
+                ThemeColor = GeneralsOnlineConstants.ThemeColor,
+                Tags = [.. GeneralsOnlineConstants.GameDataTags, .. GetVariantTags(GeneralsOnlineConstants.GameDataPatchSuffix)],
+                ChangelogUrl = release.Changelog,
+            },
+            Files = [], // Files will be populated during extraction
+            Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesForGameData(userVersion),
+        };
     }
 
     /// <summary>
@@ -395,14 +469,41 @@ public class GeneralsOnlineManifestFactory(
             ],
         });
 
+        // Create GeneralsOnlineGameData data patch
+        manifests.Add(new ContentManifest
+        {
+            Id = ManifestId.Create(ManifestIdGenerator.GeneratePublisherContentId(
+                PublisherTypeConstants.GeneralsOnline,
+                ContentType.Patch,
+                GeneralsOnlineConstants.GameDataPatchSuffix,
+                userVersion)),
+            Name = GeneralsOnlineConstants.GameDataDisplayName,
+            Version = version,
+            ContentType = ContentType.Patch,
+            TargetGame = GameType.ZeroHour,
+            Publisher = publisherInfo,
+            Metadata = new ContentMetadata
+            {
+                Description = GeneralsOnlineConstants.GameDataDescription,
+                ReleaseDate = releaseDate,
+                IconUrl = iconUrl,
+                ThemeColor = GeneralsOnlineConstants.ThemeColor,
+                Tags = [.. GeneralsOnlineConstants.GameDataTags, .. GetVariantTags(GeneralsOnlineConstants.GameDataPatchSuffix)],
+                ChangelogUrl = changelogUrl,
+            },
+            Files = [],
+            Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesForGameData(userVersion),
+        });
+
         return manifests;
     }
 
     /// <summary>
-    /// Updates manifests (60Hz and QuickMatch MapPack) with extracted file information.
+    /// Updates manifests (60Hz, QuickMatch MapPack, and GeneralsOnlineGameData data patch) with extracted file information.
     /// Computes SHA-256 hashes for all files for CAS integration.
     /// Each variant gets only the files it needs plus shared files.
     /// Maps are extracted to the MapPack manifest with UserMapsDirectory install target.
+    /// Game data files are extracted to the Patch manifest with Workspace install target.
     /// </summary>
     /// <param name="manifests">The original content manifests to update.</param>
     /// <param name="extractPath">The path to the directory containing extracted files.</param>
@@ -418,11 +519,15 @@ public class GeneralsOnlineManifestFactory(
         var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
         logger.LogInformation("Processing {Count} files", allFiles.Length);
 
-        List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap)> filesWithHashes = [];
+        List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsGameData)> filesWithHashes = [];
 
         // Detect Maps directory (case-insensitive)
         var mapsDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
             .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.MapsSubdirectory, StringComparison.OrdinalIgnoreCase));
+
+        // Detect GeneralsOnlineGameData directory (case-insensitive)
+        var gameDataDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
+            .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.GameDataSubdirectory, StringComparison.OrdinalIgnoreCase));
 
         foreach (var filePath in allFiles)
         {
@@ -435,7 +540,14 @@ public class GeneralsOnlineManifestFactory(
             var fileInfo = new FileInfo(filePath);
 
             // Determine if this file is inside the Maps directory
-            var isMap = mapsDirectory != null && filePath.StartsWith(mapsDirectory, StringComparison.OrdinalIgnoreCase);
+            var isMap = (mapsDirectory != null && filePath.StartsWith(mapsDirectory, StringComparison.OrdinalIgnoreCase)) ||
+                        relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+                        relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
+
+            // Determine if this file is inside the GeneralsOnlineGameData directory
+            var isGameData = (gameDataDirectory != null && filePath.StartsWith(gameDataDirectory, StringComparison.OrdinalIgnoreCase)) ||
+                             relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+                             relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
 
             string hash;
             using (var stream = File.OpenRead(filePath))
@@ -444,8 +556,8 @@ public class GeneralsOnlineManifestFactory(
                 hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
             }
 
-            filesWithHashes.Add((relativePath, fileInfo, hash, isMap));
-            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap})", relativePath, fileInfo.Length, hash[..8], isMap);
+            filesWithHashes.Add((relativePath, fileInfo, hash, isMap, isGameData));
+            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap}, isGameData: {IsGameData})", relativePath, fileInfo.Length, hash[..8], isMap, isGameData);
         }
 
         List<ContentManifest> updatedManifests = [];
@@ -454,11 +566,12 @@ public class GeneralsOnlineManifestFactory(
         {
             List<ManifestFile> manifestFiles = [];
             var isMapPackManifest = manifest.ContentType == ContentType.MapPack;
+            var isPatchManifest = manifest.ContentType == ContentType.Patch;
 
             if (isMapPackManifest)
             {
                 // MapPack manifest: only include map files with UserMapsDirectory install target
-                foreach (var (relativePath, fileInfo, hash, isMap) in filesWithHashes)
+                foreach (var (relativePath, fileInfo, hash, isMap, isGameData) in filesWithHashes)
                 {
                     if (!isMap)
                     {
@@ -470,26 +583,40 @@ public class GeneralsOnlineManifestFactory(
 
                 logger.LogInformation("MapPack manifest '{Name}' updated with {Count} map files", manifest.Name, manifestFiles.Count);
             }
+            else if (isPatchManifest)
+            {
+                // Data patch manifest: only include GeneralsOnlineGameData files with Workspace install target
+                foreach (var (relativePath, fileInfo, hash, isMap, isGameData) in filesWithHashes)
+                {
+                    if (!isGameData)
+                    {
+                        continue;
+                    }
+
+                    manifestFiles.Add(CreateGameDataManifestFile(relativePath, fileInfo, hash));
+                }
+
+                logger.LogInformation("GameData patch manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
+            }
             else
             {
-                // Game client manifest: include executables, shared files, AND map files
-                // Map files are included with UserMapsDirectory install target so they install to Documents
+                // Game client manifest: include executables and shared files (skipping maps and game data files)
                 // Since 060526_QFE1 the portable ships an Easy Anti-Cheat bootstrapper that starts the
                 // binary named by EasyAntiCheat/Settings.json. When present it is the only launch target;
                 // the wrapped binary stays in the workspace as ordinary content for EAC to start.
                 var hasEacLauncher = filesWithHashes.Any(file =>
-                    !file.IsMap && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacLauncherExecutable));
+                    !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacLauncherExecutable));
 
                 var targetExecutable = hasEacLauncher
                     ? GameClientConstants.GeneralsOnlineEacLauncherExecutable
                     : GameClientConstants.GeneralsOnline60HzExecutable;
 
-                foreach (var (relativePath, fileInfo, hash, isMap) in filesWithHashes)
+                foreach (var (relativePath, fileInfo, hash, isMap, isGameData) in filesWithHashes)
                 {
                     var isExecutable = false;
 
-                    // Skip map files in GameClient manifests - they belong in the MapPack manifest
-                    if (isMap)
+                    // Skip map files and game data files in GameClient manifests
+                    if (isMap || isGameData)
                     {
                         continue;
                     }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -516,12 +516,12 @@ public class GeneralsOnlineManifestFactory(
     {
         logger.LogInformation("Updating manifests with extracted files from: {Path}", extractPath);
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
         logger.LogInformation("Processing {Count} files", allFiles.Length);
 
         List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsGameData)> filesWithHashes = [];
-
-        cancellationToken.ThrowIfCancellationRequested();
 
         foreach (var filePath in allFiles)
         {
@@ -630,13 +630,26 @@ public class GeneralsOnlineManifestFactory(
                 logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
             }
 
-            if (manifestFiles.Count == 0 && (isMapPackManifest || isPatchManifest))
+            if (manifestFiles.Count == 0)
             {
-                logger.LogInformation(
-                    "Skipping empty {Type} manifest '{Name}' because no matching files were found in extract path",
-                    manifest.ContentType,
-                    manifest.Name);
-                continue;
+                if (isMapPackManifest || isPatchManifest)
+                {
+                    logger.LogInformation(
+                        "Skipping empty {Type} manifest '{Name}' because no matching files were found in extract path",
+                        manifest.ContentType,
+                        manifest.Name);
+                    continue;
+                }
+
+                if (manifest.ContentType == ContentType.GameClient)
+                {
+                    logger.LogError(
+                        "GameClient manifest '{Name}' has zero files in extract path '{ExtractPath}'",
+                        manifest.Name,
+                        extractPath);
+                    throw new InvalidDataException(
+                        $"GameClient manifest '{manifest.Name}' has no files in extract path '{extractPath}'.");
+                }
             }
 
             updatedManifests.Add(new ContentManifest

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -521,12 +521,11 @@ public class GeneralsOnlineManifestFactory(
 
         List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsGameData)> filesWithHashes = [];
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         foreach (var filePath in allFiles)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             var relativePath = Path.GetRelativePath(extractPath, filePath);
             var fileInfo = new FileInfo(filePath);
@@ -629,6 +628,15 @@ public class GeneralsOnlineManifestFactory(
                 }
 
                 logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
+            }
+
+            if (manifestFiles.Count == 0 && (isMapPackManifest || isPatchManifest))
+            {
+                logger.LogInformation(
+                    "Skipping empty {Type} manifest '{Name}' because no matching files were found in extract path",
+                    manifest.ContentType,
+                    manifest.Name);
+                continue;
             }
 
             updatedManifests.Add(new ContentManifest

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -653,6 +653,22 @@ public class GeneralsOnlineManifestFactory(
             });
         }
 
+        // If MapPack was not created from archive, remove MapPack dependency so dependency resolution does not fail
+        var hasMapPack = updatedManifests.Any(m => m.ContentType == ContentType.MapPack);
+        if (!hasMapPack)
+        {
+            foreach (var m in updatedManifests)
+            {
+                if (m.Dependencies.Any(d => d.DependencyType == ContentType.MapPack))
+                {
+                    logger.LogInformation(
+                        "Removing MapPack dependency from manifest '{Name}' because MapPack was not found in archive",
+                        m.Name);
+                    m.Dependencies = m.Dependencies.Where(d => d.DependencyType != ContentType.MapPack).ToList();
+                }
+            }
+        }
+
         return updatedManifests;
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -280,7 +280,7 @@ public class GeneralsOnlineManifestFactory(
     /// </summary>
     /// <param name="release">The Generals Online release information.</param>
     /// <returns>A content manifest for the GeneralsOnlineGameData data patch.</returns>
-    public ContentManifest CreateGameDataPatchManifest(GeneralsOnlineRelease release)
+    private ContentManifest CreateGameDataPatchManifest(GeneralsOnlineRelease release)
     {
         var provider = providerLoader.GetProvider(PublisherTypeConstants.GeneralsOnline);
         var websiteUrl = provider?.Endpoints.WebsiteUrl ?? GeneralsOnlineConstants.WebsiteUrl;
@@ -521,14 +521,6 @@ public class GeneralsOnlineManifestFactory(
 
         List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsGameData)> filesWithHashes = [];
 
-        // Detect Maps directory (case-insensitive)
-        var mapsDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
-            .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.MapsSubdirectory, StringComparison.OrdinalIgnoreCase));
-
-        // Detect GeneralsOnlineGameData directory (case-insensitive)
-        var gameDataDirectory = Directory.GetDirectories(extractPath, "*", SearchOption.TopDirectoryOnly)
-            .FirstOrDefault(d => Path.GetFileName(d).Equals(GeneralsOnlineConstants.GameDataSubdirectory, StringComparison.OrdinalIgnoreCase));
-
         foreach (var filePath in allFiles)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -540,13 +532,11 @@ public class GeneralsOnlineManifestFactory(
             var fileInfo = new FileInfo(filePath);
 
             // Determine if this file is inside the Maps directory
-            var isMap = (mapsDirectory != null && filePath.StartsWith(mapsDirectory, StringComparison.OrdinalIgnoreCase)) ||
-                        relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+            var isMap = relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
                         relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
 
             // Determine if this file is inside the GeneralsOnlineGameData directory
-            var isGameData = (gameDataDirectory != null && filePath.StartsWith(gameDataDirectory, StringComparison.OrdinalIgnoreCase)) ||
-                             relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+            var isGameData = relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
                              relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
 
             string hash;

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -276,7 +276,7 @@ public class GeneralsOnlineManifestFactory(
 
     /// <summary>
     /// Creates a content manifest for the GeneralsOnlineGameData data patch.
-    /// This manifest contains game data files (splash screens, map cache configuration).
+    /// This manifest contains game data files (community balance patch and core INI configuration).
     /// </summary>
     /// <param name="release">The Generals Online release information.</param>
     /// <returns>A content manifest for the GeneralsOnlineGameData data patch.</returns>

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -319,7 +319,9 @@ public class GeneralsOnlineManifestFactory(
                 Tags = [.. GeneralsOnlineConstants.GameDataTags, .. GetVariantTags(GeneralsOnlineConstants.GameDataPatchSuffix)],
                 ChangelogUrl = release.Changelog,
             },
-            Files = [], // Files will be populated during extraction
+
+            // Files will be populated during extraction
+            Files = [],
             Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesForGameData(userVersion),
         };
     }
@@ -393,9 +395,9 @@ public class GeneralsOnlineManifestFactory(
 
         // Get URLs from provider definition (prefer original manifest metadata if available)
         var provider = providerLoader.GetProvider(PublisherTypeConstants.GeneralsOnline);
-        var websiteUrl = provider?.Endpoints.WebsiteUrl ?? string.Empty;
-        var supportUrl = provider?.Endpoints.GetEndpoint(ProviderEndpointConstants.SupportUrl) ?? string.Empty;
-        var downloadPageUrl = provider?.Endpoints.GetEndpoint(ProviderEndpointConstants.DownloadPageUrl) ?? string.Empty;
+        var websiteUrl = provider?.Endpoints.WebsiteUrl ?? GeneralsOnlineConstants.WebsiteUrl;
+        var supportUrl = provider?.Endpoints.GetEndpoint(ProviderEndpointConstants.SupportUrl) ?? GeneralsOnlineConstants.SupportUrl;
+        var downloadPageUrl = provider?.Endpoints.GetEndpoint(ProviderEndpointConstants.DownloadPageUrl) ?? GeneralsOnlineConstants.DownloadPageUrl;
         var iconUrl = GeneralsOnlineConstants.LogoSource;
 
         // Create publisher info once (shared by all variants)
@@ -650,6 +652,14 @@ public class GeneralsOnlineManifestFactory(
                     throw new InvalidDataException(
                         $"GameClient manifest '{manifest.Name}' has no files in extract path '{extractPath}'.");
                 }
+
+                logger.LogError(
+                    "Manifest '{Name}' of type {Type} has zero files in extract path '{ExtractPath}'",
+                    manifest.Name,
+                    manifest.ContentType,
+                    extractPath);
+                throw new InvalidDataException(
+                    $"Manifest '{manifest.Name}' of type {manifest.ContentType} has no files in extract path '{extractPath}'.");
             }
 
             updatedManifests.Add(new ContentManifest

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -170,7 +170,7 @@ public class GeneralsOnlineProfileReconciler(
             // If strategy is ReplaceCurrent, we delete if the subscription/user settings allow it.
             bool shouldDeleteOldVersions = (strategy != UpdateStrategy.CreateNewProfile) && (subscription?.DeleteOldVersions ?? true);
 
-            var manifestMapping = BuildManifestMapping(oldManifests, newManifests, versionComparer.GetScheme(GeneralsOnlineConstants.PublisherType));
+            Dictionary<string, string>? manifestMapping = null;
 
             if (strategy == UpdateStrategy.CreateNewProfile)
             {
@@ -181,6 +181,8 @@ public class GeneralsOnlineProfileReconciler(
             else
             {
                 // ReplaceCurrent
+                manifestMapping = BuildManifestMapping(oldManifests, newManifests, versionComparer.GetScheme(GeneralsOnlineConstants.PublisherType));
+
                 // CRITICAL: Pass removeOld = false to prevent premature deletion
                 // We'll handle deletion after MapPack enforcement succeeds
                 var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(
@@ -219,7 +221,7 @@ public class GeneralsOnlineProfileReconciler(
             }
 
             // Step 6: Delete old manifests only if enforcement succeeded and deletion is enabled
-            if (shouldDeleteOldVersions && !anyFailure)
+            if (shouldDeleteOldVersions && !anyFailure && manifestMapping != null)
             {
                 logger.LogInformation("[GO Reconciler] Deleting old manifests that have mapped successors");
                 var oldManifestIds = oldManifests

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -52,88 +52,23 @@ public class GeneralsOnlineProfileReconciler(
                 "[GO Reconciler] Checking for GeneralsOnline updates (triggered by profile: {ProfileId})",
                 triggeringProfileId);
 
-            // Step 1: Check for updates
-            var updateResult = await updateService.CheckForUpdatesAsync(cancellationToken);
-
-            if (!updateResult.Success)
+            var checkResult = await CheckUpdateAvailabilityAndStrategyAsync(cancellationToken);
+            if (!checkResult.Success)
             {
-                logger.LogWarning(
-                    "[GO Reconciler] Update check failed: {Error}",
-                    updateResult.FirstError);
-                return OperationResult<bool>.CreateFailure(
-                    $"Failed to check for GeneralsOnline updates: {updateResult.FirstError}");
+                return OperationResult<bool>.CreateFailure(checkResult.FirstError ?? "Failed to check update availability");
             }
 
-            if (!updateResult.IsUpdateAvailable)
+            var (proceed, updateResult, strategy, subscription) = checkResult.Data;
+            if (!proceed || updateResult == null)
             {
-                logger.LogInformation(
-                    "[GO Reconciler] No update available. Current version: {Version}",
-                    updateResult.CurrentVersion);
                 return OperationResult<bool>.CreateSuccess(false);
             }
 
-            // Check if this specific version is skipped
-            var settings = userSettingsService.Get();
-            if (settings.IsVersionSkipped(GeneralsOnlineConstants.PublisherType, updateResult.LatestVersion ?? string.Empty))
-            {
-                logger.LogInformation("[GO Reconciler] User opted to skip version {Version}. Skipping.", updateResult.LatestVersion);
-                return OperationResult<bool>.CreateSuccess(false);
-            }
-
-            // Determine strategy
-            var subscription = settings.GetSubscription(GeneralsOnlineConstants.PublisherType);
-            UpdateStrategy strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
-            bool autoUpdate = subscription is { AutoUpdateEnabled: true };
-
-            // Prompt user if preference is not set (AutoUpdate is null/false or Strategy is null/implied)
-            // But we only skip dialog if AutoUpdate is TRUE.
-            if (!autoUpdate)
-            {
-                var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
-                    "Generals Online Update Available",
-                    $"A new version of **Generals Online** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
-
-                if (dialogResult == null) return OperationResult<bool>.CreateSuccess(false);
-
-                if (dialogResult.Action == "Skip")
-                {
-                    logger.LogInformation("[GO Reconciler] User skipped version {Version}.", updateResult.LatestVersion);
-
-                    // Only permanently skip if user checked "Do not ask again"
-                    if (dialogResult.IsDoNotAskAgain)
-                    {
-                        await userSettingsService.TryUpdateAndSaveAsync(s =>
-                        {
-                            s.SkipVersion(GeneralsOnlineConstants.PublisherType, updateResult.LatestVersion ?? string.Empty);
-                            return true;
-                        });
-                    }
-
-                    return OperationResult<bool>.CreateSuccess(false);
-                }
-
-                strategy = dialogResult.Strategy;
-
-                if (dialogResult.IsDoNotAskAgain)
-                {
-                    logger.LogInformation("[GO Reconciler] Saving user preference for GeneralsOnline updates");
-                    await userSettingsService.TryUpdateAndSaveAsync(s =>
-                    {
-                        var sub = s.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType, isSubscribed: true);
-                        sub.AutoUpdateEnabled = true;
-                        sub.PreferredUpdateStrategy = strategy;
-                        return true;
-                    });
-                }
-            }
-
-            // Step 2: Notify user that update is being installed
             notificationService.ShowInfo(
                 "GeneralsOnline Update Found",
                 $"Installing GeneralsOnline {updateResult.LatestVersion}. Please wait...",
                 NotificationDurations.VeryLong);
 
-            // Step 3: Find all GeneralsOnline manifests currently installed
             var oldManifests = await FindGeneralsOnlineManifestsAsync(cancellationToken);
             if (oldManifests.Count == 0)
             {
@@ -144,7 +79,6 @@ public class GeneralsOnlineProfileReconciler(
                 "[GO Reconciler] Found {Count} existing GeneralsOnline manifests to replace",
                 oldManifests.Count);
 
-            // Step 4: Download and acquire new content
             var acquireResult = await AcquireLatestVersionAsync(oldManifests, cancellationToken);
             if (!acquireResult.Success)
             {
@@ -158,60 +92,16 @@ public class GeneralsOnlineProfileReconciler(
             }
 
             var newManifests = acquireResult.Data!;
-            logger.LogInformation(
-                "[GO Reconciler] Successfully acquired {Count} new manifests",
-                newManifests.Count);
+            logger.LogInformation("[GO Reconciler] Successfully acquired {Count} new manifests", newManifests.Count);
 
-            // Step 5: Update affected profiles based on strategy
-            int profilesUpdated = 0;
-            bool anyFailure = false;
-
-            // CRITICAL: If strategy is CreateNewProfile, we MUST keep old versions because existing profiles still use them.
-            // If strategy is ReplaceCurrent, we delete if the subscription/user settings allow it.
-            bool shouldDeleteOldVersions = (strategy != UpdateStrategy.CreateNewProfile) && (subscription?.DeleteOldVersions ?? true);
-
-            Dictionary<string, string>? manifestMapping = null;
-
-            if (strategy == UpdateStrategy.CreateNewProfile)
+            var updateResultData = await ApplyUpdateStrategyAsync(strategy, oldManifests, newManifests, updateResult.LatestVersion ?? "Unknown", cancellationToken);
+            if (!updateResultData.Success)
             {
-                var createResult = await CreateNewProfilesForUpdateAsync(oldManifests, newManifests, updateResult.LatestVersion ?? "Unknown", cancellationToken);
-                if (createResult.Success) profilesUpdated = createResult.Data;
-                else notificationService.ShowWarning("GeneralsOnline Update Partial", $"Failed to create some new profiles: {createResult.FirstError}", NotificationDurations.VeryLong);
-            }
-            else
-            {
-                // ReplaceCurrent
-                manifestMapping = BuildManifestMapping(oldManifests, newManifests, versionComparer.GetScheme(GeneralsOnlineConstants.PublisherType));
-
-                // CRITICAL: Pass removeOld = false to prevent premature deletion
-                // We'll handle deletion after MapPack enforcement succeeds
-                var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(
-                    manifestMapping,
-                    removeOld: false,
-                    cancellationToken);
-
-                if (bulkUpdateResult.Success)
-                {
-                    profilesUpdated = bulkUpdateResult.Data?.ProfilesUpdated ?? 0;
-                    var failedCount = bulkUpdateResult.Data?.FailedProfilesCount ?? 0;
-                    if (failedCount > 0)
-                    {
-                        anyFailure = true;
-                        notificationService.ShowWarning("Generals Online Update Partial", $"{failedCount} profiles could not be updated.", NotificationDurations.VeryLong);
-                    }
-                }
-                else
-                {
-                    anyFailure = true;
-                    notificationService.ShowWarning("GeneralsOnline Update Partial", $"Some profiles could not be updated: {bulkUpdateResult.FirstError}", NotificationDurations.VeryLong);
-                    return OperationResult<bool>.CreateFailure($"Bulk update failed: {bulkUpdateResult.FirstError}");
-                }
+                return OperationResult<bool>.CreateFailure(updateResultData.FirstError ?? "Failed to apply update strategy");
             }
 
-            // Step 5.5: Enforce MapPack dependency (add MapPack to profile if missing)
-            // This applies to BOTH strategies (New profiles need it too, and existing ones need it)
-            // But CreateNewProfilesForUpdateAsync handles it internally for new profiles.
-            // Better to run it broadly just in case.
+            var (profilesUpdated, anyFailure, manifestMapping) = updateResultData.Data;
+
             var enforceResult = await EnforceMapPackDependencyAsync(newManifests, cancellationToken);
             if (!enforceResult.Success)
             {
@@ -220,42 +110,9 @@ public class GeneralsOnlineProfileReconciler(
                 logger.LogWarning("[GO Reconciler] MapPack enforcement failed: {Error}. Skipping old manifest deletion.", enforceResult.FirstError);
             }
 
-            // Step 6: Delete old manifests only if enforcement succeeded and deletion is enabled
-            if (shouldDeleteOldVersions && !anyFailure && manifestMapping != null)
-            {
-                logger.LogInformation("[GO Reconciler] Deleting old manifests that have mapped successors");
-                var oldManifestIds = oldManifests
-                    .Where(m => manifestMapping.ContainsKey(m.Id.Value))
-                    .Select(m => m.Id)
-                    .ToList();
+            bool shouldDeleteOldVersions = (strategy != UpdateStrategy.CreateNewProfile) && (subscription?.DeleteOldVersions ?? true);
+            await HandleOldManifestsAndCleanupAsync(shouldDeleteOldVersions, anyFailure, manifestMapping, oldManifests, cancellationToken);
 
-                if (oldManifestIds.Count > 0)
-                {
-                    var removalResult = await reconciliationService.OrchestrateBulkRemovalAsync(oldManifestIds, cancellationToken);
-                    if (!removalResult.Success)
-                    {
-                        logger.LogWarning("[GO Reconciler] Failed to remove old manifests: {Error}", removalResult.FirstError);
-                        anyFailure = true;
-                    }
-                }
-            }
-            else if (shouldDeleteOldVersions && anyFailure)
-            {
-                logger.LogWarning("[GO Reconciler] Skipping old manifest deletion due to previous failures to preserve content integrity.");
-            }
-
-            // Step 7: Run garbage collection (only if old versions were deleted AND no failures occurred)
-            // If some profiles failed, GC could delete files they still rely on.
-            if (shouldDeleteOldVersions && !anyFailure)
-            {
-                await reconciliationService.ScheduleGarbageCollectionAsync(false, cancellationToken);
-            }
-            else if (shouldDeleteOldVersions && anyFailure)
-            {
-                logger.LogWarning("[GO Reconciler] Skipping scheduled GC due to partial update failure to avoid deleting referenced content.");
-            }
-
-            // Step 8: Show success notification
             notificationService.ShowSuccess(
                 "GeneralsOnline Updated",
                 $"Successfully updated to version {updateResult.LatestVersion}. {profilesUpdated} profiles {(strategy == UpdateStrategy.CreateNewProfile ? "created" : "updated")}.",
@@ -278,9 +135,11 @@ public class GeneralsOnlineProfileReconciler(
             logger.LogError(ex, "[GO Reconciler] Reconciliation failed unexpectedly");
             notificationService.ShowError(
                 "GeneralsOnline Update Error",
-                $"An error occurred during update: {ex.Message}",
+                $"An error occurred while reconciling GeneralsOnline updates: {ex.Message}",
                 NotificationDurations.Critical);
-            return OperationResult<bool>.CreateFailure($"Reconciliation failed: {ex.Message}");
+
+            return OperationResult<bool>.CreateFailure(
+                $"GeneralsOnline update reconciliation failed: {ex.Message}");
         }
     }
 
@@ -402,6 +261,148 @@ public class GeneralsOnlineProfileReconciler(
 
         // Fallback to ID-based detection for legacy manifests
         return ExtractVariant(manifest.Id.Value);
+    }
+
+    private async Task<OperationResult<(bool Proceed, ContentUpdateCheckResult? UpdateResult, UpdateStrategy Strategy, PublisherSubscription? Subscription)>>
+        CheckUpdateAvailabilityAndStrategyAsync(CancellationToken cancellationToken)
+    {
+        var updateResult = await updateService.CheckForUpdatesAsync(cancellationToken);
+        if (!updateResult.Success)
+        {
+            logger.LogWarning("[GO Reconciler] Update check failed: {Error}", updateResult.FirstError);
+            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateFailure(
+                $"Failed to check for GeneralsOnline updates: {updateResult.FirstError}");
+        }
+
+        if (!updateResult.IsUpdateAvailable)
+        {
+            logger.LogInformation("[GO Reconciler] No update available. Current version: {Version}", updateResult.CurrentVersion);
+            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess((false, null, UpdateStrategy.ReplaceCurrent, null));
+        }
+
+        var settings = userSettingsService.Get();
+        if (settings.IsVersionSkipped(GeneralsOnlineConstants.PublisherType, updateResult.LatestVersion ?? string.Empty))
+        {
+            logger.LogInformation("[GO Reconciler] User opted to skip version {Version}. Skipping.", updateResult.LatestVersion);
+            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess((false, null, UpdateStrategy.ReplaceCurrent, null));
+        }
+
+        var subscription = settings.GetSubscription(GeneralsOnlineConstants.PublisherType);
+        UpdateStrategy strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
+        bool autoUpdate = subscription is { AutoUpdateEnabled: true };
+
+        if (!autoUpdate)
+        {
+            var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
+                "Generals Online Update Available",
+                $"A new version of **Generals Online** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
+
+            if (dialogResult == null)
+            {
+                return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess((false, null, strategy, subscription));
+            }
+
+            if (dialogResult.Action == "Skip")
+            {
+                logger.LogInformation("[GO Reconciler] User skipped version {Version}.", updateResult.LatestVersion);
+                if (dialogResult.IsDoNotAskAgain)
+                {
+                    await userSettingsService.TryUpdateAndSaveAsync(s =>
+                    {
+                        s.SkipVersion(GeneralsOnlineConstants.PublisherType, updateResult.LatestVersion ?? string.Empty);
+                        return true;
+                    });
+                }
+
+                return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess((false, null, strategy, subscription));
+            }
+
+            strategy = dialogResult.Strategy;
+            if (dialogResult.IsDoNotAskAgain)
+            {
+                logger.LogInformation("[GO Reconciler] Saving user preference for GeneralsOnline updates");
+                await userSettingsService.TryUpdateAndSaveAsync(s =>
+                {
+                    var sub = s.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType, isSubscribed: true);
+                    sub.AutoUpdateEnabled = true;
+                    sub.PreferredUpdateStrategy = strategy;
+                    return true;
+                });
+            }
+        }
+
+        return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess((true, updateResult, strategy, subscription));
+    }
+
+    private async Task<OperationResult<(int ProfilesUpdated, bool AnyFailure, Dictionary<string, string>? ManifestMapping)>>
+        ApplyUpdateStrategyAsync(
+            UpdateStrategy strategy,
+            List<ContentManifest> oldManifests,
+            List<ContentManifest> newManifests,
+            string newVersion,
+            CancellationToken cancellationToken)
+    {
+        if (strategy == UpdateStrategy.CreateNewProfile)
+        {
+            var createResult = await CreateNewProfilesForUpdateAsync(oldManifests, newManifests, newVersion, cancellationToken);
+            if (createResult.Success)
+            {
+                return OperationResult<(int, bool, Dictionary<string, string>?)>.CreateSuccess((createResult.Data, false, null));
+            }
+
+            notificationService.ShowWarning("GeneralsOnline Update Partial", $"Failed to create some new profiles: {createResult.FirstError}", NotificationDurations.VeryLong);
+            return OperationResult<(int, bool, Dictionary<string, string>?)>.CreateSuccess((0, true, null));
+        }
+
+        var manifestMapping = BuildManifestMapping(oldManifests, newManifests, versionComparer.GetScheme(GeneralsOnlineConstants.PublisherType));
+        var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(manifestMapping, removeOld: false, cancellationToken);
+
+        if (!bulkUpdateResult.Success)
+        {
+            notificationService.ShowWarning("GeneralsOnline Update Partial", $"Some profiles could not be updated: {bulkUpdateResult.FirstError}", NotificationDurations.VeryLong);
+            return OperationResult<(int, bool, Dictionary<string, string>?)>.CreateFailure($"Bulk update failed: {bulkUpdateResult.FirstError}");
+        }
+
+        int profilesUpdated = bulkUpdateResult.Data?.ProfilesUpdated ?? 0;
+        bool anyFailure = (bulkUpdateResult.Data?.FailedProfilesCount ?? 0) > 0;
+        if (anyFailure)
+        {
+            notificationService.ShowWarning("Generals Online Update Partial", $"{bulkUpdateResult.Data?.FailedProfilesCount} profiles could not be updated.", NotificationDurations.VeryLong);
+        }
+
+        return OperationResult<(int, bool, Dictionary<string, string>?)>.CreateSuccess((profilesUpdated, anyFailure, manifestMapping));
+    }
+
+    private async Task HandleOldManifestsAndCleanupAsync(
+        bool shouldDeleteOldVersions,
+        bool anyFailure,
+        Dictionary<string, string>? manifestMapping,
+        List<ContentManifest> oldManifests,
+        CancellationToken cancellationToken)
+    {
+        if (shouldDeleteOldVersions && !anyFailure && manifestMapping != null)
+        {
+            logger.LogInformation("[GO Reconciler] Deleting old manifests that have mapped successors");
+            var oldManifestIds = oldManifests
+                .Where(m => manifestMapping.ContainsKey(m.Id.Value))
+                .Select(m => m.Id)
+                .ToList();
+
+            if (oldManifestIds.Count > 0)
+            {
+                var removalResult = await reconciliationService.OrchestrateBulkRemovalAsync(oldManifestIds, cancellationToken);
+                if (!removalResult.Success)
+                {
+                    logger.LogWarning("[GO Reconciler] Failed to remove old manifests: {Error}", removalResult.FirstError);
+                }
+            }
+
+            await reconciliationService.ScheduleGarbageCollectionAsync(false, cancellationToken);
+        }
+        else if (shouldDeleteOldVersions && anyFailure)
+        {
+            logger.LogWarning("[GO Reconciler] Skipping old manifest deletion and scheduled GC due to previous failures to preserve content integrity.");
+        }
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -83,7 +83,7 @@ public class GeneralsOnlineProfileReconciler(
             // Determine strategy
             var subscription = settings.GetSubscription(GeneralsOnlineConstants.PublisherType);
             UpdateStrategy strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
-            bool autoUpdate = subscription?.AutoUpdateEnabled == true;
+            bool autoUpdate = subscription?.AutoUpdateEnabled ?? false;
 
             // Prompt user if preference is not set (AutoUpdate is null/false or Strategy is null/implied)
             // But we only skip dialog if AutoUpdate is TRUE.
@@ -419,9 +419,9 @@ public class GeneralsOnlineProfileReconciler(
         return [.. manifestsResult.Data
             .Where(m =>
                 !m.Id.Value.Contains(".local.", StringComparison.OrdinalIgnoreCase) && // Exclude local content
-                (m.Publisher?.PublisherType?.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true ||
+                (string.Equals(m.Publisher?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) ||
                   m.Id.Value.Contains(".generalsonline.", StringComparison.OrdinalIgnoreCase) ||
-                  (m.Name?.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase) == true)))];
+                  (m.Name?.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase) ?? false)))];
     }
 
     /// <summary>
@@ -612,7 +612,7 @@ public class GeneralsOnlineProfileReconciler(
         {
             // Check if profile is relevant (uses any Old GeneralsOnline manifest)
             bool isRelevant = (profile.GameClient != null && oldIds.Contains(profile.GameClient.Id)) ||
-                              (profile.EnabledContentIds?.Any(id => oldIds.Contains(id)) == true);
+                              (profile.EnabledContentIds?.Any(id => oldIds.Contains(id)) ?? false);
 
             if (!isRelevant) continue;
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -170,6 +170,8 @@ public class GeneralsOnlineProfileReconciler(
             // If strategy is ReplaceCurrent, we delete if the subscription/user settings allow it.
             bool shouldDeleteOldVersions = (strategy != UpdateStrategy.CreateNewProfile) && (subscription?.DeleteOldVersions ?? true);
 
+            var manifestMapping = BuildManifestMapping(oldManifests, newManifests, versionComparer.GetScheme(GeneralsOnlineConstants.PublisherType));
+
             if (strategy == UpdateStrategy.CreateNewProfile)
             {
                 var createResult = await CreateNewProfilesForUpdateAsync(oldManifests, newManifests, updateResult.LatestVersion ?? "Unknown", cancellationToken);
@@ -179,8 +181,6 @@ public class GeneralsOnlineProfileReconciler(
             else
             {
                 // ReplaceCurrent
-                var manifestMapping = BuildManifestMapping(oldManifests, newManifests, versionComparer.GetScheme(GeneralsOnlineConstants.PublisherType));
-
                 // CRITICAL: Pass removeOld = false to prevent premature deletion
                 // We'll handle deletion after MapPack enforcement succeeds
                 var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(
@@ -221,13 +221,20 @@ public class GeneralsOnlineProfileReconciler(
             // Step 6: Delete old manifests only if enforcement succeeded and deletion is enabled
             if (shouldDeleteOldVersions && !anyFailure)
             {
-                logger.LogInformation("[GO Reconciler] Deleting old manifests after successful enforcement");
-                var oldManifestIds = oldManifests.Select(m => m.Id).ToList();
-                var removalResult = await reconciliationService.OrchestrateBulkRemovalAsync(oldManifestIds, cancellationToken);
-                if (!removalResult.Success)
+                logger.LogInformation("[GO Reconciler] Deleting old manifests that have mapped successors");
+                var oldManifestIds = oldManifests
+                    .Where(m => manifestMapping.ContainsKey(m.Id.Value))
+                    .Select(m => m.Id)
+                    .ToList();
+
+                if (oldManifestIds.Count > 0)
                 {
-                    logger.LogWarning("[GO Reconciler] Failed to remove old manifests: {Error}", removalResult.FirstError);
-                    anyFailure = true;
+                    var removalResult = await reconciliationService.OrchestrateBulkRemovalAsync(oldManifestIds, cancellationToken);
+                    if (!removalResult.Success)
+                    {
+                        logger.LogWarning("[GO Reconciler] Failed to remove old manifests: {Error}", removalResult.FirstError);
+                        anyFailure = true;
+                    }
                 }
             }
             else if (shouldDeleteOldVersions && anyFailure)

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -83,7 +83,7 @@ public class GeneralsOnlineProfileReconciler(
             // Determine strategy
             var subscription = settings.GetSubscription(GeneralsOnlineConstants.PublisherType);
             UpdateStrategy strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
-            bool autoUpdate = subscription?.AutoUpdateEnabled ?? false;
+            bool autoUpdate = subscription is { AutoUpdateEnabled: true };
 
             // Prompt user if preference is not set (AutoUpdate is null/false or Strategy is null/implied)
             // But we only skip dialog if AutoUpdate is TRUE.
@@ -421,7 +421,7 @@ public class GeneralsOnlineProfileReconciler(
                 !m.Id.Value.Contains(".local.", StringComparison.OrdinalIgnoreCase) && // Exclude local content
                 (string.Equals(m.Publisher?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) ||
                   m.Id.Value.Contains(".generalsonline.", StringComparison.OrdinalIgnoreCase) ||
-                  (m.Name?.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase) ?? false)))];
+                  (m.Name is { } name && name.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase))))];
     }
 
     /// <summary>
@@ -555,7 +555,8 @@ public class GeneralsOnlineProfileReconciler(
                                     newGameClientIds.Contains(profile.GameClient.Id);
 
             // Check if profile already has the new MapPack
-            bool hasMapPack = profile.EnabledContentIds?.Contains(newMapPackId, StringComparer.OrdinalIgnoreCase) ?? false;
+            bool hasMapPack = profile.EnabledContentIds is { } contentIds &&
+                              contentIds.Contains(newMapPackId, StringComparer.OrdinalIgnoreCase);
 
             if (isGeneralsOnline && !hasMapPack)
             {
@@ -612,7 +613,7 @@ public class GeneralsOnlineProfileReconciler(
         {
             // Check if profile is relevant (uses any Old GeneralsOnline manifest)
             bool isRelevant = (profile.GameClient != null && oldIds.Contains(profile.GameClient.Id)) ||
-                              (profile.EnabledContentIds?.Any(id => oldIds.Contains(id)) ?? false);
+                              (profile.EnabledContentIds is { } enabledIds && enabledIds.Any(oldIds.Contains));
 
             if (!isRelevant) continue;
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -325,7 +325,8 @@ public class GeneralsOnlineProfileReconciler(
         var lastPart = parts[^1];
 
         if (lastPart.Equals(GeneralsOnlineConstants.Variant60HzSuffix, StringComparison.OrdinalIgnoreCase) ||
-            lastPart.Equals(GeneralsOnlineConstants.QuickMatchMapPackSuffix, StringComparison.OrdinalIgnoreCase))
+            lastPart.Equals(GeneralsOnlineConstants.QuickMatchMapPackSuffix, StringComparison.OrdinalIgnoreCase) ||
+            lastPart.Equals(GeneralsOnlineConstants.GameDataPatchSuffix, StringComparison.OrdinalIgnoreCase))
         {
             return lastPart.ToLowerInvariant();
         }
@@ -375,6 +376,11 @@ public class GeneralsOnlineProfileReconciler(
                 if (tag.Equals(GeneralsOnlineVariantTags.TagQuickMatchMaps, StringComparison.OrdinalIgnoreCase))
                 {
                     return GeneralsOnlineConstants.QuickMatchMapPackSuffix;
+                }
+
+                if (tag.Equals(GeneralsOnlineVariantTags.TagGameData, StringComparison.OrdinalIgnoreCase))
+                {
+                    return GeneralsOnlineConstants.GameDataPatchSuffix;
                 }
             }
         }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -229,6 +229,11 @@ public class GeneralsOnlineProvider(
             Logger.LogInformation("Successfully prepared Generals Online content {ManifestId}", manifest.Id);
             return OperationResult<ContentManifest>.CreateSuccess(resultManifest);
         }
+        catch (OperationCanceledException)
+        {
+            Logger.LogInformation("Generals Online content preparation was canceled for {Version}", manifest.Version);
+            throw;
+        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to prepare Generals Online content");

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineVariantTags.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineVariantTags.cs
@@ -12,4 +12,7 @@ internal static class GeneralsOnlineVariantTags
 
     /// <summary>Tag indicating QuickMatch MapPack variant.</summary>
     public const string TagQuickMatchMaps = GeneralsOnlineConstants.QuickMatchMapPackSuffix;
+
+    /// <summary>Tag indicating GeneralsOnlineGameData data patch variant.</summary>
+    public const string TagGameData = GeneralsOnlineConstants.GameDataPatchSuffix;
 }

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -1402,13 +1402,22 @@ Constants related to the Community Outpost (GenPatcher) catalog and metadata.
 
 Constants for Generals Online content discovery and manifest creation.
 
-- `PublisherPrefix`: Publisher prefix string (`"generalsonline"`)
-- `PublisherId`: Publisher identifier (`"generals-online"`)
-- `PublisherDisplayName`: Display name for the publisher (`"Generals Online"`)
-- `QfeMarkerPrefix`: Prefix used for QFE (Quick Fix Engineering) versions (`"qfe-"`)
+- `PublisherName`: Display name for the publisher (`"Generals Online Team"`)
+- `PublisherType`: Publisher type identifier (`"generalsonline"`)
+- `PublisherId`: Publisher identifier (`"generalsonline"`)
+- `QfeMarkerPrefix`: Prefix for QFE markers in version strings (`"QFE"`)
+- `Variant60HzSuffix`: Manifest name suffix for 60Hz variant (`"60hz"`)
+- `QuickMatchMapPackSuffix`: Manifest name suffix for QuickMatch MapPack (`"quickmatch-maps"`)
+- `GameDataPatchSuffix`: Manifest name suffix for GeneralsOnlineGameData data patch (`"gamedata"`)
+- `QuickMatchMapPackDisplayName`: Display name for QuickMatch MapPack (`"GeneralsOnline QuickMatch Maps"`)
+- `GameDataDisplayName`: Display name for GeneralsOnlineGameData data patch (`"GeneralsOnline Game Data"`)
+- `GameDataDescription`: Description for GeneralsOnlineGameData data patch (`"Game data patch for GeneralsOnline containing community balance and core INI configuration."`)
+- `MapsSubdirectory`: Subdirectory within the portable ZIP containing maps (`"Maps"`)
+- `GameDataSubdirectory`: Subdirectory within the portable ZIP containing GeneralsOnline game data (`"GeneralsOnlineGameData"`)
 - `MapPackTags`: Default tags for MapPack manifests (`["mappack", "generalsonline"]`)
+- `GameDataTags`: Default tags for GameData patch manifests (`["gamedata", "patch", "generalsonline"]`)
+- `CoverSource`: Path for cover images (`"/Assets/Covers/usa-cover.png"`)
 - `UnknownVersion`: Default version string when unknown (`"unknown"`)
-- `CoverSource`: Default path for cover images (`"/Assets/Covers/zerohour-cover.png"`)
 
 ### CNCLabsConstants Class
 
@@ -1502,61 +1511,6 @@ Constants specifically for the Map Manager feature.
 | `ToolId`                       | `"map-manager"`                            | Unique identifier for Map Manager                                                     |
 | `ToolName`                     | `"Map Manager"`                            | Display name for Map Manager                                                          |
 | `ToolDescription`              | `"Manage, import, and share custom maps. Create MapPacks for easy profile switching."` | Description of the tool |
-
-## Content Publisher Constants
-
-Constants for various community content publishers and manifest generation.
-
-### CommunityOutpostCatalogConstants Class
-
-Constants related to the Community Outpost (GenPatcher) catalog and metadata.
-
-- `CatalogFilename`: Default filename for the GenPatcher catalog (`"GenPatcher.dat"`)
-- `VersionKey`: Metadata key for version information (`"Version"`)
-- `DescriptionKey`: Metadata key for description information (`"Description"`)
-- `DownloadUrlKey`: Metadata key for download URLs (`"DownloadUrl"`)
-
-### GeneralsOnlineConstants Class
-
-Constants for Generals Online content discovery and manifest creation.
-
-- `PublisherPrefix`: Publisher prefix string (`"generalsonline"`)
-- `PublisherId`: Publisher identifier (`"generals-online"`)
-- `PublisherDisplayName`: Display name for the publisher (`"Generals Online"`)
-- `QfeMarkerPrefix`: Prefix used for QFE (Quick Fix Engineering) versions (`"qfe-"`)
-- `MapPackTags`: Default tags for MapPack manifests (`["mappack", "generalsonline"]`)
-- `UnknownVersion`: Default version string when unknown (`"unknown"`)
-- `CoverSource`: Default path for cover images (`"/Assets/Covers/zerohour-cover.png"`)
-
-### CNCLabsConstants Class
-
-Constants for CNC Labs (CNC Maps) content discovery and manifest creation.
-
-- `PublisherPrefix`: Publisher prefix string (`"cnclabs"`)
-- `PublisherId`: Publisher identifier (`"cnc-labs"`)
-- `PublisherName`: Display name for the publisher (`"CNC Labs"`)
-- `PublisherWebsite`: Main website URL (`"https://www.cnclabs.com"`)
-- `DefaultTags`: Default tags for CNC Labs manifests (`["cnclabs"]`)
-- `DefaultDownloadFilename`: Default filename for downloads when parsing fails (`"download.zip"`)
-
-### ModDBConstants Class
-
-Constants for ModDB content discovery and manifest creation.
-
-- `PublisherPrefix`: Publisher prefix string (`"moddb"`)
-- `PublisherDisplayName`: Display name for the publisher (`"ModDB"`)
-- `PublisherWebsite`: Main website URL (`"https://www.moddb.com"`)
-- `ReleaseDateFormat`: Date format used in ModDB metadata (`"MMMM dd, yyyy"`)
-- `PublisherNameFormat`: Format string for including the author with the publisher name (`"ModDB ({0})"`)
-- `DefaultDownloadFilename`: Default filename for downloads when parsing fails (`"download.zip"`)
-
-### SuperHackersConstants Class
-
-Constants for The Super Hackers content discovery and manifest creation.
-
-- `PublisherPrefix`: Publisher prefix string (`"thesuperhackers"`)
-- `PublisherDisplayName`: Display name for the publisher (`"The Super Hackers"`)
-- `VersionDelimiter`: Character used to separate components in version strings (`':'`)
 
 ---
 


### PR DESCRIPTION
## Summary
Creates a distinct `ContentManifest` for the `GeneralsOnlineGameData` directory as an optional data patch (`ContentType.Patch`).

Closes #371

## Background

Previously, all files from the extracted Generals Online archive that did not belong to `Maps/` were bundled into the GameClient manifest, including files within `GeneralsOnlineGameData/` (such as splash screens and map cache configurations).

The data patch is optional for running the game client, but requires both a base Zero Hour installation and the GeneralsOnline GameClient to work.

## Changes

- **Constants & Suffixes**: Added `GameDataPatchSuffix = "gamedata"`, `GameDataDisplayName`, `GameDataDescription`, `GameDataSubdirectory = "GeneralsOnlineGameData"`, and `GameDataTags` in `GeneralsOnlineConstants`, and registered `TagGameData` in `GeneralsOnlineVariantTags`.
- **Dependency Specification**: In `GeneralsOnlineDependencyBuilder`, added `CreateGameClient60HzDependency` and `GetDependenciesForGameData(userVersion)`. The data patch depends on Zero Hour 1.04 and the GeneralsOnline 60Hz GameClient (`ContentType.GameClient`). The GameClient remains independent of the data patch (making the data patch optional).
- **Manifest Generation**: Updated `GeneralsOnlineManifestFactory.CreateManifests` and `CreateVariantManifestsFromOriginal` to create 3 distinct manifests: 60Hz GameClient, QuickMatch MapPack, and GeneralsOnline Game Data Patch.
- **Archive Extraction & File Routing**: In `UpdateManifestsWithExtractedFiles`, files under `GeneralsOnlineGameData` are routed to the Patch manifest (`InstallTarget = ContentInstallTarget.Workspace`, `IsExecutable = false`), while the GameClient manifest excludes both `Maps/` and `GeneralsOnlineGameData/`.
- **Deliverer Registration**: In `GeneralsOnlineDeliverer`, dynamically iterates and registers all manifests created by the factory to the CAS pool.
- **CanHandle**: Added `ContentType.Patch` support for GeneralsOnline publisher in `GeneralsOnlineManifestFactory.CanHandle`.

## Testing

- Full test suite: 1573 tests passed in `GenHub.Tests.Core`, 11 in `Linux`, 3 in `MacOS`, 7 in `Windows` (all 1594 tests passing with 0 failures).
- Added `GeneralsOnlineManifestFactoryTests`:
  - `CreateManifests_GeneratesThreeManifests_IncludingGameDataPatch`: Verifies 3 manifests generated with correct IDs, content types, and metadata.
  - `Dependencies_GameDataPatch_DependsOn60HzGameClientAndZeroHour_WhileGameClientDoesNotDependOnGameData`: Confirms the dependency relationship and optionality.
  - `CanHandle_WithValidManifestTypes_ReturnsTrue`: Verifies GameClient, MapPack, and Patch are accepted.
  - `CreateManifestsFromExtractedContentAsync_SeparatesFilesCorrectly`: Tests simulated archive extraction with map files, game client binaries, and game data files routing to their respective manifests.
  - `DependencyBuilder_GetDependenciesForGameData_ReturnsExpectedDependencies`: Tests dependency builder directly.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR separates GeneralsOnline game-data files into an optional patch manifest while retaining dependencies on Zero Hour and the 60Hz client.
- Adds patch metadata, identifiers, tags, and dependency construction.
- Routes maps, client files, and game-data files into distinct manifests.
- Adds transactional registration and file-move handling plus reconciliation and coverage for the new manifest.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because cancellation can leave newly registered manifests partially acquired without reporting failed rollback.

The cancellation handler invokes rollback but ignores the returned removal errors before rethrowing, so a failed cleanup can leave the content pool in a partial state while callers observe only cancellation.

**Files Needing Attention:** GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs | Registers generated manifests transactionally, but cancellation still discards rollback failures and can leave partially acquired content unreported. |
| GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs | Creates the distinct GameData patch and routes files using directory-boundary-aware checks. |
| GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDependencyBuilder.cs | Adds version-aligned dependencies from the GameData patch to Zero Hour and the 60Hz client. |
| GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs | Extends update reconciliation to map the optional GameData patch across versions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GeneralsOnline archive] --> B[Extract files]
    B --> C[60Hz GameClient manifest]
    B --> D[QuickMatch MapPack manifest]
    B --> E[GameData Patch manifest]
    E --> C
    E --> F[Zero Hour 1.04 installation]
    C --> D
    C --> F
    C --> G[Register manifests in content pool]
    D --> G
    E --> G
    G --> H{Registration succeeds?}
    H -->|Yes| I[Complete delivery]
    H -->|No| J[Rollback newly registered manifests]
```
</details>

<sub>Reviews (10): Last reviewed commit: ["fix(generalsonline): refine deliverer pr..."](https://github.com/community-outpost/genhub/commit/37409ca4d36c3e5612c5c03289c12936d3075c4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53518064)</sub>

**Context used:**

- Knowledge Base — [Content Acquisition Pipeline](https://app.greptile.com/genhub/-/custom-context/knowledge-base/community-outpost/genhub/-/docs/content-acquisition-pipeline.md)

<!-- /greptile_comment -->