### PR TITLE
chore: Resolve Alpha 4 code review comments

### DIFF
--- a/GenHub/GenHub.Core/Constants/MapManagerConstants.cs
+++ b/GenHub/GenHub.Core/Constants/MapManagerConstants.cs
@@ -11,6 +11,26 @@ public static class MapManagerConstants
     public const long MaxMapSizeBytes = 10 * 1024 * 1024;
 
     /// <summary>
+    /// Maximum allowed entries in a map ZIP archive.
+    /// </summary>
+    public const int MaxZipEntries = 500;
+
+    /// <summary>
+    /// Maximum aggregate uncompressed bytes for a map ZIP archive (200 MB).
+    /// </summary>
+    public const long MaxAggregateUncompressedBytes = 200 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum file size for individual map assets in bytes (10 MB).
+    /// </summary>
+    public const long MaxAssetSizeBytes = 10 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum compression ratio allowed for ZIP archives.
+    /// </summary>
+    public const double MaxCompressionRatio = 100.0;
+
+    /// <summary>
     /// Number of days for rate limit reset period.
     /// </summary>
     public const int RateLimitDays = 3;

--- a/GenHub/GenHub.Core/Constants/ReplayManagerConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ReplayManagerConstants.cs
@@ -11,6 +11,21 @@ public static class ReplayManagerConstants
     public const long MaxReplaySizeBytes = 1024 * 1024;
 
     /// <summary>
+    /// Maximum allowed entries in a replay ZIP archive.
+    /// </summary>
+    public const int MaxZipEntries = 100;
+
+    /// <summary>
+    /// Maximum aggregate uncompressed bytes for a replay ZIP archive (50 MB).
+    /// </summary>
+    public const long MaxAggregateUncompressedBytes = 50 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum compression ratio allowed for replay ZIP archives.
+    /// </summary>
+    public const double MaxCompressionRatio = 50.0;
+
+    /// <summary>
     /// Maximum upload bytes per period (10 MB).
     /// </summary>
     public const long MaxUploadBytesPerPeriod = 10 * 1024 * 1024;

--- a/GenHub/GenHub.Core/Extensions/GameProfileExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/GameProfileExtensions.cs
@@ -14,6 +14,15 @@ public static class GameProfileExtensions
     /// <returns>True if the profile has custom settings, false otherwise.</returns>
     public static bool HasCustomSettings(this GameProfile profile)
     {
+        return HasCustomVideoSettings(profile) ||
+               HasCustomAudioSettings(profile) ||
+               HasCustomTshSettings(profile) ||
+               HasCustomGeneralsOnlineSettings(profile) ||
+               HasCustomNetworkSettings(profile);
+    }
+
+    private static bool HasCustomVideoSettings(GameProfile profile)
+    {
         return profile.VideoResolutionWidth.HasValue ||
                profile.VideoResolutionHeight.HasValue ||
                profile.VideoWindowed.HasValue ||
@@ -31,14 +40,22 @@ public static class GameProfileExtensions
                profile.VideoRetaliation.HasValue ||
                profile.VideoDynamicLOD.HasValue ||
                profile.VideoMaxParticleCount.HasValue ||
-               profile.VideoAntiAliasing.HasValue ||
-               profile.AudioSoundVolume.HasValue ||
+               profile.VideoAntiAliasing.HasValue;
+    }
+
+    private static bool HasCustomAudioSettings(GameProfile profile)
+    {
+        return profile.AudioSoundVolume.HasValue ||
                profile.AudioThreeDSoundVolume.HasValue ||
                profile.AudioSpeechVolume.HasValue ||
                profile.AudioMusicVolume.HasValue ||
                profile.AudioEnabled.HasValue ||
-               profile.AudioNumSounds.HasValue ||
-               profile.TshArchiveReplays.HasValue ||
+               profile.AudioNumSounds.HasValue;
+    }
+
+    private static bool HasCustomTshSettings(GameProfile profile)
+    {
+        return profile.TshArchiveReplays.HasValue ||
                profile.TshShowMoneyPerMinute.HasValue ||
                profile.TshPlayerObserverEnabled.HasValue ||
                profile.TshSystemTimeFontSize.HasValue ||
@@ -51,8 +68,12 @@ public static class GameProfileExtensions
                profile.TshCursorCaptureEnabledInWindowedMenu.HasValue ||
                profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue ||
                profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue ||
-               profile.TshMoneyTransactionVolume.HasValue ||
-               profile.GoShowFps.HasValue ||
+               profile.TshMoneyTransactionVolume.HasValue;
+    }
+
+    private static bool HasCustomGeneralsOnlineSettings(GameProfile profile)
+    {
+        return profile.GoShowFps.HasValue ||
                profile.GoShowPing.HasValue ||
                profile.GoAutoLogin.HasValue ||
                profile.GoRememberUsername.HasValue ||
@@ -75,7 +96,11 @@ public static class GameProfileExtensions
                profile.GoSocialNotificationPlayerAcceptsRequestGameplay.HasValue ||
                profile.GoSocialNotificationPlayerAcceptsRequestMenus.HasValue ||
                profile.GoSocialNotificationPlayerSendsRequestGameplay.HasValue ||
-               profile.GoSocialNotificationPlayerSendsRequestMenus.HasValue ||
-               !string.IsNullOrEmpty(profile.GameSpyIPAddress);
+               profile.GoSocialNotificationPlayerSendsRequestMenus.HasValue;
+    }
+
+    private static bool HasCustomNetworkSettings(GameProfile profile)
+    {
+        return !string.IsNullOrEmpty(profile.GameSpyIPAddress);
     }
 }

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -24,98 +24,6 @@ public static class GameSettingsMapper
         ApplyNetworkFromOptions(options, profile);
     }
 
-    private static void ApplyVideoFromOptions(IniOptions options, GameProfile profile)
-    {
-        profile.VideoResolutionWidth = options.Video.ResolutionWidth;
-        profile.VideoResolutionHeight = options.Video.ResolutionHeight;
-        profile.VideoWindowed = options.Video.Windowed;
-
-        // Convert TextureReduction back to TextureQuality
-        profile.VideoTextureQuality = options.Video.TextureReduction switch
-        {
-            GameSettingsConstants.TextureQuality.TextureReductionLow => TextureQuality.Low,
-            GameSettingsConstants.TextureQuality.TextureReductionMedium => TextureQuality.Medium,
-            GameSettingsConstants.TextureQuality.TextureReductionHigh => TextureQuality.High,
-            _ => null,
-        };
-
-        profile.EnableVideoShadows = options.Video.UseShadowVolumes;
-
-        if (options.Video.AdditionalProperties.TryGetValue("GenHubBuildingAnimations", out var ba))
-            profile.VideoBuildingAnimations = ParseBool(ba);
-
-        if (options.Video.AdditionalProperties.TryGetValue("GenHubParticleEffects", out var pe))
-            profile.VideoParticleEffects = ParseBool(pe);
-
-        profile.VideoExtraAnimations = options.Video.ExtraAnimations;
-        profile.VideoGamma = options.Video.Gamma;
-        profile.VideoAlternateMouseSetup = options.Video.AlternateMouseSetup;
-        profile.VideoHeatEffects = options.Video.HeatEffects;
-
-        // Load additional video settings from root (Flat format support)
-        if (options.Video.AdditionalProperties.TryGetValue("StaticGameLOD", out var staticLOD))
-            profile.VideoStaticGameLOD = staticLOD;
-        if (options.Video.AdditionalProperties.TryGetValue("IdealStaticGameLOD", out var idealLOD))
-            profile.VideoIdealStaticGameLOD = idealLOD;
-
-        if (options.Video.AdditionalProperties.TryGetValue("SkipEALogo", out var sel))
-            profile.VideoSkipEALogo = ParseBool(sel);
-
-        profile.VideoAntiAliasing ??= options.Video.AntiAliasing;
-
-        ApplyTshFlatSettingsFromOptions(options, profile);
-        ApplyTshHierarchicalSettingsFromOptions(options, profile);
-    }
-
-    private static void ApplyTshFlatSettingsFromOptions(IniOptions options, GameProfile profile)
-    {
-        if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
-            profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClick);
-        else if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClick", out var dbl))
-            profile.VideoUseDoubleClickAttackMove = ParseBool(dbl);
-
-        if (options.Video.AdditionalProperties.TryGetValue("ScrollFactor", out var scroll) && int.TryParse(scroll, out var scrollVal))
-            profile.VideoScrollFactor = scrollVal;
-        if (options.Video.AdditionalProperties.TryGetValue("Retaliation", out var retaliation))
-            profile.VideoRetaliation = ParseBool(retaliation);
-        if (options.Video.AdditionalProperties.TryGetValue("DynamicLOD", out var dynLOD))
-            profile.VideoDynamicLOD = ParseBool(dynLOD);
-        if (options.Video.AdditionalProperties.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
-            profile.VideoMaxParticleCount = particleVal;
-    }
-
-    private static void ApplyTshHierarchicalSettingsFromOptions(IniOptions options, GameProfile profile)
-    {
-        if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var tsh))
-        {
-            if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClickTsh))
-                profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClickTsh);
-            if (tsh.TryGetValue("ScrollFactor", out var scrollTsh) && int.TryParse(scrollTsh, out var scrollTshVal))
-                profile.VideoScrollFactor = scrollTshVal;
-            if (tsh.TryGetValue("Retaliation", out var retaliationTsh))
-                profile.VideoRetaliation = ParseBool(retaliationTsh);
-            if (tsh.TryGetValue("DynamicLOD", out var dynLODTsh))
-                profile.VideoDynamicLOD = ParseBool(dynLODTsh);
-            if (tsh.TryGetValue("MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, out var particlesTshVal))
-                profile.VideoMaxParticleCount = particlesTshVal;
-        }
-    }
-
-    private static void ApplyAudioFromOptions(IniOptions options, GameProfile profile)
-    {
-        profile.AudioSoundVolume = options.Audio.SFXVolume;
-        profile.AudioThreeDSoundVolume = options.Audio.SFX3DVolume;
-        profile.AudioSpeechVolume = options.Audio.VoiceVolume;
-        profile.AudioMusicVolume = options.Audio.MusicVolume;
-        profile.AudioEnabled = options.Audio.AudioEnabled;
-        profile.AudioNumSounds = options.Audio.NumSounds;
-    }
-
-    private static void ApplyNetworkFromOptions(IniOptions options, GameProfile profile)
-    {
-        profile.GameSpyIPAddress = options.Network.GameSpyIPAddress;
-    }
-
     /// <summary>
     /// Applies settings from GeneralsOnlineSettings to a GameProfile.
     /// Used when creating new profiles to inherit existing GO settings.
@@ -192,64 +100,6 @@ public static class GameSettingsMapper
         ApplyGoTshSettings(profile, settings);
     }
 
-    private static void ApplyGoGeneralSettings(GameProfile profile, GeneralsOnlineSettings settings)
-    {
-        settings.ShowFps = profile.GoShowFps ?? false;
-        settings.ShowPing = profile.GoShowPing ?? true;
-        settings.ShowPlayerRanks = profile.GoShowPlayerRanks ?? true;
-        settings.AutoLogin = profile.GoAutoLogin ?? false;
-        settings.RememberUsername = profile.GoRememberUsername ?? true;
-        settings.EnableNotifications = profile.GoEnableNotifications ?? true;
-        settings.EnableSoundNotifications = profile.GoEnableSoundNotifications ?? true;
-        settings.ChatFontSize = profile.GoChatFontSize ?? 12;
-    }
-
-    private static void ApplyGoCameraAndChatSettings(GameProfile profile, GeneralsOnlineSettings settings)
-    {
-        settings.Camera.MaxHeightOnlyWhenLobbyHost = profile.GoCameraMaxHeightOnlyWhenLobbyHost ?? 310.0f;
-        settings.Camera.MinHeight = profile.GoCameraMinHeight ?? 310.0f;
-        settings.Camera.MoveSpeedRatio = profile.GoCameraMoveSpeedRatio ?? 1.5f;
-        settings.Chat.DurationSecondsUntilFadeOut = profile.GoChatDurationSecondsUntilFadeOut ?? 30;
-    }
-
-    private static void ApplyGoRenderAndDebugSettings(GameProfile profile, GeneralsOnlineSettings settings)
-    {
-        settings.Debug.VerboseLogging = profile.GoDebugVerboseLogging ?? false;
-        settings.Render.FpsLimit = profile.GoRenderFpsLimit ?? 144;
-        settings.Render.LimitFramerate = profile.GoRenderLimitFramerate ?? true;
-        settings.Render.StatsOverlay = profile.GoRenderStatsOverlay ?? true;
-    }
-
-    private static void ApplyGoSocialSettings(GameProfile profile, GeneralsOnlineSettings settings)
-    {
-        settings.Social.NotificationFriendComesOnlineGameplay = profile.GoSocialNotificationFriendComesOnlineGameplay ?? true;
-        settings.Social.NotificationFriendComesOnlineMenus = profile.GoSocialNotificationFriendComesOnlineMenus ?? true;
-        settings.Social.NotificationFriendGoesOfflineGameplay = profile.GoSocialNotificationFriendGoesOfflineGameplay ?? true;
-        settings.Social.NotificationFriendGoesOfflineMenus = profile.GoSocialNotificationFriendGoesOfflineMenus ?? true;
-        settings.Social.NotificationPlayerAcceptsRequestGameplay = profile.GoSocialNotificationPlayerAcceptsRequestGameplay ?? true;
-        settings.Social.NotificationPlayerAcceptsRequestMenus = profile.GoSocialNotificationPlayerAcceptsRequestMenus ?? true;
-        settings.Social.NotificationPlayerSendsRequestGameplay = profile.GoSocialNotificationPlayerSendsRequestGameplay ?? true;
-        settings.Social.NotificationPlayerSendsRequestMenus = profile.GoSocialNotificationPlayerSendsRequestMenus ?? true;
-    }
-
-    private static void ApplyGoTshSettings(GameProfile profile, GeneralsOnlineSettings settings)
-    {
-        settings.ArchiveReplays = profile.TshArchiveReplays ?? false;
-        settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
-        settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
-        settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled;
-        settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
-        settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
-        settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
-        settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
-        settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame;
-        settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu;
-        settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame;
-        settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu;
-        settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp;
-        settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
-    }
-
     /// <summary>
     /// Applies profile settings to IniOptions with validation.
     /// </summary>
@@ -262,251 +112,6 @@ public static class GameSettingsMapper
         ApplyVideoAdditionalToOptions(profile, options, logger);
         ApplyAudioToOptions(profile, options, logger);
         ApplyTshToOptions(profile, options);
-    }
-
-    private static void ApplyVideoResolutionAndQualityToOptions(GameProfile profile, IniOptions options, ILogger? logger)
-    {
-        if (profile.VideoResolutionWidth.HasValue)
-        {
-            if (profile.VideoResolutionWidth.Value >= GameSettingsConstants.Resolution.MinWidth &&
-                profile.VideoResolutionWidth.Value <= GameSettingsConstants.Resolution.MaxWidth)
-            {
-                options.Video.ResolutionWidth = profile.VideoResolutionWidth.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid VideoResolutionWidth {Width} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.VideoResolutionWidth.Value,
-                    profile.Id,
-                    GameSettingsConstants.Resolution.MinWidth,
-                    GameSettingsConstants.Resolution.MaxWidth);
-            }
-        }
-
-        if (profile.VideoResolutionHeight.HasValue)
-        {
-            if (profile.VideoResolutionHeight.Value >= GameSettingsConstants.Resolution.MinHeight &&
-                profile.VideoResolutionHeight.Value <= GameSettingsConstants.Resolution.MaxHeight)
-            {
-                options.Video.ResolutionHeight = profile.VideoResolutionHeight.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid VideoResolutionHeight {Height} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.VideoResolutionHeight.Value,
-                    profile.Id,
-                    GameSettingsConstants.Resolution.MinHeight,
-                    GameSettingsConstants.Resolution.MaxHeight);
-            }
-        }
-
-        if (profile.VideoWindowed.HasValue)
-        {
-            options.Video.Windowed = profile.VideoWindowed.Value;
-        }
-
-        if (profile.VideoTextureQuality.HasValue)
-        {
-            options.Video.TextureReduction = profile.VideoTextureQuality.Value switch
-            {
-                TextureQuality.Low => GameSettingsConstants.TextureQuality.TextureReductionLow,
-                TextureQuality.Medium => GameSettingsConstants.TextureQuality.TextureReductionMedium,
-                TextureQuality.High => GameSettingsConstants.TextureQuality.TextureReductionHigh,
-                TextureQuality.VeryHigh => GameSettingsConstants.TextureQuality.TextureReductionHigh,
-                _ => GameSettingsConstants.TextureQuality.TextureReductionHigh,
-            };
-        }
-
-        if (profile.EnableVideoShadows.HasValue)
-        {
-            options.Video.UseShadowVolumes = profile.EnableVideoShadows.Value;
-            options.Video.UseShadowDecals = profile.EnableVideoShadows.Value;
-        }
-
-        if (profile.VideoExtraAnimations.HasValue)
-        {
-            options.Video.ExtraAnimations = profile.VideoExtraAnimations.Value;
-        }
-    }
-
-    private static void ApplyVideoAdditionalToOptions(GameProfile profile, IniOptions options, ILogger? logger)
-    {
-        if (profile.VideoGamma.HasValue)
-        {
-            if (profile.VideoGamma.Value >= GameSettingsConstants.Gamma.Min &&
-                profile.VideoGamma.Value <= GameSettingsConstants.Gamma.Max)
-            {
-                options.Video.Gamma = profile.VideoGamma.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid VideoGamma {Gamma} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.VideoGamma.Value,
-                    profile.Id,
-                    GameSettingsConstants.Gamma.Min,
-                    GameSettingsConstants.Gamma.Max);
-            }
-        }
-
-        if (profile.VideoAlternateMouseSetup.HasValue)
-        {
-            options.Video.AlternateMouseSetup = profile.VideoAlternateMouseSetup.Value;
-            options.Video.AdditionalProperties["UseAlternateMouse"] = profile.VideoAlternateMouseSetup.Value ? "yes" : "no";
-        }
-
-        if (profile.VideoHeatEffects.HasValue)
-        {
-            options.Video.HeatEffects = profile.VideoHeatEffects.Value;
-        }
-
-        if (profile.VideoStaticGameLOD != null)
-            options.Video.AdditionalProperties["StaticGameLOD"] = profile.VideoStaticGameLOD;
-        if (profile.VideoIdealStaticGameLOD != null)
-            options.Video.AdditionalProperties["IdealStaticGameLOD"] = profile.VideoIdealStaticGameLOD;
-        if (profile.VideoAntiAliasing.HasValue)
-            options.Video.AntiAliasing = profile.VideoAntiAliasing.Value;
-
-        if (profile.VideoUseDoubleClickAttackMove.HasValue)
-        {
-            options.Video.AdditionalProperties["UseDoubleClickAttackMove"] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
-            options.Video.AdditionalProperties["UseDoubleClick"] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
-        }
-
-        if (profile.VideoScrollFactor.HasValue)
-            options.Video.AdditionalProperties["ScrollFactor"] = profile.VideoScrollFactor.Value.ToString();
-        if (profile.VideoRetaliation.HasValue)
-            options.Video.AdditionalProperties["Retaliation"] = profile.VideoRetaliation.Value ? "yes" : "no";
-        if (profile.VideoDynamicLOD.HasValue)
-            options.Video.AdditionalProperties["DynamicLOD"] = profile.VideoDynamicLOD.Value ? "yes" : "no";
-        if (profile.VideoMaxParticleCount.HasValue)
-            options.Video.AdditionalProperties["MaxParticleCount"] = profile.VideoMaxParticleCount.Value.ToString();
-        if (profile.VideoSkipEALogo.HasValue)
-            options.Video.AdditionalProperties["SkipEALogo"] = profile.VideoSkipEALogo.Value ? "yes" : "no";
-    }
-
-    private static void ApplyAudioToOptions(GameProfile profile, IniOptions options, ILogger? logger)
-    {
-        if (profile.AudioSoundVolume.HasValue)
-        {
-            if (profile.AudioSoundVolume.Value >= GameSettingsConstants.Volume.Min &&
-                profile.AudioSoundVolume.Value <= GameSettingsConstants.Volume.Max)
-            {
-                options.Audio.SFXVolume = profile.AudioSoundVolume.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid AudioSoundVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.AudioSoundVolume.Value,
-                    profile.Id,
-                    GameSettingsConstants.Volume.Min,
-                    GameSettingsConstants.Volume.Max);
-            }
-        }
-
-        if (profile.AudioThreeDSoundVolume.HasValue)
-        {
-            if (profile.AudioThreeDSoundVolume.Value >= GameSettingsConstants.Volume.Min &&
-                profile.AudioThreeDSoundVolume.Value <= GameSettingsConstants.Volume.Max)
-            {
-                options.Audio.SFX3DVolume = profile.AudioThreeDSoundVolume.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid AudioThreeDSoundVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.AudioThreeDSoundVolume.Value,
-                    profile.Id,
-                    GameSettingsConstants.Volume.Min,
-                    GameSettingsConstants.Volume.Max);
-            }
-        }
-
-        if (profile.AudioSpeechVolume.HasValue)
-        {
-            if (profile.AudioSpeechVolume.Value >= GameSettingsConstants.Volume.Min &&
-                profile.AudioSpeechVolume.Value <= GameSettingsConstants.Volume.Max)
-            {
-                options.Audio.VoiceVolume = profile.AudioSpeechVolume.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid AudioSpeechVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.AudioSpeechVolume.Value,
-                    profile.Id,
-                    GameSettingsConstants.Volume.Min,
-                    GameSettingsConstants.Volume.Max);
-            }
-        }
-
-        if (profile.AudioMusicVolume.HasValue)
-        {
-            if (profile.AudioMusicVolume.Value >= GameSettingsConstants.Volume.Min &&
-                profile.AudioMusicVolume.Value <= GameSettingsConstants.Volume.Max)
-            {
-                options.Audio.MusicVolume = profile.AudioMusicVolume.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid AudioMusicVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.AudioMusicVolume.Value,
-                    profile.Id,
-                    GameSettingsConstants.Volume.Min,
-                    GameSettingsConstants.Volume.Max);
-            }
-        }
-
-        if (profile.AudioEnabled.HasValue)
-        {
-            options.Audio.AudioEnabled = profile.AudioEnabled.Value;
-        }
-
-        if (profile.AudioNumSounds.HasValue)
-        {
-            if (profile.AudioNumSounds.Value >= GameSettingsConstants.Audio.MinNumSounds &&
-                profile.AudioNumSounds.Value <= GameSettingsConstants.Audio.MaxNumSounds)
-            {
-                options.Audio.NumSounds = profile.AudioNumSounds.Value;
-            }
-            else
-            {
-                logger?.LogWarning(
-                    "Invalid AudioNumSounds {NumSounds} for profile {ProfileId}, must be {Min}-{Max}",
-                    profile.AudioNumSounds.Value,
-                    profile.Id,
-                    GameSettingsConstants.Audio.MinNumSounds,
-                    GameSettingsConstants.Audio.MaxNumSounds);
-            }
-        }
-    }
-
-    private static void ApplyTshToOptions(GameProfile profile, IniOptions options)
-    {
-        var tshDict = new Dictionary<string, string>();
-        if (profile.TshArchiveReplays.HasValue) tshDict["ArchiveReplays"] = BoolToString(profile.TshArchiveReplays.Value);
-        if (profile.TshShowMoneyPerMinute.HasValue) tshDict["ShowMoneyPerMinute"] = BoolToString(profile.TshShowMoneyPerMinute.Value);
-        if (profile.TshPlayerObserverEnabled.HasValue) tshDict["PlayerObserverEnabled"] = BoolToString(profile.TshPlayerObserverEnabled.Value);
-        if (profile.TshSystemTimeFontSize.HasValue) tshDict["SystemTimeFontSize"] = profile.TshSystemTimeFontSize.Value.ToString();
-        if (profile.TshNetworkLatencyFontSize.HasValue) tshDict["NetworkLatencyFontSize"] = profile.TshNetworkLatencyFontSize.Value.ToString();
-        if (profile.TshRenderFpsFontSize.HasValue) tshDict["RenderFpsFontSize"] = profile.TshRenderFpsFontSize.Value.ToString();
-        if (profile.TshResolutionFontAdjustment.HasValue) tshDict["ResolutionFontAdjustment"] = profile.TshResolutionFontAdjustment.Value.ToString();
-        if (profile.TshCursorCaptureEnabledInFullscreenGame.HasValue) tshDict["CursorCaptureEnabledInFullscreenGame"] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenGame.Value);
-        if (profile.TshCursorCaptureEnabledInFullscreenMenu.HasValue) tshDict["CursorCaptureEnabledInFullscreenMenu"] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenMenu.Value);
-        if (profile.TshCursorCaptureEnabledInWindowedGame.HasValue) tshDict["CursorCaptureEnabledInWindowedGame"] = BoolToString(profile.TshCursorCaptureEnabledInWindowedGame.Value);
-        if (profile.TshCursorCaptureEnabledInWindowedMenu.HasValue) tshDict["CursorCaptureEnabledInWindowedMenu"] = BoolToString(profile.TshCursorCaptureEnabledInWindowedMenu.Value);
-        if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) tshDict["ScreenEdgeScrollEnabledInFullscreenApp"] = BoolToString(profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value);
-        if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) tshDict["ScreenEdgeScrollEnabledInWindowedApp"] = BoolToString(profile.TshScreenEdgeScrollEnabledInWindowedApp.Value);
-        if (profile.TshMoneyTransactionVolume.HasValue) tshDict["MoneyTransactionVolume"] = profile.TshMoneyTransactionVolume.Value.ToString();
-
-        if (tshDict.Count > 0)
-        {
-            options.AdditionalSections["TheSuperHackers"] = tshDict;
-        }
     }
 
     /// <summary>
@@ -703,80 +308,6 @@ public static class GameSettingsMapper
         profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
     }
 
-    private static void PatchVideoSettings(GameProfile profile, CreateProfileRequest request)
-    {
-        profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
-        profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
-        profile.VideoWindowed = request.VideoWindowed ?? profile.VideoWindowed;
-        profile.VideoTextureQuality = request.VideoTextureQuality ?? profile.VideoTextureQuality;
-        profile.EnableVideoShadows = request.EnableVideoShadows ?? profile.EnableVideoShadows;
-        profile.VideoParticleEffects = request.VideoParticleEffects ?? profile.VideoParticleEffects;
-        profile.VideoExtraAnimations = request.VideoExtraAnimations ?? profile.VideoExtraAnimations;
-        profile.VideoBuildingAnimations = request.VideoBuildingAnimations ?? profile.VideoBuildingAnimations;
-        profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
-        profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
-        profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
-    }
-
-    private static void PatchAudioSettings(GameProfile profile, CreateProfileRequest request)
-    {
-        profile.AudioSoundVolume = request.AudioSoundVolume ?? profile.AudioSoundVolume;
-        profile.AudioThreeDSoundVolume = request.AudioThreeDSoundVolume ?? profile.AudioThreeDSoundVolume;
-        profile.AudioSpeechVolume = request.AudioSpeechVolume ?? profile.AudioSpeechVolume;
-        profile.AudioMusicVolume = request.AudioMusicVolume ?? profile.AudioMusicVolume;
-        profile.AudioEnabled = request.AudioEnabled ?? profile.AudioEnabled;
-        profile.AudioNumSounds = request.AudioNumSounds ?? profile.AudioNumSounds;
-    }
-
-    private static void PatchTshSettings(GameProfile profile, CreateProfileRequest request)
-    {
-        profile.TshArchiveReplays = request.TshArchiveReplays ?? profile.TshArchiveReplays;
-        profile.TshShowMoneyPerMinute = request.TshShowMoneyPerMinute ?? profile.TshShowMoneyPerMinute;
-        profile.TshPlayerObserverEnabled = request.TshPlayerObserverEnabled ?? profile.TshPlayerObserverEnabled;
-        profile.TshSystemTimeFontSize = request.TshSystemTimeFontSize ?? profile.TshSystemTimeFontSize;
-        profile.TshNetworkLatencyFontSize = request.TshNetworkLatencyFontSize ?? profile.TshNetworkLatencyFontSize;
-        profile.TshRenderFpsFontSize = request.TshRenderFpsFontSize ?? profile.TshRenderFpsFontSize;
-        profile.TshResolutionFontAdjustment = request.TshResolutionFontAdjustment ?? profile.TshResolutionFontAdjustment;
-        profile.TshCursorCaptureEnabledInFullscreenGame = request.TshCursorCaptureEnabledInFullscreenGame ?? profile.TshCursorCaptureEnabledInFullscreenGame;
-        profile.TshCursorCaptureEnabledInFullscreenMenu = request.TshCursorCaptureEnabledInFullscreenMenu ?? profile.TshCursorCaptureEnabledInFullscreenMenu;
-        profile.TshCursorCaptureEnabledInWindowedGame = request.TshCursorCaptureEnabledInWindowedGame ?? profile.TshCursorCaptureEnabledInWindowedGame;
-        profile.TshCursorCaptureEnabledInWindowedMenu = request.TshCursorCaptureEnabledInWindowedMenu ?? profile.TshCursorCaptureEnabledInWindowedMenu;
-        profile.TshScreenEdgeScrollEnabledInFullscreenApp = request.TshScreenEdgeScrollEnabledInFullscreenApp ?? profile.TshScreenEdgeScrollEnabledInFullscreenApp;
-        profile.TshScreenEdgeScrollEnabledInWindowedApp = request.TshScreenEdgeScrollEnabledInWindowedApp ?? profile.TshScreenEdgeScrollEnabledInWindowedApp;
-        profile.TshMoneyTransactionVolume = request.TshMoneyTransactionVolume ?? profile.TshMoneyTransactionVolume;
-    }
-
-    private static void PatchGeneralsOnlineSettings(GameProfile profile, CreateProfileRequest request)
-    {
-        profile.GoShowFps = request.GoShowFps ?? profile.GoShowFps;
-        profile.GoShowPing = request.GoShowPing ?? profile.GoShowPing;
-        profile.GoShowPlayerRanks = request.GoShowPlayerRanks ?? profile.GoShowPlayerRanks;
-        profile.GoAutoLogin = request.GoAutoLogin ?? profile.GoAutoLogin;
-        profile.GoRememberUsername = request.GoRememberUsername ?? profile.GoRememberUsername;
-        profile.GoEnableNotifications = request.GoEnableNotifications ?? profile.GoEnableNotifications;
-        profile.GoEnableSoundNotifications = request.GoEnableSoundNotifications ?? profile.GoEnableSoundNotifications;
-        profile.GoChatFontSize = request.GoChatFontSize ?? profile.GoChatFontSize;
-
-        profile.GoCameraMaxHeightOnlyWhenLobbyHost = request.GoCameraMaxHeightOnlyWhenLobbyHost ?? profile.GoCameraMaxHeightOnlyWhenLobbyHost;
-        profile.GoCameraMinHeight = request.GoCameraMinHeight ?? profile.GoCameraMinHeight;
-        profile.GoCameraMoveSpeedRatio = request.GoCameraMoveSpeedRatio ?? profile.GoCameraMoveSpeedRatio;
-        profile.GoChatDurationSecondsUntilFadeOut = request.GoChatDurationSecondsUntilFadeOut ?? profile.GoChatDurationSecondsUntilFadeOut;
-        profile.GoDebugVerboseLogging = request.GoDebugVerboseLogging ?? profile.GoDebugVerboseLogging;
-
-        profile.GoRenderFpsLimit = request.GoRenderFpsLimit ?? profile.GoRenderFpsLimit;
-        profile.GoRenderLimitFramerate = request.GoRenderLimitFramerate ?? profile.GoRenderLimitFramerate;
-        profile.GoRenderStatsOverlay = request.GoRenderStatsOverlay ?? profile.GoRenderStatsOverlay;
-
-        profile.GoSocialNotificationFriendComesOnlineGameplay = request.GoSocialNotificationFriendComesOnlineGameplay ?? profile.GoSocialNotificationFriendComesOnlineGameplay;
-        profile.GoSocialNotificationFriendComesOnlineMenus = request.GoSocialNotificationFriendComesOnlineMenus ?? profile.GoSocialNotificationFriendComesOnlineMenus;
-        profile.GoSocialNotificationFriendGoesOfflineGameplay = request.GoSocialNotificationFriendGoesOfflineGameplay ?? profile.GoSocialNotificationFriendGoesOfflineGameplay;
-        profile.GoSocialNotificationFriendGoesOfflineMenus = request.GoSocialNotificationFriendGoesOfflineMenus ?? profile.GoSocialNotificationFriendGoesOfflineMenus;
-        profile.GoSocialNotificationPlayerAcceptsRequestGameplay = request.GoSocialNotificationPlayerAcceptsRequestGameplay ?? profile.GoSocialNotificationPlayerAcceptsRequestGameplay;
-        profile.GoSocialNotificationPlayerAcceptsRequestMenus = request.GoSocialNotificationPlayerAcceptsRequestMenus ?? profile.GoSocialNotificationPlayerAcceptsRequestMenus;
-        profile.GoSocialNotificationPlayerSendsRequestGameplay = request.GoSocialNotificationPlayerSendsRequestGameplay ?? profile.GoSocialNotificationPlayerSendsRequestGameplay;
-        profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus ?? profile.GoSocialNotificationPlayerSendsRequestMenus;
-    }
-
     /// <summary>
     /// Patches a GameProfile with non-null values from an UpdateProfileRequest.
     /// </summary>
@@ -794,88 +325,6 @@ public static class GameSettingsMapper
 
         profile.GameSpyIPAddress = request.GameSpyIPAddress ?? profile.GameSpyIPAddress;
         profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
-    }
-
-    private static void UpdateVideoFromRequest(GameProfile profile, UpdateProfileRequest request)
-    {
-        profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
-        profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
-        profile.VideoWindowed = request.VideoWindowed ?? profile.VideoWindowed;
-        profile.VideoTextureQuality = request.VideoTextureQuality ?? profile.VideoTextureQuality;
-        profile.EnableVideoShadows = request.EnableVideoShadows ?? profile.EnableVideoShadows;
-        profile.VideoParticleEffects = request.VideoParticleEffects ?? profile.VideoParticleEffects;
-        profile.VideoExtraAnimations = request.VideoExtraAnimations ?? profile.VideoExtraAnimations;
-        profile.VideoBuildingAnimations = request.VideoBuildingAnimations ?? profile.VideoBuildingAnimations;
-        profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
-        profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
-        profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
-        profile.VideoStaticGameLOD = request.VideoStaticGameLOD ?? profile.VideoStaticGameLOD;
-        profile.VideoIdealStaticGameLOD = request.VideoIdealStaticGameLOD ?? profile.VideoIdealStaticGameLOD;
-        profile.VideoUseDoubleClickAttackMove = request.VideoUseDoubleClickAttackMove ?? profile.VideoUseDoubleClickAttackMove;
-        profile.VideoScrollFactor = request.VideoScrollFactor ?? profile.VideoScrollFactor;
-        profile.VideoRetaliation = request.VideoRetaliation ?? profile.VideoRetaliation;
-        profile.VideoDynamicLOD = request.VideoDynamicLOD ?? profile.VideoDynamicLOD;
-        profile.VideoMaxParticleCount = request.VideoMaxParticleCount ?? profile.VideoMaxParticleCount;
-        profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
-    }
-
-    private static void UpdateAudioFromRequest(GameProfile profile, UpdateProfileRequest request)
-    {
-        profile.AudioSoundVolume = request.AudioSoundVolume ?? profile.AudioSoundVolume;
-        profile.AudioThreeDSoundVolume = request.AudioThreeDSoundVolume ?? profile.AudioThreeDSoundVolume;
-        profile.AudioSpeechVolume = request.AudioSpeechVolume ?? profile.AudioSpeechVolume;
-        profile.AudioMusicVolume = request.AudioMusicVolume ?? profile.AudioMusicVolume;
-        profile.AudioEnabled = request.AudioEnabled ?? profile.AudioEnabled;
-        profile.AudioNumSounds = request.AudioNumSounds ?? profile.AudioNumSounds;
-    }
-
-    private static void UpdateTshFromRequest(GameProfile profile, UpdateProfileRequest request)
-    {
-        profile.TshArchiveReplays = request.TshArchiveReplays ?? profile.TshArchiveReplays;
-        profile.TshShowMoneyPerMinute = request.TshShowMoneyPerMinute ?? profile.TshShowMoneyPerMinute;
-        profile.TshPlayerObserverEnabled = request.TshPlayerObserverEnabled ?? profile.TshPlayerObserverEnabled;
-        profile.TshSystemTimeFontSize = request.TshSystemTimeFontSize ?? profile.TshSystemTimeFontSize;
-        profile.TshNetworkLatencyFontSize = request.TshNetworkLatencyFontSize ?? profile.TshNetworkLatencyFontSize;
-        profile.TshRenderFpsFontSize = request.TshRenderFpsFontSize ?? profile.TshRenderFpsFontSize;
-        profile.TshResolutionFontAdjustment = request.TshResolutionFontAdjustment ?? profile.TshResolutionFontAdjustment;
-        profile.TshCursorCaptureEnabledInFullscreenGame = request.TshCursorCaptureEnabledInFullscreenGame ?? profile.TshCursorCaptureEnabledInFullscreenGame;
-        profile.TshCursorCaptureEnabledInFullscreenMenu = request.TshCursorCaptureEnabledInFullscreenMenu ?? profile.TshCursorCaptureEnabledInFullscreenMenu;
-        profile.TshCursorCaptureEnabledInWindowedGame = request.TshCursorCaptureEnabledInWindowedGame ?? profile.TshCursorCaptureEnabledInWindowedGame;
-        profile.TshCursorCaptureEnabledInWindowedMenu = request.TshCursorCaptureEnabledInWindowedMenu ?? profile.TshCursorCaptureEnabledInWindowedMenu;
-        profile.TshScreenEdgeScrollEnabledInFullscreenApp = request.TshScreenEdgeScrollEnabledInFullscreenApp ?? profile.TshScreenEdgeScrollEnabledInFullscreenApp;
-        profile.TshScreenEdgeScrollEnabledInWindowedApp = request.TshScreenEdgeScrollEnabledInWindowedApp ?? profile.TshScreenEdgeScrollEnabledInWindowedApp;
-        profile.TshMoneyTransactionVolume = request.TshMoneyTransactionVolume ?? profile.TshMoneyTransactionVolume;
-    }
-
-    private static void UpdateGeneralsOnlineFromRequest(GameProfile profile, UpdateProfileRequest request)
-    {
-        profile.GoShowFps = request.GoShowFps ?? profile.GoShowFps;
-        profile.GoShowPing = request.GoShowPing ?? profile.GoShowPing;
-        profile.GoShowPlayerRanks = request.GoShowPlayerRanks ?? profile.GoShowPlayerRanks;
-        profile.GoAutoLogin = request.GoAutoLogin ?? profile.GoAutoLogin;
-        profile.GoRememberUsername = request.GoRememberUsername ?? profile.GoRememberUsername;
-        profile.GoEnableNotifications = request.GoEnableNotifications ?? profile.GoEnableNotifications;
-        profile.GoEnableSoundNotifications = request.GoEnableSoundNotifications ?? profile.GoEnableSoundNotifications;
-        profile.GoChatFontSize = request.GoChatFontSize ?? profile.GoChatFontSize;
-
-        profile.GoCameraMaxHeightOnlyWhenLobbyHost = request.GoCameraMaxHeightOnlyWhenLobbyHost ?? profile.GoCameraMaxHeightOnlyWhenLobbyHost;
-        profile.GoCameraMinHeight = request.GoCameraMinHeight ?? profile.GoCameraMinHeight;
-        profile.GoCameraMoveSpeedRatio = request.GoCameraMoveSpeedRatio ?? profile.GoCameraMoveSpeedRatio;
-        profile.GoChatDurationSecondsUntilFadeOut = request.GoChatDurationSecondsUntilFadeOut ?? profile.GoChatDurationSecondsUntilFadeOut;
-        profile.GoDebugVerboseLogging = request.GoDebugVerboseLogging ?? profile.GoDebugVerboseLogging;
-
-        profile.GoRenderFpsLimit = request.GoRenderFpsLimit ?? profile.GoRenderFpsLimit;
-        profile.GoRenderLimitFramerate = request.GoRenderLimitFramerate ?? profile.GoRenderLimitFramerate;
-        profile.GoRenderStatsOverlay = request.GoRenderStatsOverlay ?? profile.GoRenderStatsOverlay;
-
-        profile.GoSocialNotificationFriendComesOnlineGameplay = request.GoSocialNotificationFriendComesOnlineGameplay ?? profile.GoSocialNotificationFriendComesOnlineGameplay;
-        profile.GoSocialNotificationFriendComesOnlineMenus = request.GoSocialNotificationFriendComesOnlineMenus ?? profile.GoSocialNotificationFriendComesOnlineMenus;
-        profile.GoSocialNotificationFriendGoesOfflineGameplay = request.GoSocialNotificationFriendGoesOfflineGameplay ?? profile.GoSocialNotificationFriendGoesOfflineGameplay;
-        profile.GoSocialNotificationFriendGoesOfflineMenus = request.GoSocialNotificationFriendGoesOfflineMenus ?? profile.GoSocialNotificationFriendGoesOfflineMenus;
-        profile.GoSocialNotificationPlayerAcceptsRequestGameplay = request.GoSocialNotificationPlayerAcceptsRequestGameplay ?? profile.GoSocialNotificationPlayerAcceptsRequestGameplay;
-        profile.GoSocialNotificationPlayerAcceptsRequestMenus = request.GoSocialNotificationPlayerAcceptsRequestMenus ?? profile.GoSocialNotificationPlayerAcceptsRequestMenus;
-        profile.GoSocialNotificationPlayerSendsRequestGameplay = request.GoSocialNotificationPlayerSendsRequestGameplay ?? profile.GoSocialNotificationPlayerSendsRequestGameplay;
-        profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus ?? profile.GoSocialNotificationPlayerSendsRequestMenus;
     }
 
     /// <summary>
@@ -1062,6 +511,564 @@ public static class GameSettingsMapper
         target.UseSteamLaunch = source.UseSteamLaunch;
         target.GameSpyIPAddress = source.GameSpyIPAddress;
         target.VideoSkipEALogo = source.VideoSkipEALogo;
+    }
+
+    private static void ApplyVideoFromOptions(IniOptions options, GameProfile profile)
+    {
+        profile.VideoResolutionWidth = options.Video.ResolutionWidth;
+        profile.VideoResolutionHeight = options.Video.ResolutionHeight;
+        profile.VideoWindowed = options.Video.Windowed;
+
+        // Convert TextureReduction back to TextureQuality
+        profile.VideoTextureQuality = options.Video.TextureReduction switch
+        {
+            GameSettingsConstants.TextureQuality.TextureReductionLow => TextureQuality.Low,
+            GameSettingsConstants.TextureQuality.TextureReductionMedium => TextureQuality.Medium,
+            GameSettingsConstants.TextureQuality.TextureReductionHigh => TextureQuality.High,
+            _ => null,
+        };
+
+        profile.EnableVideoShadows = options.Video.UseShadowVolumes;
+
+        if (options.Video.AdditionalProperties.TryGetValue("GenHubBuildingAnimations", out var ba))
+            profile.VideoBuildingAnimations = ParseBool(ba);
+
+        if (options.Video.AdditionalProperties.TryGetValue("GenHubParticleEffects", out var pe))
+            profile.VideoParticleEffects = ParseBool(pe);
+
+        profile.VideoExtraAnimations = options.Video.ExtraAnimations;
+        profile.VideoGamma = options.Video.Gamma;
+        profile.VideoAlternateMouseSetup = options.Video.AlternateMouseSetup;
+        profile.VideoHeatEffects = options.Video.HeatEffects;
+
+        // Load additional video settings from root (Flat format support)
+        if (options.Video.AdditionalProperties.TryGetValue("StaticGameLOD", out var staticLOD))
+            profile.VideoStaticGameLOD = staticLOD;
+        if (options.Video.AdditionalProperties.TryGetValue("IdealStaticGameLOD", out var idealLOD))
+            profile.VideoIdealStaticGameLOD = idealLOD;
+
+        if (options.Video.AdditionalProperties.TryGetValue("SkipEALogo", out var sel))
+            profile.VideoSkipEALogo = ParseBool(sel);
+
+        profile.VideoAntiAliasing ??= options.Video.AntiAliasing;
+
+        ApplyTshFlatSettingsFromOptions(options, profile);
+        ApplyTshHierarchicalSettingsFromOptions(options, profile);
+    }
+
+    private static void ApplyTshFlatSettingsFromOptions(IniOptions options, GameProfile profile)
+    {
+        if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
+            profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClick);
+        else if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClick", out var dbl))
+            profile.VideoUseDoubleClickAttackMove = ParseBool(dbl);
+
+        if (options.Video.AdditionalProperties.TryGetValue("ScrollFactor", out var scroll) && int.TryParse(scroll, out var scrollVal))
+            profile.VideoScrollFactor = scrollVal;
+        if (options.Video.AdditionalProperties.TryGetValue("Retaliation", out var retaliation))
+            profile.VideoRetaliation = ParseBool(retaliation);
+        if (options.Video.AdditionalProperties.TryGetValue("DynamicLOD", out var dynLOD))
+            profile.VideoDynamicLOD = ParseBool(dynLOD);
+        if (options.Video.AdditionalProperties.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
+            profile.VideoMaxParticleCount = particleVal;
+    }
+
+    private static void ApplyTshHierarchicalSettingsFromOptions(IniOptions options, GameProfile profile)
+    {
+        if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var tsh))
+        {
+            if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClickTsh))
+                profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClickTsh);
+            if (tsh.TryGetValue("ScrollFactor", out var scrollTsh) && int.TryParse(scrollTsh, out var scrollTshVal))
+                profile.VideoScrollFactor = scrollTshVal;
+            if (tsh.TryGetValue("Retaliation", out var retaliationTsh))
+                profile.VideoRetaliation = ParseBool(retaliationTsh);
+            if (tsh.TryGetValue("DynamicLOD", out var dynLODTsh))
+                profile.VideoDynamicLOD = ParseBool(dynLODTsh);
+            if (tsh.TryGetValue("MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, out var particlesTshVal))
+                profile.VideoMaxParticleCount = particlesTshVal;
+        }
+    }
+
+    private static void ApplyAudioFromOptions(IniOptions options, GameProfile profile)
+    {
+        profile.AudioSoundVolume = options.Audio.SFXVolume;
+        profile.AudioThreeDSoundVolume = options.Audio.SFX3DVolume;
+        profile.AudioSpeechVolume = options.Audio.VoiceVolume;
+        profile.AudioMusicVolume = options.Audio.MusicVolume;
+        profile.AudioEnabled = options.Audio.AudioEnabled;
+        profile.AudioNumSounds = options.Audio.NumSounds;
+    }
+
+    private static void ApplyNetworkFromOptions(IniOptions options, GameProfile profile)
+    {
+        profile.GameSpyIPAddress = options.Network.GameSpyIPAddress;
+    }
+
+    private static void ApplyGoGeneralSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
+        settings.ShowFps = profile.GoShowFps ?? false;
+        settings.ShowPing = profile.GoShowPing ?? true;
+        settings.ShowPlayerRanks = profile.GoShowPlayerRanks ?? true;
+        settings.AutoLogin = profile.GoAutoLogin ?? false;
+        settings.RememberUsername = profile.GoRememberUsername ?? true;
+        settings.EnableNotifications = profile.GoEnableNotifications ?? true;
+        settings.EnableSoundNotifications = profile.GoEnableSoundNotifications ?? true;
+        settings.ChatFontSize = profile.GoChatFontSize ?? 12;
+    }
+
+    private static void ApplyGoCameraAndChatSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
+        settings.Camera.MaxHeightOnlyWhenLobbyHost = profile.GoCameraMaxHeightOnlyWhenLobbyHost ?? 310.0f;
+        settings.Camera.MinHeight = profile.GoCameraMinHeight ?? 310.0f;
+        settings.Camera.MoveSpeedRatio = profile.GoCameraMoveSpeedRatio ?? 1.5f;
+        settings.Chat.DurationSecondsUntilFadeOut = profile.GoChatDurationSecondsUntilFadeOut ?? 30;
+    }
+
+    private static void ApplyGoRenderAndDebugSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
+        settings.Debug.VerboseLogging = profile.GoDebugVerboseLogging ?? false;
+        settings.Render.FpsLimit = profile.GoRenderFpsLimit ?? 144;
+        settings.Render.LimitFramerate = profile.GoRenderLimitFramerate ?? true;
+        settings.Render.StatsOverlay = profile.GoRenderStatsOverlay ?? true;
+    }
+
+    private static void ApplyGoSocialSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
+        settings.Social.NotificationFriendComesOnlineGameplay = profile.GoSocialNotificationFriendComesOnlineGameplay ?? true;
+        settings.Social.NotificationFriendComesOnlineMenus = profile.GoSocialNotificationFriendComesOnlineMenus ?? true;
+        settings.Social.NotificationFriendGoesOfflineGameplay = profile.GoSocialNotificationFriendGoesOfflineGameplay ?? true;
+        settings.Social.NotificationFriendGoesOfflineMenus = profile.GoSocialNotificationFriendGoesOfflineMenus ?? true;
+        settings.Social.NotificationPlayerAcceptsRequestGameplay = profile.GoSocialNotificationPlayerAcceptsRequestGameplay ?? true;
+        settings.Social.NotificationPlayerAcceptsRequestMenus = profile.GoSocialNotificationPlayerAcceptsRequestMenus ?? true;
+        settings.Social.NotificationPlayerSendsRequestGameplay = profile.GoSocialNotificationPlayerSendsRequestGameplay ?? true;
+        settings.Social.NotificationPlayerSendsRequestMenus = profile.GoSocialNotificationPlayerSendsRequestMenus ?? true;
+    }
+
+    private static void ApplyGoTshSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
+        settings.ArchiveReplays = profile.TshArchiveReplays ?? false;
+        settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
+        settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
+        settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled;
+        settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
+        settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
+        settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
+        settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
+        settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame;
+        settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu;
+        settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame;
+        settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu;
+        settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp;
+        settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
+    }
+
+    private static void ApplyVideoResolutionAndQualityToOptions(GameProfile profile, IniOptions options, ILogger? logger)
+    {
+        if (profile.VideoResolutionWidth.HasValue)
+        {
+            if (profile.VideoResolutionWidth.Value >= GameSettingsConstants.Resolution.MinWidth &&
+                profile.VideoResolutionWidth.Value <= GameSettingsConstants.Resolution.MaxWidth)
+            {
+                options.Video.ResolutionWidth = profile.VideoResolutionWidth.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid VideoResolutionWidth {Width} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.VideoResolutionWidth.Value,
+                    profile.Id,
+                    GameSettingsConstants.Resolution.MinWidth,
+                    GameSettingsConstants.Resolution.MaxWidth);
+            }
+        }
+
+        if (profile.VideoResolutionHeight.HasValue)
+        {
+            if (profile.VideoResolutionHeight.Value >= GameSettingsConstants.Resolution.MinHeight &&
+                profile.VideoResolutionHeight.Value <= GameSettingsConstants.Resolution.MaxHeight)
+            {
+                options.Video.ResolutionHeight = profile.VideoResolutionHeight.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid VideoResolutionHeight {Height} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.VideoResolutionHeight.Value,
+                    profile.Id,
+                    GameSettingsConstants.Resolution.MinHeight,
+                    GameSettingsConstants.Resolution.MaxHeight);
+            }
+        }
+
+        if (profile.VideoWindowed.HasValue)
+        {
+            options.Video.Windowed = profile.VideoWindowed.Value;
+        }
+
+        if (profile.VideoTextureQuality.HasValue)
+        {
+            options.Video.TextureReduction = profile.VideoTextureQuality.Value switch
+            {
+                TextureQuality.Low => GameSettingsConstants.TextureQuality.TextureReductionLow,
+                TextureQuality.Medium => GameSettingsConstants.TextureQuality.TextureReductionMedium,
+                TextureQuality.High => GameSettingsConstants.TextureQuality.TextureReductionHigh,
+                TextureQuality.VeryHigh => GameSettingsConstants.TextureQuality.TextureReductionHigh,
+                _ => options.Video.TextureReduction,
+            };
+        }
+
+        if (profile.EnableVideoShadows.HasValue)
+        {
+            options.Video.UseShadowVolumes = profile.EnableVideoShadows.Value;
+            options.Video.UseShadowDecals = profile.EnableVideoShadows.Value;
+        }
+
+        if (profile.VideoExtraAnimations.HasValue)
+        {
+            options.Video.ExtraAnimations = profile.VideoExtraAnimations.Value;
+        }
+    }
+
+    private static void ApplyVideoAdditionalToOptions(GameProfile profile, IniOptions options, ILogger? logger)
+    {
+        if (profile.VideoGamma.HasValue)
+        {
+            if (profile.VideoGamma.Value >= GameSettingsConstants.Gamma.Min &&
+                profile.VideoGamma.Value <= GameSettingsConstants.Gamma.Max)
+            {
+                options.Video.Gamma = profile.VideoGamma.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid VideoGamma {Gamma} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.VideoGamma.Value,
+                    profile.Id,
+                    GameSettingsConstants.Gamma.Min,
+                    GameSettingsConstants.Gamma.Max);
+            }
+        }
+
+        if (profile.VideoAlternateMouseSetup.HasValue)
+            options.Video.AlternateMouseSetup = profile.VideoAlternateMouseSetup.Value;
+
+        if (profile.VideoHeatEffects.HasValue)
+            options.Video.HeatEffects = profile.VideoHeatEffects.Value;
+
+        if (profile.VideoBuildingAnimations.HasValue)
+            options.Video.AdditionalProperties["GenHubBuildingAnimations"] = profile.VideoBuildingAnimations.Value ? "yes" : "no";
+
+        if (profile.VideoParticleEffects.HasValue)
+            options.Video.AdditionalProperties["GenHubParticleEffects"] = profile.VideoParticleEffects.Value ? "yes" : "no";
+
+        if (profile.VideoStaticGameLOD != null)
+            options.Video.AdditionalProperties["StaticGameLOD"] = profile.VideoStaticGameLOD;
+
+        if (profile.VideoIdealStaticGameLOD != null)
+            options.Video.AdditionalProperties["IdealStaticGameLOD"] = profile.VideoIdealStaticGameLOD;
+
+        if (profile.VideoAntiAliasing.HasValue)
+            options.Video.AntiAliasing = profile.VideoAntiAliasing.Value;
+
+        if (profile.VideoUseDoubleClickAttackMove.HasValue)
+        {
+            options.Video.AdditionalProperties["UseDoubleClickAttackMove"] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
+            options.Video.AdditionalProperties["UseDoubleClick"] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
+        }
+
+        if (profile.VideoScrollFactor.HasValue)
+            options.Video.AdditionalProperties["ScrollFactor"] = profile.VideoScrollFactor.Value.ToString();
+
+        if (profile.VideoRetaliation.HasValue)
+            options.Video.AdditionalProperties["Retaliation"] = profile.VideoRetaliation.Value ? "yes" : "no";
+
+        if (profile.VideoDynamicLOD.HasValue)
+            options.Video.AdditionalProperties["DynamicLOD"] = profile.VideoDynamicLOD.Value ? "yes" : "no";
+
+        if (profile.VideoMaxParticleCount.HasValue)
+            options.Video.AdditionalProperties["MaxParticleCount"] = profile.VideoMaxParticleCount.Value.ToString();
+
+        if (profile.VideoSkipEALogo.HasValue)
+            options.Video.AdditionalProperties["SkipEALogo"] = profile.VideoSkipEALogo.Value ? "yes" : "no";
+    }
+
+    private static void ApplyAudioToOptions(GameProfile profile, IniOptions options, ILogger? logger)
+    {
+        if (profile.AudioSoundVolume.HasValue)
+        {
+            if (profile.AudioSoundVolume.Value >= GameSettingsConstants.Volume.Min &&
+                profile.AudioSoundVolume.Value <= GameSettingsConstants.Volume.Max)
+            {
+                options.Audio.SFXVolume = profile.AudioSoundVolume.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid AudioSoundVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.AudioSoundVolume.Value,
+                    profile.Id,
+                    GameSettingsConstants.Volume.Min,
+                    GameSettingsConstants.Volume.Max);
+            }
+        }
+
+        if (profile.AudioThreeDSoundVolume.HasValue)
+        {
+            if (profile.AudioThreeDSoundVolume.Value >= GameSettingsConstants.Volume.Min &&
+                profile.AudioThreeDSoundVolume.Value <= GameSettingsConstants.Volume.Max)
+            {
+                options.Audio.SFX3DVolume = profile.AudioThreeDSoundVolume.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid AudioThreeDSoundVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.AudioThreeDSoundVolume.Value,
+                    profile.Id,
+                    GameSettingsConstants.Volume.Min,
+                    GameSettingsConstants.Volume.Max);
+            }
+        }
+
+        if (profile.AudioSpeechVolume.HasValue)
+        {
+            if (profile.AudioSpeechVolume.Value >= GameSettingsConstants.Volume.Min &&
+                profile.AudioSpeechVolume.Value <= GameSettingsConstants.Volume.Max)
+            {
+                options.Audio.VoiceVolume = profile.AudioSpeechVolume.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid AudioSpeechVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.AudioSpeechVolume.Value,
+                    profile.Id,
+                    GameSettingsConstants.Volume.Min,
+                    GameSettingsConstants.Volume.Max);
+            }
+        }
+
+        if (profile.AudioMusicVolume.HasValue)
+        {
+            if (profile.AudioMusicVolume.Value >= GameSettingsConstants.Volume.Min &&
+                profile.AudioMusicVolume.Value <= GameSettingsConstants.Volume.Max)
+            {
+                options.Audio.MusicVolume = profile.AudioMusicVolume.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid AudioMusicVolume {Volume} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.AudioMusicVolume.Value,
+                    profile.Id,
+                    GameSettingsConstants.Volume.Min,
+                    GameSettingsConstants.Volume.Max);
+            }
+        }
+
+        if (profile.AudioEnabled.HasValue)
+        {
+            options.Audio.AudioEnabled = profile.AudioEnabled.Value;
+        }
+
+        if (profile.AudioNumSounds.HasValue)
+        {
+            if (profile.AudioNumSounds.Value >= GameSettingsConstants.Audio.MinNumSounds &&
+                profile.AudioNumSounds.Value <= GameSettingsConstants.Audio.MaxNumSounds)
+            {
+                options.Audio.NumSounds = profile.AudioNumSounds.Value;
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "Invalid AudioNumSounds {NumSounds} for profile {ProfileId}, must be {Min}-{Max}",
+                    profile.AudioNumSounds.Value,
+                    profile.Id,
+                    GameSettingsConstants.Audio.MinNumSounds,
+                    GameSettingsConstants.Audio.MaxNumSounds);
+            }
+        }
+    }
+
+    private static void ApplyTshToOptions(GameProfile profile, IniOptions options)
+    {
+        var tshDict = new Dictionary<string, string>();
+        if (profile.TshArchiveReplays.HasValue) tshDict["ArchiveReplays"] = BoolToString(profile.TshArchiveReplays.Value);
+        if (profile.TshShowMoneyPerMinute.HasValue) tshDict["ShowMoneyPerMinute"] = BoolToString(profile.TshShowMoneyPerMinute.Value);
+        if (profile.TshPlayerObserverEnabled.HasValue) tshDict["PlayerObserverEnabled"] = BoolToString(profile.TshPlayerObserverEnabled.Value);
+        if (profile.TshSystemTimeFontSize.HasValue) tshDict["SystemTimeFontSize"] = profile.TshSystemTimeFontSize.Value.ToString();
+        if (profile.TshNetworkLatencyFontSize.HasValue) tshDict["NetworkLatencyFontSize"] = profile.TshNetworkLatencyFontSize.Value.ToString();
+        if (profile.TshRenderFpsFontSize.HasValue) tshDict["RenderFpsFontSize"] = profile.TshRenderFpsFontSize.Value.ToString();
+        if (profile.TshResolutionFontAdjustment.HasValue) tshDict["ResolutionFontAdjustment"] = profile.TshResolutionFontAdjustment.Value.ToString();
+        if (profile.TshCursorCaptureEnabledInFullscreenGame.HasValue) tshDict["CursorCaptureEnabledInFullscreenGame"] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenGame.Value);
+        if (profile.TshCursorCaptureEnabledInFullscreenMenu.HasValue) tshDict["CursorCaptureEnabledInFullscreenMenu"] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenMenu.Value);
+        if (profile.TshCursorCaptureEnabledInWindowedGame.HasValue) tshDict["CursorCaptureEnabledInWindowedGame"] = BoolToString(profile.TshCursorCaptureEnabledInWindowedGame.Value);
+        if (profile.TshCursorCaptureEnabledInWindowedMenu.HasValue) tshDict["CursorCaptureEnabledInWindowedMenu"] = BoolToString(profile.TshCursorCaptureEnabledInWindowedMenu.Value);
+        if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) tshDict["ScreenEdgeScrollEnabledInFullscreenApp"] = BoolToString(profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value);
+        if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) tshDict["ScreenEdgeScrollEnabledInWindowedApp"] = BoolToString(profile.TshScreenEdgeScrollEnabledInWindowedApp.Value);
+        if (profile.TshMoneyTransactionVolume.HasValue) tshDict["MoneyTransactionVolume"] = profile.TshMoneyTransactionVolume.Value.ToString();
+
+        if (tshDict.Count > 0)
+        {
+            options.AdditionalSections["TheSuperHackers"] = tshDict;
+        }
+    }
+
+    private static void PatchVideoSettings(GameProfile profile, CreateProfileRequest request)
+    {
+        profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
+        profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
+        profile.VideoWindowed = request.VideoWindowed ?? profile.VideoWindowed;
+        profile.VideoTextureQuality = request.VideoTextureQuality ?? profile.VideoTextureQuality;
+        profile.EnableVideoShadows = request.EnableVideoShadows ?? profile.EnableVideoShadows;
+        profile.VideoParticleEffects = request.VideoParticleEffects ?? profile.VideoParticleEffects;
+        profile.VideoExtraAnimations = request.VideoExtraAnimations ?? profile.VideoExtraAnimations;
+        profile.VideoBuildingAnimations = request.VideoBuildingAnimations ?? profile.VideoBuildingAnimations;
+        profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
+        profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
+        profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
+    }
+
+    private static void PatchAudioSettings(GameProfile profile, CreateProfileRequest request)
+    {
+        profile.AudioSoundVolume = request.AudioSoundVolume ?? profile.AudioSoundVolume;
+        profile.AudioThreeDSoundVolume = request.AudioThreeDSoundVolume ?? profile.AudioThreeDSoundVolume;
+        profile.AudioSpeechVolume = request.AudioSpeechVolume ?? profile.AudioSpeechVolume;
+        profile.AudioMusicVolume = request.AudioMusicVolume ?? profile.AudioMusicVolume;
+        profile.AudioEnabled = request.AudioEnabled ?? profile.AudioEnabled;
+        profile.AudioNumSounds = request.AudioNumSounds ?? profile.AudioNumSounds;
+    }
+
+    private static void PatchTshSettings(GameProfile profile, CreateProfileRequest request)
+    {
+        profile.TshArchiveReplays = request.TshArchiveReplays ?? profile.TshArchiveReplays;
+        profile.TshShowMoneyPerMinute = request.TshShowMoneyPerMinute ?? profile.TshShowMoneyPerMinute;
+        profile.TshPlayerObserverEnabled = request.TshPlayerObserverEnabled ?? profile.TshPlayerObserverEnabled;
+        profile.TshSystemTimeFontSize = request.TshSystemTimeFontSize ?? profile.TshSystemTimeFontSize;
+        profile.TshNetworkLatencyFontSize = request.TshNetworkLatencyFontSize ?? profile.TshNetworkLatencyFontSize;
+        profile.TshRenderFpsFontSize = request.TshRenderFpsFontSize ?? profile.TshRenderFpsFontSize;
+        profile.TshResolutionFontAdjustment = request.TshResolutionFontAdjustment ?? profile.TshResolutionFontAdjustment;
+        profile.TshCursorCaptureEnabledInFullscreenGame = request.TshCursorCaptureEnabledInFullscreenGame ?? profile.TshCursorCaptureEnabledInFullscreenGame;
+        profile.TshCursorCaptureEnabledInFullscreenMenu = request.TshCursorCaptureEnabledInFullscreenMenu ?? profile.TshCursorCaptureEnabledInFullscreenMenu;
+        profile.TshCursorCaptureEnabledInWindowedGame = request.TshCursorCaptureEnabledInWindowedGame ?? profile.TshCursorCaptureEnabledInWindowedGame;
+        profile.TshCursorCaptureEnabledInWindowedMenu = request.TshCursorCaptureEnabledInWindowedMenu ?? profile.TshCursorCaptureEnabledInWindowedMenu;
+        profile.TshScreenEdgeScrollEnabledInFullscreenApp = request.TshScreenEdgeScrollEnabledInFullscreenApp ?? profile.TshScreenEdgeScrollEnabledInFullscreenApp;
+        profile.TshScreenEdgeScrollEnabledInWindowedApp = request.TshScreenEdgeScrollEnabledInWindowedApp ?? profile.TshScreenEdgeScrollEnabledInWindowedApp;
+        profile.TshMoneyTransactionVolume = request.TshMoneyTransactionVolume ?? profile.TshMoneyTransactionVolume;
+    }
+
+    private static void PatchGeneralsOnlineSettings(GameProfile profile, CreateProfileRequest request)
+    {
+        profile.GoShowFps = request.GoShowFps ?? profile.GoShowFps;
+        profile.GoShowPing = request.GoShowPing ?? profile.GoShowPing;
+        profile.GoShowPlayerRanks = request.GoShowPlayerRanks ?? profile.GoShowPlayerRanks;
+        profile.GoAutoLogin = request.GoAutoLogin ?? profile.GoAutoLogin;
+        profile.GoRememberUsername = request.GoRememberUsername ?? profile.GoRememberUsername;
+        profile.GoEnableNotifications = request.GoEnableNotifications ?? profile.GoEnableNotifications;
+        profile.GoEnableSoundNotifications = request.GoEnableSoundNotifications ?? profile.GoEnableSoundNotifications;
+        profile.GoChatFontSize = request.GoChatFontSize ?? profile.GoChatFontSize;
+
+        profile.GoCameraMaxHeightOnlyWhenLobbyHost = request.GoCameraMaxHeightOnlyWhenLobbyHost ?? profile.GoCameraMaxHeightOnlyWhenLobbyHost;
+        profile.GoCameraMinHeight = request.GoCameraMinHeight ?? profile.GoCameraMinHeight;
+        profile.GoCameraMoveSpeedRatio = request.GoCameraMoveSpeedRatio ?? profile.GoCameraMoveSpeedRatio;
+        profile.GoChatDurationSecondsUntilFadeOut = request.GoChatDurationSecondsUntilFadeOut ?? profile.GoChatDurationSecondsUntilFadeOut;
+        profile.GoDebugVerboseLogging = request.GoDebugVerboseLogging ?? profile.GoDebugVerboseLogging;
+
+        profile.GoRenderFpsLimit = request.GoRenderFpsLimit ?? profile.GoRenderFpsLimit;
+        profile.GoRenderLimitFramerate = request.GoRenderLimitFramerate ?? profile.GoRenderLimitFramerate;
+        profile.GoRenderStatsOverlay = request.GoRenderStatsOverlay ?? profile.GoRenderStatsOverlay;
+
+        profile.GoSocialNotificationFriendComesOnlineGameplay = request.GoSocialNotificationFriendComesOnlineGameplay ?? profile.GoSocialNotificationFriendComesOnlineGameplay;
+        profile.GoSocialNotificationFriendComesOnlineMenus = request.GoSocialNotificationFriendComesOnlineMenus ?? profile.GoSocialNotificationFriendComesOnlineMenus;
+        profile.GoSocialNotificationFriendGoesOfflineGameplay = request.GoSocialNotificationFriendGoesOfflineGameplay ?? profile.GoSocialNotificationFriendGoesOfflineGameplay;
+        profile.GoSocialNotificationFriendGoesOfflineMenus = request.GoSocialNotificationFriendGoesOfflineMenus ?? profile.GoSocialNotificationFriendGoesOfflineMenus;
+        profile.GoSocialNotificationPlayerAcceptsRequestGameplay = request.GoSocialNotificationPlayerAcceptsRequestGameplay ?? profile.GoSocialNotificationPlayerAcceptsRequestGameplay;
+        profile.GoSocialNotificationPlayerAcceptsRequestMenus = request.GoSocialNotificationPlayerAcceptsRequestMenus ?? profile.GoSocialNotificationPlayerAcceptsRequestMenus;
+        profile.GoSocialNotificationPlayerSendsRequestGameplay = request.GoSocialNotificationPlayerSendsRequestGameplay ?? profile.GoSocialNotificationPlayerSendsRequestGameplay;
+        profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus ?? profile.GoSocialNotificationPlayerSendsRequestMenus;
+    }
+
+    private static void UpdateVideoFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
+        profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
+        profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
+        profile.VideoWindowed = request.VideoWindowed ?? profile.VideoWindowed;
+        profile.VideoTextureQuality = request.VideoTextureQuality ?? profile.VideoTextureQuality;
+        profile.EnableVideoShadows = request.EnableVideoShadows ?? profile.EnableVideoShadows;
+        profile.VideoParticleEffects = request.VideoParticleEffects ?? profile.VideoParticleEffects;
+        profile.VideoExtraAnimations = request.VideoExtraAnimations ?? profile.VideoExtraAnimations;
+        profile.VideoBuildingAnimations = request.VideoBuildingAnimations ?? profile.VideoBuildingAnimations;
+        profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
+        profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
+        profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
+        profile.VideoStaticGameLOD = request.VideoStaticGameLOD ?? profile.VideoStaticGameLOD;
+        profile.VideoIdealStaticGameLOD = request.VideoIdealStaticGameLOD ?? profile.VideoIdealStaticGameLOD;
+        profile.VideoUseDoubleClickAttackMove = request.VideoUseDoubleClickAttackMove ?? profile.VideoUseDoubleClickAttackMove;
+        profile.VideoScrollFactor = request.VideoScrollFactor ?? profile.VideoScrollFactor;
+        profile.VideoRetaliation = request.VideoRetaliation ?? profile.VideoRetaliation;
+        profile.VideoDynamicLOD = request.VideoDynamicLOD ?? profile.VideoDynamicLOD;
+        profile.VideoMaxParticleCount = request.VideoMaxParticleCount ?? profile.VideoMaxParticleCount;
+        profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
+    }
+
+    private static void UpdateAudioFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
+        profile.AudioSoundVolume = request.AudioSoundVolume ?? profile.AudioSoundVolume;
+        profile.AudioThreeDSoundVolume = request.AudioThreeDSoundVolume ?? profile.AudioThreeDSoundVolume;
+        profile.AudioSpeechVolume = request.AudioSpeechVolume ?? profile.AudioSpeechVolume;
+        profile.AudioMusicVolume = request.AudioMusicVolume ?? profile.AudioMusicVolume;
+        profile.AudioEnabled = request.AudioEnabled ?? profile.AudioEnabled;
+        profile.AudioNumSounds = request.AudioNumSounds ?? profile.AudioNumSounds;
+    }
+
+    private static void UpdateTshFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
+        profile.TshArchiveReplays = request.TshArchiveReplays ?? profile.TshArchiveReplays;
+        profile.TshShowMoneyPerMinute = request.TshShowMoneyPerMinute ?? profile.TshShowMoneyPerMinute;
+        profile.TshPlayerObserverEnabled = request.TshPlayerObserverEnabled ?? profile.TshPlayerObserverEnabled;
+        profile.TshSystemTimeFontSize = request.TshSystemTimeFontSize ?? profile.TshSystemTimeFontSize;
+        profile.TshNetworkLatencyFontSize = request.TshNetworkLatencyFontSize ?? profile.TshNetworkLatencyFontSize;
+        profile.TshRenderFpsFontSize = request.TshRenderFpsFontSize ?? profile.TshRenderFpsFontSize;
+        profile.TshResolutionFontAdjustment = request.TshResolutionFontAdjustment ?? profile.TshResolutionFontAdjustment;
+        profile.TshCursorCaptureEnabledInFullscreenGame = request.TshCursorCaptureEnabledInFullscreenGame ?? profile.TshCursorCaptureEnabledInFullscreenGame;
+        profile.TshCursorCaptureEnabledInFullscreenMenu = request.TshCursorCaptureEnabledInFullscreenMenu ?? profile.TshCursorCaptureEnabledInFullscreenMenu;
+        profile.TshCursorCaptureEnabledInWindowedGame = request.TshCursorCaptureEnabledInWindowedGame ?? profile.TshCursorCaptureEnabledInWindowedGame;
+        profile.TshCursorCaptureEnabledInWindowedMenu = request.TshCursorCaptureEnabledInWindowedMenu ?? profile.TshCursorCaptureEnabledInWindowedMenu;
+        profile.TshScreenEdgeScrollEnabledInFullscreenApp = request.TshScreenEdgeScrollEnabledInFullscreenApp ?? profile.TshScreenEdgeScrollEnabledInFullscreenApp;
+        profile.TshScreenEdgeScrollEnabledInWindowedApp = request.TshScreenEdgeScrollEnabledInWindowedApp ?? profile.TshScreenEdgeScrollEnabledInWindowedApp;
+        profile.TshMoneyTransactionVolume = request.TshMoneyTransactionVolume ?? profile.TshMoneyTransactionVolume;
+    }
+
+    private static void UpdateGeneralsOnlineFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
+        profile.GoShowFps = request.GoShowFps ?? profile.GoShowFps;
+        profile.GoShowPing = request.GoShowPing ?? profile.GoShowPing;
+        profile.GoShowPlayerRanks = request.GoShowPlayerRanks ?? profile.GoShowPlayerRanks;
+        profile.GoAutoLogin = request.GoAutoLogin ?? profile.GoAutoLogin;
+        profile.GoRememberUsername = request.GoRememberUsername ?? profile.GoRememberUsername;
+        profile.GoEnableNotifications = request.GoEnableNotifications ?? profile.GoEnableNotifications;
+        profile.GoEnableSoundNotifications = request.GoEnableSoundNotifications ?? profile.GoEnableSoundNotifications;
+        profile.GoChatFontSize = request.GoChatFontSize ?? profile.GoChatFontSize;
+
+        profile.GoCameraMaxHeightOnlyWhenLobbyHost = request.GoCameraMaxHeightOnlyWhenLobbyHost ?? profile.GoCameraMaxHeightOnlyWhenLobbyHost;
+        profile.GoCameraMinHeight = request.GoCameraMinHeight ?? profile.GoCameraMinHeight;
+        profile.GoCameraMoveSpeedRatio = request.GoCameraMoveSpeedRatio ?? profile.GoCameraMoveSpeedRatio;
+        profile.GoChatDurationSecondsUntilFadeOut = request.GoChatDurationSecondsUntilFadeOut ?? profile.GoChatDurationSecondsUntilFadeOut;
+        profile.GoDebugVerboseLogging = request.GoDebugVerboseLogging ?? profile.GoDebugVerboseLogging;
+
+        profile.GoRenderFpsLimit = request.GoRenderFpsLimit ?? profile.GoRenderFpsLimit;
+        profile.GoRenderLimitFramerate = request.GoRenderLimitFramerate ?? profile.GoRenderLimitFramerate;
+        profile.GoRenderStatsOverlay = request.GoRenderStatsOverlay ?? profile.GoRenderStatsOverlay;
+
+        profile.GoSocialNotificationFriendComesOnlineGameplay = request.GoSocialNotificationFriendComesOnlineGameplay ?? profile.GoSocialNotificationFriendComesOnlineGameplay;
+        profile.GoSocialNotificationFriendComesOnlineMenus = request.GoSocialNotificationFriendComesOnlineMenus ?? profile.GoSocialNotificationFriendComesOnlineMenus;
+        profile.GoSocialNotificationFriendGoesOfflineGameplay = request.GoSocialNotificationFriendGoesOfflineGameplay ?? profile.GoSocialNotificationFriendGoesOfflineGameplay;
+        profile.GoSocialNotificationFriendGoesOfflineMenus = request.GoSocialNotificationFriendGoesOfflineMenus ?? profile.GoSocialNotificationFriendGoesOfflineMenus;
+        profile.GoSocialNotificationPlayerAcceptsRequestGameplay = request.GoSocialNotificationPlayerAcceptsRequestGameplay ?? profile.GoSocialNotificationPlayerAcceptsRequestGameplay;
+        profile.GoSocialNotificationPlayerAcceptsRequestMenus = request.GoSocialNotificationPlayerAcceptsRequestMenus ?? profile.GoSocialNotificationPlayerAcceptsRequestMenus;
+        profile.GoSocialNotificationPlayerSendsRequestGameplay = request.GoSocialNotificationPlayerSendsRequestGameplay ?? profile.GoSocialNotificationPlayerSendsRequestGameplay;
+        profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus ?? profile.GoSocialNotificationPlayerSendsRequestMenus;
     }
 
     private static bool ParseBool(string value) =>

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -714,7 +714,7 @@ public static class GameSettingsMapper
                 TextureQuality.Medium => GameSettingsConstants.TextureQuality.TextureReductionMedium,
                 TextureQuality.High => GameSettingsConstants.TextureQuality.TextureReductionHigh,
                 TextureQuality.VeryHigh => GameSettingsConstants.TextureQuality.TextureReductionHigh,
-                _ => options.Video.TextureReduction,
+                _ => GameSettingsConstants.TextureQuality.TextureReductionHigh,
             };
         }
 
@@ -751,7 +751,10 @@ public static class GameSettingsMapper
         }
 
         if (profile.VideoAlternateMouseSetup.HasValue)
+        {
             options.Video.AlternateMouseSetup = profile.VideoAlternateMouseSetup.Value;
+            options.Video.AdditionalProperties["UseAlternateMouse"] = profile.VideoAlternateMouseSetup.Value ? "yes" : "no";
+        }
 
         if (profile.VideoHeatEffects.HasValue)
             options.Video.HeatEffects = profile.VideoHeatEffects.Value;

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -19,7 +19,13 @@ public static class GameSettingsMapper
     /// <param name="profile">The GameProfile to populate.</param>
     public static void ApplyFromOptions(IniOptions options, GameProfile profile)
     {
-        // Video settings
+        ApplyVideoFromOptions(options, profile);
+        ApplyAudioFromOptions(options, profile);
+        ApplyNetworkFromOptions(options, profile);
+    }
+
+    private static void ApplyVideoFromOptions(IniOptions options, GameProfile profile)
+    {
         profile.VideoResolutionWidth = options.Video.ResolutionWidth;
         profile.VideoResolutionHeight = options.Video.ResolutionHeight;
         profile.VideoWindowed = options.Video.Windowed;
@@ -57,7 +63,12 @@ public static class GameSettingsMapper
 
         profile.VideoAntiAliasing ??= options.Video.AntiAliasing;
 
-        // TSH settings from root (Flat format support)
+        ApplyTshFlatSettingsFromOptions(options, profile);
+        ApplyTshHierarchicalSettingsFromOptions(options, profile);
+    }
+
+    private static void ApplyTshFlatSettingsFromOptions(IniOptions options, GameProfile profile)
+    {
         if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
             profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClick);
         else if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClick", out var dbl))
@@ -71,8 +82,10 @@ public static class GameSettingsMapper
             profile.VideoDynamicLOD = ParseBool(dynLOD);
         if (options.Video.AdditionalProperties.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
             profile.VideoMaxParticleCount = particleVal;
+    }
 
-        // TSH-specific settings from the [TheSuperHackers] section (Hierarchical format support)
+    private static void ApplyTshHierarchicalSettingsFromOptions(IniOptions options, GameProfile profile)
+    {
         if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var tsh))
         {
             if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClickTsh))
@@ -86,16 +99,20 @@ public static class GameSettingsMapper
             if (tsh.TryGetValue("MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, out var particlesTshVal))
                 profile.VideoMaxParticleCount = particlesTshVal;
         }
+    }
 
-        // Audio settings
+    private static void ApplyAudioFromOptions(IniOptions options, GameProfile profile)
+    {
         profile.AudioSoundVolume = options.Audio.SFXVolume;
         profile.AudioThreeDSoundVolume = options.Audio.SFX3DVolume;
         profile.AudioSpeechVolume = options.Audio.VoiceVolume;
         profile.AudioMusicVolume = options.Audio.MusicVolume;
         profile.AudioEnabled = options.Audio.AudioEnabled;
         profile.AudioNumSounds = options.Audio.NumSounds;
+    }
 
-        // Network settings
+    private static void ApplyNetworkFromOptions(IniOptions options, GameProfile profile)
+    {
         profile.GameSpyIPAddress = options.Network.GameSpyIPAddress;
     }
 
@@ -168,8 +185,15 @@ public static class GameSettingsMapper
     /// <param name="settings">The GeneralsOnlineSettings to populate.</param>
     public static void ApplyToGeneralsOnlineSettings(GameProfile profile, GeneralsOnlineSettings settings)
     {
-        // GeneralsOnline settings - use null-coalescing with model defaults
-        // This ensures predictable behavior: always set a value, never rely on constructor defaults
+        ApplyGoGeneralSettings(profile, settings);
+        ApplyGoCameraAndChatSettings(profile, settings);
+        ApplyGoRenderAndDebugSettings(profile, settings);
+        ApplyGoSocialSettings(profile, settings);
+        ApplyGoTshSettings(profile, settings);
+    }
+
+    private static void ApplyGoGeneralSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
         settings.ShowFps = profile.GoShowFps ?? false;
         settings.ShowPing = profile.GoShowPing ?? true;
         settings.ShowPlayerRanks = profile.GoShowPlayerRanks ?? true;
@@ -178,24 +202,26 @@ public static class GameSettingsMapper
         settings.EnableNotifications = profile.GoEnableNotifications ?? true;
         settings.EnableSoundNotifications = profile.GoEnableSoundNotifications ?? true;
         settings.ChatFontSize = profile.GoChatFontSize ?? 12;
+    }
 
-        // Camera settings
+    private static void ApplyGoCameraAndChatSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
         settings.Camera.MaxHeightOnlyWhenLobbyHost = profile.GoCameraMaxHeightOnlyWhenLobbyHost ?? 310.0f;
         settings.Camera.MinHeight = profile.GoCameraMinHeight ?? 310.0f;
         settings.Camera.MoveSpeedRatio = profile.GoCameraMoveSpeedRatio ?? 1.5f;
-
-        // Chat settings
         settings.Chat.DurationSecondsUntilFadeOut = profile.GoChatDurationSecondsUntilFadeOut ?? 30;
+    }
 
-        // Debug settings
+    private static void ApplyGoRenderAndDebugSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
         settings.Debug.VerboseLogging = profile.GoDebugVerboseLogging ?? false;
-
-        // Render settings
         settings.Render.FpsLimit = profile.GoRenderFpsLimit ?? 144;
         settings.Render.LimitFramerate = profile.GoRenderLimitFramerate ?? true;
         settings.Render.StatsOverlay = profile.GoRenderStatsOverlay ?? true;
+    }
 
-        // Social notification settings
+    private static void ApplyGoSocialSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
         settings.Social.NotificationFriendComesOnlineGameplay = profile.GoSocialNotificationFriendComesOnlineGameplay ?? true;
         settings.Social.NotificationFriendComesOnlineMenus = profile.GoSocialNotificationFriendComesOnlineMenus ?? true;
         settings.Social.NotificationFriendGoesOfflineGameplay = profile.GoSocialNotificationFriendGoesOfflineGameplay ?? true;
@@ -204,8 +230,10 @@ public static class GameSettingsMapper
         settings.Social.NotificationPlayerAcceptsRequestMenus = profile.GoSocialNotificationPlayerAcceptsRequestMenus ?? true;
         settings.Social.NotificationPlayerSendsRequestGameplay = profile.GoSocialNotificationPlayerSendsRequestGameplay ?? true;
         settings.Social.NotificationPlayerSendsRequestMenus = profile.GoSocialNotificationPlayerSendsRequestMenus ?? true;
+    }
 
-        // TSH settings (that exist in settings.json) - use null-coalescing with defaults
+    private static void ApplyGoTshSettings(GameProfile profile, GeneralsOnlineSettings settings)
+    {
         settings.ArchiveReplays = profile.TshArchiveReplays ?? false;
         settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
         settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
@@ -230,7 +258,14 @@ public static class GameSettingsMapper
     /// <param name="logger">Optional logger for validation warnings.</param>
     public static void ApplyToOptions(GameProfile profile, IniOptions options, ILogger? logger = null)
     {
-        // Video settings with validation
+        ApplyVideoResolutionAndQualityToOptions(profile, options, logger);
+        ApplyVideoAdditionalToOptions(profile, options, logger);
+        ApplyAudioToOptions(profile, options, logger);
+        ApplyTshToOptions(profile, options);
+    }
+
+    private static void ApplyVideoResolutionAndQualityToOptions(GameProfile profile, IniOptions options, ILogger? logger)
+    {
         if (profile.VideoResolutionWidth.HasValue)
         {
             if (profile.VideoResolutionWidth.Value >= GameSettingsConstants.Resolution.MinWidth &&
@@ -274,8 +309,6 @@ public static class GameSettingsMapper
 
         if (profile.VideoTextureQuality.HasValue)
         {
-            // Engine Value (TextureReduction): 2=Low, 1=Medium, 0=High/Max
-            // Clamp anything higher than 'High' to Max Quality to prevent invalid values
             options.Video.TextureReduction = profile.VideoTextureQuality.Value switch
             {
                 TextureQuality.Low => GameSettingsConstants.TextureQuality.TextureReductionLow,
@@ -296,7 +329,10 @@ public static class GameSettingsMapper
         {
             options.Video.ExtraAnimations = profile.VideoExtraAnimations.Value;
         }
+    }
 
+    private static void ApplyVideoAdditionalToOptions(GameProfile profile, IniOptions options, ILogger? logger)
+    {
         if (profile.VideoGamma.HasValue)
         {
             if (profile.VideoGamma.Value >= GameSettingsConstants.Gamma.Min &&
@@ -318,6 +354,7 @@ public static class GameSettingsMapper
         if (profile.VideoAlternateMouseSetup.HasValue)
         {
             options.Video.AlternateMouseSetup = profile.VideoAlternateMouseSetup.Value;
+            options.Video.AdditionalProperties["UseAlternateMouse"] = profile.VideoAlternateMouseSetup.Value ? "yes" : "no";
         }
 
         if (profile.VideoHeatEffects.HasValue)
@@ -325,7 +362,6 @@ public static class GameSettingsMapper
             options.Video.HeatEffects = profile.VideoHeatEffects.Value;
         }
 
-        // Additional video settings to AdditionalProperties (Standard root)
         if (profile.VideoStaticGameLOD != null)
             options.Video.AdditionalProperties["StaticGameLOD"] = profile.VideoStaticGameLOD;
         if (profile.VideoIdealStaticGameLOD != null)
@@ -333,7 +369,6 @@ public static class GameSettingsMapper
         if (profile.VideoAntiAliasing.HasValue)
             options.Video.AntiAliasing = profile.VideoAntiAliasing.Value;
 
-        // TSH settings (writing to root for maximum compatibility as some clients prefer flat Options.ini)
         if (profile.VideoUseDoubleClickAttackMove.HasValue)
         {
             options.Video.AdditionalProperties["UseDoubleClickAttackMove"] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
@@ -350,12 +385,10 @@ public static class GameSettingsMapper
             options.Video.AdditionalProperties["MaxParticleCount"] = profile.VideoMaxParticleCount.Value.ToString();
         if (profile.VideoSkipEALogo.HasValue)
             options.Video.AdditionalProperties["SkipEALogo"] = profile.VideoSkipEALogo.Value ? "yes" : "no";
+    }
 
-        // Mirror Alternate Mouse
-        if (profile.VideoAlternateMouseSetup.HasValue)
-            options.Video.AdditionalProperties["UseAlternateMouse"] = profile.VideoAlternateMouseSetup.Value ? "yes" : "no";
-
-        // Audio settings with validation
+    private static void ApplyAudioToOptions(GameProfile profile, IniOptions options, ILogger? logger)
+    {
         if (profile.AudioSoundVolume.HasValue)
         {
             if (profile.AudioSoundVolume.Value >= GameSettingsConstants.Volume.Min &&
@@ -450,8 +483,10 @@ public static class GameSettingsMapper
                     GameSettingsConstants.Audio.MaxNumSounds);
             }
         }
+    }
 
-        // TheSuperHackers settings
+    private static void ApplyTshToOptions(GameProfile profile, IniOptions options)
+    {
         var tshDict = new Dictionary<string, string>();
         if (profile.TshArchiveReplays.HasValue) tshDict["ArchiveReplays"] = BoolToString(profile.TshArchiveReplays.Value);
         if (profile.TshShowMoneyPerMinute.HasValue) tshDict["ShowMoneyPerMinute"] = BoolToString(profile.TshShowMoneyPerMinute.Value);
@@ -659,6 +694,17 @@ public static class GameSettingsMapper
     /// <param name="request">The request containing potentially partial settings.</param>
     public static void PatchGameProfile(GameProfile profile, CreateProfileRequest request)
     {
+        PatchVideoSettings(profile, request);
+        PatchAudioSettings(profile, request);
+        PatchTshSettings(profile, request);
+        PatchGeneralsOnlineSettings(profile, request);
+
+        profile.GameSpyIPAddress = request.GameSpyIPAddress ?? profile.GameSpyIPAddress;
+        profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
+    }
+
+    private static void PatchVideoSettings(GameProfile profile, CreateProfileRequest request)
+    {
         profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
         profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
         profile.VideoWindowed = request.VideoWindowed ?? profile.VideoWindowed;
@@ -670,14 +716,20 @@ public static class GameSettingsMapper
         profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
         profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
         profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
+    }
 
+    private static void PatchAudioSettings(GameProfile profile, CreateProfileRequest request)
+    {
         profile.AudioSoundVolume = request.AudioSoundVolume ?? profile.AudioSoundVolume;
         profile.AudioThreeDSoundVolume = request.AudioThreeDSoundVolume ?? profile.AudioThreeDSoundVolume;
         profile.AudioSpeechVolume = request.AudioSpeechVolume ?? profile.AudioSpeechVolume;
         profile.AudioMusicVolume = request.AudioMusicVolume ?? profile.AudioMusicVolume;
         profile.AudioEnabled = request.AudioEnabled ?? profile.AudioEnabled;
         profile.AudioNumSounds = request.AudioNumSounds ?? profile.AudioNumSounds;
+    }
 
+    private static void PatchTshSettings(GameProfile profile, CreateProfileRequest request)
+    {
         profile.TshArchiveReplays = request.TshArchiveReplays ?? profile.TshArchiveReplays;
         profile.TshShowMoneyPerMinute = request.TshShowMoneyPerMinute ?? profile.TshShowMoneyPerMinute;
         profile.TshPlayerObserverEnabled = request.TshPlayerObserverEnabled ?? profile.TshPlayerObserverEnabled;
@@ -692,7 +744,10 @@ public static class GameSettingsMapper
         profile.TshScreenEdgeScrollEnabledInFullscreenApp = request.TshScreenEdgeScrollEnabledInFullscreenApp ?? profile.TshScreenEdgeScrollEnabledInFullscreenApp;
         profile.TshScreenEdgeScrollEnabledInWindowedApp = request.TshScreenEdgeScrollEnabledInWindowedApp ?? profile.TshScreenEdgeScrollEnabledInWindowedApp;
         profile.TshMoneyTransactionVolume = request.TshMoneyTransactionVolume ?? profile.TshMoneyTransactionVolume;
+    }
 
+    private static void PatchGeneralsOnlineSettings(GameProfile profile, CreateProfileRequest request)
+    {
         profile.GoShowFps = request.GoShowFps ?? profile.GoShowFps;
         profile.GoShowPing = request.GoShowPing ?? profile.GoShowPing;
         profile.GoShowPlayerRanks = request.GoShowPlayerRanks ?? profile.GoShowPlayerRanks;
@@ -705,9 +760,7 @@ public static class GameSettingsMapper
         profile.GoCameraMaxHeightOnlyWhenLobbyHost = request.GoCameraMaxHeightOnlyWhenLobbyHost ?? profile.GoCameraMaxHeightOnlyWhenLobbyHost;
         profile.GoCameraMinHeight = request.GoCameraMinHeight ?? profile.GoCameraMinHeight;
         profile.GoCameraMoveSpeedRatio = request.GoCameraMoveSpeedRatio ?? profile.GoCameraMoveSpeedRatio;
-
         profile.GoChatDurationSecondsUntilFadeOut = request.GoChatDurationSecondsUntilFadeOut ?? profile.GoChatDurationSecondsUntilFadeOut;
-
         profile.GoDebugVerboseLogging = request.GoDebugVerboseLogging ?? profile.GoDebugVerboseLogging;
 
         profile.GoRenderFpsLimit = request.GoRenderFpsLimit ?? profile.GoRenderFpsLimit;
@@ -722,9 +775,6 @@ public static class GameSettingsMapper
         profile.GoSocialNotificationPlayerAcceptsRequestMenus = request.GoSocialNotificationPlayerAcceptsRequestMenus ?? profile.GoSocialNotificationPlayerAcceptsRequestMenus;
         profile.GoSocialNotificationPlayerSendsRequestGameplay = request.GoSocialNotificationPlayerSendsRequestGameplay ?? profile.GoSocialNotificationPlayerSendsRequestGameplay;
         profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus ?? profile.GoSocialNotificationPlayerSendsRequestMenus;
-
-        profile.GameSpyIPAddress = request.GameSpyIPAddress ?? profile.GameSpyIPAddress;
-        profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
     }
 
     /// <summary>
@@ -733,6 +783,20 @@ public static class GameSettingsMapper
     /// <param name="profile">The GameProfile to patch.</param>
     /// <param name="request">The request containing potentially partial settings.</param>
     public static void UpdateFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
+        UpdateVideoFromRequest(profile, request);
+        UpdateAudioFromRequest(profile, request);
+        UpdateTshFromRequest(profile, request);
+        UpdateGeneralsOnlineFromRequest(profile, request);
+
+        if (request.UseSteamLaunch.HasValue)
+            profile.UseSteamLaunch = request.UseSteamLaunch.Value;
+
+        profile.GameSpyIPAddress = request.GameSpyIPAddress ?? profile.GameSpyIPAddress;
+        profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
+    }
+
+    private static void UpdateVideoFromRequest(GameProfile profile, UpdateProfileRequest request)
     {
         profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
         profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
@@ -753,14 +817,20 @@ public static class GameSettingsMapper
         profile.VideoDynamicLOD = request.VideoDynamicLOD ?? profile.VideoDynamicLOD;
         profile.VideoMaxParticleCount = request.VideoMaxParticleCount ?? profile.VideoMaxParticleCount;
         profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
+    }
 
+    private static void UpdateAudioFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
         profile.AudioSoundVolume = request.AudioSoundVolume ?? profile.AudioSoundVolume;
         profile.AudioThreeDSoundVolume = request.AudioThreeDSoundVolume ?? profile.AudioThreeDSoundVolume;
         profile.AudioSpeechVolume = request.AudioSpeechVolume ?? profile.AudioSpeechVolume;
         profile.AudioMusicVolume = request.AudioMusicVolume ?? profile.AudioMusicVolume;
         profile.AudioEnabled = request.AudioEnabled ?? profile.AudioEnabled;
         profile.AudioNumSounds = request.AudioNumSounds ?? profile.AudioNumSounds;
+    }
 
+    private static void UpdateTshFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
         profile.TshArchiveReplays = request.TshArchiveReplays ?? profile.TshArchiveReplays;
         profile.TshShowMoneyPerMinute = request.TshShowMoneyPerMinute ?? profile.TshShowMoneyPerMinute;
         profile.TshPlayerObserverEnabled = request.TshPlayerObserverEnabled ?? profile.TshPlayerObserverEnabled;
@@ -775,7 +845,10 @@ public static class GameSettingsMapper
         profile.TshScreenEdgeScrollEnabledInFullscreenApp = request.TshScreenEdgeScrollEnabledInFullscreenApp ?? profile.TshScreenEdgeScrollEnabledInFullscreenApp;
         profile.TshScreenEdgeScrollEnabledInWindowedApp = request.TshScreenEdgeScrollEnabledInWindowedApp ?? profile.TshScreenEdgeScrollEnabledInWindowedApp;
         profile.TshMoneyTransactionVolume = request.TshMoneyTransactionVolume ?? profile.TshMoneyTransactionVolume;
+    }
 
+    private static void UpdateGeneralsOnlineFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
         profile.GoShowFps = request.GoShowFps ?? profile.GoShowFps;
         profile.GoShowPing = request.GoShowPing ?? profile.GoShowPing;
         profile.GoShowPlayerRanks = request.GoShowPlayerRanks ?? profile.GoShowPlayerRanks;
@@ -788,9 +861,7 @@ public static class GameSettingsMapper
         profile.GoCameraMaxHeightOnlyWhenLobbyHost = request.GoCameraMaxHeightOnlyWhenLobbyHost ?? profile.GoCameraMaxHeightOnlyWhenLobbyHost;
         profile.GoCameraMinHeight = request.GoCameraMinHeight ?? profile.GoCameraMinHeight;
         profile.GoCameraMoveSpeedRatio = request.GoCameraMoveSpeedRatio ?? profile.GoCameraMoveSpeedRatio;
-
         profile.GoChatDurationSecondsUntilFadeOut = request.GoChatDurationSecondsUntilFadeOut ?? profile.GoChatDurationSecondsUntilFadeOut;
-
         profile.GoDebugVerboseLogging = request.GoDebugVerboseLogging ?? profile.GoDebugVerboseLogging;
 
         profile.GoRenderFpsLimit = request.GoRenderFpsLimit ?? profile.GoRenderFpsLimit;
@@ -805,12 +876,6 @@ public static class GameSettingsMapper
         profile.GoSocialNotificationPlayerAcceptsRequestMenus = request.GoSocialNotificationPlayerAcceptsRequestMenus ?? profile.GoSocialNotificationPlayerAcceptsRequestMenus;
         profile.GoSocialNotificationPlayerSendsRequestGameplay = request.GoSocialNotificationPlayerSendsRequestGameplay ?? profile.GoSocialNotificationPlayerSendsRequestGameplay;
         profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus ?? profile.GoSocialNotificationPlayerSendsRequestMenus;
-
-        if (request.UseSteamLaunch.HasValue)
-            profile.UseSteamLaunch = request.UseSteamLaunch.Value;
-
-        profile.GameSpyIPAddress = request.GameSpyIPAddress ?? profile.GameSpyIPAddress;
-        profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
@@ -162,22 +162,18 @@ public static partial class GameVersionHelper
             || qfeDigits.Length == 0
             || !qfeDigits.All(character => character is >= '0' and <= '9')
             || !int.TryParse(qfeDigits, NumberStyles.None, CultureInfo.InvariantCulture, out var qfe)
-            || !int.TryParse(datePart[0..2], NumberStyles.None, CultureInfo.InvariantCulture, out var month)
-            || !int.TryParse(datePart[2..4], NumberStyles.None, CultureInfo.InvariantCulture, out var day)
-            || !int.TryParse(datePart[4..6], NumberStyles.None, CultureInfo.InvariantCulture, out var twoDigitYear))
+            || !DateOnly.TryParseExact(datePart, "MMddyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
         {
             return ExtractVersionFromVersionString(version);
         }
 
         try
         {
-            _ = new DateTime(2000 + twoDigitYear, month, day);
+            var month = date.Month;
+            var day = date.Day;
+            var twoDigitYear = date.Year % 100;
             var mmddyy = (month * 10000) + (day * 100) + twoDigitYear;
             return checked((mmddyy * 10) + qfe);
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            return ExtractVersionFromVersionString(version);
         }
         catch (OverflowException)
         {

--- a/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
@@ -22,34 +22,29 @@ public static partial class GameVersionHelper
             return 0;
         }
 
+        // Try extracting an 8-digit date pattern first (e.g., "2025-11-07", "weekly-2025-11-21", "1.20260116")
+        var dateMatch = Regex.Match(version, @"\b(\d{4})[-_.]?(\d{2})[-_.]?(\d{2})\b", RegexOptions.None, TimeSpan.FromSeconds(1));
+        if (dateMatch.Success && int.TryParse($"{dateMatch.Groups[1].Value}{dateMatch.Groups[2].Value}{dateMatch.Groups[3].Value}", NumberStyles.Integer, CultureInfo.InvariantCulture, out var dateVal))
+        {
+            return dateVal;
+        }
+
         // Extract all digits from the version string
         var digits = NonDigitRegex().Replace(version, string.Empty);
-
-        // If it looks like a long date (YYYYMMDD) preceded by a segment (e.g. "1.20260116"),
-        // we might want the latter part if it's the date.
-        // But for now, let's just avoid the 8-digit truncation if it causes mangling
-        // and only truncate IF it would actually overflow int.
-        if (digits.Length > 9 && digits.StartsWith('0'))
+        if (string.IsNullOrEmpty(digits))
         {
-            digits = digits.TrimStart('0');
+            return 0;
         }
 
-        if (digits.Length > 10)
+        digits = digits.TrimStart('0');
+        if (digits.Length == 0)
         {
-             // int.MaxValue is ~2.1 billion (10 digits)
-            digits = digits[..10];
+            return 0;
         }
 
-        if (long.TryParse(digits, out var longResult))
+        if (int.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intResult))
         {
-            if (longResult > int.MaxValue)
-            {
-                // If it's still too large for int, cap at int.MaxValue to prevent incorrect comparisons
-                // Most callers expect int.
-                return int.MaxValue;
-            }
-
-            return (int)longResult;
+            return intResult;
         }
 
         return 0;

--- a/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameVersionHelper.cs
@@ -42,9 +42,20 @@ public static partial class GameVersionHelper
             return 0;
         }
 
-        if (int.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intResult))
+        if (digits.Length > 10)
         {
-            return intResult;
+            // int.MaxValue is 10 digits; truncate to 10 digits for legacy manifest ID compatibility
+            digits = digits[..10];
+        }
+
+        if (long.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longResult))
+        {
+            if (longResult > int.MaxValue)
+            {
+                return int.MaxValue;
+            }
+
+            return (int)longResult;
         }
 
         return 0;

--- a/GenHub/GenHub.Core/Helpers/SteamAppIdResolver.cs
+++ b/GenHub/GenHub.Core/Helpers/SteamAppIdResolver.cs
@@ -45,7 +45,7 @@ public static partial class SteamAppIdResolver
             return false;
         }
 
-        IEnumerable<string> manifests;
+        IEnumerable<string> manifests = [];
         try
         {
             manifests = Directory.EnumerateFiles(steamAppsDir.FullName, "appmanifest_*.acf", SearchOption.TopDirectoryOnly);
@@ -57,7 +57,7 @@ public static partial class SteamAppIdResolver
 
         foreach (var manifestPath in manifests)
         {
-            string raw;
+            string raw = string.Empty;
             try
             {
                 raw = File.ReadAllText(manifestPath);

--- a/GenHub/GenHub.Core/Models/Common/UserSettings.cs
+++ b/GenHub/GenHub.Core/Models/Common/UserSettings.cs
@@ -7,7 +7,7 @@ using GenHub.Core.Models.Storage;
 namespace GenHub.Core.Models.Common;
 
 /// <summary>Represents application-level and user-specific settings for GenHub.</summary>
-public class UserSettings : ICloneable
+public class UserSettings
 {
     /// <summary>Gets or sets the application theme preference.</summary>
     public string? Theme { get; set; } = GenHub.Core.Constants.AppConstants.DefaultThemeName;
@@ -137,7 +137,7 @@ public class UserSettings : ICloneable
 
     /// <summary>Creates a deep copy of the current UserSettings instance.</summary>
     /// <returns>A new UserSettings instance with all properties deeply copied.</returns>
-    public object Clone()
+    public UserSettings Clone()
     {
         return new UserSettings
         {

--- a/GenHub/GenHub.Core/Models/Common/UserSettings.cs
+++ b/GenHub/GenHub.Core/Models/Common/UserSettings.cs
@@ -267,7 +267,7 @@ public class UserSettings : ICloneable
     /// <returns>True if subscribed; otherwise, false.</returns>
     public bool IsSubscribedTo(string publisherId)
     {
-        return GetSubscription(publisherId)?.IsActive ?? false; // Default to not subscribed for safety
+        return GetSubscription(publisherId)?.IsActive == true; // Default to not subscribed for safety
     }
 
     /// <summary>
@@ -296,7 +296,7 @@ public class UserSettings : ICloneable
     {
         // Check new subscription system
         var subscription = GetSubscription(publisherId);
-        if (subscription != null && subscription.ShouldSkipVersion(version))
+        if (subscription?.ShouldSkipVersion(version) == true)
         {
             return true;
         }

--- a/GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs
+++ b/GenHub/GenHub.Core/Models/CommunityOutpost/GenPatcherContentRegistry.cs
@@ -471,7 +471,7 @@ public static class GenPatcherContentRegistry
         }
 
         // Try to parse the version (positions 1-2)
-        var versionPart = code.Substring(1, 2);
+        var versionPart = code[1..3];
         if (!int.TryParse(versionPart, out var versionNumber))
         {
             return null;

--- a/GenHub/GenHub.Core/Models/Manifest/EntryPointResolution.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/EntryPointResolution.cs
@@ -57,10 +57,18 @@ public sealed class EntryPointResolution
     /// Builds a log-ready description including the candidates considered.
     /// </summary>
     /// <returns>A diagnostic string.</returns>
-    public override string ToString() =>
-        Success
-            ? $"{RelativePath} ({Reason})"
-            : Candidates.Count == 0
-                ? Reason
-                : $"{Reason} Candidates: {string.Join(", ", Candidates)}";
+    public override string ToString()
+    {
+        if (Success)
+        {
+            return $"{RelativePath} ({Reason})";
+        }
+
+        if (Candidates.Count == 0)
+        {
+            return Reason;
+        }
+
+        return $"{Reason} Candidates: {string.Join(", ", Candidates)}";
+    }
 }

--- a/GenHub/GenHub.Core/Models/Manifest/VersionConstraint.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/VersionConstraint.cs
@@ -10,8 +10,8 @@ namespace GenHub.Core.Models.Manifest;
 /// </summary>
 public partial class VersionConstraint
 {
-    private static readonly string[] OrSeparators = new[] { "||" };
-    private static readonly char[] SpaceSeparators = new[] { ' ' };
+    private static readonly string[] OrSeparators = ["||"];
+    private static readonly char[] SpaceSeparators = [' '];
 
     /// <summary>
     /// Gets or sets the minimum version required (inclusive by default).

--- a/GenHub/GenHub.Core/Models/Notifications/NotificationMessage.cs
+++ b/GenHub/GenHub.Core/Models/Notifications/NotificationMessage.cs
@@ -46,7 +46,7 @@ public record NotificationMessage
     /// <summary>
     /// Gets a value indicating whether this notification has any actionable buttons.
     /// </summary>
-    public bool IsActionable => Actions != null && Actions.Count > 0;
+    public bool IsActionable => Actions?.Count > 0;
 
     /// <summary>
     /// Gets a value indicating whether this notification should persist in the feed
@@ -116,7 +116,7 @@ public record NotificationMessage
         IsDismissed = false;
 
         // Support both old single-action and new multi-action patterns
-        if (actions != null && actions.Count > 0)
+        if (actions is { Count: > 0 })
         {
             Actions = actions;
         }

--- a/GenHub/GenHub.Core/Models/Providers/ProviderEndpoints.cs
+++ b/GenHub/GenHub.Core/Models/Providers/ProviderEndpoints.cs
@@ -66,58 +66,46 @@ public class ProviderEndpoints
     public string? GetEndpoint(string name)
     {
         // Check standard endpoints first
-        if (string.Equals(name, ProviderEndpointConstants.CatalogUrl, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, ProviderEndpointConstants.Catalog, StringComparison.OrdinalIgnoreCase))
+        if ((string.Equals(name, ProviderEndpointConstants.CatalogUrl, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(name, ProviderEndpointConstants.Catalog, StringComparison.OrdinalIgnoreCase)) &&
+            !string.IsNullOrEmpty(CatalogUrl))
         {
-            if (!string.IsNullOrEmpty(CatalogUrl))
-            {
-                return CatalogUrl;
-            }
+            return CatalogUrl;
         }
 
-        if (string.Equals(name, ProviderEndpointConstants.DownloadBaseUrl, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, ProviderEndpointConstants.DownloadBase, StringComparison.OrdinalIgnoreCase))
+        if ((string.Equals(name, ProviderEndpointConstants.DownloadBaseUrl, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(name, ProviderEndpointConstants.DownloadBase, StringComparison.OrdinalIgnoreCase)) &&
+            !string.IsNullOrEmpty(DownloadBaseUrl))
         {
-            if (!string.IsNullOrEmpty(DownloadBaseUrl))
-            {
-                return DownloadBaseUrl;
-            }
+            return DownloadBaseUrl;
         }
 
-        if (string.Equals(name, ProviderEndpointConstants.WebsiteUrl, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, ProviderEndpointConstants.Website, StringComparison.OrdinalIgnoreCase))
+        if ((string.Equals(name, ProviderEndpointConstants.WebsiteUrl, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(name, ProviderEndpointConstants.Website, StringComparison.OrdinalIgnoreCase)) &&
+            !string.IsNullOrEmpty(WebsiteUrl))
         {
-            if (!string.IsNullOrEmpty(WebsiteUrl))
-            {
-                return WebsiteUrl;
-            }
+            return WebsiteUrl;
         }
 
-        if (string.Equals(name, ProviderEndpointConstants.SupportUrl, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, ProviderEndpointConstants.Support, StringComparison.OrdinalIgnoreCase))
+        if ((string.Equals(name, ProviderEndpointConstants.SupportUrl, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(name, ProviderEndpointConstants.Support, StringComparison.OrdinalIgnoreCase)) &&
+            !string.IsNullOrEmpty(SupportUrl))
         {
-            if (!string.IsNullOrEmpty(SupportUrl))
-            {
-                return SupportUrl;
-            }
+            return SupportUrl;
         }
 
-        if (string.Equals(name, ProviderEndpointConstants.LatestVersionUrl, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, ProviderEndpointConstants.LatestVersion, StringComparison.OrdinalIgnoreCase))
+        if ((string.Equals(name, ProviderEndpointConstants.LatestVersionUrl, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(name, ProviderEndpointConstants.LatestVersion, StringComparison.OrdinalIgnoreCase)) &&
+            !string.IsNullOrEmpty(LatestVersionUrl))
         {
-            if (!string.IsNullOrEmpty(LatestVersionUrl))
-            {
-                return LatestVersionUrl;
-            }
+            return LatestVersionUrl;
         }
 
-        if (string.Equals(name, ProviderEndpointConstants.ManifestApiUrl, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, ProviderEndpointConstants.ManifestApi, StringComparison.OrdinalIgnoreCase))
+        if ((string.Equals(name, ProviderEndpointConstants.ManifestApiUrl, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(name, ProviderEndpointConstants.ManifestApi, StringComparison.OrdinalIgnoreCase)) &&
+            !string.IsNullOrEmpty(ManifestApiUrl))
         {
-            if (!string.IsNullOrEmpty(ManifestApiUrl))
-            {
-                return ManifestApiUrl;
-            }
+            return ManifestApiUrl;
         }
 
         // Check custom endpoints

--- a/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
+++ b/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
@@ -12,6 +12,7 @@ namespace GenHub.Core.Serialization;
 public class JsonWorkspaceStrategyConverter : JsonConverter<WorkspaceStrategy>
 {
     /// <inheritdoc />
+    [SuppressMessage("Maintainability", "CS-R1138:Inappropriate ordering of parameters", Justification = "Signature is defined by System.Text.Json.Serialization.JsonConverter<T>.Read")]
     public override WorkspaceStrategy Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Number)

--- a/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
+++ b/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using GenHub.Core.Models.Enums;

--- a/GenHub/GenHub.Core/Services/Providers/ProviderDefinitionLoader.cs
+++ b/GenHub/GenHub.Core/Services/Providers/ProviderDefinitionLoader.cs
@@ -240,6 +240,11 @@ public class ProviderDefinitionLoader : IProviderDefinitionLoader
         }
 
         var removed = this.providers.TryRemove(providerId, out _);
+        if (!removed)
+        {
+            var normalized = providerId.Replace("-", string.Empty);
+            removed = this.providers.TryRemove(normalized, out _);
+        }
 
         if (removed)
         {

--- a/GenHub/GenHub.Core/Services/Providers/ProviderDefinitionLoader.cs
+++ b/GenHub/GenHub.Core/Services/Providers/ProviderDefinitionLoader.cs
@@ -141,7 +141,18 @@ public class ProviderDefinitionLoader : IProviderDefinitionLoader
             this.EnsureProvidersLoaded();
         }
 
-        return this.providers.TryGetValue(providerId, out var provider) ? provider : null;
+        if (this.providers.TryGetValue(providerId, out var provider))
+        {
+            return provider;
+        }
+
+        var normalized = providerId.Replace("-", string.Empty);
+        if (this.providers.TryGetValue(normalized, out provider))
+        {
+            return provider;
+        }
+
+        return null;
     }
 
     /// <inheritdoc/>

--- a/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
+++ b/GenHub/GenHub.Core/Utilities/ExecutableFileClassifier.cs
@@ -266,8 +266,22 @@ public static class ExecutableFileClassifier
             read = stream.ReadAtLeast(header, MagicHeaderLength, throwOnEndOfStream: false);
             return true;
         }
-        catch (Exception ex) when (
-            ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        catch (IOException)
+        {
+            read = 0;
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            read = 0;
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            read = 0;
+            return false;
+        }
+        catch (NotSupportedException)
         {
             read = 0;
             return false;

--- a/GenHub/GenHub.Linux/GameInstallations/CdisoInstallation.cs
+++ b/GenHub/GenHub.Linux/GameInstallations/CdisoInstallation.cs
@@ -357,10 +357,8 @@ public class CdisoInstallation(ILogger<CdisoInstallation>? logger = null) : IGam
                                             logger?.LogInformation("CD/ISO path found in Wine registry using value '{ValueName}': {InstallPath}", valueName, installPath);
                                             return true;
                                         }
-                                        else
-                                        {
-                                            logger?.LogDebug("Found registry value '{ValueName}' but path does not exist: {InstallPath}", valueName, installPath);
-                                        }
+
+                                        logger?.LogDebug("Found registry value '{ValueName}' but path does not exist: {InstallPath}", valueName, installPath);
                                     }
                                 }
                             }

--- a/GenHub/GenHub.Linux/Program.cs
+++ b/GenHub/GenHub.Linux/Program.cs
@@ -38,11 +38,10 @@ public class Program
         // Create lockfile to guarantee that only one instance is running on linux
         var lockFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".genhub", "lock");
         Directory.CreateDirectory(Path.GetDirectoryName(lockFilePath)!);
+        FileStream? lockFile = null;
         try
         {
-            using var lockFile = new FileStream(lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-
-            // If we get here, we have the lock
+            lockFile = new FileStream(lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
         }
         catch (IOException)
         {
@@ -50,7 +49,8 @@ public class Program
             return;
         }
 
-        using var bootstrapLoggerFactory = LoggingModule.CreateBootstrapLoggerFactory();
+        using (lockFile)
+        using (var bootstrapLoggerFactory = LoggingModule.CreateBootstrapLoggerFactory())
         var bootstrapLogger = bootstrapLoggerFactory.CreateLogger<Program>();
         try
         {

--- a/GenHub/GenHub.Linux/Program.cs
+++ b/GenHub/GenHub.Linux/Program.cs
@@ -51,33 +51,35 @@ public class Program
 
         using (lockFile)
         using (var bootstrapLoggerFactory = LoggingModule.CreateBootstrapLoggerFactory())
-        var bootstrapLogger = bootstrapLoggerFactory.CreateLogger<Program>();
-        try
         {
-            bootstrapLogger.LogInformation("Starting GenHub Linux application");
-
-            var services = new ServiceCollection();
-
+            var bootstrapLogger = bootstrapLoggerFactory.CreateLogger<Program>();
             try
             {
-                // Register shared services and Linux-specific services
-                services.ConfigureApplicationServices(s => s.AddLinuxServices());
+                bootstrapLogger.LogInformation("Starting GenHub Linux application");
+
+                var services = new ServiceCollection();
+
+                try
+                {
+                    // Register shared services and Linux-specific services
+                    services.ConfigureApplicationServices(s => s.AddLinuxServices());
+                }
+                catch (Exception configEx)
+                {
+                    bootstrapLogger.LogCritical(configEx, "Failed to configure application services");
+                    throw;
+                }
+
+                var serviceProvider = services.BuildServiceProvider();
+                AppLocator.Services = serviceProvider;
+
+                BuildAvaloniaApp(serviceProvider).StartWithClassicDesktopLifetime(args);
             }
-            catch (Exception configEx)
+            catch (Exception ex)
             {
-                bootstrapLogger.LogCritical(configEx, "Failed to configure application services");
+                bootstrapLogger.LogCritical(ex, "Application terminated unexpectedly");
                 throw;
             }
-
-            var serviceProvider = services.BuildServiceProvider();
-            AppLocator.Services = serviceProvider;
-
-            BuildAvaloniaApp(serviceProvider).StartWithClassicDesktopLifetime(args);
-        }
-        catch (Exception ex)
-        {
-            bootstrapLogger.LogCritical(ex, "Application terminated unexpectedly");
-            throw;
         }
     }
 

--- a/GenHub/GenHub.MacOS/GameInstallations/MacOSInstallationDetector.cs
+++ b/GenHub/GenHub.MacOS/GameInstallations/MacOSInstallationDetector.cs
@@ -222,12 +222,12 @@ public class MacOSInstallationDetector(ILogger<MacOSInstallationDetector> logger
 
         foreach (var container in bottleContainers)
         {
-            string[] bottles;
+            string[] bottles = [];
             try
             {
                 bottles = Directory.Exists(container) ? Directory.GetDirectories(container) : [];
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 // An unreadable bottle container is not a detection failure.
                 continue;

--- a/GenHub/GenHub.ProxyLauncher/Program.cs
+++ b/GenHub/GenHub.ProxyLauncher/Program.cs
@@ -54,7 +54,7 @@ internal class Program
             LogLaunchDetails(configPath, config, workingDir);
 
             var (startInfo, tempExePath) = PrepareProcessStartInfo(config, workingDir!, args);
-            var (exitCode, spawnedFound) = await ExecuteAndMonitorProcessAsync(config, startInfo);
+            var (exitCode, _) = await ExecuteAndMonitorProcessAsync(config, startInfo);
 
             CleanupTempExecutable(tempExePath);
             LogInfo($"Process completed. Final Exit Code: {exitCode}");
@@ -442,7 +442,7 @@ internal class Program
         try
         {
             var logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ProxyConstants.LogFileName);
-            File.AppendAllText(logPath, $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}] INFO: {message}{Environment.NewLine}");
+            File.AppendAllText(logPath, $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}Z] INFO: {message}{Environment.NewLine}");
         }
         catch
         {
@@ -459,7 +459,7 @@ internal class Program
         try
         {
             var logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ProxyConstants.LogFileName);
-            File.AppendAllText(logPath, $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}] ERROR: {message}{Environment.NewLine}");
+            File.AppendAllText(logPath, $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}Z] ERROR: {message}{Environment.NewLine}");
         }
         catch
         {

--- a/GenHub/GenHub.ProxyLauncher/Program.cs
+++ b/GenHub/GenHub.ProxyLauncher/Program.cs
@@ -27,7 +27,7 @@ internal class Program
         if (!createdNew)
         {
             LogError($"Another instance of proxy launcher is already running for directory: {baseDir}");
-            return 1;
+            return 0;
         }
 
         try

--- a/GenHub/GenHub.ProxyLauncher/Program.cs
+++ b/GenHub/GenHub.ProxyLauncher/Program.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 namespace GenHub.ProxyLauncher;
@@ -18,259 +20,269 @@ internal class Program
     /// <returns>The exit code of the process.</returns>
     private static async Task<int> Main(string[] args)
     {
-        // Prevent multiple instances from running simultaneously
-        // This can happen when Steam triggers the proxy again while it's already running
-        const string mutexName = ProxyConstants.SingleInstanceMutexName;
+        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+        var mutexName = GetScopedMutexName(baseDir);
+
         using var mutex = new Mutex(true, mutexName, out bool createdNew);
         if (!createdNew)
         {
-            // Another instance is already running - silently exit
-            // No logging here since we don't want to spam the log
-            return 0;
+            LogError($"Another instance of proxy launcher is already running for directory: {baseDir}");
+            return 1;
         }
-
-        int finalExitCode = 0;
 
         try
         {
-            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
             var configPath = Path.Combine(baseDir, ConfigFileName);
-
             if (!File.Exists(configPath))
             {
-                // Fallback: If no config, try to launch the original game if it exists as .bak
-                // This is a safety measure if someone runs the proxy manually without GenHub setup
                 return await TryLaunchBackupAsync(baseDir, args);
             }
 
-            var configJson = await File.ReadAllTextAsync(configPath);
-            var config = JsonSerializer.Deserialize<ProxyConfig>(configJson);
-
+            var config = await LoadConfigAsync(configPath);
             if (config == null || string.IsNullOrWhiteSpace(config.TargetExecutable))
             {
                 LogError("Invalid configuration: TargetExecutable is missing.");
                 return 1;
             }
 
-            // Log configuration for debugging
-            LogInfo($"Proxy Launcher started at {DateTime.Now}");
-            LogInfo($"Configuration loaded from: {configPath}");
-            LogInfo($"Target Executable: {config.TargetExecutable}");
-            LogInfo($"Working Directory: {config.WorkingDirectory ?? Path.GetDirectoryName(config.TargetExecutable)}");
-            LogInfo($"Arguments: {(config.Arguments != null ? string.Join(" ", config.Arguments) : "(none)")}");
-
-            // Validate target executable exists
-            if (!File.Exists(config.TargetExecutable))
-            {
-                var errorMsg = $"Target executable not found: {config.TargetExecutable}";
-                LogError(errorMsg);
-                return 1;
-            }
-
-            // Validate working directory exists
             var workingDir = config.WorkingDirectory ?? Path.GetDirectoryName(config.TargetExecutable);
-            if (!Directory.Exists(workingDir))
+            if (!ValidatePaths(config.TargetExecutable, workingDir))
             {
-                var errorMsg = $"Working directory not found: {workingDir}";
-                LogError(errorMsg);
                 return 1;
             }
 
-            // Prepare process start info
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = config.TargetExecutable,
-                WorkingDirectory = workingDir,
-                UseShellExecute = false,
-                CreateNoWindow = false, // Allow the game window to appear
-            };
+            LogLaunchDetails(configPath, config, workingDir);
 
-            // Detect whether Steam launched us. Some titles do not set the common env flags even when launched by Steam.
-            var steamContext = IsSteamLaunched();
-            if (!steamContext && !string.IsNullOrWhiteSpace(config.SteamAppId))
-            {
-                // Previously we exited after asking Steam to relaunch via steam:// which left the target unstarted and
-                // resulted in "invalid license". Now we continue and inject Steam env + steam_appid.txt ourselves.
-                LogInfo("Steam context not detected from environment; continuing with injected Steam env instead of exiting.");
-            }
+            var (startInfo, tempExePath) = PrepareProcessStartInfo(config, workingDir!, args);
+            var (exitCode, spawnedFound) = await ExecuteAndMonitorProcessAsync(config, startInfo);
 
-            // Propagate Steam identifiers so overlay/playtime work even when launched outside Steam.
-            if (!string.IsNullOrWhiteSpace(config.SteamAppId))
-            {
-                // Ensure steam_appid.txt exists both where the proxy runs (working dir) and where the target exe resides.
-                EnsureSteamAppId(config.SteamAppId, workingDir);
-                var targetDir = Path.GetDirectoryName(config.TargetExecutable) ?? workingDir;
-                if (!string.Equals(targetDir, workingDir, StringComparison.OrdinalIgnoreCase))
-                {
-                    EnsureSteamAppId(config.SteamAppId, targetDir);
-                }
-
-                // Inject common Steam env vars so SteamAPI sees the app even if Steam didn't set them for the proxy.
-                startInfo.Environment["SteamAppId"] = config.SteamAppId;
-                startInfo.Environment["SteamGameId"] = config.SteamAppId;
-                startInfo.Environment["SteamClientLaunch"] = "1";
-                startInfo.Environment["SteamEnv"] = "1";
-                startInfo.Environment["SteamOverlayGameId"] = config.SteamAppId;
-            }
-
-            // Pass through arguments from the config first, then any command line args passed to this proxy
-            // Steam might pass args like -quickstart etc.
-            // BUT: Steam's %command% might pass the original exe path - filter those out
-            var arguments = new List<string>();
-
-            var dedupe = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            if (config.Arguments != null)
-            {
-                foreach (var arg in config.Arguments)
-                {
-                    if (string.IsNullOrWhiteSpace(arg))
-                    {
-                        continue;
-                    }
-
-                    if (dedupe.Add(arg))
-                    {
-                        arguments.Add(arg);
-                    }
-                }
-            }
-
-            if (args.Length > 0)
-            {
-                // Filter out exe paths that Steam passes via %command%
-                // These are typically the original game executable paths
-                foreach (var arg in args)
-                {
-                    // Skip arguments that match the current executable (the proxy itself)
-                    // This handles Steam's %command% expansion which passes the full path to this executable
-                    var cleanArg = arg.Trim('"');
-                    if (string.Equals(cleanArg, Environment.ProcessPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        LogInfo($"Filtering out Steam %command% executable arg (matches ProcessPath): {arg}");
-                        continue;
-                    }
-
-                    if (string.IsNullOrWhiteSpace(arg))
-                    {
-                        continue;
-                    }
-
-                    // Avoid double-applying flags like -win when Steam passes them via %command%
-                    if (dedupe.Add(arg))
-                    {
-                        arguments.Add(arg);
-                    }
-                }
-            }
-
-            startInfo.Arguments = string.Join(" ", arguments);
-
-            // Some game launchers (like Community Patch) check their own executable path location.
-            // If the target exe is NOT in the working directory, we need to copy it there temporarily.
-            string? tempExePath = null;
-            var targetExeDir = Path.GetDirectoryName(config.TargetExecutable) ?? string.Empty;
-            if (!string.Equals(targetExeDir, workingDir, StringComparison.OrdinalIgnoreCase))
-            {
-                // Copy the target exe to a temp file in the working directory
-                var exeName = Path.GetFileNameWithoutExtension(config.TargetExecutable);
-                var tempExeName = $"{exeName}_genhub_temp_{Guid.NewGuid():N}.exe";
-                tempExePath = Path.Combine(workingDir!, tempExeName);
-
-                LogInfo($"Target exe not in working directory - creating temp copy at: {tempExePath}");
-                try
-                {
-                    File.Copy(config.TargetExecutable, tempExePath, overwrite: true);
-                    startInfo.FileName = tempExePath;
-                    LogInfo($"Temp copy created successfully");
-                }
-                catch (Exception ex)
-                {
-                    LogError($"Failed to create temp copy: {ex.Message}");
-
-                    // Fall back to original path
-                    tempExePath = null;
-                }
-            }
-
-            // Log the full command line being executed
-            LogInfo($"Launching: \"{startInfo.FileName}\" {startInfo.Arguments}");
-            LogInfo($"Working Directory: {startInfo.WorkingDirectory}");
-
-            // Launch the target game
-            var sw = Stopwatch.StartNew();
-            var launchStartUtc = DateTime.UtcNow;
-            using var process = Process.Start(startInfo);
-            if (process == null)
-            {
-                var errorMsg = $"Failed to start target process: {config.TargetExecutable}";
-                LogError(errorMsg);
-                return 1;
-            }
-
-            LogInfo($"Process started successfully. PID: {process.Id}");
-
-            // Important for Steam: We must wait for the game to exit.
-            // Steam watches THIS process. If we exit, Steam thinks the game stopped.
-            await process.WaitForExitAsync();
-            sw.Stop();
-
-            finalExitCode = process.ExitCode;
-            LogInfo($"Process exited. Exit Code: {finalExitCode}, Duration: {(int)sw.Elapsed.TotalSeconds}s");
-
-            // Some launchers spawn the real game and then exit quickly.
-            // If that happens, keep THIS proxy alive by waiting on the spawned child process.
-            // Steam tracks the process it started (the proxy). If we exit, playtime/overlay stop.
-            if (sw.Elapsed.TotalSeconds < 30)
-            {
-                var baseName = Path.GetFileNameWithoutExtension(startInfo.FileName);
-                var spawned = TryFindSpawnedProcess(baseName, startInfo.WorkingDirectory, launchStartUtc, process.Id);
-                if (spawned != null)
-                {
-                    LogInfo($"Detected spawned process {spawned.Id} for {baseName}; waiting for it to exit to preserve Steam tracking.");
-                    try
-                    {
-                        // Restart stopwatch to track total session time
-                        sw.Restart();
-                        await spawned.WaitForExitAsync();
-                        sw.Stop();
-                        finalExitCode = spawned.ExitCode;
-                        LogInfo($"Spawned process exited. Exit Code: {finalExitCode}, Total Session Duration: {(int)sw.Elapsed.TotalSeconds}s");
-                    }
-                    catch (Exception ex)
-                    {
-                        LogError($"Error waiting for spawned process: {ex.Message}");
-                    }
-                }
-            }
-
-            // Log information about problematic exits, but do not show a message box.
-            // Note: C&C games often exit with non-zero codes (e.g. 0xc0000005) on normal shutdown.
-            // We only log an error if it happened quickly, suggesting it didn't even start.
-            // Ensure we just log completion and exit
-            LogInfo($"Process completed. Final Exit Code: {finalExitCode}");
-
-            // Cleanup: Delete temp exe copy if we created one
-            if (tempExePath != null && File.Exists(tempExePath))
-            {
-                try
-                {
-                    File.Delete(tempExePath);
-                    LogInfo($"Cleaned up temp exe: {tempExePath}");
-                }
-                catch (Exception ex)
-                {
-                    LogError($"Failed to cleanup temp exe: {ex.Message}");
-                }
-            }
+            CleanupTempExecutable(tempExePath);
+            LogInfo($"Process completed. Final Exit Code: {exitCode}");
+            return exitCode;
         }
         catch (Exception ex)
         {
             LogError($"Critical error in proxy launcher: {ex.Message}");
-            finalExitCode = 1;
+            return 1;
+        }
+    }
+
+    private static string GetScopedMutexName(string baseDir)
+    {
+        var normalizedDir = Path.GetFullPath(baseDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToUpperInvariant();
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedDir));
+        return $"{ProxyConstants.MutexPrefix}{Convert.ToHexString(hashBytes)[..16]}";
+    }
+
+    private static async Task<ProxyConfig?> LoadConfigAsync(string configPath)
+    {
+        var configJson = await File.ReadAllTextAsync(configPath);
+        return JsonSerializer.Deserialize<ProxyConfig>(configJson);
+    }
+
+    private static bool ValidatePaths(string targetExecutable, string? workingDir)
+    {
+        if (!File.Exists(targetExecutable))
+        {
+            LogError($"Target executable not found: {targetExecutable}");
+            return false;
         }
 
-        return finalExitCode;
+        if (string.IsNullOrWhiteSpace(workingDir) || !Directory.Exists(workingDir))
+        {
+            LogError($"Working directory not found: {workingDir}");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void LogLaunchDetails(string configPath, ProxyConfig config, string? workingDir)
+    {
+        LogInfo($"Proxy Launcher started at {DateTime.UtcNow:O}");
+        LogInfo($"Configuration loaded from: {configPath}");
+        LogInfo($"Target Executable: {config.TargetExecutable}");
+        LogInfo($"Working Directory: {workingDir}");
+        LogInfo($"Arguments: {(config.Arguments != null ? string.Join(" ", config.Arguments) : "(none)")}");
+    }
+
+    private static (ProcessStartInfo StartInfo, string? TempExePath) PrepareProcessStartInfo(
+        ProxyConfig config,
+        string workingDir,
+        string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = config.TargetExecutable!,
+            WorkingDirectory = workingDir,
+            UseShellExecute = false,
+            CreateNoWindow = false,
+        };
+
+        ConfigureSteamEnvironment(startInfo, config, workingDir);
+        startInfo.Arguments = BuildArgumentString(config, args);
+
+        var tempExePath = PrepareTemporaryExecutable(config, workingDir, startInfo);
+        return (startInfo, tempExePath);
+    }
+
+    private static void ConfigureSteamEnvironment(ProcessStartInfo startInfo, ProxyConfig config, string workingDir)
+    {
+        var steamContext = IsSteamLaunched();
+        if (!steamContext && !string.IsNullOrWhiteSpace(config.SteamAppId))
+        {
+            LogInfo("Steam context not detected from environment; continuing with injected Steam env instead of exiting.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(config.SteamAppId))
+        {
+            EnsureSteamAppId(config.SteamAppId, workingDir);
+            var targetDir = Path.GetDirectoryName(config.TargetExecutable) ?? workingDir;
+            if (!string.Equals(targetDir, workingDir, StringComparison.OrdinalIgnoreCase))
+            {
+                EnsureSteamAppId(config.SteamAppId, targetDir);
+            }
+
+            startInfo.Environment["SteamAppId"] = config.SteamAppId;
+            startInfo.Environment["SteamGameId"] = config.SteamAppId;
+            startInfo.Environment["SteamClientLaunch"] = "1";
+            startInfo.Environment["SteamEnv"] = "1";
+            startInfo.Environment["SteamOverlayGameId"] = config.SteamAppId;
+        }
+    }
+
+    private static string BuildArgumentString(ProxyConfig config, string[] args)
+    {
+        var arguments = new List<string>();
+        var dedupe = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (config.Arguments != null)
+        {
+            foreach (var arg in config.Arguments)
+            {
+                if (!string.IsNullOrWhiteSpace(arg) && dedupe.Add(arg))
+                {
+                    arguments.Add(arg);
+                }
+            }
+        }
+
+        if (args.Length > 0)
+        {
+            foreach (var arg in args)
+            {
+                var cleanArg = arg.Trim('"');
+                if (string.Equals(cleanArg, Environment.ProcessPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    LogInfo($"Filtering out Steam %command% executable arg (matches ProcessPath): {arg}");
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(arg) && dedupe.Add(arg))
+                {
+                    arguments.Add(arg);
+                }
+            }
+        }
+
+        return string.Join(" ", arguments);
+    }
+
+    private static string? PrepareTemporaryExecutable(ProxyConfig config, string workingDir, ProcessStartInfo startInfo)
+    {
+        var targetExeDir = Path.GetDirectoryName(config.TargetExecutable) ?? string.Empty;
+        if (string.Equals(targetExeDir, workingDir, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var exeName = Path.GetFileNameWithoutExtension(config.TargetExecutable);
+        var tempExeName = $"{exeName}_genhub_temp_{Guid.NewGuid():N}.exe";
+        var tempExePath = Path.Combine(workingDir, tempExeName);
+
+        LogInfo($"Target exe not in working directory - creating temp copy at: {tempExePath}");
+        try
+        {
+            File.Copy(config.TargetExecutable!, tempExePath, overwrite: true);
+            startInfo.FileName = tempExePath;
+            LogInfo("Temp copy created successfully");
+            return tempExePath;
+        }
+        catch (Exception ex)
+        {
+            LogError($"Failed to create temp copy: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static async Task<(int ExitCode, bool SpawnedFound)> ExecuteAndMonitorProcessAsync(
+        ProxyConfig config,
+        ProcessStartInfo startInfo)
+    {
+        LogInfo($"Launching: \"{startInfo.FileName}\" {startInfo.Arguments}");
+        LogInfo($"Working Directory: {startInfo.WorkingDirectory}");
+
+        var sw = Stopwatch.StartNew();
+        var launchStartUtc = DateTime.UtcNow;
+        using var process = Process.Start(startInfo);
+        if (process == null)
+        {
+            LogError($"Failed to start target process: {config.TargetExecutable}");
+            return (1, false);
+        }
+
+        LogInfo($"Process started successfully. PID: {process.Id}");
+        await process.WaitForExitAsync();
+        sw.Stop();
+
+        var finalExitCode = process.ExitCode;
+        LogInfo($"Process exited. Exit Code: {finalExitCode}, Duration: {(int)sw.Elapsed.TotalSeconds}s");
+
+        var spawnedFound = false;
+        if (sw.Elapsed.TotalSeconds < 30)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(config.TargetExecutable);
+            var spawned = TryFindSpawnedProcess(baseName, startInfo.WorkingDirectory, launchStartUtc, process.Id);
+            if (spawned != null)
+            {
+                spawnedFound = true;
+                LogInfo($"Detected spawned process {spawned.Id} for {baseName}; waiting for it to exit to preserve Steam tracking.");
+                try
+                {
+                    sw.Restart();
+                    await spawned.WaitForExitAsync();
+                    sw.Stop();
+                    finalExitCode = spawned.ExitCode;
+                    LogInfo($"Spawned process exited. Exit Code: {finalExitCode}, Total Session Duration: {(int)sw.Elapsed.TotalSeconds}s");
+                }
+                catch (Exception ex)
+                {
+                    LogError($"Error waiting for spawned process: {ex.Message}");
+                }
+                finally
+                {
+                    spawned.Dispose();
+                }
+            }
+        }
+
+        return (finalExitCode, spawnedFound);
+    }
+
+    private static void CleanupTempExecutable(string? tempExePath)
+    {
+        if (tempExePath != null && File.Exists(tempExePath))
+        {
+            try
+            {
+                File.Delete(tempExePath);
+                LogInfo($"Cleaned up temp exe: {tempExePath}");
+            }
+            catch (Exception ex)
+            {
+                LogError($"Failed to cleanup temp exe: {ex.Message}");
+            }
+        }
     }
 
     /// <summary>
@@ -318,8 +330,6 @@ internal class Program
     /// <returns>True if Steam environment variables are detected.</returns>
     private static bool IsSteamLaunched()
     {
-        // Steam typically sets one or more of these when launching a game.
-        // We use a relaxed check to avoid tight coupling to a single flag.
         return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SteamClientLaunch"))
             || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SteamEnv"))
             || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SteamTenfoot"))
@@ -334,7 +344,7 @@ internal class Program
     /// <param name="launchStartUtc">The time when the launch started.</param>
     /// <param name="excludedPid">The PID of the launcher itself to exclude.</param>
     /// <returns>The found process, or null if not found.</returns>
-    private static Process? TryFindSpawnedProcess(string baseName, string? workingDir, DateTime launchStartUtc, int excludedPid)
+    private static Process? TryFindSpawnedProcess(string? baseName, string? workingDir, DateTime launchStartUtc, int excludedPid)
     {
         try
         {
@@ -343,7 +353,6 @@ internal class Program
                 return null;
             }
 
-            // Give the launcher a moment to spawn the real game.
             Thread.Sleep(ProxyConstants.LauncherToGameSpawnDelayMs);
 
             var candidates = Process.GetProcessesByName(baseName);
@@ -356,7 +365,6 @@ internal class Program
                         continue;
                     }
 
-                    // StartTime is local time; compare with a small grace window.
                     var startUtc = p.StartTime.ToUniversalTime();
                     if (startUtc < launchStartUtc.AddSeconds(-2))
                     {
@@ -401,8 +409,6 @@ internal class Program
     /// <returns>The exit code of the launched process, or 1 if not found.</returns>
     private static async Task<int> TryLaunchBackupAsync(string baseDir, string[] args)
     {
-        // Try to find generals.exe.ghbak or similar (using standardized extension)
-        // This is a naive heuristic, mainly for safety
         var exeName = Path.GetFileName(Environment.ProcessPath);
         var backupPath = Path.Combine(baseDir, exeName + global::GenHub.Core.Constants.SteamConstants.BackupExtension);
 
@@ -427,21 +433,6 @@ internal class Program
         return 1;
     }
 
-    // Simple helper to show error since we might not have console
-    // In a real scenario, we might want to log to a file
-
-    /// <summary>
-    /// Displays a message box with the specified message and title.
-    /// </summary>
-    /// <param name="message">The message to display.</param>
-    /// <param name="title">The title of the message box.</param>
-    private static void MessageBox(string message, string title)
-    {
-        // User explicitly requested to remove all message boxes
-        // Just log the error
-        LogError($"{title}: {message}");
-    }
-
     /// <summary>
     /// Logs an informational message to the proxy log file.
     /// </summary>
@@ -451,7 +442,7 @@ internal class Program
         try
         {
             var logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ProxyConstants.LogFileName);
-            File.AppendAllText(logPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] INFO: {message}{Environment.NewLine}");
+            File.AppendAllText(logPath, $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}] INFO: {message}{Environment.NewLine}");
         }
         catch
         {
@@ -468,7 +459,7 @@ internal class Program
         try
         {
             var logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ProxyConstants.LogFileName);
-            File.AppendAllText(logPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] ERROR: {message}{Environment.NewLine}");
+            File.AppendAllText(logPath, $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}] ERROR: {message}{Environment.NewLine}");
         }
         catch
         {

--- a/GenHub/GenHub.ProxyLauncher/ProxyConstants.cs
+++ b/GenHub/GenHub.ProxyLauncher/ProxyConstants.cs
@@ -16,9 +16,9 @@ internal static class ProxyConstants
     public const string LogFileName = "genhub_proxy.log";
 
     /// <summary>
-    /// The name of the mutex used to ensure a single instance.
+    /// Prefix for the per-installation mutex.
     /// </summary>
-    public const string SingleInstanceMutexName = "GenHubProxyLauncher_SingleInstance";
+    public const string MutexPrefix = "GenHubProxyLauncher_";
 
     /// <summary>
     /// Delay in milliseconds to wait for the launcher to spawn the game process.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/DownloadServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/DownloadServiceTests.cs
@@ -33,7 +33,7 @@ public class DownloadServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DownloadFileAsync_SuccessfulDownload_WritesFileAndReturnsSuccess()
+    public async Task DownloadFileAsync_SuccessfulDownload_WritesFileAndReturnsSuccessAsync()
     {
         // Arrange
         var fileContent = new byte[] { 1, 2, 3, 4, 5 };
@@ -80,7 +80,7 @@ public class DownloadServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DownloadFileAsync_HashVerification_FailsOnWrongHash()
+    public async Task DownloadFileAsync_HashVerification_FailsOnWrongHashAsync()
     {
         // Arrange
         var fileContent = new byte[] { 1, 2, 3 };
@@ -130,7 +130,7 @@ public class DownloadServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DownloadFileAsync_RetriesOnFailure_AndReturnsFailedResult()
+    public async Task DownloadFileAsync_RetriesOnFailure_AndReturnsFailedResultAsync()
     {
         // Arrange
         var handler = new Mock<HttpMessageHandler>();
@@ -177,7 +177,7 @@ public class DownloadServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ComputeFileHashAsync_ReturnsCorrectHash()
+    public async Task ComputeFileHashAsync_ReturnsCorrectHashAsync()
     {
         // Arrange
         var bytes = new byte[] { 1, 2, 3, 4 };

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/UserSettingsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/UserSettingsServiceTests.cs
@@ -74,7 +74,7 @@ public class UserSettingsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task SaveAsync_CreatesFileWithCorrectData()
+    public async Task SaveAsync_CreatesFileWithCorrectDataAsync()
     {
         var service = CreateService();
         var settingsPath = Path.Combine(_tempDirectory, FileTypes.JsonFileExtension);
@@ -99,7 +99,7 @@ public class UserSettingsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadSettings_AfterSave_LoadsCorrectData()
+    public async Task LoadSettings_AfterSave_LoadsCorrectDataAsync()
     {
         // Use a unique temp directory for this test
         var testDir = Path.Combine(_tempDirectory, Guid.NewGuid().ToString());
@@ -137,7 +137,7 @@ public class UserSettingsServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadSettings_AfterSave_PreservesInstallationPoolProvenanceMarker()
+    public async Task LoadSettings_AfterSave_PreservesInstallationPoolProvenanceMarkerAsync()
     {
         var settingsPath = Path.Combine(_tempDirectory, "provenance", FileTypes.SettingsFileName);
         var historicalPoolPath = "/historical/installation/.genhub-cas";
@@ -170,7 +170,7 @@ public class UserSettingsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetSettings_WithCorruptedJson_ReturnsDefaults()
+    public async Task GetSettings_WithCorruptedJson_ReturnsDefaultsAsync()
     {
         var testDir = Path.Combine(_tempDirectory, Guid.NewGuid().ToString());
         Directory.CreateDirectory(testDir);
@@ -226,7 +226,7 @@ public class UserSettingsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task SaveAsync_CreatesDirectoryIfNotExists()
+    public async Task SaveAsync_CreatesDirectoryIfNotExistsAsync()
     {
         var nestedPath = Path.Combine(_tempDirectory, "nested", "path");
         var settingsPath = Path.Combine(nestedPath, FileTypes.JsonFileExtension);
@@ -255,7 +255,7 @@ public class UserSettingsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task SaveAsync_WithLongPath_CreatesNestedDirectories()
+    public async Task SaveAsync_WithLongPath_CreatesNestedDirectoriesAsync()
     {
         // Arrange
         var deepPath = Path.Combine(_tempDirectory, "very", "deep", "nested", "path");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/OctokitGitHubApiClientTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/OctokitGitHubApiClientTests.cs
@@ -18,7 +18,7 @@ public class OctokitGitHubApiClientTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetLatestReleaseAsync_ReturnsNullWhenNotFound()
+    public async Task GetLatestReleaseAsync_ReturnsNullWhenNotFoundAsync()
     {
         // Arrange
         var releasesClientMock = new Mock<Octokit.IReleasesClient>();
@@ -52,7 +52,7 @@ public class OctokitGitHubApiClientTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetReleasesAsync_ReturnsEmptyCollectionWhenNoReleases()
+    public async Task GetReleasesAsync_ReturnsEmptyCollectionWhenNoReleasesAsync()
     {
         // Arrange
         var releasesClientMock = new Mock<Octokit.IReleasesClient>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/VelopackUpdateManagerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/VelopackUpdateManagerTests.cs
@@ -55,7 +55,7 @@ public class VelopackUpdateManagerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CheckForUpdatesAsync_InDevEnvironment_ShouldReturnNull()
+    public async Task CheckForUpdatesAsync_InDevEnvironment_ShouldReturnNullAsync()
     {
         // Arrange
         var manager = CreateManager();
@@ -72,7 +72,7 @@ public class VelopackUpdateManagerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CheckForUpdatesAsync_WithCancellation_ShouldHandleGracefully()
+    public async Task CheckForUpdatesAsync_WithCancellation_ShouldHandleGracefullyAsync()
     {
         // Arrange
         var manager = CreateManager();
@@ -91,7 +91,7 @@ public class VelopackUpdateManagerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DownloadUpdatesAsync_WhenNotInitialized_ShouldThrowInvalidOperationException()
+    public async Task DownloadUpdatesAsync_WhenNotInitialized_ShouldThrowInvalidOperationExceptionAsync()
     {
         // Arrange
         var manager = CreateManager();
@@ -174,7 +174,7 @@ public class VelopackUpdateManagerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CheckForArtifactUpdatesAsync_WithoutPAT_ShouldReturnNull()
+    public async Task CheckForArtifactUpdatesAsync_WithoutPAT_ShouldReturnNullAsync()
     {
         // Arrange
         _mockGitHubTokenStorage.Setup(x => x.HasToken()).Returns(false);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/ViewModels/UpdateNotificationViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/ViewModels/UpdateNotificationViewModelTests.cs
@@ -16,7 +16,7 @@ public class UpdateNotificationViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CheckForUpdatesCommand_WhenNoUpdateAvailable_UpdatesStatus()
+    public async Task CheckForUpdatesCommand_WhenNoUpdateAvailable_UpdatesStatusAsync()
     {
         var mockVelopack = new Mock<IVelopackUpdateManager>();
         mockVelopack.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -19,7 +19,7 @@ public class BaseContentProviderTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareContentAsync_ValidatesManifestBeforePreparation()
+    public async Task PrepareContentAsync_ValidatesManifestBeforePreparationAsync()
     {
         // Arrange
         var validatorMock = new Mock<IContentValidator>();
@@ -56,7 +56,7 @@ public class BaseContentProviderTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareContentAsync_FailsWhenManifestValidationHasErrors()
+    public async Task PrepareContentAsync_FailsWhenManifestValidationHasErrorsAsync()
     {
         // Arrange
         var validatorMock = new Mock<IContentValidator>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CNCLabsMapDiscovererTests.cs
@@ -35,7 +35,7 @@ public class CNCLabsMapDiscovererTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverAsync_NullQuery_ReturnsFailure()
+    public async Task DiscoverAsync_NullQuery_ReturnsFailureAsync()
     {
         // Arrange
         using var http = CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.OK));
@@ -56,7 +56,7 @@ public class CNCLabsMapDiscovererTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverAsync_MissingSearchTermAndFilters_ReturnsFailure()
+    public async Task DiscoverAsync_MissingSearchTermAndFilters_ReturnsFailureAsync()
     {
         // Arrange: neither SearchTerm nor both TargetGame & ContentType
         var query = new ContentSearchQuery
@@ -82,7 +82,7 @@ public class CNCLabsMapDiscovererTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverAsync_CancellationRequested_ReturnsFailure()
+    public async Task DiscoverAsync_CancellationRequested_ReturnsFailureAsync()
     {
         // Arrange
         var query = new ContentSearchQuery
@@ -110,7 +110,7 @@ public class CNCLabsMapDiscovererTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverAsync_HttpThrows_ReturnsFailure_AndLogs()
+    public async Task DiscoverAsync_HttpThrows_ReturnsFailure_AndLogsAsync()
     {
         // Arrange - any request throws
         using var http = new HttpClient(new ThrowingHandler(new HttpRequestException("boom")));
@@ -138,7 +138,7 @@ public class CNCLabsMapDiscovererTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverAsync_WithFilters_ParsesListAndProjectsResults()
+    public async Task DiscoverAsync_WithFilters_ParsesListAndProjectsResultsAsync()
     {
         // Arrange
         var query = new ContentSearchQuery

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CommunityOutpost/CommunityOutpostDiscovererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CommunityOutpost/CommunityOutpostDiscovererTests.cs
@@ -86,7 +86,7 @@ public class CommunityOutpostDiscovererTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverAsync_GeneratesCorrectIdForCommunityPatch()
+    public async Task DiscoverAsync_GeneratesCorrectIdForCommunityPatchAsync()
     {
         // Arrange
         var mockHttp = new Mock<IHttpClientFactory>();
@@ -100,9 +100,9 @@ public class CommunityOutpostDiscovererTests
             PublisherType = "communityoutpost",
             DisplayName = "Community Outpost",
         };
-        provider.Endpoints.CatalogUrl = "http://example.com/dl.dat";
+        provider.Endpoints.CatalogUrl = "https://example.com/dl.dat";
         provider.Endpoints.Mirrors.Add(new MirrorEndpoint { Name = "Main", Priority = 1 });
-        provider.Endpoints.Custom["patchPageUrl"] = "http://example.com/patch";
+        provider.Endpoints.Custom["patchPageUrl"] = "https://example.com/patch";
 
         var htmlContent = @"<a href=""https://legi.cc/patch/generalszh-2026-01-28.zip"">Download Latest</a>";
         var handler = new Mock<HttpMessageHandler>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CommunityOutpost/CommunityOutpostManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CommunityOutpost/CommunityOutpostManifestFactoryTests.cs
@@ -59,7 +59,7 @@ public class CommunityOutpostManifestFactoryTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_WithHleiPackage_ShouldSplitIntoMultipleManifests()
+    public async Task CreateManifestsFromExtractedContentAsync_WithHleiPackage_ShouldSplitIntoMultipleManifestsAsync()
     {
         // Arrange
         var zhEnDir = Path.Combine(_tempDir, "ZH", "BIG EN");
@@ -114,7 +114,7 @@ public class CommunityOutpostManifestFactoryTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_WithNoVariants_ShouldReturnSingleManifest()
+    public async Task CreateManifestsFromExtractedContentAsync_WithNoVariants_ShouldReturnSingleManifestAsync()
     {
         // Arrange
         File.WriteAllText(Path.Combine(_tempDir, "mod.big"), "mock content");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CommunityOutpost/CompressedImageToTgaConverterTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CommunityOutpost/CompressedImageToTgaConverterTests.cs
@@ -58,7 +58,7 @@ public class CompressedImageToTgaConverterTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ConvertFileAsync_AvifOnUnsupportedRuntime_ThrowsPlatformNotSupported()
+    public async Task ConvertFileAsync_AvifOnUnsupportedRuntime_ThrowsPlatformNotSupportedAsync()
     {
         var source = Path.Combine(_tempDir, "texture.avif");
         await File.WriteAllBytesAsync(source, Convert.FromBase64String(TinyAvifBase64));
@@ -91,7 +91,7 @@ public class CompressedImageToTgaConverterTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ConvertDirectoryAsync_UnconvertibleAvif_IsLeftOnDisk()
+    public async Task ConvertDirectoryAsync_UnconvertibleAvif_IsLeftOnDiskAsync()
     {
         var source = Path.Combine(_tempDir, "texture.avif");
         await File.WriteAllBytesAsync(source, Convert.FromBase64String(TinyAvifBase64));
@@ -112,7 +112,7 @@ public class CompressedImageToTgaConverterTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ConvertFileAsync_ConcurrentAvifProbes_DoNotExposeNativeLoaderFailure()
+    public async Task ConvertFileAsync_ConcurrentAvifProbes_DoNotExposeNativeLoaderFailureAsync()
     {
         var tasks = Enumerable.Range(0, 8)
             .Select(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -47,7 +47,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SearchAsync_AggregatesResultsFromMultipleProviders_Successfully()
+    public async Task SearchAsync_AggregatesResultsFromMultipleProviders_SuccessfullyAsync()
     {
         // Arrange
         var provider1Mock = new Mock<IContentProvider>();
@@ -92,7 +92,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AcquireContentAsync_ValidatesAndStoresContent_Successfully()
+    public async Task AcquireContentAsync_ValidatesAndStoresContent_SuccessfullyAsync()
     {
         // Arrange
         var searchResult = new ContentSearchResult

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -22,12 +22,12 @@ namespace GenHub.Tests.Core.Features.Content;
 /// </summary>
 public class ContentOrchestratorTests
 {
-    private readonly Mock<IDynamicContentCache> _cacheMock = default!;
-    private readonly Mock<IContentValidator> _contentValidatorMock = default!;
-    private readonly Mock<IContentManifestPool> _manifestPoolMock = default!;
-    private readonly Mock<IGameInstallationService> _installationServiceMock = default!;
-    private readonly Mock<IInstallationCasPoolService> _installationCasPoolServiceMock = default!;
-    private readonly Mock<ILogger<ContentOrchestrator>> _loggerMock = default!;
+    private readonly Mock<IDynamicContentCache> _cacheMock;
+    private readonly Mock<IContentValidator> _contentValidatorMock;
+    private readonly Mock<IContentManifestPool> _manifestPoolMock;
+    private readonly Mock<IGameInstallationService> _installationServiceMock;
+    private readonly Mock<IInstallationCasPoolService> _installationCasPoolServiceMock;
+    private readonly Mock<ILogger<ContentOrchestrator>> _loggerMock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ContentOrchestratorTests"/> class.
@@ -153,7 +153,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AcquireContentAsync_WhenGameClientPoolCannotBeEnsured_ReturnsFailure()
+    public async Task AcquireContentAsync_WhenGameClientPoolCannotBeEnsured_ReturnsFailureAsync()
     {
         var searchResult = new ContentSearchResult
         {
@@ -233,7 +233,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SearchAsync_WhenProviderCancels_PropagatesCancellation()
+    public async Task SearchAsync_WhenProviderCancels_PropagatesCancellationAsync()
     {
         var providerMock = new Mock<IContentProvider>();
         providerMock.Setup(provider => provider.IsEnabled).Returns(true);
@@ -263,7 +263,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SearchAsync_WhenCancelledBeforeCacheHit_PropagatesCancellation()
+    public async Task SearchAsync_WhenCancelledBeforeCacheHit_PropagatesCancellationAsync()
     {
         _cacheMock
             .Setup(cache => cache.GetAsync<List<ContentSearchResult>>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -296,7 +296,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SearchAsync_WhenProviderTimesOut_KeepsResultsFromOtherProviders()
+    public async Task SearchAsync_WhenProviderTimesOut_KeepsResultsFromOtherProvidersAsync()
     {
         var timingOutProviderMock = new Mock<IContentProvider>();
         timingOutProviderMock.Setup(provider => provider.IsEnabled).Returns(true);
@@ -337,7 +337,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AcquireContentAsync_WhenProviderCancels_PropagatesCancellation()
+    public async Task AcquireContentAsync_WhenProviderCancels_PropagatesCancellationAsync()
     {
         var searchResult = new ContentSearchResult
         {
@@ -376,7 +376,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AcquireContentAsync_WhenProviderTimesOut_ReturnsFailure()
+    public async Task AcquireContentAsync_WhenProviderTimesOut_ReturnsFailureAsync()
     {
         var searchResult = new ContentSearchResult
         {
@@ -414,7 +414,7 @@ public class ContentOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AcquireContentAsync_WhenInstallationDetectionCancels_PropagatesCancellation()
+    public async Task AcquireContentAsync_WhenInstallationDetectionCancels_PropagatesCancellationAsync()
     {
         var searchResult = new ContentSearchResult
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
@@ -61,7 +61,7 @@ public class GitHubContentProviderTests
     /// A task representing the asynchronous operation.
     /// </returns>
     [Fact]
-    public async Task SearchAsync_OrchestratesDiscoveryAndResolution_Successfully()
+    public async Task SearchAsync_OrchestratesDiscoveryAndResolution_SuccessfullyAsync()
     {
         // Arrange
         var query = new ContentSearchQuery { SearchTerm = "Test" };
@@ -105,7 +105,7 @@ public class GitHubContentProviderTests
     /// A task representing the asynchronous operation.
     /// </returns>
     [Fact]
-    public async Task PrepareContentAsync_CallsDelivererAndValidator_Successfully()
+    public async Task PrepareContentAsync_CallsDelivererAndValidator_SuccessfullyAsync()
     {
         // Arrange
         var manifest = new ContentManifest { Id = "1.0.genhub.mod.ghtestmod", Files = [] };

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubResolverTests.cs
@@ -46,7 +46,7 @@ public class GitHubResolverTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Fact]
-    public async Task ResolveAsync_WithValidDiscoveredItem_ReturnsSuccessfulManifest()
+    public async Task ResolveAsync_WithValidDiscoveredItem_ReturnsSuccessfulManifestAsync()
     {
         var discoveredItem = CreateItem("v1.0");
         var release = CreateRelease("v1.0");
@@ -67,7 +67,7 @@ public class GitHubResolverTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Fact]
-    public async Task ResolveAsync_WithLatestTag_CallsGetLatestRelease()
+    public async Task ResolveAsync_WithLatestTag_CallsGetLatestReleaseAsync()
     {
         var discoveredItem = CreateItem("latest");
         var release = CreateRelease("v1.1");
@@ -88,7 +88,7 @@ public class GitHubResolverTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Fact]
-    public async Task ResolveAsync_WhenLatestReleaseNotFound_FallsBackToAnyRelease()
+    public async Task ResolveAsync_WhenLatestReleaseNotFound_FallsBackToAnyReleaseAsync()
     {
         var discoveredItem = CreateItem("latest");
         var preRelease = CreateRelease("v0.5-beta");
@@ -113,7 +113,7 @@ public class GitHubResolverTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ResolveAsync_MissingMetadata_ReturnsFailure()
+    public async Task ResolveAsync_MissingMetadata_ReturnsFailureAsync()
     {
         var discoveredItem = new ContentSearchResult { ResolverId = "GitHubRelease" };
         var result = await _resolver.ResolveAsync(discoveredItem);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubResolverTests.cs
@@ -144,7 +144,7 @@ public class GitHubResolverTests : IDisposable
         {
             TagName = tag,
             PublishedAt = DateTimeOffset.Now,
-            Assets = [new GitHubReleaseAsset { Name = "test.zip", BrowserDownloadUrl = "http://test.com" },],
+            Assets = [new GitHubReleaseAsset { Name = "test.zip", BrowserDownloadUrl = "https://test.com" },],
         };
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Providers/ProviderDefinitionLoaderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Providers/ProviderDefinitionLoaderTests.cs
@@ -36,7 +36,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadProvidersAsync_LoadsValidProviders_Successfully()
+    public async Task LoadProvidersAsync_LoadsValidProviders_SuccessfullyAsync()
     {
         // Arrange
         var provider1Json = @"{
@@ -79,7 +79,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetProvider_ReturnsCorrectProvider_AfterLoading()
+    public async Task GetProvider_ReturnsCorrectProvider_AfterLoadingAsync()
     {
         // Arrange
         var providerJson = @"{
@@ -118,7 +118,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetProvider_AutoLoadsProviders_WhenNotInitialized()
+    public async Task GetProvider_AutoLoadsProviders_WhenNotInitializedAsync()
     {
         // Arrange
         var providerJson = @"{
@@ -147,7 +147,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetProvider_ReturnsNull_ForNonExistentProvider()
+    public async Task GetProvider_ReturnsNull_ForNonExistentProviderAsync()
     {
         // Arrange
         var loader = new ProviderDefinitionLoader(_loggerMock.Object, _testProvidersDirectory);
@@ -165,7 +165,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetProvider_IsCaseInsensitive()
+    public async Task GetProvider_IsCaseInsensitiveAsync()
     {
         // Arrange
         var providerJson = @"{
@@ -193,7 +193,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadProvidersAsync_HandlesInvalidJson_Gracefully()
+    public async Task LoadProvidersAsync_HandlesInvalidJson_GracefullyAsync()
     {
         // Arrange
         var validJson = @"{
@@ -230,7 +230,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadProvidersAsync_HandlesMissingProviderId_Gracefully()
+    public async Task LoadProvidersAsync_HandlesMissingProviderId_GracefullyAsync()
     {
         // Arrange
         var validJson = @"{
@@ -271,7 +271,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ReloadProvidersAsync_ClearsAndReloads_Successfully()
+    public async Task ReloadProvidersAsync_ClearsAndReloads_SuccessfullyAsync()
     {
         // Arrange
         var initialJson = @"{
@@ -316,7 +316,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task AddCustomProvider_AddsProvider_Successfully()
+    public async Task AddCustomProvider_AddsProvider_SuccessfullyAsync()
     {
         // Arrange
         var loader = new ProviderDefinitionLoader(_loggerMock.Object, _testProvidersDirectory);
@@ -345,7 +345,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task RemoveCustomProvider_RemovesProvider_Successfully()
+    public async Task RemoveCustomProvider_RemovesProvider_SuccessfullyAsync()
     {
         // Arrange
         var loader = new ProviderDefinitionLoader(_loggerMock.Object, _testProvidersDirectory);
@@ -375,7 +375,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetAllProviders_ReturnsOnlyEnabledProviders()
+    public async Task GetAllProviders_ReturnsOnlyEnabledProvidersAsync()
     {
         // Arrange
         var enabledJson = @"{
@@ -416,7 +416,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetProvidersByType_ReturnsCorrectlyFilteredProviders()
+    public async Task GetProvidersByType_ReturnsCorrectlyFilteredProvidersAsync()
     {
         // Arrange
         var staticJson = @"{
@@ -463,7 +463,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadProvidersAsync_ParsesCustomEndpoints_Correctly()
+    public async Task LoadProvidersAsync_ParsesCustomEndpoints_CorrectlyAsync()
     {
         // Arrange
         var providerJson = @"{
@@ -504,7 +504,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadProvidersAsync_HandlesEmptyDirectory_Gracefully()
+    public async Task LoadProvidersAsync_HandlesEmptyDirectory_GracefullyAsync()
     {
         // Arrange - directory is already empty
         var loader = new ProviderDefinitionLoader(_loggerMock.Object, _testProvidersDirectory);
@@ -523,7 +523,7 @@ public class ProviderDefinitionLoaderTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task LoadProvidersAsync_HandlesNonExistentDirectory_Gracefully()
+    public async Task LoadProvidersAsync_HandlesNonExistentDirectory_GracefullyAsync()
     {
         // Arrange
         var nonExistentPath = Path.Combine(Path.GetTempPath(), "GenHub.Tests", "NonExistent", Guid.NewGuid().ToString());

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
@@ -76,7 +76,7 @@ public class CommunityOutpostProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_NoUpdateAvailable_ReturnsFalse()
+    public async Task CheckAndReconcileIfNeededAsync_NoUpdateAvailable_ReturnsFalseAsync()
     {
         _updateServiceMock
             .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
@@ -93,7 +93,7 @@ public class CommunityOutpostProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_UpdateCheckFails_ReturnsFailure()
+    public async Task CheckAndReconcileIfNeededAsync_UpdateCheckFails_ReturnsFailureAsync()
     {
         _updateServiceMock
             .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
@@ -109,7 +109,7 @@ public class CommunityOutpostProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_VersionSkipped_ReturnsFalse()
+    public async Task CheckAndReconcileIfNeededAsync_VersionSkipped_ReturnsFalseAsync()
     {
         const string latestVersion = "2.0.0";
 
@@ -135,7 +135,7 @@ public class CommunityOutpostProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_UserSkipsDialog_ReturnsFalse()
+    public async Task CheckAndReconcileIfNeededAsync_UserSkipsDialog_ReturnsFalseAsync()
     {
         _updateServiceMock
             .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
@@ -166,7 +166,7 @@ public class CommunityOutpostProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_AcquireFails_ReturnsFailure()
+    public async Task CheckAndReconcileIfNeededAsync_AcquireFails_ReturnsFailureAsync()
     {
         const string latestVersion = "2.0.0";
 
@@ -204,7 +204,7 @@ public class CommunityOutpostProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellation()
+    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellationAsync()
     {
         const string latestVersion = "2.0.0";
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/ContentStorageServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/ContentStorageServiceTests.cs
@@ -80,7 +80,7 @@ public class ContentStorageServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task StoreContentAsync_WithTraversingSourcePath_ShouldFail()
+    public async Task StoreContentAsync_WithTraversingSourcePath_ShouldFailAsync()
     {
         // Arrange
         // Source Dir: /Temp/Source
@@ -121,7 +121,7 @@ public class ContentStorageServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task StoreContentAsync_WithValidExternalSourcePath_ShouldSucceed()
+    public async Task StoreContentAsync_WithValidExternalSourcePath_ShouldSucceedAsync()
     {
         // Arrange
         // Source Dir: /Temp/ExternalGame

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParserTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParserTests.cs
@@ -44,7 +44,7 @@ public class GeneralsOnlineJsonCatalogParserTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ParseAsync_WithPascalCaseJson_ParsesCorrectly()
+    public async Task ParseAsync_WithPascalCaseJson_ParsesCorrectlyAsync()
     {
         // Arrange
         var json = @"{
@@ -70,7 +70,7 @@ public class GeneralsOnlineJsonCatalogParserTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ParseAsync_WithCamelCaseJson_ParsesCorrectly()
+    public async Task ParseAsync_WithCamelCaseJson_ParsesCorrectlyAsync()
     {
         // Arrange
         // Standard lowercase/camelCase that matches exact property names if attributes weren't there

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
@@ -33,7 +33,7 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_MarksWrapperAsExecutable()
+    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_MarksWrapperAsExecutableAsync()
     {
         WriteEacPortableLayout();
 
@@ -54,7 +54,7 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_RetainsWrappedBinaryAsWorkspaceFile()
+    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_RetainsWrappedBinaryAsWorkspaceFileAsync()
     {
         WriteEacPortableLayout();
 
@@ -74,7 +74,7 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_RetainsDefaultBinaryAsWorkspaceFile()
+    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_RetainsDefaultBinaryAsWorkspaceFileAsync()
     {
         WriteEacPortableLayout();
 
@@ -94,7 +94,7 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_NestedWrapperName_DoesNotBecomeLaunchTarget()
+    public async Task CreateManifestsFromExtractedContentAsync_NestedWrapperName_DoesNotBecomeLaunchTargetAsync()
     {
         WriteFile(GameClientConstants.GeneralsOnline60HzExecutable);
         WriteFile(Path.Combine("tools", GameClientConstants.GeneralsOnlineEacLauncherExecutable));
@@ -114,7 +114,7 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_PreEacLayout_MarksSixtyHertzBinaryAsExecutable()
+    public async Task CreateManifestsFromExtractedContentAsync_PreEacLayout_MarksSixtyHertzBinaryAsExecutableAsync()
     {
         WriteFile(GameClientConstants.GeneralsOnline60HzExecutable);
         WriteFile("libcurl.dll");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -183,7 +183,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the test execution.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_SeparatesFilesCorrectly()
+    public async Task CreateManifestsFromExtractedContentAsync_SeparatesFilesCorrectlyAsync()
     {
         // Arrange: Create simulated extracted directory structure
         var exePath = Path.Combine(_tempDir, GameClientConstants.GeneralsOnline60HzExecutable);
@@ -254,7 +254,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_SiblingDirectories_AreNotMisclassified()
+    public async Task CreateManifestsFromExtractedContentAsync_SiblingDirectories_AreNotMisclassifiedAsync()
     {
         // Arrange
         var siblingMapDir = Path.Combine(_tempDir, "Maps_backup");
@@ -296,7 +296,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_PreCancelledToken_ThrowsOperationCanceledException()
+    public async Task CreateManifestsFromExtractedContentAsync_PreCancelledToken_ThrowsOperationCanceledExceptionAsync()
     {
         // Arrange
         var originalManifest = new ContentManifest
@@ -349,7 +349,7 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateManifestsFromExtractedContentAsync_EmptyGameClient_ThrowsInvalidDataException()
+    public async Task CreateManifestsFromExtractedContentAsync_EmptyGameClient_ThrowsInvalidDataExceptionAsync()
     {
         // Arrange: Only create map files, no GameClient files
         var mapsDir = Path.Combine(_tempDir, GeneralsOnlineConstants.MapsSubdirectory, "TestMap");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineUpdateServiceTests.cs
@@ -23,7 +23,7 @@ public class GeneralsOnlineUpdateServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CheckForUpdatesAsync_MultipleInstalledVersions_UsesNewestVersion()
+    public async Task CheckForUpdatesAsync_MultipleInstalledVersions_UsesNewestVersionAsync()
     {
         var manifestPool = new Mock<IContentManifestPool>();
         manifestPool

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GitHub/GitHubContentDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GitHub/GitHubContentDelivererTests.cs
@@ -75,7 +75,7 @@ public class GitHubContentDelivererTests
     [InlineData(GenHub.Core.Models.Enums.ContentType.ModdingTool, true)]
     [InlineData(GenHub.Core.Models.Enums.ContentType.Executable, true)]
     [InlineData(GenHub.Core.Models.Enums.ContentType.MapPack, false)]
-    public Task DeliverContentAsync_ShouldExtractZip_ForMatchingContentTypes(GenHub.Core.Models.Enums.ContentType contentType, bool shouldExtract)
+    public Task DeliverContentAsync_ShouldExtractZip_ForMatchingContentTypesAsync(GenHub.Core.Models.Enums.ContentType contentType, bool shouldExtract)
     {
         // Dummy usage to satisfy xUnit analysis
         Assert.True(Enum.IsDefined(typeof(GenHub.Core.Models.Enums.ContentType), contentType));

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
@@ -76,7 +76,7 @@ public class SuperHackersProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_NoUpdateAvailable_ReturnsFalse()
+    public async Task CheckAndReconcileIfNeededAsync_NoUpdateAvailable_ReturnsFalseAsync()
     {
         _updateServiceMock
             .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
@@ -93,7 +93,7 @@ public class SuperHackersProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_UpdateCheckFails_ReturnsFailure()
+    public async Task CheckAndReconcileIfNeededAsync_UpdateCheckFails_ReturnsFailureAsync()
     {
         _updateServiceMock
             .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
@@ -109,7 +109,7 @@ public class SuperHackersProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_VersionSkipped_ReturnsFalse()
+    public async Task CheckAndReconcileIfNeededAsync_VersionSkipped_ReturnsFalseAsync()
     {
         const string latestVersion = "2.0.0";
 
@@ -136,7 +136,7 @@ public class SuperHackersProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_UserSkipsDialog_ReturnsFalse()
+    public async Task CheckAndReconcileIfNeededAsync_UserSkipsDialog_ReturnsFalseAsync()
     {
         _updateServiceMock
             .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
@@ -167,7 +167,7 @@ public class SuperHackersProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_AcquireFails_ReturnsFailure()
+    public async Task CheckAndReconcileIfNeededAsync_AcquireFails_ReturnsFailureAsync()
     {
         const string latestVersion = "2.0.0";
 
@@ -205,7 +205,7 @@ public class SuperHackersProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellation()
+    public async Task CheckAndReconcileIfNeededAsync_AcquireCancelled_PropagatesCancellationAsync()
     {
         const string latestVersion = "2.0.0";
 
@@ -249,7 +249,7 @@ public class SuperHackersProfileReconcilerTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckAndReconcileIfNeededAsync_AcquireFailsWhileCancelled_PropagatesCancellation()
+    public async Task CheckAndReconcileIfNeededAsync_AcquireFailsWhileCancelled_PropagatesCancellationAsync()
     {
         const string latestVersion = "2.0.0";
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/PublisherCardViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/PublisherCardViewModelTests.cs
@@ -171,7 +171,7 @@ public class PublisherCardViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RefreshInstallationStatus_GeneralsOnlineAcrossYearBoundary_ShowsUpdate()
+    public async Task RefreshInstallationStatus_GeneralsOnlineAcrossYearBoundary_ShowsUpdateAsync()
     {
         var vm = CreateSystem();
         vm.PublisherId = PublisherTypeConstants.GeneralsOnline;
@@ -184,7 +184,7 @@ public class PublisherCardViewModelTests
             ContentType = GenHub.Core.Models.Enums.ContentType.GameClient,
             ProviderName = PublisherTypeConstants.GeneralsOnline,
             AuthorName = "Generals Online Team",
-            LastUpdated = DateTime.Now,
+            LastUpdated = DateTime.UtcNow,
         });
 
         vm.ContentTypes.Add(new ContentTypeGroup

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/PublisherCardViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/PublisherCardViewModelTests.cs
@@ -50,7 +50,7 @@ public class PublisherCardViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RefreshInstallationStatus_DifferentAddonsSameVersion_DoNotCollide()
+    public async Task RefreshInstallationStatus_DifferentAddonsSameVersion_DoNotCollideAsync()
     {
         // Arrange
         var vm = CreateSystem();
@@ -65,7 +65,7 @@ public class PublisherCardViewModelTests
             ContentType = GenHub.Core.Models.Enums.ContentType.Addon,
             ProviderName = "testprovider",
             AuthorName = "Test Author",
-            LastUpdated = DateTime.Now,
+            LastUpdated = DateTime.UtcNow,
         });
 
         // Item 2: HUD Mod v1.0
@@ -77,7 +77,7 @@ public class PublisherCardViewModelTests
             ContentType = GenHub.Core.Models.Enums.ContentType.Addon,
             ProviderName = "testprovider",
             AuthorName = "Test Author",
-            LastUpdated = DateTime.Now,
+            LastUpdated = DateTime.UtcNow,
         });
 
         vm.ContentTypes.Add(new ContentTypeGroup
@@ -119,7 +119,7 @@ public class PublisherCardViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RefreshInstallationStatus_GameClient_AllowsVersionMatch()
+    public async Task RefreshInstallationStatus_GameClient_AllowsVersionMatchAsync()
     {
         // Arrange
         var vm = CreateSystem();
@@ -134,7 +134,7 @@ public class PublisherCardViewModelTests
             ContentType = GenHub.Core.Models.Enums.ContentType.GameClient,
             ProviderName = "testprovider",
             AuthorName = "Test Author",
-            LastUpdated = DateTime.Now,
+            LastUpdated = DateTime.UtcNow,
         });
 
         vm.ContentTypes.Add(new ContentTypeGroup

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectionOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectionOrchestratorTests.cs
@@ -40,7 +40,7 @@ public class GameClientDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllClientsAsync_OrchestratesDetection_Successfully()
+    public async Task DetectAllClientsAsync_OrchestratesDetection_SuccessfullyAsync()
     {
         // Arrange
         var installation = new GameInstallation("C:\\Test", GameInstallationType.Retail);
@@ -77,7 +77,7 @@ public class GameClientDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllClientsAsync_ReturnsFailure_WhenInstallationDetectionFails()
+    public async Task DetectAllClientsAsync_ReturnsFailure_WhenInstallationDetectionFailsAsync()
     {
         // Arrange
         _installationOrchestratorMock.Setup(i => i.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientDetectorTests.cs
@@ -72,7 +72,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsInstallation_DetectsGeneralsClient()
+    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsInstallation_DetectsGeneralsClientAsync()
     {
         // Arrange
         var generalsPath = Path.Combine(_tempDirectory, "Generals");
@@ -122,7 +122,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectGameClientsFromInstallationsAsync_WithZeroHourInstallation_DetectsZeroHourClient()
+    public async Task DetectGameClientsFromInstallationsAsync_WithZeroHourInstallation_DetectsZeroHourClientAsync()
     {
         // Arrange
         var zeroHourPath = Path.Combine(_tempDirectory, "ZeroHour");
@@ -172,7 +172,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ScanDirectoryForGameClientsAsync_WithValidExecutable_FindsGameClient()
+    public async Task ScanDirectoryForGameClientsAsync_WithValidExecutable_FindsGameClientAsync()
     {
         // Arrange
         var gameDir = Path.Combine(_tempDirectory, "TestGame");
@@ -214,7 +214,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ScanDirectoryForGameClientsAsync_WithNonExistentDirectory_ReturnsFailure()
+    public async Task ScanDirectoryForGameClientsAsync_WithNonExistentDirectory_ReturnsFailureAsync()
     {
         // Arrange
         var nonExistentPath = Path.Combine(_tempDirectory, "NonExistent");
@@ -232,7 +232,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ValidateGameClientAsync_WithValidClient_ReturnsTrue()
+    public async Task ValidateGameClientAsync_WithValidClient_ReturnsTrueAsync()
     {
         // Arrange
         var executablePath = Path.Combine(_tempDirectory, "generals.exe");
@@ -255,7 +255,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ValidateGameClientAsync_WithInvalidClient_ReturnsFalse()
+    public async Task ValidateGameClientAsync_WithInvalidClient_ReturnsFalseAsync()
     {
         // Arrange
         var client = new GameClient
@@ -275,7 +275,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ScanDirectoryForGameClientsAsync_WithUnknownHash_CreatesUnknownClient()
+    public async Task ScanDirectoryForGameClientsAsync_WithUnknownHash_CreatesUnknownClientAsync()
     {
         // Arrange
         var gameDir = Path.Combine(_tempDirectory, "UnknownGame");
@@ -318,7 +318,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ScanDirectoryForGameClientsAsync_WithEacLauncherBesideSixtyHertz_FindsOnlyWrapper()
+    public async Task ScanDirectoryForGameClientsAsync_WithEacLauncherBesideSixtyHertz_FindsOnlyWrapperAsync()
     {
         var gameDir = Path.Combine(_tempDirectory, "GeneralsOnline");
         Directory.CreateDirectory(gameDir);
@@ -356,7 +356,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ScanDirectoryForGameClientsAsync_WithEacLauncherAndUnknownHash_ClassifiesAsZeroHourGeneralsOnline()
+    public async Task ScanDirectoryForGameClientsAsync_WithEacLauncherAndUnknownHash_ClassifiesAsZeroHourGeneralsOnlineAsync()
     {
         var gameDir = Path.Combine(_tempDirectory, "GeneralsOnline");
         Directory.CreateDirectory(gameDir);
@@ -408,7 +408,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ScanDirectoryForGameClientsAsync_WhenAnIdentifierThrows_StillTriesTheRest()
+    public async Task ScanDirectoryForGameClientsAsync_WhenAnIdentifierThrows_StillTriesTheRestAsync()
     {
         var gameDir = Path.Combine(_tempDirectory, "GeneralsOnline");
         Directory.CreateDirectory(gameDir);
@@ -456,7 +456,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ScanDirectoryForGameClientsAsync_WithoutEacLauncher_FindsSixtyHertzClient()
+    public async Task ScanDirectoryForGameClientsAsync_WithoutEacLauncher_FindsSixtyHertzClientAsync()
     {
         var gameDir = Path.Combine(_tempDirectory, "GeneralsOnlinePreEac");
         Directory.CreateDirectory(gameDir);
@@ -489,7 +489,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsOnline60HzExecutable_DetectsClient()
+    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsOnline60HzExecutable_DetectsClientAsync()
     {
         // Arrange - Create identifier for GeneralsOnline 60Hz
         var generalsOnlineIdentifierMock = new Mock<IGameClientIdentifier>();
@@ -589,7 +589,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectGameClientsFromInstallationsAsync_WithEacLauncherBesideSixtyHertz_DetectsOnlyWrapper()
+    public async Task DetectGameClientsFromInstallationsAsync_WithEacLauncherBesideSixtyHertz_DetectsOnlyWrapperAsync()
     {
         var identifierMock = new Mock<IGameClientIdentifier>();
         identifierMock.Setup(x => x.PublisherId).Returns(PublisherTypeConstants.GeneralsOnline);
@@ -640,7 +640,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsOnline60HzExecutable_DetectsZeroHourClient()
+    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsOnline60HzExecutable_DetectsZeroHourClientAsync()
     {
         // Arrange - Create identifier for GeneralsOnline 60Hz
         var generalsOnlineIdentifierMock = new Mock<IGameClientIdentifier>();
@@ -724,7 +724,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsOnline60HzVariant_DetectsClientWithStandard()
+    public async Task DetectGameClientsFromInstallationsAsync_WithGeneralsOnline60HzVariant_DetectsClientWithStandardAsync()
     {
         // Arrange - Create identifier for 60Hz
         var identifier60HzMock = new Mock<IGameClientIdentifier>();
@@ -799,7 +799,7 @@ public class GameClientDetectorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectGameClientsFromInstallationsAsync_WithMissingGeneralsOnlineExecutable_SkipsAndContinues()
+    public async Task DetectGameClientsFromInstallationsAsync_WithMissingGeneralsOnlineExecutable_SkipsAndContinuesAsync()
     {
         // Arrange - create installation with only standard executable, no GeneralsOnline
         var generalsPath = Path.Combine(_tempDirectory, "GeneralsNoGeneralsOnline");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientManifestIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameClients/GameClientManifestIntegrationTests.cs
@@ -66,7 +66,7 @@ public class GameClientManifestIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GenerateGameClientManifest_WithSteamGeneralsInstallation_CreatesManifestWithExecutable()
+    public async Task GenerateGameClientManifest_WithSteamGeneralsInstallation_CreatesManifestWithExecutableAsync()
     {
         var generalsPath = Path.Combine(_tempDirectory, "Steam", "Generals");
         Directory.CreateDirectory(generalsPath);
@@ -99,7 +99,7 @@ public class GameClientManifestIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GenerateGameClientManifest_ExecutableHashIsComputed()
+    public async Task GenerateGameClientManifest_ExecutableHashIsComputedAsync()
     {
         var clientPath = Path.Combine(_tempDirectory, "TestClient");
         Directory.CreateDirectory(clientPath);
@@ -125,7 +125,7 @@ public class GameClientManifestIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GenerateGameClientManifest_IncludesAllExpectedFiles()
+    public async Task GenerateGameClientManifest_IncludesAllExpectedFilesAsync()
     {
         var clientPath = Path.Combine(_tempDirectory, "FullClient");
         Directory.CreateDirectory(clientPath);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationDetectionOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationDetectionOrchestratorTests.cs
@@ -18,7 +18,7 @@ public class GameInstallationDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllInstallationsAsync_AllDetectorsSucceed_CombinesItems()
+    public async Task DetectAllInstallationsAsync_AllDetectorsSucceed_CombinesItemsAsync()
     {
         // Arrange
         var instA = new GameInstallation("C:\\Steam\\Games", GameInstallationType.Steam, NullLogger<GameInstallation>.Instance);
@@ -55,7 +55,7 @@ public class GameInstallationDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllInstallationsAsync_DetectorFails_ReturnsFailed()
+    public async Task DetectAllInstallationsAsync_DetectorFails_ReturnsFailedAsync()
     {
         // Arrange
         var mockD = new Mock<IGameInstallationDetector>();
@@ -81,7 +81,7 @@ public class GameInstallationDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllInstallationsAsync_PlatformFiltering_SkipsIncompatibleDetectors()
+    public async Task DetectAllInstallationsAsync_PlatformFiltering_SkipsIncompatibleDetectorsAsync()
     {
         // Arrange
         var instA = new GameInstallation("C:\\Steam\\Games", GameInstallationType.Steam, NullLogger<GameInstallation>.Instance);
@@ -117,7 +117,7 @@ public class GameInstallationDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllInstallationsAsync_MixedResults_CombinesSuccessAndFailures()
+    public async Task DetectAllInstallationsAsync_MixedResults_CombinesSuccessAndFailuresAsync()
     {
         // Arrange
         var instA = new GameInstallation("C:\\Steam\\Games", GameInstallationType.Steam, NullLogger<GameInstallation>.Instance);
@@ -151,7 +151,7 @@ public class GameInstallationDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllInstallationsAsync_EmptyDetectors_ReturnsEmptySuccess()
+    public async Task DetectAllInstallationsAsync_EmptyDetectors_ReturnsEmptySuccessAsync()
     {
         // Arrange
         var svc = new GameInstallationDetectionOrchestrator(
@@ -172,7 +172,7 @@ public class GameInstallationDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DetectAllInstallationsAsync_DetectorThrowsException_HandlesGracefully()
+    public async Task DetectAllInstallationsAsync_DetectorThrowsException_HandlesGracefullyAsync()
     {
         // Arrange
         var mockSuccess = new Mock<IGameInstallationDetector>();
@@ -204,7 +204,7 @@ public class GameInstallationDetectionOrchestratorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetDetectedInstallationsAsync_ReturnsResults()
+    public async Task GetDetectedInstallationsAsync_ReturnsResultsAsync()
     {
         // Arrange
         var instA = new GameInstallation("C:\\Steam\\Games", GameInstallationType.Steam, NullLogger<GameInstallation>.Instance);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
@@ -81,7 +81,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetInstallationAsync_WithValidId_ShouldReturnInstallation()
+    public async Task GetInstallationAsync_WithValidId_ShouldReturnInstallationAsync()
     {
         // Arrange
         var installation = new GameInstallation(Path.GetTempPath(), GameInstallationType.Steam, new Mock<ILogger<GameInstallation>>().Object);
@@ -104,7 +104,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetInstallationAsync_WithInvalidId_ShouldReturnFailure()
+    public async Task GetInstallationAsync_WithInvalidId_ShouldReturnFailureAsync()
     {
         // Arrange
         var detectionResult = DetectionResult<GameInstallation>.CreateSuccess([], TimeSpan.Zero);
@@ -124,7 +124,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetInstallationAsync_WithDetectionFailure_ShouldReturnFailure()
+    public async Task GetInstallationAsync_WithDetectionFailure_ShouldReturnFailureAsync()
     {
         // Arrange
         var detectionResult = DetectionResult<GameInstallation>.CreateFailure("Detection failed");
@@ -144,7 +144,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetInstallationAsync_WithNullId_ShouldReturnFailure()
+    public async Task GetInstallationAsync_WithNullId_ShouldReturnFailureAsync()
     {
         // Act
         var result = await _service.GetInstallationAsync(null!);
@@ -159,7 +159,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetInstallationAsync_WithEmptyId_ShouldReturnFailure()
+    public async Task GetInstallationAsync_WithEmptyId_ShouldReturnFailureAsync()
     {
         // Act
         var result = await _service.GetInstallationAsync(string.Empty);
@@ -174,7 +174,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllInstallationsAsync_ShouldReturnAllInstallations()
+    public async Task GetAllInstallationsAsync_ShouldReturnAllInstallationsAsync()
     {
         // Arrange
         var installation1 = new GameInstallation(Path.GetTempPath(), GameInstallationType.Steam, new Mock<ILogger<GameInstallation>>().Object);
@@ -205,7 +205,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </remarks>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllInstallationsAsync_WithDetectionFailure_ShouldReturnFailure()
+    public async Task GetAllInstallationsAsync_WithDetectionFailure_ShouldReturnFailureAsync()
     {
         // Arrange
         _service.InvalidateCache();
@@ -226,7 +226,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetInstallationAsync_WithCaching_ShouldUseCachedResults()
+    public async Task GetInstallationAsync_WithCaching_ShouldUseCachedResultsAsync()
     {
         // Arrange
         var installation = new GameInstallation(Path.GetTempPath(), GameInstallationType.Steam, new Mock<ILogger<GameInstallation>>().Object);
@@ -265,7 +265,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllInstallationsAsync_WhenDetectionFailsWithNoResults_DoesNotCacheAndRescansOnRetry()
+    public async Task GetAllInstallationsAsync_WhenDetectionFailsWithNoResults_DoesNotCacheAndRescansOnRetryAsync()
     {
         var denied = DetectionResult<GameInstallation>.CreateFailure(
             "Could not search /Users/test/Documents because macOS denied access");
@@ -295,7 +295,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllInstallationsAsync_WhenDetectionFailsWithPersistedManifest_DoesNotCache()
+    public async Task GetAllInstallationsAsync_WhenDetectionFailsWithPersistedManifest_DoesNotCacheAsync()
     {
         var denied = DetectionResult<GameInstallation>.CreateFailure(
             "Could not search /Users/test/Documents because macOS denied access");
@@ -338,7 +338,7 @@ public class GameInstallationServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllInstallationsAsync_WhenDetectionSucceedsWithNoResults_CachesTheEmptyResult()
+    public async Task GetAllInstallationsAsync_WhenDetectionSucceedsWithNoResults_CachesTheEmptyResultAsync()
     {
         _orchestratorMock.Setup(x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(DetectionResult<GameInstallation>.CreateSuccess([], TimeSpan.Zero));

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProfileManagerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProfileManagerTests.cs
@@ -399,7 +399,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_ClearWorkspace_When_ContentChanges()
+    public async Task UpdateProfileAsync_Should_ClearWorkspace_When_ContentChangesAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -435,7 +435,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_ClearWorkspace_When_GameClientChanges()
+    public async Task UpdateProfileAsync_Should_ClearWorkspace_When_GameClientChangesAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -472,7 +472,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_KeepWorkspace_When_ContentUnchanged()
+    public async Task UpdateProfileAsync_Should_KeepWorkspace_When_ContentUnchangedAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -508,7 +508,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_KeepWorkspace_When_ContentUpdateRequestIsNull()
+    public async Task UpdateProfileAsync_Should_KeepWorkspace_When_ContentUpdateRequestIsNullAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -544,7 +544,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_SendProfileUpdatedMessage_OnSuccess()
+    public async Task UpdateProfileAsync_Should_SendProfileUpdatedMessage_OnSuccessAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -578,10 +578,7 @@ public class GameProfileManagerTests
 
         ProfileUpdatedMessage? receivedMessage = null;
 
-        WeakReferenceMessenger.Default.Register<ProfileUpdatedMessage>(this, (r, m) =>
-        {
-            receivedMessage = m;
-        });
+        WeakReferenceMessenger.Default.Register<ProfileUpdatedMessage>(this, (_, m) => receivedMessage = m);
 
         // Act
         var result = await _profileManager.UpdateProfileAsync(profileId, request);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProfileManagerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/GameProfileManagerTests.cs
@@ -46,7 +46,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateProfileAsync_Should_ReturnSuccess_When_InstallationAndClientExist()
+    public async Task CreateProfileAsync_Should_ReturnSuccess_When_InstallationAndClientExistAsync()
     {
         // Arrange
         var clientId = Guid.NewGuid().ToString();
@@ -78,7 +78,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateProfileAsync_Should_ReturnFailure_When_InstallationNotFound()
+    public async Task CreateProfileAsync_Should_ReturnFailure_When_InstallationNotFoundAsync()
     {
         // Arrange
         var request = new CreateProfileRequest { Name = "New Profile", GameInstallationId = "bad-id", GameClientId = "v1" };
@@ -98,7 +98,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateProfileAsync_Should_ReturnFailure_When_ClientNotFoundInInstallation()
+    public async Task CreateProfileAsync_Should_ReturnFailure_When_ClientNotFoundInInstallationAsync()
     {
         // Arrange
         var installation = CreateTestInstallation("client-1");
@@ -125,7 +125,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateProfileAsync_Should_ReturnFailure_When_RepositorySaveFails()
+    public async Task CreateProfileAsync_Should_ReturnFailure_When_RepositorySaveFailsAsync()
     {
         // Arrange
         var clientId = Guid.NewGuid().ToString();
@@ -155,7 +155,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_ReturnSuccess_When_ProfileExists()
+    public async Task UpdateProfileAsync_Should_ReturnSuccess_When_ProfileExistsAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -186,7 +186,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_ReturnFailure_When_ProfileNotFound()
+    public async Task UpdateProfileAsync_Should_ReturnFailure_When_ProfileNotFoundAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -208,7 +208,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task DeleteProfileAsync_Should_ReturnSuccess_When_ProfileExists()
+    public async Task DeleteProfileAsync_Should_ReturnSuccess_When_ProfileExistsAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -238,7 +238,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAvailableContentAsync_Should_ReturnFilteredManifests()
+    public async Task GetAvailableContentAsync_Should_ReturnFilteredManifestsAsync()
     {
         // Arrange
         var gameClient = new GameClient { GameType = GameType.Generals };
@@ -265,7 +265,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAvailableContentAsync_Should_ReturnFailure_When_ManifestPoolFails()
+    public async Task GetAvailableContentAsync_Should_ReturnFailure_When_ManifestPoolFailsAsync()
     {
         // Arrange
         var gameClient = new GameClient { GameType = GameType.Generals };
@@ -285,7 +285,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAvailableContentAsync_Should_ReturnEmptyList_When_NoCompatibleContent()
+    public async Task GetAvailableContentAsync_Should_ReturnEmptyList_When_NoCompatibleContentAsync()
     {
         // Arrange
         var gameClient = new GameClient { GameType = GameType.Generals };
@@ -310,7 +310,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllProfilesAsync_Should_ReturnAllProfiles()
+    public async Task GetAllProfilesAsync_Should_ReturnAllProfilesAsync()
     {
         // Arrange
         var profiles = new List<GameProfile>
@@ -336,7 +336,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CreateProfileAsync_Should_ValidateProfile_BeforeCreation()
+    public async Task CreateProfileAsync_Should_ValidateProfile_BeforeCreationAsync()
     {
         // Arrange
         var clientId = Guid.NewGuid().ToString();
@@ -364,7 +364,7 @@ public class GameProfileManagerTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UpdateProfileAsync_Should_UpdateEnabledContent_Successfully()
+    public async Task UpdateProfileAsync_Should_UpdateEnabledContent_SuccessfullyAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientLaunchIntegrationTests.cs
@@ -42,7 +42,7 @@ public class NativeClientLaunchIntegrationTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task RealNativeClient_LaunchesThroughGameProcessManager()
+    public async Task RealNativeClient_LaunchesThroughGameProcessManagerAsync()
     {
         var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
@@ -94,7 +94,7 @@ public class NativeClientLaunchIntegrationTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task RealNativeClient_RequiresItsInstallDirectoryAsWorkingDirectory()
+    public async Task RealNativeClient_RequiresItsInstallDirectoryAsWorkingDirectoryAsync()
     {
         var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeClientManifestLaunchTests.cs
@@ -42,7 +42,7 @@ public class NativeClientManifestLaunchTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ManifestResolvedEntryPoint_LaunchesTheRealEngine()
+    public async Task ManifestResolvedEntryPoint_LaunchesTheRealEngineAsync()
     {
         var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/NativeLaunchDiagnosticsTests.cs
@@ -39,7 +39,7 @@ public class NativeLaunchDiagnosticsTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task NonExecutableFile_IsRefusedWithANamedError()
+    public async Task NonExecutableFile_IsRefusedWithANamedErrorAsync()
     {
         if (!OnUnix)
         {
@@ -71,7 +71,7 @@ public class NativeLaunchDiagnosticsTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ProcessThatDiesAtStartup_SurfacesItsStderr()
+    public async Task ProcessThatDiesAtStartup_SurfacesItsStderrAsync()
     {
         if (!OnUnix)
         {
@@ -109,7 +109,7 @@ public class NativeLaunchDiagnosticsTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ChattyProcess_StillLaunchesWithoutDeadlocking()
+    public async Task ChattyProcess_StillLaunchesWithoutDeadlockingAsync()
     {
         if (!OnUnix)
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/RetailArchiveRootTests.cs
@@ -41,7 +41,7 @@ public class RetailArchiveRootTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EngineOnlyWorkspace_ReachesRetailArchivesThroughEnvironment()
+    public async Task EngineOnlyWorkspace_ReachesRetailArchivesThroughEnvironmentAsync()
     {
         var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)
@@ -91,7 +91,7 @@ public class RetailArchiveRootTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EngineOnlyWorkspace_WithoutArchiveRoots_DoesNotSurvive()
+    public async Task EngineOnlyWorkspace_WithoutArchiveRoots_DoesNotSurviveAsync()
     {
         var installDirectory = NativeClientFixture.Directory;
         if (installDirectory is null)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/ProfileLauncherFacadeCancellationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/ProfileLauncherFacadeCancellationTests.cs
@@ -30,7 +30,7 @@ public class ProfileLauncherFacadeCancellationTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WhenCancelled_PropagatesCancellation()
+    public async Task LaunchProfileAsync_WhenCancelled_PropagatesCancellationAsync()
     {
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
@@ -51,7 +51,7 @@ public class ProfileLauncherFacadeCancellationTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WhenDependencyTimesOut_ReturnsFailure()
+    public async Task LaunchProfileAsync_WhenDependencyTimesOut_ReturnsFailureAsync()
     {
         _profileManagerMock
             .Setup(manager => manager.GetProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/DownloadsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/DownloadsViewModelTests.cs
@@ -18,7 +18,7 @@ public class DownloadsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task InitializeAsync_CompletesSuccessfully()
+    public async Task InitializeAsync_CompletesSuccessfullyAsync()
     {
         // Arrange
         var mockServiceProvider = new Mock<IServiceProvider>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileItemViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileItemViewModelTests.cs
@@ -57,7 +57,7 @@ public class GameProfileItemViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CopyProfileCommand_CallsCopyAction()
+    public async Task CopyProfileCommand_CallsCopyActionAsync()
     {
         // Arrange
         var mockProfile = new Mock<IGameProfile>();
@@ -92,8 +92,10 @@ public class GameProfileItemViewModelTests
         mockProfile.SetupGet(p => p.Version).Returns("1.0");
         mockProfile.SetupGet(p => p.ExecutablePath).Returns("C:/fake/path.exe");
 
-        var vm = new GameProfileItemViewModel("test-profile-id", mockProfile.Object, "icon.png", "cover.jpg");
-        vm.CopyProfileAction = _ => Task.CompletedTask;
+        var vm = new GameProfileItemViewModel("test-profile-id", mockProfile.Object, "icon.png", "cover.jpg")
+        {
+            CopyProfileAction = _ => Task.CompletedTask,
+        };
 
         // Act & Assert
         Assert.True(vm.CopyProfileCommand.CanExecute(null));
@@ -123,7 +125,7 @@ public class GameProfileItemViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CopyProfileCommand_Execute_WhenActionIsNull_DoesNotThrow()
+    public async Task CopyProfileCommand_Execute_WhenActionIsNull_DoesNotThrowAsync()
     {
         // Arrange
         var mockProfile = new Mock<IGameProfile>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
@@ -79,7 +79,7 @@ public class GameProfileLauncherViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task InitializeAsync_LoadsProfiles_Successfully()
+    public async Task InitializeAsync_LoadsProfiles_SuccessfullyAsync()
     {
         var installationService = new Mock<IGameInstallationService>();
         var vm = new GameProfileLauncherViewModel(
@@ -123,7 +123,7 @@ public class GameProfileLauncherViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ScanForGamesCommand_WithSuccessfulScan_ShowsSuccess()
+    public async Task ScanForGamesCommand_WithSuccessfulScan_ShowsSuccessAsync()
     {
         var installationService = new Mock<IGameInstallationService>();
         var installations = new List<GameInstallation>
@@ -174,7 +174,7 @@ public class GameProfileLauncherViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ScanForGamesCommand_WithFailedScan_ShowsFailure()
+    public async Task ScanForGamesCommand_WithFailedScan_ShowsFailureAsync()
     {
         var installationService = new Mock<IGameInstallationService>();
         const string expectedError = "Detection service unavailable";
@@ -212,7 +212,7 @@ public class GameProfileLauncherViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ScanForGamesCommand_WithException_HandlesGracefully()
+    public async Task ScanForGamesCommand_WithException_HandlesGracefullyAsync()
     {
         var installationService = new Mock<IGameInstallationService>();
         installationService.Setup(x => x.GetAllInstallationsAsync(It.IsAny<CancellationToken>()))
@@ -249,7 +249,7 @@ public class GameProfileLauncherViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ScanForGamesCommand_WithoutService_ShowsError()
+    public async Task ScanForGamesCommand_WithoutService_ShowsErrorAsync()
     {
         var installationService = new Mock<IGameInstallationService>();
         var shortcutService = new Mock<IShortcutService>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -73,7 +73,7 @@ public class GameProfileSettingsViewModelDependencyTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task Save_Fails_WhenGameInstallationIdMismatch()
+    public async Task Save_Fails_WhenGameInstallationIdMismatchAsync()
     {
         // Arrange
         var modManifestId = new ManifestId("1.0.0.mod.example");
@@ -154,7 +154,7 @@ public class GameProfileSettingsViewModelDependencyTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task Save_Succeeds_WhenGameInstallationIdMatches()
+    public async Task Save_Succeeds_WhenGameInstallationIdMatchesAsync()
     {
         // Arrange
         var modManifestId = new ManifestId("1.0.0.mod.example");
@@ -232,7 +232,7 @@ public class GameProfileSettingsViewModelDependencyTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task Save_Succeeds_WhenOptionalDependencyIsMissing()
+    public async Task Save_Succeeds_WhenOptionalDependencyIsMissingAsync()
     {
         // Arrange
         var modManifestId = new ManifestId("1.0.0.mod.example");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -322,7 +322,7 @@ public class GameProfileSettingsViewModelDependencyTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task EnableContent_AutoSwitches_GameInstallation_When_Dependency_Requires_Different_Type()
+    public async Task EnableContent_AutoSwitches_GameInstallation_When_Dependency_Requires_Different_TypeAsync()
     {
         // Arrange
         var modManifestId = new ManifestId("1.0.0.mod.generalsonline");
@@ -405,7 +405,7 @@ public class GameProfileSettingsViewModelDependencyTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task EnableContent_AutoSwitches_Installation_For_Standard_GameClient_Missing_Manifest()
+    public async Task EnableContent_AutoSwitches_Installation_For_Standard_GameClient_Missing_ManifestAsync()
     {
         // Arrange
         var standardClientId = new ManifestId("1.04.eaapp.gameclient.zerohour");
@@ -475,7 +475,7 @@ public class GameProfileSettingsViewModelDependencyTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task EnableContent_AutoEnables_DependentContent()
+    public async Task EnableContent_AutoEnables_DependentContentAsync()
     {
         // Arrange
         var clientManifestId = new ManifestId("1.0.0.gameclient.generalsonline");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
@@ -161,7 +161,7 @@ public class GameProfileSettingsViewModelTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ReceiveManifestReplacedMessage_UpdatesEnabledContent_WithoutDuplication()
+    public async Task ReceiveManifestReplacedMessage_UpdatesEnabledContent_WithoutDuplicationAsync()
     {
         // Arrange
         var mockGameSettingsService = new Mock<IGameSettingsService>();
@@ -189,16 +189,6 @@ public class GameProfileSettingsViewModelTests
             Version = "2.0",
         };
 
-        var newItem = new GenHub.Features.GameProfiles.ViewModels.ContentDisplayItem
-        {
-            ManifestId = GenHub.Core.Models.Manifest.ManifestId.Create(newId),
-            DisplayName = "My Mod v2",
-            IsEnabled = true,
-            ContentType = GenHub.Core.Models.Enums.ContentType.Mod,
-            GameType = GenHub.Core.Models.Enums.GameType.Generals,
-            InstallationType = GenHub.Core.Models.Enums.GameInstallationType.Steam,
-            Version = "2.0",
-        };
 
         mockManifestPool
             .Setup(x => x.GetManifestAsync(It.Is<GenHub.Core.Models.Manifest.ManifestId>(id => id.Value == newId), It.IsAny<System.Threading.CancellationToken>()))

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
@@ -25,7 +25,7 @@ public class GameProfileSettingsViewModelTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task InitializeForNewProfileAsync_WithRequiredServices_SetsDefaultsAndLoadsContent()
+    public async Task InitializeForNewProfileAsync_WithRequiredServices_SetsDefaultsAndLoadsContentAsync()
     {
         // Arrange
         var mockGameSettingsService = new Mock<IGameSettingsService>();
@@ -126,7 +126,7 @@ public class GameProfileSettingsViewModelTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task InitializeForProfileAsync_WithoutProfileManager_SetsLoadingError()
+    public async Task InitializeForProfileAsync_WithoutProfileManager_SetsLoadingErrorAsync()
     {
         // Arrange
         var mockGameSettingsService = new Mock<IGameSettingsService>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelTests.cs
@@ -189,7 +189,6 @@ public class GameProfileSettingsViewModelTests
             Version = "2.0",
         };
 
-
         mockManifestPool
             .Setup(x => x.GetManifestAsync(It.Is<GenHub.Core.Models.Manifest.ManifestId>(id => id.Value == newId), It.IsAny<System.Threading.CancellationToken>()))
             .ReturnsAsync(OperationResult<ContentManifest?>.CreateSuccess(newManifest));

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -58,7 +58,7 @@ public class GameSettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task InitializeForProfileAsync_Should_LoadFromIniOptions_WhenNoProfileSettings()
+    public async Task InitializeForProfileAsync_Should_LoadFromIniOptions_WhenNoProfileSettingsAsync()
     {
         // Arrange
         var profile = new GameProfile
@@ -119,7 +119,7 @@ public class GameSettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task InitializeForProfileAsync_Should_LoadFromProfile_WhenProfileHasSettings()
+    public async Task InitializeForProfileAsync_Should_LoadFromProfile_WhenProfileHasSettingsAsync()
     {
         // Arrange
         var profile = new GameProfile
@@ -310,7 +310,7 @@ public class GameSettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task OnSelectedGameTypeChanged_Should_LoadSettings_WhenNotInitializing()
+    public async Task OnSelectedGameTypeChanged_Should_LoadSettings_WhenNotInitializingAsync()
     {
         // Arrange
         var options = new IniOptions
@@ -337,7 +337,7 @@ public class GameSettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task OnSelectedGameTypeChanged_Should_NotLoadSettings_WhenSetBeforeInitialization()
+    public async Task OnSelectedGameTypeChanged_Should_NotLoadSettings_WhenSetBeforeInitializationAsync()
     {
         // Arrange
         var profile = new GameProfile
@@ -360,7 +360,7 @@ public class GameSettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task LoadSettings_Should_HandleFailureGracefully()
+    public async Task LoadSettings_Should_HandleFailureGracefullyAsync()
     {
         // Arrange
         _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.Generals))
@@ -382,7 +382,7 @@ public class GameSettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SaveSettings_Should_HandleFailureGracefully()
+    public async Task SaveSettings_Should_HandleFailureGracefullyAsync()
     {
         // Arrange
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.Generals, It.IsAny<IniOptions>()))

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
@@ -218,6 +218,9 @@ public class MainViewModelTests
             case NavigationTab.Info:
                 Assert.IsType<InfoViewModel>(currentViewModel);
                 break;
+            default:
+                // No additional specific tab assertions
+                break;
         }
     }
 
@@ -245,7 +248,6 @@ public class MainViewModelTests
         var mockWorkspaceManager = new Mock<IWorkspaceManager>();
         var mockManifestPool = new Mock<IContentManifestPool>();
         var mockUpdateManager = new Mock<IVelopackUpdateManager>();
-        var mockNotificationService = new Mock<INotificationService>();
         var mockNotificationServiceForSettings = new Mock<INotificationService>();
         var mockConfigurationProvider = new Mock<IConfigurationProviderService>();
         var mockInstallationService = new Mock<IGameInstallationService>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
@@ -125,7 +125,7 @@ public class MainViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task InitializeAsync_MultipleCallsAreSafe()
+    public async Task InitializeAsync_MultipleCallsAreSafeAsync()
     {
         // Arrange
         var (settingsVm, userSettingsMock) = CreateSettingsVm();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -107,7 +107,7 @@ public class SettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task SaveSettingsCommand_UpdatesUserSettingsService()
+    public async Task SaveSettingsCommand_UpdatesUserSettingsServiceAsync()
     {
         // Arrange
         var viewModel = new SettingsViewModel(
@@ -141,7 +141,7 @@ public class SettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ResetToDefaultsCommand_ResetsAllProperties()
+    public async Task ResetToDefaultsCommand_ResetsAllPropertiesAsync()
     {
         // Arrange
         var viewModel = new SettingsViewModel(
@@ -273,7 +273,7 @@ public class SettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task SaveSettingsCommand_HandlesUserSettingsServiceException()
+    public async Task SaveSettingsCommand_HandlesUserSettingsServiceExceptionAsync()
     {
         // Arrange
         _mockConfigService.Setup(x => x.SaveAsync(default)).ThrowsAsync(new IOException("Disk full"));
@@ -395,7 +395,7 @@ public class SettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task UninstallGenHubCommand_CallsService()
+    public async Task UninstallGenHubCommand_CallsServiceAsync()
     {
         // Arrange
         var viewModel = new SettingsViewModel(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -339,7 +339,7 @@ public class SettingsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DeleteCasStorageCommand_ReportsGarbageCollectionIsDisabled()
+    public async Task DeleteCasStorageCommand_ReportsGarbageCollectionIsDisabledAsync()
     {
         // Arrange
         // Setup stats to return valid data so update method works

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
@@ -117,7 +117,7 @@ public class GameSettingsServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task LoadOptionsAsync_Should_ParseValidIniFile()
+    public async Task LoadOptionsAsync_Should_ParseValidIniFileAsync()
     {
         // Arrange
         var iniContent = @"[AUDIO]
@@ -186,7 +186,7 @@ Gamma=60
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task LoadOptionsAsync_Should_ReturnSuccessWithDefaults_WhenFileDoesNotExist()
+    public async Task LoadOptionsAsync_Should_ReturnSuccessWithDefaults_WhenFileDoesNotExistAsync()
     {
         // Arrange
         var mockService = new Mock<GameSettingsService>(MockBehavior.Loose, _loggerMock.Object, _pathProviderMock.Object)
@@ -209,7 +209,7 @@ Gamma=60
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task LoadOptionsAsync_Should_HandleMalformedIniFile()
+    public async Task LoadOptionsAsync_Should_HandleMalformedIniFileAsync()
     {
         // Arrange
         var iniContent = @"[AUDIO]
@@ -248,7 +248,7 @@ MissingBracket
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SaveOptionsAsync_Should_SaveOptionsToFile()
+    public async Task SaveOptionsAsync_Should_SaveOptionsToFileAsync()
     {
         // Arrange
         var tempFile = Path.GetTempFileName();
@@ -310,7 +310,7 @@ MissingBracket
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task BoolToString_Should_SerializeCorrectly(bool value)
+    public async Task BoolToString_Should_SerializeCorrectlyAsync(bool value)
     {
         // This is testing the private BoolToString method indirectly through SaveOptionsAsync
         var options = new IniOptions
@@ -350,7 +350,7 @@ MissingBracket
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SaveOptionsAsync_Should_PreserveUnknownSections()
+    public async Task SaveOptionsAsync_Should_PreserveUnknownSectionsAsync()
     {
         // Arrange
         var originalContent = @"[AUDIO]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -150,7 +150,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithValidProfile_ShouldSucceed()
+    public async Task LaunchProfileAsync_WithValidProfile_ShouldSucceedAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -200,7 +200,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithProfileNotFound_ShouldFail()
+    public async Task LaunchProfileAsync_WithProfileNotFound_ShouldFailAsync()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -220,7 +220,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithManifestNotFound_ShouldFail()
+    public async Task LaunchProfileAsync_WithManifestNotFound_ShouldFailAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -246,7 +246,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithNullManifest_ShouldFail()
+    public async Task LaunchProfileAsync_WithNullManifest_ShouldFailAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -272,7 +272,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithWorkspaceFailure_ShouldFail()
+    public async Task LaunchProfileAsync_WithWorkspaceFailure_ShouldFailAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -297,7 +297,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithProcessStartFailure_ShouldFail()
+    public async Task LaunchProfileAsync_WithProcessStartFailure_ShouldFailAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -332,7 +332,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task TerminateGameAsync_WithValidLaunchId_ShouldSucceed()
+    public async Task TerminateGameAsync_WithValidLaunchId_ShouldSucceedAsync()
     {
         // Arrange
         var launchId = Guid.NewGuid().ToString();
@@ -362,7 +362,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task TerminateGameAsync_WithInvalidLaunchId_ShouldFail()
+    public async Task TerminateGameAsync_WithInvalidLaunchId_ShouldFailAsync()
     {
         // Arrange
         var launchId = Guid.NewGuid().ToString();
@@ -381,7 +381,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithProgressTracking_ShouldReportProgress()
+    public async Task LaunchProfileAsync_WithProgressTracking_ShouldReportProgressAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -460,7 +460,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithCancellation_ShouldRespectCancellation()
+    public async Task LaunchProfileAsync_WithCancellation_ShouldRespectCancellationAsync()
     {
         // Arrange
         var profileId = "test-profile";
@@ -482,7 +482,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_ConcurrentSteamProfilesSharingInstallation_SerializesSetup()
+    public async Task LaunchProfileAsync_ConcurrentSteamProfilesSharingInstallation_SerializesSetupAsync()
     {
         // Arrange
         var testRoot = Path.Combine(
@@ -583,7 +583,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithEmptyEnabledContent_ShouldSucceed()
+    public async Task LaunchProfileAsync_WithEmptyEnabledContent_ShouldSucceedAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -613,7 +613,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task TerminateGameAsync_WithProcessTerminationFailure_ShouldNotUnregister()
+    public async Task TerminateGameAsync_WithProcessTerminationFailure_ShouldNotUnregisterAsync()
     {
         // Arrange
         var launchId = Guid.NewGuid().ToString();
@@ -644,7 +644,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task GetActiveGamesAsync_ShouldReturnActiveProcesses()
+    public async Task GetActiveGamesAsync_ShouldReturnActiveProcessesAsync()
     {
         // Arrange
         var activeProcesses = new List<GameProcessInfo>
@@ -671,7 +671,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchRegistry_ShouldTrackActiveLaunches()
+    public async Task LaunchRegistry_ShouldTrackActiveLaunchesAsync()
     {
         // Arrange
         var activeLaunches = new List<GameLaunchInfo>
@@ -705,7 +705,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithMultipleContentManifests_ShouldResolveAll()
+    public async Task LaunchProfileAsync_WithMultipleContentManifests_ShouldResolveAllAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -752,7 +752,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithProfileSettings_ShouldWriteIniOptionsBeforeLaunch()
+    public async Task LaunchProfileAsync_WithProfileSettings_ShouldWriteIniOptionsBeforeLaunchAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -815,7 +815,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithWindowedMode_ShouldAddWinArgument()
+    public async Task LaunchProfileAsync_WithWindowedMode_ShouldAddWinArgumentAsync()
     {
         // Arrange
         var profile = CreateTestProfile();
@@ -864,7 +864,7 @@ public class GameLauncherTests : IDisposable
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
-    public async Task LaunchProfileAsync_WithoutProfileSettings_ShouldStillSaveOptionsIni()
+    public async Task LaunchProfileAsync_WithoutProfileSettings_ShouldStillSaveOptionsIniAsync()
     {
         // Arrange
         var profile = CreateTestProfile();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/LaunchRegistryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/LaunchRegistryTests.cs
@@ -27,7 +27,7 @@ public class LaunchRegistryTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RegisterLaunchAsync_ShouldAddLaunchInfo()
+    public async Task RegisterLaunchAsync_ShouldAddLaunchInfoAsync()
     {
         // Arrange
         var launchInfo = new GameLaunchInfo
@@ -53,7 +53,7 @@ public class LaunchRegistryTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetLaunchInfoAsync_WithNonExistentId_ShouldReturnNull()
+    public async Task GetLaunchInfoAsync_WithNonExistentId_ShouldReturnNullAsync()
     {
         // Act
         var result = await _registry.GetLaunchInfoAsync("non-existent-id");
@@ -67,7 +67,7 @@ public class LaunchRegistryTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task UnregisterLaunchAsync_ShouldRemoveLaunchInfo()
+    public async Task UnregisterLaunchAsync_ShouldRemoveLaunchInfoAsync()
     {
         // Arrange
         var launchInfo = new GameLaunchInfo

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/SteamLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/SteamLauncherTests.cs
@@ -47,7 +47,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_ValidPaths_DeploysProxyAndPreservesExistingDependencies()
+    public async Task PrepareForProfileAsync_ValidPaths_DeploysProxyAndPreservesExistingDependenciesAsync()
     {
         // Arrange
         var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
@@ -76,7 +76,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_MissingWorkspaceExecutable_DoesNotMutateInstallation()
+    public async Task PrepareForProfileAsync_MissingWorkspaceExecutable_DoesNotMutateInstallationAsync()
     {
         // Arrange
         var missingExecutable = Path.Combine(_workspacePath, "missing.exe");
@@ -99,7 +99,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_MissingTargetWithBackup_DeploysProxyFromRecoveryState()
+    public async Task PrepareForProfileAsync_MissingTargetWithBackup_DeploysProxyFromRecoveryStateAsync()
     {
         // Arrange
         var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
@@ -120,7 +120,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_LateWriteFailure_RestoresOriginalAndPreExistingFiles()
+    public async Task PrepareForProfileAsync_LateWriteFailure_RestoresOriginalAndPreExistingFilesAsync()
     {
         // Arrange
         var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
@@ -132,7 +132,7 @@ public sealed class SteamLauncherTests : IDisposable
         File.WriteAllText(workspaceAppIdPath, "pre-existing app id");
 
         var writeCount = 0;
-        async Task FailingWriter(string path, string contents, CancellationToken cancellationToken)
+        async Task FailingWriterAsync(string path, string contents, CancellationToken cancellationToken)
         {
             writeCount++;
             await File.WriteAllTextAsync(path, contents, cancellationToken);
@@ -143,7 +143,7 @@ public sealed class SteamLauncherTests : IDisposable
         }
 
         // Act
-        var result = await PrepareAsync(CreateLauncher(FailingWriter), steamAppId: "12345");
+        var result = await PrepareAsync(CreateLauncher(FailingWriterAsync), steamAppId: "12345");
 
         // Assert
         Assert.False(result.Success);
@@ -160,7 +160,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_UnrelatedPreExistingBackup_FailsWithoutMutation()
+    public async Task PrepareForProfileAsync_UnrelatedPreExistingBackup_FailsWithoutMutationAsync()
     {
         // Arrange
         var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
@@ -184,7 +184,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CleanupGameDirectoryAsync_UnrelatedBackup_PreservesExecutableAndArtifacts()
+    public async Task CleanupGameDirectoryAsync_UnrelatedBackup_PreservesExecutableAndArtifactsAsync()
     {
         // Arrange
         var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
@@ -209,7 +209,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CleanupGameDirectoryAsync_DeployedProxy_RestoresVerifiedBackup()
+    public async Task CleanupGameDirectoryAsync_DeployedProxy_RestoresVerifiedBackupAsync()
     {
         // Arrange
         var backupPath = _originalExecutablePath + SteamConstants.BackupExtension;
@@ -235,7 +235,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CleanupGameDirectoryAsync_DeployedProxyWithoutBackup_FailsClosed()
+    public async Task CleanupGameDirectoryAsync_DeployedProxyWithoutBackup_FailsClosedAsync()
     {
         // Arrange
         var configPath = Path.Combine(_gameInstallPath, "proxy_config.json");
@@ -258,7 +258,7 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_ConcurrentProfilesSharingInstallation_SerializesMutations()
+    public async Task PrepareForProfileAsync_ConcurrentProfilesSharingInstallation_SerializesMutationsAsync()
     {
         // Arrange
         var firstWriteStarted = new TaskCompletionSource<bool>(
@@ -268,26 +268,26 @@ public sealed class SteamLauncherTests : IDisposable
         var secondWriteStarted = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
-        async Task BlockingWriter(string path, string contents, CancellationToken cancellationToken)
+        async Task BlockingWriterAsync(string path, string contents, CancellationToken cancellationToken)
         {
             firstWriteStarted.TrySetResult(true);
             await releaseFirstWrite.Task.WaitAsync(cancellationToken);
             await File.WriteAllTextAsync(path, contents, cancellationToken);
         }
 
-        async Task ObservedWriter(string path, string contents, CancellationToken cancellationToken)
+        async Task ObservedWriterAsync(string path, string contents, CancellationToken cancellationToken)
         {
             secondWriteStarted.TrySetResult(true);
             await File.WriteAllTextAsync(path, contents, cancellationToken);
         }
 
         var firstPreparation = PrepareAsync(
-            CreateLauncher(BlockingWriter),
+            CreateLauncher(BlockingWriterAsync),
             profileId: "first-profile");
         await firstWriteStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         var secondPreparation = PrepareAsync(
-            CreateLauncher(ObservedWriter),
+            CreateLauncher(ObservedWriterAsync),
             profileId: "second-profile");
 
         try
@@ -313,13 +313,13 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_CanceledAfterMutation_RollsBackCurrentAttempt()
+    public async Task PrepareForProfileAsync_CanceledAfterMutation_RollsBackCurrentAttemptAsync()
     {
         // Arrange
         using var cancellationSource = new CancellationTokenSource();
         var writeCount = 0;
 
-        async Task CancelingWriter(string path, string contents, CancellationToken cancellationToken)
+        async Task CancelingWriterAsync(string path, string contents, CancellationToken cancellationToken)
         {
             writeCount++;
             await File.WriteAllTextAsync(path, contents, cancellationToken);
@@ -331,7 +331,7 @@ public sealed class SteamLauncherTests : IDisposable
 
         // Act
         var result = await PrepareAsync(
-            CreateLauncher(CancelingWriter),
+            CreateLauncher(CancelingWriterAsync),
             steamAppId: "12345",
             cancellationToken: cancellationSource.Token);
 
@@ -349,10 +349,10 @@ public sealed class SteamLauncherTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task PrepareForProfileAsync_ExecutableChangesDuringFailure_ReportsRollbackConflict()
+    public async Task PrepareForProfileAsync_ExecutableChangesDuringFailure_ReportsRollbackConflictAsync()
     {
         // Arrange
-        async Task ConflictingWriter(string path, string contents, CancellationToken cancellationToken)
+        async Task ConflictingWriterAsync(string path, string contents, CancellationToken cancellationToken)
         {
             await File.WriteAllTextAsync(path, contents, cancellationToken);
             File.WriteAllText(_originalExecutablePath, "external executable change");
@@ -360,7 +360,7 @@ public sealed class SteamLauncherTests : IDisposable
         }
 
         // Act
-        var result = await PrepareAsync(CreateLauncher(ConflictingWriter));
+        var result = await PrepareAsync(CreateLauncher(ConflictingWriterAsync));
 
         // Assert
         Assert.False(result.Success);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
@@ -234,7 +234,7 @@ public class ContentManifestBuilderTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AddFilesFromDirectoryAsync_SetsCorrectInstallTargets()
+    public async Task AddFilesFromDirectoryAsync_SetsCorrectInstallTargetsAsync()
     {
         // Arrange
         var tempDir = Path.Combine(Path.GetTempPath(), "GenHubTest_" + Guid.NewGuid());

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestPoolTests.cs
@@ -49,7 +49,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AddManifestAsync_WithStoredContent_ShouldSucceed()
+    public async Task AddManifestAsync_WithStoredContent_ShouldSucceedAsync()
     {
         // Arrange
         var manifest = CreateTestManifest();
@@ -74,7 +74,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AddManifestAsync_WithoutStoredContent_ShouldFail()
+    public async Task AddManifestAsync_WithoutStoredContent_ShouldFailAsync()
     {
         // Arrange
         var manifest = CreateTestManifest();
@@ -94,7 +94,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AddManifestAsync_WithSourceDirectory_ShouldSucceed()
+    public async Task AddManifestAsync_WithSourceDirectory_ShouldSucceedAsync()
     {
         // Arrange
         var manifest = CreateTestManifest();
@@ -118,7 +118,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetManifestAsync_WhenExists_ShouldReturnManifest()
+    public async Task GetManifestAsync_WhenExists_ShouldReturnManifestAsync()
     {
         // Arrange
         var manifest = CreateTestManifest();
@@ -143,7 +143,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetManifestAsync_WithNullVariants_PreservesEmptyCollection()
+    public async Task GetManifestAsync_WithNullVariants_PreservesEmptyCollectionAsync()
     {
         var manifestId = ManifestId.Create("1.0.genhub.mod.nullvariants");
         var manifestPath = Path.Combine(_tempDirectory, "null-variants.json");
@@ -167,7 +167,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetManifestAsync_WhenNotExists_ShouldReturnNull()
+    public async Task GetManifestAsync_WhenNotExists_ShouldReturnNullAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.nonexistent";
@@ -189,7 +189,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllManifestsAsync_ShouldReturnAllManifests()
+    public async Task GetAllManifestsAsync_ShouldReturnAllManifestsAsync()
     {
         // Arrange
         var manifests = new List<ContentManifest>
@@ -227,7 +227,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetAllManifestsAsync_WhenNoDirectory_ShouldReturnEmptyList()
+    public async Task GetAllManifestsAsync_WhenNoDirectory_ShouldReturnEmptyListAsync()
     {
         // Arrange
         _storageServiceMock.Setup(x => x.GetContentStorageRoot())
@@ -246,7 +246,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SearchManifestsAsync_WithQuery_ShouldReturnFilteredResults()
+    public async Task SearchManifestsAsync_WithQuery_ShouldReturnFilteredResultsAsync()
     {
         // Arrange
         var manifests = new List<ContentManifest>
@@ -278,7 +278,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RemoveManifestAsync_ShouldSucceedAndCleanupByDefault()
+    public async Task RemoveManifestAsync_ShouldSucceedAndCleanupByDefaultAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.publisher";
@@ -302,7 +302,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RemoveManifestAsync_WithSkipCleanup_ShouldSucceed()
+    public async Task RemoveManifestAsync_WithSkipCleanup_ShouldSucceedAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.publisher";
@@ -323,7 +323,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RemoveManifestAsync_WhenStorageFails_ShouldFail()
+    public async Task RemoveManifestAsync_WhenStorageFails_ShouldFailAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.publisher";
@@ -343,7 +343,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task IsManifestAcquiredAsync_ShouldReturnCorrectStatus()
+    public async Task IsManifestAcquiredAsync_ShouldReturnCorrectStatusAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.publisher";
@@ -363,7 +363,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetContentDirectoryAsync_WhenExists_ShouldReturnPath()
+    public async Task GetContentDirectoryAsync_WhenExists_ShouldReturnPathAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.publisher";
@@ -387,7 +387,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetContentDirectoryAsync_WhenNotExists_ShouldReturnNull()
+    public async Task GetContentDirectoryAsync_WhenNotExists_ShouldReturnNullAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.publisher";
@@ -410,7 +410,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetManifestAsync_WhenExceptionThrown_ShouldReturnFailure()
+    public async Task GetManifestAsync_WhenExceptionThrown_ShouldReturnFailureAsync()
     {
         // Arrange
         var manifestId = "1.0.genhub.mod.publisher";
@@ -456,7 +456,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </remarks>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task AddManifestAsync_WithVariants_RejectsBeforeStoringContent()
+    public async Task AddManifestAsync_WithVariants_RejectsBeforeStoringContentAsync()
     {
         var manifest = CreateTestManifest();
         manifest.Variants.Add(new ArtifactVariant());
@@ -479,7 +479,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task AddManifestAsync_WithSourceDirectory_WithVariants_RejectsBeforeStoringContent()
+    public async Task AddManifestAsync_WithSourceDirectory_WithVariants_RejectsBeforeStoringContentAsync()
     {
         var manifest = CreateTestManifest();
         manifest.Variants.Add(new ArtifactVariant());
@@ -507,7 +507,7 @@ public class ContentManifestPoolTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task AddManifestAsync_WithoutVariants_IsNotRejectedByTheGate()
+    public async Task AddManifestAsync_WithoutVariants_IsNotRejectedByTheGateAsync()
     {
         var manifest = CreateTestManifest();
         _storageServiceMock.Setup(x => x.IsContentStoredAsync(manifest.Id, It.IsAny<CancellationToken>()))

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
@@ -306,7 +306,11 @@ public class ManifestDiscoveryServiceTests : IDisposable
                 Directory.Delete(_tempDirectory, true);
             }
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (IOException)
+        {
+            // Best-effort cleanup should not fail an otherwise successful test.
+        }
+        catch (UnauthorizedAccessException)
         {
             // Best-effort cleanup should not fail an otherwise successful test.
         }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestDiscoveryServiceTests.cs
@@ -108,7 +108,7 @@ public class ManifestDiscoveryServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverManifestsAsync_DiscoversNestedJsonManifest_AndIgnoresNonJsonFile()
+    public async Task DiscoverManifestsAsync_DiscoversNestedJsonManifest_AndIgnoresNonJsonFileAsync()
     {
         // Arrange
         const string nestedManifestId = "1.0.genhub.mod.nested";
@@ -136,7 +136,7 @@ public class ManifestDiscoveryServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverManifestsAsync_WithMalformedJson_ContinuesDiscoveringNestedManifest()
+    public async Task DiscoverManifestsAsync_WithMalformedJson_ContinuesDiscoveringNestedManifestAsync()
     {
         // Arrange
         const string nestedManifestId = "1.0.genhub.mod.valid";
@@ -160,7 +160,7 @@ public class ManifestDiscoveryServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DiscoverManifestsAsync_WithUnavailableDescendants_ContinuesDiscoveringAccessibleManifests()
+    public async Task DiscoverManifestsAsync_WithUnavailableDescendants_ContinuesDiscoveringAccessibleManifestsAsync()
     {
         // Arrange
         const string accessibleManifestId = "1.0.genhub.mod.accessible";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -76,7 +76,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameClientManifestAsync_IncludesExecutableWithHash()
+    public async Task CreateGameClientManifestAsync_IncludesExecutableWithHashAsync()
     {
         // Arrange
         await File.WriteAllTextAsync(Path.Combine(_tempDirectory, "generals.exe"), "dummy exe content");
@@ -100,7 +100,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameClientManifestAsync_IncludesExecutableWithCorrectSize()
+    public async Task CreateGameClientManifestAsync_IncludesExecutableWithCorrectSizeAsync()
     {
         // Arrange
         var (clientPath, executablePath) = await PrepareDummyExeAsync();
@@ -124,7 +124,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameClientManifestAsync_ThrowsWhenExecutableMissing()
+    public async Task CreateGameClientManifestAsync_ThrowsWhenExecutableMissingAsync()
     {
         // Arrange
         var clientPath = Path.Combine(_tempDirectory, "TestClient");
@@ -142,7 +142,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameClientManifestAsync_IncludesRequiredDllsWhenPresent()
+    public async Task CreateGameClientManifestAsync_IncludesRequiredDllsWhenPresentAsync()
     {
         // Arrange
         var (clientPath, executablePath) = await PrepareDummyExeAsync();
@@ -166,7 +166,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameClientManifestAsync_IncludesConfigFilesWhenPresent()
+    public async Task CreateGameClientManifestAsync_IncludesConfigFilesWhenPresentAsync()
     {
         // Arrange
         var (clientPath, executablePath) = await PrepareDummyExeAsync();
@@ -190,7 +190,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameClientManifestAsync_ManifestContainsMultipleFiles()
+    public async Task CreateGameClientManifestAsync_ManifestContainsMultipleFilesAsync()
     {
         // Arrange
         var (clientPath, executablePath) = await PrepareDummyExeAsync();
@@ -214,7 +214,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameClientManifestAsync_IncludesAllDllsAndGeneralsDatForEaApp()
+    public async Task CreateGameClientManifestAsync_IncludesAllDllsAndGeneralsDatForEaAppAsync()
     {
         // Arrange
         var clientPath = Path.Combine(_tempDirectory, "EaAppClient");
@@ -254,7 +254,7 @@ public class ManifestGenerationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task CreateGameInstallationManifestAsync_UsesCsvWhenAvailable()
+    public async Task CreateGameInstallationManifestAsync_UsesCsvWhenAvailableAsync()
     {
         // Arrange
         var installationPath = Path.Combine(_tempDirectory, "GeneralsInstall");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestProviderTests.cs
@@ -59,7 +59,7 @@ public class ManifestProviderTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task GetManifestAsync_WithGameClient_ReturnsFromCache_WhenAvailable()
+    public async Task GetManifestAsync_WithGameClient_ReturnsFromCache_WhenAvailableAsync()
     {
         // Arrange
         var gameClient = new GameClient
@@ -113,7 +113,7 @@ public class ManifestProviderTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task GetManifestAsync_WithGameInstallation_BuildsCorrectManifestId()
+    public async Task GetManifestAsync_WithGameInstallation_BuildsCorrectManifestIdAsync()
     {
         // Arrange
         var installation = new GameInstallation(
@@ -174,7 +174,7 @@ public class ManifestProviderTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetManifestAsync_WithZeroHourInstallation_UsesZeroHourId()
+    public async Task GetManifestAsync_WithZeroHourInstallation_UsesZeroHourIdAsync()
     {
         // Arrange
         var tempZeroHourPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -223,7 +223,7 @@ public class ManifestProviderTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task GetManifestAsync_ReturnsNull_WhenManifestNotFoundInCacheAndResources()
+    public async Task GetManifestAsync_ReturnsNull_WhenManifestNotFoundInCacheAndResourcesAsync()
     {
         // Arrange
         var gameClient = new GameClient { Id = "1.0.genhub.nonexistent" };
@@ -242,7 +242,7 @@ public class ManifestProviderTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task GetManifestAsync_ThrowsValidationException_WhenManifestIdMismatch()
+    public async Task GetManifestAsync_ThrowsValidationException_WhenManifestIdMismatchAsync()
     {
         // Arrange
         var gameClient = new GameClient

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestProviderTests.cs
@@ -91,7 +91,7 @@ public class ManifestProviderTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetManifestAsync_WithCachedVariantManifest_ThrowsValidationException()
+    public async Task GetManifestAsync_WithCachedVariantManifest_ThrowsValidationExceptionAsync()
     {
         var gameClient = new GameClient { Id = "1.0.genhub.mod.variant" };
         var manifest = new ContentManifest
@@ -147,7 +147,7 @@ public class ManifestProviderTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GetManifestAsync_WithInstallationCachedVariantManifest_ThrowsValidationException()
+    public async Task GetManifestAsync_WithInstallationCachedVariantManifest_ThrowsValidationExceptionAsync()
     {
         var installation = new GameInstallation(
             installationPath: @"C:\TestPath",

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ContentReconciliationOrchestratorGarbageCollectionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ContentReconciliationOrchestratorGarbageCollectionTests.cs
@@ -22,7 +22,7 @@ public class ContentReconciliationOrchestratorGarbageCollectionTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Fact]
-    public async Task ExecuteContentReplacementAsync_WhenGcDisabled_ReturnsWarning()
+    public async Task ExecuteContentReplacementAsync_WhenGcDisabled_ReturnsWarningAsync()
     {
         var reconciliationService = new Mock<IContentReconciliationService>();
         reconciliationService
@@ -64,7 +64,7 @@ public class ContentReconciliationOrchestratorGarbageCollectionTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Fact]
-    public async Task ExecuteContentRemovalAsync_WhenGcDisabled_ReturnsWarning()
+    public async Task ExecuteContentRemovalAsync_WhenGcDisabled_ReturnsWarningAsync()
     {
         var reconciliationService = new Mock<IContentReconciliationService>();
         var lifecycleManager = CreateDisabledLifecycleManager();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ReconciliationStrategyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Reconciliation/ReconciliationStrategyTests.cs
@@ -68,7 +68,7 @@ public class ReconciliationStrategyTests : IDisposable
     [InlineData(WorkspaceStrategy.HardLink)]
     [InlineData(WorkspaceStrategy.SymlinkOnly)]
     [InlineData(WorkspaceStrategy.FullCopy)]
-    public async Task ReconcileBulkManifestReplacement_ShouldPreserveStrategy(WorkspaceStrategy strategy)
+    public async Task ReconcileBulkManifestReplacement_ShouldPreserveStrategyAsync(WorkspaceStrategy strategy)
     {
         // Arrange
         var profileId = $"profile_{strategy}";
@@ -117,7 +117,7 @@ public class ReconciliationStrategyTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ReconcileBulkManifestReplacement_WithMultipleProfiles_ShouldPreserveAllStrategies()
+    public async Task ReconcileBulkManifestReplacement_WithMultipleProfiles_ShouldPreserveAllStrategiesAsync()
     {
         // Arrange
         var profiles = new[]
@@ -189,7 +189,7 @@ public class ReconciliationStrategyTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ReconcileManifestRemoval_ShouldNotSetWorkspaceStrategy()
+    public async Task ReconcileManifestRemoval_ShouldNotSetWorkspaceStrategyAsync()
     {
         // Arrange
         var profileId = "profile_hardlink";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasGarbageCollectionDisabledTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/CasGarbageCollectionDisabledTests.cs
@@ -23,7 +23,7 @@ public class CasGarbageCollectionDisabledTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public async Task CasService_RunGarbageCollectionAsync_IsDisabledWithoutStorageAccess(bool force)
+    public async Task CasService_RunGarbageCollectionAsync_IsDisabledWithoutStorageAccessAsync(bool force)
     {
         var storage = new Mock<ICasStorage>(MockBehavior.Strict);
         var referenceTracker = new Mock<ICasReferenceTracker>(MockBehavior.Strict);
@@ -51,7 +51,7 @@ public class CasGarbageCollectionDisabledTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Fact]
-    public async Task CasLifecycleManager_RunGarbageCollectionAsync_ReportsDisabled()
+    public async Task CasLifecycleManager_RunGarbageCollectionAsync_ReportsDisabledAsync()
     {
         var casService = new Mock<ICasService>();
         casService

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/InstallationCasPoolServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Storage/InstallationCasPoolServiceTests.cs
@@ -37,7 +37,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsurePoolPathAsync_WhenHistoricalPathIsUnwritable_PreservesLegacyLookup()
+    public async Task EnsurePoolPathAsync_WhenHistoricalPathIsUnwritable_PreservesLegacyLookupAsync()
     {
         var installation = CreateInstallation();
         var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
@@ -66,7 +66,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsurePoolPathAsync_WhenCustomPathIsConfigured_PreservesIt()
+    public async Task EnsurePoolPathAsync_WhenCustomPathIsConfigured_PreservesItAsync()
     {
         var installation = CreateInstallation();
         var customPath = Path.Combine(_tempPath, "custom-cas");
@@ -93,7 +93,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsurePoolPathAsync_WhenAdjacentPathIsWritable_RecordsAutoDerivedProvenance()
+    public async Task EnsurePoolPathAsync_WhenAdjacentPathIsWritable_RecordsAutoDerivedProvenanceAsync()
     {
         var installation = CreateInstallation();
         var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
@@ -116,7 +116,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsurePoolPathAsync_WhenNoInstallations_ContinuesWithPrimaryPool()
+    public async Task EnsurePoolPathAsync_WhenNoInstallations_ContinuesWithPrimaryPoolAsync()
     {
         var service = CreateService();
 
@@ -133,7 +133,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsurePoolPathAsync_WhenInstallationDirectoryContainsDot_UsesFullDirectory()
+    public async Task EnsurePoolPathAsync_WhenInstallationDirectoryContainsDot_UsesFullDirectoryAsync()
     {
         var installation = CreateInstallation("ZeroHour v1.04");
         var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
@@ -153,7 +153,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsurePoolPathAsync_WhenCancelledBeforeSave_DoesNotPersistSettings()
+    public async Task EnsurePoolPathAsync_WhenCancelledBeforeSave_DoesNotPersistSettingsAsync()
     {
         var installation = CreateInstallation();
         var poolPath = Path.Combine(installation.InstallationPath, DirectoryNames.GenHubCasPool);
@@ -296,7 +296,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CasStorage_ObjectExistsAsync_DoesNotCreateWriteDirectories()
+    public async Task CasStorage_ObjectExistsAsync_DoesNotCreateWriteDirectoriesAsync()
     {
         var rootPath = Path.Combine(_tempPath, "read-only-cas");
         var hash = new string('a', 64);
@@ -318,7 +318,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CasService_GetContentPathAsync_FindsContentInLegacyPool()
+    public async Task CasService_GetContentPathAsync_FindsContentInLegacyPoolAsync()
     {
         var primaryPath = Path.Combine(_tempPath, "primary-lookup");
         var legacyPath = Path.Combine(_tempPath, "legacy-lookup");
@@ -460,7 +460,7 @@ public sealed class InstallationCasPoolServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsurePoolPathAsync_WhenPoolMovesAgain_RetainsEveryPreviousRoot()
+    public async Task EnsurePoolPathAsync_WhenPoolMovesAgain_RetainsEveryPreviousRootAsync()
     {
         var firstLegacyPath = Path.Combine(_tempPath, "first-legacy");
         var currentInstallation = CreateInstallation("CurrentGame");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/ToolSystemIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/ToolSystemIntegrationTests.cs
@@ -53,7 +53,7 @@ public class ToolSystemIntegrationTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CompleteWorkflow_AddAndRemoveTool_WorksCorrectly()
+    public async Task CompleteWorkflow_AddAndRemoveTool_WorksCorrectlyAsync()
     {
         // Arrange
         var mockPlugin = new MockToolPlugin("test.tool", "Test Tool", "1.0.0", "Test Author");
@@ -117,7 +117,7 @@ public class ToolSystemIntegrationTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task LoadSavedTools_LoadsMultipleToolsFromSettings()
+    public async Task LoadSavedTools_LoadsMultipleToolsFromSettingsAsync()
     {
         // Arrange
         var path1 = @"C:\Test\Tool1.dll";
@@ -163,7 +163,7 @@ public class ToolSystemIntegrationTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task AddTool_PreventsDuplicateToolIds()
+    public async Task AddTool_PreventsDuplicateToolIdsAsync()
     {
         // Arrange
         var path1 = @"C:\Test\Tool_v1.dll";
@@ -206,7 +206,7 @@ public class ToolSystemIntegrationTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ReplaceTool_ByRemovingAndAddingNewVersion()
+    public async Task ReplaceTool_ByRemovingAndAddingNewVersionAsync()
     {
         // Arrange
         var path1 = @"C:\Test\Tool_v1.dll";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/UploadHistoryServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/UploadHistoryServiceTests.cs
@@ -39,7 +39,7 @@ public sealed class UploadHistoryServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task RemoveHistoryItemAsync_WhenItemExists_RemovesLocalRecord()
+    public async Task RemoveHistoryItemAsync_WhenItemExists_RemovesLocalRecordAsync()
     {
         var service = CreateService();
         service.RecordUpload(1024, "https://utfs.io/f/example", "example.zip");
@@ -55,7 +55,7 @@ public sealed class UploadHistoryServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task RemoveHistoryItemAsync_WhenOtherItemsExist_PreservesOtherRecords()
+    public async Task RemoveHistoryItemAsync_WhenOtherItemsExist_PreservesOtherRecordsAsync()
     {
         var service = CreateService();
         service.RecordUpload(1024, "https://utfs.io/f/first", "first.zip");
@@ -73,7 +73,7 @@ public sealed class UploadHistoryServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task RemoveHistoryItemAsync_WhenUrlDoesNotMatch_PreservesHistory()
+    public async Task RemoveHistoryItemAsync_WhenUrlDoesNotMatch_PreservesHistoryAsync()
     {
         var service = CreateService();
         service.RecordUpload(1024, "https://utfs.io/f/example", "example.zip");
@@ -90,7 +90,7 @@ public sealed class UploadHistoryServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ClearHistoryAsync_WhenItemsExist_RemovesAllLocalRecords()
+    public async Task ClearHistoryAsync_WhenItemsExist_RemovesAllLocalRecordsAsync()
     {
         var service = CreateService();
         service.RecordUpload(1024, "https://utfs.io/f/first", "first.zip");
@@ -107,7 +107,7 @@ public sealed class UploadHistoryServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ClearHistoryAsync_WhenHistoryIsEmpty_RemainsEmpty()
+    public async Task ClearHistoryAsync_WhenHistoryIsEmpty_RemainsEmptyAsync()
     {
         var service = CreateService();
 
@@ -122,7 +122,7 @@ public sealed class UploadHistoryServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task GetUploadHistoryAsync_WhenLegacyRecordIsPendingDeletion_RemovesRecord()
+    public async Task GetUploadHistoryAsync_WhenLegacyRecordIsPendingDeletion_RemovesRecordAsync()
     {
         var historyPath = Path.Combine(_tempDirectory, "upload_history.json");
         var timestamp = DateTime.UtcNow.ToString("O");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/UploadThingServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/UploadThingServiceTests.cs
@@ -17,7 +17,7 @@ public class UploadThingServiceTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task UploadFileAsync_WhenCredentialsAreUnavailable_ReturnsNull()
+    public async Task UploadFileAsync_WhenCredentialsAreUnavailable_ReturnsNullAsync()
     {
         var result = await _service.UploadFileAsync("unused.zip");
 
@@ -29,7 +29,7 @@ public class UploadThingServiceTests
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DeleteFileAsync_WhenCredentialsAreUnavailable_ReturnsFalse()
+    public async Task DeleteFileAsync_WhenCredentialsAreUnavailable_ReturnsFalseAsync()
     {
         var result = await _service.DeleteFileAsync("unused-key");
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/ViewModels/ToolsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/ViewModels/ToolsViewModelTests.cs
@@ -56,7 +56,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task InitializeAsync_LoadsToolsSuccessfully()
+    public async Task InitializeAsync_LoadsToolsSuccessfullyAsync()
     {
         // Arrange
         var plugin1 = new MockToolPlugin("test.tool1", "Test Tool 1", "1.0.0", "Author 1");
@@ -83,7 +83,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task InitializeAsync_SetsHasToolsToFalse_WhenNoToolsLoaded()
+    public async Task InitializeAsync_SetsHasToolsToFalse_WhenNoToolsLoadedAsync()
     {
         // Arrange
         var emptyTools = new List<IToolPlugin>();
@@ -107,7 +107,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task InitializeAsync_HandlesFailureFromService()
+    public async Task InitializeAsync_HandlesFailureFromServiceAsync()
     {
         // Arrange
         _mockToolService.Setup(x => x.LoadSavedToolsAsync())
@@ -129,7 +129,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task InitializeAsync_HandlesExceptionsGracefully()
+    public async Task InitializeAsync_HandlesExceptionsGracefullyAsync()
     {
         // Arrange
         _mockToolService.Setup(x => x.LoadSavedToolsAsync())
@@ -149,7 +149,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task InitializeAsync_SetsIsLoadingCorrectly()
+    public async Task InitializeAsync_SetsIsLoadingCorrectlyAsync()
     {
         // Arrange
         var tools = new List<IToolPlugin>();
@@ -180,7 +180,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RemoveToolAsync_RemovesToolSuccessfully()
+    public async Task RemoveToolAsync_RemovesToolSuccessfullyAsync()
     {
         // Arrange
         var plugin = new MockToolPlugin("test.tool", "Test Tool", "1.0.0", "Test Author");
@@ -208,7 +208,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RemoveToolAsync_SelectsAnotherTool_WhenToolsRemain()
+    public async Task RemoveToolAsync_SelectsAnotherTool_WhenToolsRemainAsync()
     {
         // Arrange
         var plugin1 = new MockToolPlugin("test.tool1", "Test Tool 1", "1.0.0", "Author 1");
@@ -236,7 +236,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RemoveToolAsync_DoesNothing_WhenNoToolSelected()
+    public async Task RemoveToolAsync_DoesNothing_WhenNoToolSelectedAsync()
     {
         // Arrange
         _viewModel.SelectedTool = null;
@@ -253,7 +253,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RemoveToolAsync_HandlesServiceFailure()
+    public async Task RemoveToolAsync_HandlesServiceFailureAsync()
     {
         // Arrange
         var plugin = new MockToolPlugin("test.tool", "Test Tool", "1.0.0", "Test Author");
@@ -277,7 +277,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RemoveToolAsync_HandlesExceptionsGracefully()
+    public async Task RemoveToolAsync_HandlesExceptionsGracefullyAsync()
     {
         // Arrange
         var plugin = new MockToolPlugin("test.tool", "Test Tool", "1.0.0", "Test Author");
@@ -300,7 +300,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RefreshToolsAsync_ReloadsToolsSuccessfully()
+    public async Task RefreshToolsAsync_ReloadsToolsSuccessfullyAsync()
     {
         // Arrange
         var plugin1 = new MockToolPlugin("test.tool1", "Test Tool 1", "1.0.0", "Author 1");
@@ -327,7 +327,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RefreshToolsAsync_DeactivatesCurrentTool_BeforeRefresh()
+    public async Task RefreshToolsAsync_DeactivatesCurrentTool_BeforeRefreshAsync()
     {
         // Arrange
         var plugin = new MockToolPlugin("test.tool", "Test Tool", "1.0.0", "Test Author");
@@ -351,7 +351,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RefreshToolsAsync_RestoresPreviouslySelectedTool()
+    public async Task RefreshToolsAsync_RestoresPreviouslySelectedToolAsync()
     {
         // Arrange
         var plugin1 = new MockToolPlugin("test.tool1", "Test Tool 1", "1.0.0", "Author 1");
@@ -376,7 +376,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RefreshToolsAsync_HandlesServiceFailure()
+    public async Task RefreshToolsAsync_HandlesServiceFailureAsync()
     {
         // Arrange
         _mockToolService.Setup(x => x.LoadSavedToolsAsync())
@@ -395,7 +395,7 @@ public class ToolsViewModelTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task RefreshToolsAsync_HandlesExceptionsGracefully()
+    public async Task RefreshToolsAsync_HandlesExceptionsGracefullyAsync()
     {
         // Arrange
         _mockToolService.Setup(x => x.LoadSavedToolsAsync())

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceTests.cs
@@ -120,7 +120,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task InstallUserDataAsync_ZeroHourGameDataPatch_DeploysPreservingSubdirectories()
+    public async Task InstallUserDataAsync_ZeroHourGameDataPatch_DeploysPreservingSubdirectoriesAsync()
     {
         // Arrange
         var files = new List<ManifestFile>
@@ -170,7 +170,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task InstallUserDataAsync_GeneralsGameDataPatch_DeploysToGeneralsDirectory()
+    public async Task InstallUserDataAsync_GeneralsGameDataPatch_DeploysToGeneralsDirectoryAsync()
     {
         // Arrange
         var files = new List<ManifestFile>
@@ -205,7 +205,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task InstallAndUninstall_WithExistingUserFile_SafelyBacksUpAndRestoresOriginal()
+    public async Task InstallAndUninstall_WithExistingUserFile_SafelyBacksUpAndRestoresOriginalAsync()
     {
         // Arrange: simulate pre-existing user file in Documents\...\GeneralsOnlineGameData\splash.bmp
         var gameDataDir = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData");
@@ -260,7 +260,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task DeactivateAndActivateProfileUserDataAsync_ProperlyTogglesFiles()
+    public async Task DeactivateAndActivateProfileUserDataAsync_ProperlyTogglesFilesAsync()
     {
         // Arrange
         var files = new List<ManifestFile>
@@ -309,7 +309,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task UninstallUserDataAsync_CleansUpEmptySubdirectory_PreservesRootUserDataFolder()
+    public async Task UninstallUserDataAsync_CleansUpEmptySubdirectory_PreservesRootUserDataFolderAsync()
     {
         // Arrange
         var files = new List<ManifestFile>
@@ -352,7 +352,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task DeactivateProfileUserDataAsync_WhenUserModifiesDeployedFile_PreservesModifiedFileAndDoesNotOverwriteWithBackup()
+    public async Task DeactivateProfileUserDataAsync_WhenUserModifiesDeployedFile_PreservesModifiedFileAndDoesNotOverwriteWithBackupAsync()
     {
         // Arrange: pre-existing user file
         var gameDataDir = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData");
@@ -413,7 +413,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ReactivateProfileUserDataAsync_WhenUserModifiesRestoredFileWhileDeactivated_BacksUpNewContentAndRestoresItOnSubsequentDeactivation()
+    public async Task ReactivateProfileUserDataAsync_WhenUserModifiesRestoredFileWhileDeactivated_BacksUpNewContentAndRestoresItOnSubsequentDeactivationAsync()
     {
         // Arrange
         var gameDataDir = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData");
@@ -476,7 +476,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ActivateProfileUserDataAsync_WhenMaterializationFails_RollsBackAndRestoresBackup()
+    public async Task ActivateProfileUserDataAsync_WhenMaterializationFails_RollsBackAndRestoresBackupAsync()
     {
         // Arrange
         var gameDataDir = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData");
@@ -534,7 +534,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ActivateProfileUserDataAsync_WhenCanceled_RollsBackAndRethrows()
+    public async Task ActivateProfileUserDataAsync_WhenCanceled_RollsBackAndRethrowsAsync()
     {
         // Arrange
         var gameDataDir = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData");
@@ -603,7 +603,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task DeactivateProfileUserDataAsync_WhenCanceled_PreservesManifestActiveForRetry()
+    public async Task DeactivateProfileUserDataAsync_WhenCanceled_PreservesManifestActiveForRetryAsync()
     {
         // Arrange
         var files = new List<ManifestFile>
@@ -668,7 +668,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task InstallUserDataAsync_WithUserMapsDirectoryTarget_NormalizesPathAndDetectsConflict()
+    public async Task InstallUserDataAsync_WithUserMapsDirectoryTarget_NormalizesPathAndDetectsConflictAsync()
     {
         // Arrange
         var files = new List<ManifestFile>
@@ -718,7 +718,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task InstallUserDataAsync_WhenRelativePathEscapesUserDataDirectory_Fails()
+    public async Task InstallUserDataAsync_WhenRelativePathEscapesUserDataDirectory_FailsAsync()
     {
         // Arrange
         var validFilePath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "valid.bmp");
@@ -760,7 +760,7 @@ public sealed class UserDataTrackerServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task InstallUserDataAsync_WhenBackupFails_AbortsInstallationToPreventDataLoss()
+    public async Task InstallUserDataAsync_WhenBackupFails_AbortsInstallationToPreventDataLossAsync()
     {
         // Arrange
         var gameDataDir = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/FileSystemValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/FileSystemValidatorTests.cs
@@ -18,7 +18,7 @@ public class FileSystemValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateDirectoriesAsync_MissingDirectory_ReturnsIssue()
+    public async Task ValidateDirectoriesAsync_MissingDirectory_ReturnsIssueAsync()
     {
         var logger = new Mock<ILogger>().Object;
         var validator = new TestFileSystemValidator(logger);
@@ -33,7 +33,7 @@ public class FileSystemValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateFilesAsync_PathTraversal_Throws()
+    public async Task ValidateFilesAsync_PathTraversal_ThrowsAsync()
     {
         var logger = new Mock<ILogger>().Object;
         var validator = new TestFileSystemValidator(logger);
@@ -47,7 +47,7 @@ public class FileSystemValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateFilesAsync_IOException_ReportsIssue()
+    public async Task ValidateFilesAsync_IOException_ReportsIssueAsync()
     {
         var logger = new Mock<ILogger>().Object;
         var validator = new TestFileSystemValidator(logger);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameClientValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameClientValidatorTests.cs
@@ -66,7 +66,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_WithKnownAddonInManifest_DetectsAddonAsWarning()
+    public async Task ValidateAsync_WithKnownAddonInManifest_DetectsAddonAsWarningAsync()
     {
         // Arrange
         var tempDir = Directory.CreateTempSubdirectory();
@@ -105,7 +105,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_WithUnexpectedFile_DetectsUnexpectedFile()
+    public async Task ValidateAsync_WithUnexpectedFile_DetectsUnexpectedFileAsync()
     {
         // Arrange
         var tempDir = Directory.CreateTempSubdirectory();
@@ -140,7 +140,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_ManifestNotFound_AddsIssue()
+    public async Task ValidateAsync_ManifestNotFound_AddsIssueAsync()
     {
         _manifestProviderMock.Setup(m => m.GetManifestAsync(It.IsAny<GameClient>(), It.IsAny<CancellationToken>())).ReturnsAsync((ContentManifest?)null);
         var tempDir = Directory.CreateTempSubdirectory();
@@ -163,7 +163,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_MissingFile_AddsMissingFileIssue()
+    public async Task ValidateAsync_MissingFile_AddsMissingFileIssueAsync()
     {
         var manifest = new ContentManifest { Files = new() { new ManifestFile { RelativePath = "missing.txt", Size = 0, Hash = string.Empty } } };
         _manifestProviderMock.Setup(m => m.GetManifestAsync(It.IsAny<GameClient>(), default)).ReturnsAsync(manifest);
@@ -194,7 +194,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_Cancellation_ThrowsOperationCanceledException()
+    public async Task ValidateAsync_Cancellation_ThrowsOperationCanceledExceptionAsync()
     {
         var tempDir = Directory.CreateTempSubdirectory();
         var cts = new CancellationTokenSource();
@@ -209,7 +209,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_WithMultipleKnownAddons_DetectsAllAddons()
+    public async Task ValidateAsync_WithMultipleKnownAddons_DetectsAllAddonsAsync()
     {
         // Arrange
         var tempDir = Directory.CreateTempSubdirectory();
@@ -252,7 +252,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_WithProgressCallback_ReportsProgress()
+    public async Task ValidateAsync_WithProgressCallback_ReportsProgressAsync()
     {
         // Arrange
         var tempDir = Directory.CreateTempSubdirectory();
@@ -285,7 +285,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_WithHashMismatch_DetectsCorruption()
+    public async Task ValidateAsync_WithHashMismatch_DetectsCorruptionAsync()
     {
         // Arrange
         var tempDir = Directory.CreateTempSubdirectory();
@@ -325,7 +325,7 @@ public class GameClientValidatorTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_WithEmptyDirectory_HandlesGracefully()
+    public async Task ValidateAsync_WithEmptyDirectory_HandlesGracefullyAsync()
     {
         // Arrange
         var tempDir = Directory.CreateTempSubdirectory();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameInstallationValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameInstallationValidatorTests.cs
@@ -48,7 +48,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_WithProgressCallback_ReportsProgress()
+    public async Task ValidateAsync_WithProgressCallback_ReportsProgressAsync()
     {
         var tempDir = Directory.CreateTempSubdirectory();
         try
@@ -129,7 +129,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_ManifestNotFound_AddsIssue()
+    public async Task ValidateAsync_ManifestNotFound_AddsIssueAsync()
     {
         _manifestProviderMock
             .Setup(m => m.GetManifestAsync(It.IsAny<GameInstallation>(), It.IsAny<CancellationToken>()))
@@ -152,7 +152,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_MissingFile_AddsMissingFileIssue()
+    public async Task ValidateAsync_MissingFile_AddsMissingFileIssueAsync()
     {
         var manifest = new ContentManifest
         {
@@ -206,7 +206,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_Cancellation_ThrowsOperationCanceledException()
+    public async Task ValidateAsync_Cancellation_ThrowsOperationCanceledExceptionAsync()
     {
         var cts = new CancellationTokenSource();
         cts.Cancel();
@@ -225,7 +225,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_MissingRequiredDirectory_AddsMissingDirectoryIssue()
+    public async Task ValidateAsync_MissingRequiredDirectory_AddsMissingDirectoryIssueAsync()
     {
         var tempDir = Directory.CreateTempSubdirectory();
         try
@@ -267,7 +267,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_EmptyManifest_HandlesGracefully()
+    public async Task ValidateAsync_EmptyManifest_HandlesGracefullyAsync()
     {
         var tempDir = Directory.CreateTempSubdirectory();
         try
@@ -302,7 +302,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_UnexpectedFiles_DetectsAsWarnings()
+    public async Task ValidateAsync_UnexpectedFiles_DetectsAsWarningsAsync()
     {
         var tempDir = Directory.CreateTempSubdirectory();
         try
@@ -354,7 +354,7 @@ public class GameInstallationValidatorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ValidateAsync_ContentValidatorException_HandlesGracefully()
+    public async Task ValidateAsync_ContentValidatorException_HandlesGracefullyAsync()
     {
         var tempDir = Directory.CreateTempSubdirectory();
         try

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameInstallationValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Validation/GameInstallationValidatorTests.cs
@@ -92,11 +92,11 @@ public class GameInstallationValidatorTests
             await _validator.ValidateAsync(installation, progress);
 
             // Assert
-            var reportsList = progress.Reports.ToList();
+            var reportsList = progress.GetReports();
             Assert.True(reportsList.Count > 0, "Expected progress reports to be generated");
 
             // Find the final progress report (highest processed count)
-            var finalProgress = reportsList.OrderBy(p => p.Processed).Last();
+            var finalProgress = reportsList.MaxBy(p => p.Processed)!;
 
             // Verify the final progress shows completion
             Assert.Equal(finalProgress.Total, finalProgress.Processed);
@@ -395,14 +395,11 @@ public class GameInstallationValidatorTests
         private readonly List<T> _reports = new();
         private readonly object _lock = new();
 
-        public IReadOnlyList<T> Reports
+        public IReadOnlyList<T> GetReports()
         {
-            get
+            lock (_lock)
             {
-                lock (_lock)
-                {
-                    return _reports.ToList();
-                }
+                return _reports.ToList();
             }
         }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ExecutablePermissionIsolationTests.cs
@@ -61,7 +61,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ChmodThroughHardLink_AlsoChangesTheTarget()
+    public async Task ChmodThroughHardLink_AlsoChangesTheTargetAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -94,7 +94,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CopyBeforeChmod_LeavesTheStoredBlobUntouched()
+    public async Task CopyBeforeChmod_LeavesTheStoredBlobUntouchedAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -131,7 +131,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task ExecutableMaterialization_ReplacesDestinationAtomically()
+    public async Task ExecutableMaterialization_ReplacesDestinationAtomicallyAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -162,7 +162,7 @@ public class ExecutablePermissionIsolationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task RepairingABrickedEntryPoint_LeavesTheStoredBlobUntouched()
+    public async Task RepairingABrickedEntryPoint_LeavesTheStoredBlobUntouchedAsync()
     {
         if (OperatingSystem.IsWindows())
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -37,7 +37,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CopyFileAsync_CreatesFile()
+    public async Task CopyFileAsync_CreatesFileAsync()
     {
         var src = Path.Combine(_tempDir, "source.txt");
         var dst = Path.Combine(_tempDir, "destination.txt");
@@ -54,7 +54,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CreateSymlinkAsync_CreatesSymlinkOrCopies()
+    public async Task CreateSymlinkAsync_CreatesSymlinkOrCopiesAsync()
     {
         var src = Path.Combine(_tempDir, "source.txt");
         var link = Path.Combine(_tempDir, "link.txt");
@@ -110,7 +110,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CreateHardLinkAsync_OnBaseService_RefusesInsteadOfCopying()
+    public async Task CreateHardLinkAsync_OnBaseService_RefusesInsteadOfCopyingAsync()
     {
         var src = Path.Combine(_tempDir, "source.txt");
         var link = Path.Combine(_tempDir, "hardlink.txt");
@@ -133,7 +133,7 @@ public class FileOperationsServiceTests : IDisposable
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task VerifyFileHashAsync_HandlesCase(bool caseSensitive)
+    public async Task VerifyFileHashAsync_HandlesCaseAsync(bool caseSensitive)
     {
         var file = Path.Combine(_tempDir, "test.txt");
         await File.WriteAllTextAsync(file, "test");
@@ -158,7 +158,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task VerifyFileHashAsync_ReturnsFalse_WhenHashDoesNotMatch()
+    public async Task VerifyFileHashAsync_ReturnsFalse_WhenHashDoesNotMatchAsync()
     {
         var file = Path.Combine(_tempDir, "test.txt");
         await File.WriteAllTextAsync(file, "test");
@@ -180,7 +180,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task DownloadFileAsync_UsesDownloadService_Successfully()
+    public async Task DownloadFileAsync_UsesDownloadService_SuccessfullyAsync()
     {
         var testUrl = "https://example.com/file.txt";
         var destination = Path.Combine(_tempDir, "download.txt");
@@ -215,7 +215,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task DownloadFileAsync_ThrowsException_WhenDownloadServiceFails()
+    public async Task DownloadFileAsync_ThrowsException_WhenDownloadServiceFailsAsync()
     {
         var downloadServiceMock = new Mock<IDownloadService>();
         downloadServiceMock.Setup(s => s.DownloadFileAsync(
@@ -237,7 +237,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CopyFileAsync_ThrowsException_WhenSourceFileNotFound()
+    public async Task CopyFileAsync_ThrowsException_WhenSourceFileNotFoundAsync()
     {
         var nonExistentSource = Path.Combine(_tempDir, "nonexistent.txt");
         var destination = Path.Combine(_tempDir, "destination.txt");
@@ -251,7 +251,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CopyFileAsync_CreatesDirectoryStructure()
+    public async Task CopyFileAsync_CreatesDirectoryStructureAsync()
     {
         var source = Path.Combine(_tempDir, "source.txt");
         var destination = Path.Combine(_tempDir, "nested", "deep", "destination.txt");
@@ -269,7 +269,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task VerifyFileHashAsync_ReturnsFalse_WhenFileNotExists()
+    public async Task VerifyFileHashAsync_ReturnsFalse_WhenFileNotExistsAsync()
     {
         var nonExistentFile = Path.Combine(_tempDir, "nonexistent.txt");
         var hash = "somehash";
@@ -287,7 +287,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task VerifyFileHashAsync_HandlesExceptions_Gracefully()
+    public async Task VerifyFileHashAsync_HandlesExceptions_GracefullyAsync()
     {
         var file = Path.Combine(_tempDir, "test.txt");
         await File.WriteAllTextAsync(file, "test");
@@ -306,7 +306,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CreateSymlinkAsync_WithAllowFallbackTrue_SucceedsAlways()
+    public async Task CreateSymlinkAsync_WithAllowFallbackTrue_SucceedsAlwaysAsync()
     {
         var src = Path.Combine(_tempDir, "source.txt");
         var link = Path.Combine(_tempDir, "link.txt");
@@ -326,7 +326,7 @@ public class FileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CreateSymlinkAsync_WithDefaultParameter_AllowsFallback()
+    public async Task CreateSymlinkAsync_WithDefaultParameter_AllowsFallbackAsync()
     {
         var src = Path.Combine(_tempDir, "source.txt");
         var link = Path.Combine(_tempDir, "link_default.txt");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -229,7 +229,7 @@ public class FileOperationsServiceTests : IDisposable
 
         // Act & Assert
         await Assert.ThrowsAsync<HttpRequestException>(() =>
-            fileOps.DownloadFileAsync(new Uri("http://fail"), "fail.zip"));
+            fileOps.DownloadFileAsync(new Uri("https://fail"), "fail.zip"));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
@@ -353,7 +353,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
         var manifests = CreateTestManifests();
         var workspaceConfig = new WorkspaceConfiguration
         {
-            Id = $"test-workspace-{strategy.ToString().ToLower()}",
+            Id = $"test-workspace-{strategy.ToString().ToLowerInvariant()}",
             Manifests = manifests,
             GameClient = new GameClient
             {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/GameProfileWorkspaceIntegrationTest.cs
@@ -109,7 +109,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_FullCopyStrategy_CopiesGameInstallationAndClientFiles()
+    public async Task PrepareWorkspace_FullCopyStrategy_CopiesGameInstallationAndClientFilesAsync()
     {
         // Arrange
         var manifests = CreateTestManifests();
@@ -161,7 +161,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_SymlinkStrategy_LinksGameInstallationAndClientFiles()
+    public async Task PrepareWorkspace_SymlinkStrategy_LinksGameInstallationAndClientFilesAsync()
     {
         // Skip on systems that don't support symlinks
         bool isWindows = OperatingSystem.IsWindows();
@@ -220,7 +220,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_MixedContentTypes_HandlesGameInstallationAndGameClientCorrectly()
+    public async Task PrepareWorkspace_MixedContentTypes_HandlesGameInstallationAndGameClientCorrectlyAsync()
     {
         bool isWindows = OperatingSystem.IsWindows();
         bool isAdmin = isWindows &&
@@ -326,7 +326,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     [InlineData(WorkspaceStrategy.SymlinkOnly)]
     [InlineData(WorkspaceStrategy.HybridCopySymlink)]
     [InlineData(WorkspaceStrategy.HardLink)]
-    public async Task PrepareWorkspace_AllStrategies_HandleGameInstallationFiles(WorkspaceStrategy strategy)
+    public async Task PrepareWorkspace_AllStrategies_HandleGameInstallationFilesAsync(WorkspaceStrategy strategy)
     {
         bool isWindows = OperatingSystem.IsWindows();
         bool isAdmin = isWindows &&
@@ -394,7 +394,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CleanupWorkspace_RemovesAllFiles()
+    public async Task CleanupWorkspace_RemovesAllFilesAsync()
     {
         // Arrange
         var manifests = CreateTestManifests();
@@ -432,7 +432,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_EmptyManifests_CreatesEmptyWorkspace()
+    public async Task PrepareWorkspace_EmptyManifests_CreatesEmptyWorkspaceAsync()
     {
         // Arrange
         var workspaceConfig = new WorkspaceConfiguration
@@ -465,7 +465,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_ForceRecreate_RemovesExistingWorkspace()
+    public async Task PrepareWorkspace_ForceRecreate_RemovesExistingWorkspaceAsync()
     {
         // Arrange
         var manifests = CreateTestManifests();
@@ -506,7 +506,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_NestedDirectories_PreservesStructure()
+    public async Task PrepareWorkspace_NestedDirectories_PreservesStructureAsync()
     {
         // Arrange
         var manifests = CreateTestManifests();
@@ -542,7 +542,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_LargeFiles_CopiesSuccessfully()
+    public async Task PrepareWorkspace_LargeFiles_CopiesSuccessfullyAsync()
     {
         // Arrange - Create a larger test file
         var largeFilePath = Path.Combine(_tempGameInstall, "large.dat");
@@ -596,7 +596,7 @@ public class GameProfileWorkspaceIntegrationTest : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_OverlappingManifests_HandlesCorrectly()
+    public async Task PrepareWorkspace_OverlappingManifests_HandlesCorrectlyAsync()
     {
         // Arrange
         var manifest1 = new ContentManifest

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/MixedInstallationIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/MixedInstallationIntegrationTests.cs
@@ -23,7 +23,7 @@ namespace GenHub.Tests.Core.Features.Workspace;
 /// </summary>
 public class MixedInstallationIntegrationTests : IDisposable
 {
-    private static async Task CreateTestFile(string path, string content)
+    private static async Task CreateTestFileAsync(string path, string content)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         await File.WriteAllTextAsync(path, content);
@@ -99,7 +99,7 @@ public class MixedInstallationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task INT1_OfficialOnly_SteamBaseWithSteamClient_WorksCorrectly()
+    public async Task INT1_OfficialOnly_SteamBaseWithSteamClient_WorksCorrectlyAsync()
     {
         // Arrange
         // Create manifests for Steam installation
@@ -148,7 +148,7 @@ public class MixedInstallationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task INT2_MixedInstallation_SteamBaseWithCommunityClient_CombinesCorrectly()
+    public async Task INT2_MixedInstallation_SteamBaseWithCommunityClient_CombinesCorrectlyAsync()
     {
         // Arrange
         var gameInstallManifest = await CreateManifestAsync(
@@ -212,11 +212,11 @@ public class MixedInstallationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task INT3_FullStack_EABaseWithCommunityClientAndMods_CombinesCorrectly()
+    public async Task INT3_FullStack_EABaseWithCommunityClientAndMods_CombinesCorrectlyAsync()
     {
         // Create physical files for all sources
-        await CreateTestFile(Path.Combine(_tempModsFolder, "ShockWave", "Data", "INI", "Weapon.ini"), "[ShockWaveMod]");
-        await CreateTestFile(Path.Combine(_tempModsFolder, "Maps", "DesertStorm.map"), "MapData");
+        await CreateTestFileAsync(Path.Combine(_tempModsFolder, "ShockWave", "Data", "INI", "Weapon.ini"), "[ShockWaveMod]");
+        await CreateTestFileAsync(Path.Combine(_tempModsFolder, "Maps", "DesertStorm.map"), "MapData");
 
         // Arrange - Create 4 different content sources
         var gameInstallManifest = await CreateManifestAsync(
@@ -281,7 +281,7 @@ public class MixedInstallationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task INT4_DependencyValidation_IncompatibleGameType_Blocked()
+    public async Task INT4_DependencyValidation_IncompatibleGameType_BlockedAsync()
     {
         // This test validates at the ProfileLauncherFacade level, not WorkspaceManager
         // WorkspaceManager doesn't validate dependencies - that's ProfileLauncherFacade's job
@@ -351,12 +351,12 @@ public class MixedInstallationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task INT5_ConflictResolution_ModBeatsInstallation_CorrectPriority()
+    public async Task INT5_ConflictResolution_ModBeatsInstallation_CorrectPriorityAsync()
     {
         // Create different content for each version
-        await CreateTestFile(Path.Combine(_tempSteamInstall, "Data", "INI", "GameData.ini"), "[Steam-Official]");
-        await CreateTestFile(Path.Combine(_tempCommunityClient, "Data", "INI", "GameData.ini"), "[GenTool-Modified]");
-        await CreateTestFile(Path.Combine(_tempModsFolder, "Data", "INI", "GameData.ini"), "[ShockWave-Mod]");
+        await CreateTestFileAsync(Path.Combine(_tempSteamInstall, "Data", "INI", "GameData.ini"), "[Steam-Official]");
+        await CreateTestFileAsync(Path.Combine(_tempCommunityClient, "Data", "INI", "GameData.ini"), "[GenTool-Modified]");
+        await CreateTestFileAsync(Path.Combine(_tempModsFolder, "Data", "INI", "GameData.ini"), "[ShockWave-Mod]");
 
         // Arrange - Create manifests with overlapping files
         var gameInstallManifest = await CreateManifestAsync(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ProcessLocalFileAsyncTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ProcessLocalFileAsyncTests.cs
@@ -37,7 +37,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
-    public async Task FullCopyStrategy_ProcessLocalFileAsync_CopiesFile()
+    public async Task FullCopyStrategy_ProcessLocalFileAsync_CopiesFileAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<FullCopyStrategy>>();
@@ -73,7 +73,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
-    public async Task SymlinkOnlyStrategy_ProcessLocalFileAsync_CreatesSymlink()
+    public async Task SymlinkOnlyStrategy_ProcessLocalFileAsync_CreatesSymlinkAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<SymlinkOnlyStrategy>>();
@@ -106,7 +106,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
-    public async Task HybridCopySymlinkStrategy_ProcessLocalFileAsync_CopiesEssentialFiles()
+    public async Task HybridCopySymlinkStrategy_ProcessLocalFileAsync_CopiesEssentialFilesAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<HybridCopySymlinkStrategy>>();
@@ -138,7 +138,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
-    public async Task HybridCopySymlinkStrategy_ProcessLocalFileAsync_SymlinksNonEssentialFiles()
+    public async Task HybridCopySymlinkStrategy_ProcessLocalFileAsync_SymlinksNonEssentialFilesAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<HybridCopySymlinkStrategy>>();
@@ -171,7 +171,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
-    public async Task HardLinkStrategy_ProcessLocalFileAsync_CreatesHardLinksOnSameVolume()
+    public async Task HardLinkStrategy_ProcessLocalFileAsync_CreatesHardLinksOnSameVolumeAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<HardLinkStrategy>>();
@@ -211,7 +211,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     [InlineData(WorkspaceStrategy.SymlinkOnly)]
     [InlineData(WorkspaceStrategy.HybridCopySymlink)]
     [InlineData(WorkspaceStrategy.HardLink)]
-    public async Task AllStrategies_ProcessLocalFileAsync_HandlesMissingSourceFiles(WorkspaceStrategy strategyType)
+    public async Task AllStrategies_ProcessLocalFileAsync_HandlesMissingSourceFilesAsync(WorkspaceStrategy strategyType)
     {
         // Arrange
         var strategy = CreateStrategy(strategyType);
@@ -239,7 +239,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
-    public async Task AllStrategies_ProcessLocalFileAsync_ValidatesConfiguration()
+    public async Task AllStrategies_ProcessLocalFileAsync_ValidatesConfigurationAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<FullCopyStrategy>>();
@@ -264,7 +264,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
     [InlineData(WorkspaceStrategy.SymlinkOnly)]
     [InlineData(WorkspaceStrategy.HybridCopySymlink)]
     [InlineData(WorkspaceStrategy.HardLink)]
-    public async Task AllStrategies_ProcessGameInstallationFileAsync_UsesSourcePathDirectly(WorkspaceStrategy strategyType)
+    public async Task AllStrategies_ProcessGameInstallationFileAsync_UsesSourcePathDirectlyAsync(WorkspaceStrategy strategyType)
     {
         // Arrange
         var strategy = CreateStrategy(strategyType);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ProcessLocalFileAsyncTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/ProcessLocalFileAsyncTests.cs
@@ -46,15 +46,7 @@ public class ProcessLocalFileAsyncTests : IDisposable
         var sourceFile = Path.Combine(_tempSourceDir, "test.exe");
         await File.WriteAllTextAsync(sourceFile, "test content");
 
-        var file = new ManifestFile
-        {
-            RelativePath = "test.exe",
-            Size = 12,
-            SourceType = ContentSourceType.LocalFile,
-        };
-
         var config = CreateTestConfiguration();
-        var targetPath = Path.Combine(_tempWorkspaceDir, file.RelativePath);
 
         // Act
         await strategy.PrepareAsync(config, null, CancellationToken.None);
@@ -78,13 +70,6 @@ public class ProcessLocalFileAsyncTests : IDisposable
         // Arrange
         var logger = new Mock<ILogger<SymlinkOnlyStrategy>>();
         var strategy = new SymlinkOnlyStrategy(_mockFileOperations.Object, logger.Object);
-
-        var file = new ManifestFile
-        {
-            RelativePath = "test.exe",
-            Size = 12,
-            SourceType = ContentSourceType.LocalFile,
-        };
 
         var config = CreateTestConfiguration();
 
@@ -112,13 +97,6 @@ public class ProcessLocalFileAsyncTests : IDisposable
         var logger = new Mock<ILogger<HybridCopySymlinkStrategy>>();
         var strategy = new HybridCopySymlinkStrategy(_mockFileOperations.Object, logger.Object);
 
-        var file = new ManifestFile
-        {
-            RelativePath = "generals.exe", // Essential file
-            Size = 500, // Small size - essential
-            SourceType = ContentSourceType.LocalFile,
-        };
-
         var config = CreateTestConfiguration();
 
         // Act
@@ -143,13 +121,6 @@ public class ProcessLocalFileAsyncTests : IDisposable
         // Arrange
         var logger = new Mock<ILogger<HybridCopySymlinkStrategy>>();
         var strategy = new HybridCopySymlinkStrategy(_mockFileOperations.Object, logger.Object);
-
-        var file = new ManifestFile
-        {
-            RelativePath = "video.bik", // Non-essential file
-            Size = 50000000, // Large size - non-essential
-            SourceType = ContentSourceType.LocalFile,
-        };
 
         var config = CreateTestConfiguration();
 
@@ -176,13 +147,6 @@ public class ProcessLocalFileAsyncTests : IDisposable
         // Arrange
         var logger = new Mock<ILogger<HardLinkStrategy>>();
         var strategy = new HardLinkStrategy(_mockFileOperations.Object, logger.Object);
-
-        var file = new ManifestFile
-        {
-            RelativePath = "test.dat",
-            Size = 1000,
-            SourceType = ContentSourceType.LocalFile,
-        };
 
         var config = CreateTestConfiguration();
 
@@ -346,6 +310,10 @@ public class ProcessLocalFileAsyncTests : IDisposable
                             gameInstallationPath, // Should use SourcePath directly
                             It.IsAny<CancellationToken>()),
                         Times.Once);
+                    break;
+
+                default:
+                    // No assertions for other strategies
                     break;
             }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/QuarantineClearingTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/QuarantineClearingTests.cs
@@ -114,10 +114,10 @@ public sealed class QuarantineClearingTests : IDisposable
 
     private static bool HasQuarantine(string path)
     {
-        return RunXattr($"-p com.apple.quarantine \"{path}\"").exitCode == 0;
+        return RunXattr($"-p com.apple.quarantine \"{path}\"").ExitCode == 0;
     }
 
-    private static (int exitCode, string output) RunXattr(string arguments)
+    private static (int ExitCode, string Output) RunXattr(string arguments)
     {
         using var process = Process.Start(new ProcessStartInfo("/usr/bin/xattr", arguments)
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
@@ -221,7 +221,7 @@ public class StrategyTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AllStrategies_PrepareAsync_HandlesCancellation()
+    public async Task AllStrategies_PrepareAsync_HandlesCancellationAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<FullCopyStrategy>>();
@@ -241,7 +241,7 @@ public class StrategyTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AllStrategies_PrepareAsync_ValidatesNullConfiguration()
+    public async Task AllStrategies_PrepareAsync_ValidatesNullConfigurationAsync()
     {
         // Arrange
         var logger = new Mock<ILogger<FullCopyStrategy>>();
@@ -257,7 +257,7 @@ public class StrategyTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task HardLinkStrategy_WhenVolumesDiffer_FallsBackToCopy()
+    public async Task HardLinkStrategy_WhenVolumesDiffer_FallsBackToCopyAsync()
     {
         const string Hash = "test-hash";
         var strategy = new HardLinkStrategy(_fileOps.Object, new Mock<ILogger<HardLinkStrategy>>().Object);
@@ -326,7 +326,7 @@ public class StrategyTests : IDisposable
     [InlineData(WorkspaceStrategy.SymlinkOnly)]
     [InlineData(WorkspaceStrategy.HybridCopySymlink)]
     [InlineData(WorkspaceStrategy.HardLink)]
-    public async Task AllStrategies_NonWorkspaceTarget_ExcludesFromFileOperations(WorkspaceStrategy strategyType)
+    public async Task AllStrategies_NonWorkspaceTarget_ExcludesFromFileOperationsAsync(WorkspaceStrategy strategyType)
     {
         // Arrange
         var strategy = CreateStrategy(strategyType);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/UnixFileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/UnixFileOperationsServiceTests.cs
@@ -56,7 +56,7 @@ public class UnixFileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CreateHardLinkAsync_ProducesRealLinkNotCopy()
+    public async Task CreateHardLinkAsync_ProducesRealLinkNotCopyAsync()
     {
         if (!OnUnix)
         {
@@ -93,7 +93,7 @@ public class UnixFileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CreateHardLinkAsync_MissingTarget_ThrowsFileNotFound()
+    public async Task CreateHardLinkAsync_MissingTarget_ThrowsFileNotFoundAsync()
     {
         if (!OnUnix)
         {
@@ -114,7 +114,7 @@ public class UnixFileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CreateHardLinkAsync_ExistingDestination_IsReplaced()
+    public async Task CreateHardLinkAsync_ExistingDestination_IsReplacedAsync()
     {
         if (!OnUnix)
         {
@@ -137,7 +137,7 @@ public class UnixFileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CopyFromCasAsync_ProducesIndependentCopy()
+    public async Task CopyFromCasAsync_ProducesIndependentCopyAsync()
     {
         var casBlob = Path.Combine(_tempDir, "cas-copy-source.dat");
         var copy = Path.Combine(_tempDir, "cas-copy-destination.dat");
@@ -161,7 +161,7 @@ public class UnixFileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task BaseService_CreateHardLinkAsync_ThrowsRatherThanCopying()
+    public async Task BaseService_CreateHardLinkAsync_ThrowsRatherThanCopyingAsync()
     {
         var baseService = new FileOperationsService(
             NullLogger<FileOperationsService>.Instance,

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceIntegrationTests.cs
@@ -89,7 +89,7 @@ public class WorkspaceIntegrationTests : IDisposable
 
         _serviceProvider = services.BuildServiceProvider();
         _workspaceValidator = _serviceProvider.GetRequiredService<IWorkspaceValidator>();
-        SetupTestGameInstallation().Wait();
+        SetupTestGameInstallationAsync().Wait();
     }
 
     /// <summary>
@@ -101,7 +101,7 @@ public class WorkspaceIntegrationTests : IDisposable
     [InlineData(WorkspaceStrategy.FullCopy)]
     [InlineData(WorkspaceStrategy.SymlinkOnly)]
     [InlineData(WorkspaceStrategy.HybridCopySymlink)]
-    public async Task EndToEndWorkspaceCreation_AllStrategies(WorkspaceStrategy strategy)
+    public async Task EndToEndWorkspaceCreation_AllStrategiesAsync(WorkspaceStrategy strategy)
     {
         var manager = _serviceProvider.GetRequiredService<IWorkspaceManager>();
         var config = CreateTestConfiguration(strategy);
@@ -145,7 +145,7 @@ public class WorkspaceIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_CreatesDirectory()
+    public async Task PrepareWorkspaceAsync_CreatesDirectoryAsync()
     {
         var mockDownloadService = new Mock<IDownloadService>();
         var mockCasService = new Mock<ICasService>();
@@ -231,7 +231,7 @@ public class WorkspaceIntegrationTests : IDisposable
     /// <param name="workspace">The workspace info.</param>
     /// <param name="strategy">The workspace strategy.</param>
     /// <returns>A completed <see cref="Task"/>.</returns>
-    private static Task VerifyWorkspaceStrategy(WorkspaceInfo workspace, WorkspaceStrategy strategy)
+    private static Task VerifyWorkspaceStrategyAsync(WorkspaceInfo workspace, WorkspaceStrategy strategy)
     {
         var testFile = Directory.GetFiles(workspace.WorkspacePath, "*.exe").First();
         var fileInfo = new FileInfo(testFile);
@@ -304,7 +304,7 @@ public class WorkspaceIntegrationTests : IDisposable
     /// Sets up the test game installation files and directories.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous setup.</returns>
-    private async Task SetupTestGameInstallation()
+    private async Task SetupTestGameInstallationAsync()
     {
         Directory.CreateDirectory(_tempGameInstall);
         var testFiles = new[]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceIntegrationTests.cs
@@ -236,14 +236,13 @@ public class WorkspaceIntegrationTests : IDisposable
         var testFile = Directory.GetFiles(workspace.WorkspacePath, "*.exe").First();
         var fileInfo = new FileInfo(testFile);
 
-        switch (strategy)
+        if (strategy == WorkspaceStrategy.FullCopy)
         {
-            case WorkspaceStrategy.FullCopy:
-                Assert.Null(fileInfo.LinkTarget);
-                break;
-            case WorkspaceStrategy.SymlinkOnly:
-                Assert.NotNull(fileInfo.LinkTarget);
-                break;
+            Assert.Null(fileInfo.LinkTarget);
+        }
+        else if (strategy == WorkspaceStrategy.SymlinkOnly)
+        {
+            Assert.NotNull(fileInfo.LinkTarget);
         }
 
         return Task.CompletedTask;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerReuseTests.cs
@@ -77,7 +77,7 @@ public class WorkspaceManagerReuseTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_WhenManifestVersionChanges_ShouldRecreateWorkspace()
+    public async Task PrepareWorkspaceAsync_WhenManifestVersionChanges_ShouldRecreateWorkspaceAsync()
     {
         // Arrange
         var workspaceId = "test-workspace";
@@ -137,7 +137,7 @@ public class WorkspaceManagerReuseTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_WhenManifestVersionSame_ShouldReuseWorkspace()
+    public async Task PrepareWorkspaceAsync_WhenManifestVersionSame_ShouldReuseWorkspaceAsync()
     {
         // Arrange
         var workspaceId = "test-workspace";
@@ -200,7 +200,7 @@ public class WorkspaceManagerReuseTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_WhenEntryPointCannotBeRepaired_ShouldRecreateWorkspace()
+    public async Task PrepareWorkspaceAsync_WhenEntryPointCannotBeRepaired_ShouldRecreateWorkspaceAsync()
     {
         // Arrange
         var workspaceId = "test-workspace";
@@ -256,7 +256,7 @@ public class WorkspaceManagerReuseTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_WhenEntryPointBricked_RepairsAndReusesWorkspace()
+    public async Task PrepareWorkspaceAsync_WhenEntryPointBricked_RepairsAndReusesWorkspaceAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -322,7 +322,7 @@ public class WorkspaceManagerReuseTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_WhenWorkspaceRootIsBlank_ShouldReuseWorkspace()
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceRootIsBlank_ShouldReuseWorkspaceAsync()
     {
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";
@@ -381,7 +381,7 @@ public class WorkspaceManagerReuseTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_WhenStorageRootChanges_ShouldRecreateWorkspace()
+    public async Task PrepareWorkspaceAsync_WhenStorageRootChanges_ShouldRecreateWorkspaceAsync()
     {
         var workspaceId = "test-workspace";
         var manifestId = "1.0.local.mod.testmanifest";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceManagerTests.cs
@@ -56,7 +56,7 @@ public class WorkspaceManagerTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspaceAsync_InvalidStrategy_ThrowsInvalidOperationException()
+    public async Task PrepareWorkspaceAsync_InvalidStrategy_ThrowsInvalidOperationExceptionAsync()
     {
         var config = new WorkspaceConfiguration
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceReconcilerConflictTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceReconcilerConflictTests.cs
@@ -42,7 +42,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AnalyzeWorkspaceDelta_ModVsGameInstallation_ModWins()
+    public async Task AnalyzeWorkspaceDelta_ModVsGameInstallation_ModWinsAsync()
     {
         // Arrange
         var testFile = "Data\\Art\\Textures\\test.dds";
@@ -73,7 +73,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AnalyzeWorkspaceDelta_PatchVsGameClient_PatchWins()
+    public async Task AnalyzeWorkspaceDelta_PatchVsGameClient_PatchWinsAsync()
     {
         // Arrange
         var testFile = "generals.exe";
@@ -104,7 +104,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AnalyzeWorkspaceDelta_GameClientVsGameInstallation_GameClientWins()
+    public async Task AnalyzeWorkspaceDelta_GameClientVsGameInstallation_GameClientWinsAsync()
     {
         // Arrange
         var testFile = "options.ini";
@@ -135,7 +135,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AnalyzeWorkspaceDelta_ThreeWayConflict_HighestPriorityWins()
+    public async Task AnalyzeWorkspaceDelta_ThreeWayConflict_HighestPriorityWinsAsync()
     {
         // Arrange
         var testFile = "Data\\INI\\GameData.ini";
@@ -168,7 +168,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AnalyzeWorkspaceDelta_NoConflict_FileAddedNormally()
+    public async Task AnalyzeWorkspaceDelta_NoConflict_FileAddedNormallyAsync()
     {
         // Arrange
         var testFile = "unique.dat";
@@ -195,7 +195,7 @@ public class WorkspaceReconcilerConflictTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AnalyzeWorkspaceDelta_ConflictOccurs_LogsWarning()
+    public async Task AnalyzeWorkspaceDelta_ConflictOccurs_LogsWarningAsync()
     {
         // Arrange
         var testFile = "conflict.txt";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceSyncTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceSyncTests.cs
@@ -79,7 +79,7 @@ public class WorkspaceSyncTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_SwitchingContent_ShouldSyncCorrectly()
+    public async Task PrepareWorkspace_SwitchingContent_ShouldSyncCorrectlyAsync()
     {
         // Arrange
         var profileId = "profile-1";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -51,7 +51,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ValidateConfigurationAsync_ValidConfiguration_ReturnsSuccess()
+    public async Task ValidateConfigurationAsync_ValidConfiguration_ReturnsSuccessAsync()
     {
         // Arrange
         var config = CreateValidConfiguration();
@@ -75,7 +75,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ValidateConfigurationAsync_MissingRequiredProperties_ReturnsErrors()
+    public async Task ValidateConfigurationAsync_MissingRequiredProperties_ReturnsErrorsAsync()
     {
         // Arrange
         var config = new WorkspaceConfiguration
@@ -98,7 +98,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ValidateConfigurationAsync_NonExistentSourcePath_ReturnsError()
+    public async Task ValidateConfigurationAsync_NonExistentSourcePath_ReturnsErrorAsync()
     {
         // Arrange
         var config = CreateValidConfiguration();
@@ -116,7 +116,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ValidateConfigurationAsync_EmptyManifest_ReturnsError()
+    public async Task ValidateConfigurationAsync_EmptyManifest_ReturnsErrorAsync()
     {
         // Arrange
         var config = CreateValidConfiguration();
@@ -134,7 +134,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ValidatePrerequisitesAsync_AdminRequired_ValidatesCorrectly()
+    public async Task ValidatePrerequisitesAsync_AdminRequired_ValidatesCorrectlyAsync()
     {
         // Arrange
         var mockStrategy = new Mock<IWorkspaceStrategy>();
@@ -171,7 +171,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ValidatePrerequisitesAsync_DifferentVolumes_ReturnsWarning()
+    public async Task ValidatePrerequisitesAsync_DifferentVolumes_ReturnsWarningAsync()
     {
         // Arrange
         var mockStrategy = new Mock<IWorkspaceStrategy>();
@@ -217,7 +217,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ValidatePrerequisitesAsync_InsufficientDiskSpace_ReturnsWarning()
+    public async Task ValidatePrerequisitesAsync_InsufficientDiskSpace_ReturnsWarningAsync()
     {
         // Arrange - Use a concrete strategy that can return large disk usage
         var fileOps = new Mock<IFileOperationsService>();
@@ -267,7 +267,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_RepairsEntryPoint()
+    public async Task ValidateWorkspaceAsync_OtherOnlyExecuteBit_RepairsEntryPointAsync()
     {
         // Root bypasses the permission bits entirely: faccessat reports execute access for
         // an other-only bit, so the behaviour under test does not exist for uid 0. Checked
@@ -308,7 +308,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_BrickedEntryPoint_RestoresExecuteMode()
+    public async Task EnsureEntryPointExecutableAsync_BrickedEntryPoint_RestoresExecuteModeAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -340,7 +340,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_AlreadyExecutable_ReportsNoRepair()
+    public async Task EnsureEntryPointExecutableAsync_AlreadyExecutable_ReportsNoRepairAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -371,7 +371,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_MissingEntryPoint_FailsWithoutCreatingFile()
+    public async Task EnsureEntryPointExecutableAsync_MissingEntryPoint_FailsWithoutCreatingFileAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -398,7 +398,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ValidateWorkspaceAsync_MissingEntryPoint_ReportsErrorWithoutCreatingFile()
+    public async Task ValidateWorkspaceAsync_MissingEntryPoint_ReportsErrorWithoutCreatingFileAsync()
     {
         var executablePath = Path.Combine(_workspaceDir, "missing-client");
 
@@ -426,7 +426,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_RootedPathOutsideWorkspace_RefusesWithoutMutation()
+    public async Task EnsureEntryPointExecutableAsync_RootedPathOutsideWorkspace_RefusesWithoutMutationAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -463,7 +463,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_TraversalPath_RefusesWithoutMutation()
+    public async Task EnsureEntryPointExecutableAsync_TraversalPath_RefusesWithoutMutationAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -495,7 +495,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_RootedPathInsideWorkspace_StillRepairs()
+    public async Task EnsureEntryPointExecutableAsync_RootedPathInsideWorkspace_StillRepairsAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -527,7 +527,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ValidateWorkspaceAsync_EntryPointOutsideWorkspace_ReportsErrorWithoutMutation()
+    public async Task ValidateWorkspaceAsync_EntryPointOutsideWorkspace_ReportsErrorWithoutMutationAsync()
     {
         var outsidePath = Path.Combine(_sourceDir, "client");
         await File.WriteAllTextAsync(outsidePath, "outside binary");
@@ -568,7 +568,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_SymlinkedIntermediateDirectory_RefusesWithoutMutation()
+    public async Task EnsureEntryPointExecutableAsync_SymlinkedIntermediateDirectory_RefusesWithoutMutationAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -606,7 +606,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_SymlinkedLeafExecutable_RepairsCopyAndLeavesTargetUntouched()
+    public async Task EnsureEntryPointExecutableAsync_SymlinkedLeafExecutable_RepairsCopyAndLeavesTargetUntouchedAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -645,7 +645,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_PreExistingTemporaryFile_IsNotClobbered()
+    public async Task EnsureEntryPointExecutableAsync_PreExistingTemporaryFile_IsNotClobberedAsync()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -679,7 +679,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task EnsureEntryPointExecutableAsync_OnWindows_IsANoOp()
+    public async Task EnsureEntryPointExecutableAsync_OnWindows_IsANoOpAsync()
     {
         if (!OperatingSystem.IsWindows())
         {
@@ -709,7 +709,7 @@ public partial class WorkspaceValidatorTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task ValidateWorkspaceAsync_ExecutableEntryPoint_HasNoAccessError()
+    public async Task ValidateWorkspaceAsync_ExecutableEntryPoint_HasNoAccessErrorAsync()
     {
         if (OperatingSystem.IsWindows())
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/WorkspaceValidatorTests.cs
@@ -219,11 +219,6 @@ public partial class WorkspaceValidatorTests : IDisposable
     [Fact]
     public async Task ValidatePrerequisitesAsync_InsufficientDiskSpace_ReturnsWarningAsync()
     {
-        // Arrange - Use a concrete strategy that can return large disk usage
-        var fileOps = new Mock<IFileOperationsService>();
-        var logger = new Mock<ILogger<FullCopyStrategy>>();
-        var strategy = new FullCopyStrategy(fileOps.Object, logger.Object);
-
         // Create a configuration with large files to trigger disk space warning
         var largeFileManifest = new ContentManifest
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameVersionHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameVersionHelperTests.cs
@@ -69,7 +69,7 @@ public class GameVersionHelperTests
     [Theory]
     [InlineData("101525_QFE-1", 1015251)]
     [InlineData("101525_QFEQFE-2", 1015252)]
-    [InlineData("101525_QFE2147483647", 1015252147)]
+    [InlineData("101525_QFE2147483647", 1_015_252_147)]
     public void GetGeneralsOnlineManifestIdComponent_FallsBackForInvalidQfe(string version, int expected)
     {
         Assert.Equal(expected, GameVersionHelper.GetGeneralsOnlineManifestIdComponent(version));

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Converters/InvertedBoolToVisibilityConverterTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Converters/InvertedBoolToVisibilityConverterTests.cs
@@ -52,12 +52,12 @@ public class InvertedBoolToVisibilityConverterTests
     }
 
     /// <summary>
-    /// Tests that <see cref="InvertedBoolToVisibilityConverter.ConvertBack"/> throws <see cref="NotImplementedException"/>.
+    /// Tests that <see cref="InvertedBoolToVisibilityConverter.ConvertBack"/> throws <see cref="NotSupportedException"/>.
     /// </summary>
     [Fact]
-    public void ConvertBack_ThrowsNotImplementedException()
+    public void ConvertBack_ThrowsNotSupportedException()
     {
-        Assert.Throws<NotImplementedException>(() =>
+        Assert.Throws<NotSupportedException>(() =>
             _converter.ConvertBack("Collapsed", typeof(bool), null, _culture));
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
@@ -55,7 +55,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_ConvertsGibToBig()
+    public async Task NormalizeFilesAsync_ConvertsGibToBigAsync()
     {
         var gibPath = Path.Combine(_tempDir, "data.gib");
         await File.WriteAllTextAsync(gibPath, "gib-content");
@@ -73,7 +73,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_RemovesSuffixes()
+    public async Task NormalizeFilesAsync_RemovesSuffixesAsync()
     {
         var glrPath = Path.Combine(_tempDir, "sound.wav.GLR");
         var gofPath = Path.Combine(_tempDir, "texture.tga.GOF");
@@ -96,7 +96,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_ConvertsGibWithSuffixToBig()
+    public async Task NormalizeFilesAsync_ConvertsGibWithSuffixToBigAsync()
     {
         var sourcePath = Path.Combine(_tempDir, "sound.gib.GLR");
         await File.WriteAllTextAsync(sourcePath, "gib-content");
@@ -115,7 +115,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_SkipsWhenDestinationExists()
+    public async Task NormalizeFilesAsync_SkipsWhenDestinationExistsAsync()
     {
         var gibPath = Path.Combine(_tempDir, "data.gib");
         var bigPath = Path.Combine(_tempDir, "data.big");
@@ -137,7 +137,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_DetectsAndRenamesSuffixDirectory_PreservingContents()
+    public async Task NormalizeFilesAsync_DetectsAndRenamesSuffixDirectory_PreservingContentsAsync()
     {
         var gltcDir = Path.Combine(_tempDir, "Maps.GLTC");
         Directory.CreateDirectory(gltcDir);
@@ -162,7 +162,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_SkipsDirectorySuffixRemoval_WhenDestinationExists()
+    public async Task NormalizeFilesAsync_SkipsDirectorySuffixRemoval_WhenDestinationExistsAsync()
     {
         var gltcDir = Path.Combine(_tempDir, "Maps.GLTC");
         Directory.CreateDirectory(gltcDir);
@@ -186,7 +186,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_RemovesFileSymlink()
+    public async Task NormalizeFilesAsync_RemovesFileSymlinkAsync()
     {
         if (!TryCreateFileSymlink(out var skipReason))
         {
@@ -212,7 +212,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_RemovesDanglingFileSymlink()
+    public async Task NormalizeFilesAsync_RemovesDanglingFileSymlinkAsync()
     {
         if (!TryCreateFileSymlink(out var skipReason))
         {
@@ -236,7 +236,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_RemovesDanglingDirectorySymlink()
+    public async Task NormalizeFilesAsync_RemovesDanglingDirectorySymlinkAsync()
     {
         if (!TryCreateDirectorySymlink(out var skipReason))
         {
@@ -260,7 +260,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task NormalizeFilesAsync_HonorsCancellation()
+    public async Task NormalizeFilesAsync_HonorsCancellationAsync()
     {
         var gibPath = Path.Combine(_tempDir, "data.gib");
         await File.WriteAllTextAsync(gibPath, "gib-content");
@@ -279,7 +279,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task DetectGenLauncherFilesAsync_FindsNestedFiles()
+    public async Task DetectGenLauncherFilesAsync_FindsNestedFilesAsync()
     {
         var nestedDir = Path.Combine(_tempDir, "mods", "audio");
         Directory.CreateDirectory(nestedDir);
@@ -303,7 +303,7 @@ public class GenLauncherNormalizationServiceTests : IDisposable
     [Theory]
     [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01 })]
     [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 })]
-    public async Task NormalizeFilesAsync_UnmasksNativeBinaryForMagicByteClassification(byte[] header)
+    public async Task NormalizeFilesAsync_UnmasksNativeBinaryForMagicByteClassificationAsync(byte[] header)
     {
         var suffixedPath = Path.Combine(_tempDir, "generals" + GenLauncherConstants.OriginalFileSuffix);
         await File.WriteAllBytesAsync(suffixedPath, header);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationConcurrencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationConcurrencyTests.cs
@@ -30,6 +30,7 @@ public class ContentReconciliationConcurrencyTests
     private readonly Mock<ICasLifecycleManager> _casServiceMock;
     private readonly Mock<ILogger<ContentReconciliationService>> _loggerMock;
     private readonly Mock<ICasReferenceTracker> _casReferenceTrackerMock;
+    private readonly object _syncLock = new();
     private readonly ContentReconciliationService _service;
 
     /// <summary>
@@ -74,27 +75,28 @@ public class ContentReconciliationConcurrencyTests
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task ReconcileBulkManifestReplacementAsync_ShouldSerializeConcurrentCalls()
+    public async Task ReconcileBulkManifestReplacementAsync_ShouldSerializeConcurrentCallsAsync()
     {
         // Arrange
         var callCounter = 0;
         var maxConcurrent = 0;
-        var lockObj = new object();
 
         _profileManagerMock.Setup(x => x.GetAllProfilesAsync(It.IsAny<CancellationToken>()))
             .Returns(async () =>
             {
-                int current;
-                lock (lockObj)
+                lock (_syncLock)
                 {
                     callCounter++;
-                    current = callCounter;
-                    if (current > maxConcurrent) maxConcurrent = current;
+                    var current = callCounter;
+                    if (current > maxConcurrent)
+                    {
+                        maxConcurrent = current;
+                    }
                 }
 
                 await Task.Delay(100);
 
-                lock (lockObj)
+                lock (_syncLock)
                 {
                     callCounter--;
                 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
@@ -80,7 +80,7 @@ public class ContentReconciliationServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task OrchestrateLocalUpdateAsync_WhenIdChanges_ShouldAddManifestToPool_AndUpdateProfiles()
+    public async Task OrchestrateLocalUpdateAsync_WhenIdChanges_ShouldAddManifestToPool_AndUpdateProfilesAsync()
     {
         // Arrange
         var oldId = "1.0.local.gameclient.old";
@@ -126,7 +126,7 @@ public class ContentReconciliationServiceTests
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 "profile-1",
-                It.Is<UpdateProfileRequest>(r => r.GameClient != null && r.GameClient.Id == newId),
+                It.Is<UpdateProfileRequest>(r => r.GameClient?.Id == newId),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should update profile with new manifest ID");
@@ -137,7 +137,7 @@ public class ContentReconciliationServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task OrchestrateLocalUpdateAsync_WhenTrackingFails_ShouldReturnFailure()
+    public async Task OrchestrateLocalUpdateAsync_WhenTrackingFails_ShouldReturnFailureAsync()
     {
         // Arrange
         var oldId = "1.0.local.gameclient.old";
@@ -176,7 +176,7 @@ public class ContentReconciliationServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task OrchestrateBulkUpdateAsync_WhenManifestIsNull_ShouldSkipSpecificManifests()
+    public async Task OrchestrateBulkUpdateAsync_WhenManifestIsNull_ShouldSkipSpecificManifestsAsync()
     {
         // Arrange
         var oldId = "1.0.test.mod.old";
@@ -219,7 +219,7 @@ public class ContentReconciliationServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task OrchestrateBulkUpdateAsync_WhenManifestResolutionFails_ShouldSkipSpecificManifests()
+    public async Task OrchestrateBulkUpdateAsync_WhenManifestResolutionFails_ShouldSkipSpecificManifestsAsync()
     {
         // Arrange
         var oldId = "1.0.test.mod.old";
@@ -262,7 +262,7 @@ public class ContentReconciliationServiceTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Fact]
-    public async Task ScheduleGarbageCollectionAsync_WhenDisabled_ReturnsFailure()
+    public async Task ScheduleGarbageCollectionAsync_WhenDisabled_ReturnsFailureAsync()
     {
         _casServiceMock
             .Setup(service => service.RunGarbageCollectionAsync(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
@@ -126,7 +126,7 @@ public class ContentReconciliationServiceTests
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 "profile-1",
-                It.Is<UpdateProfileRequest>(r => r.GameClient?.Id == newId),
+                It.Is<UpdateProfileRequest>(r => r.GameClient != null && r.GameClient.Id == newId),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should update profile with new manifest ID");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
@@ -304,7 +304,7 @@ public class ReconciliationIntegrationTests : IDisposable
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 profile.Id,
-                It.Is<UpdateProfileRequest>(r => r.EnabledContentIds?.Contains(newMapPack.Id.Value) == true),
+                It.Is<UpdateProfileRequest>(r => r.EnabledContentIds != null && r.EnabledContentIds.Contains(newMapPack.Id.Value)),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -385,7 +385,7 @@ public class ReconciliationIntegrationTests : IDisposable
         // Verify that the profile was updated with the generals GameClient ID (not zerohour)
         _profileManagerMock.Verify(
             x => x.CreateProfileAsync(
-                It.Is<CreateProfileRequest>(req => req.GameClient?.Id == newGeneralsParams.Id.Value),
+                It.Is<CreateProfileRequest>(req => req.GameClient != null && req.GameClient.Id == newGeneralsParams.Id.Value),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should preserve the generals GameClient ID variant");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
@@ -103,7 +103,7 @@ public class ReconciliationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task CommunityOutpost_UpdateAvailable_ShouldUpdateProfile()
+    public async Task CommunityOutpost_UpdateAvailable_ShouldUpdateProfileAsync()
     {
         // Arrange
         var oldManifestId = "1.10.communityoutpost.patch.communitypatch";
@@ -184,7 +184,7 @@ public class ReconciliationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task GeneralsOnline_UpdateWithMapPack_ShouldEnforceDependency()
+    public async Task GeneralsOnline_UpdateWithMapPack_ShouldEnforceDependencyAsync()
     {
         // Arrange
         var updateServiceMock = new Mock<IGeneralsOnlineUpdateService>();
@@ -314,7 +314,7 @@ public class ReconciliationIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SuperHackers_UpdateVariants_ShouldPreserveGameType()
+    public async Task SuperHackers_UpdateVariants_ShouldPreserveGameTypeAsync()
     {
         // Arrange
         var updateServiceMock = new Mock<ISuperHackersUpdateService>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
@@ -304,7 +304,7 @@ public class ReconciliationIntegrationTests : IDisposable
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 profile.Id,
-                It.Is<UpdateProfileRequest>(r => r.EnabledContentIds != null && r.EnabledContentIds.Contains(newMapPack.Id.Value)),
+                It.Is<UpdateProfileRequest>(r => r.EnabledContentIds?.Contains(newMapPack.Id.Value) == true),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -385,7 +385,7 @@ public class ReconciliationIntegrationTests : IDisposable
         // Verify that the profile was updated with the generals GameClient ID (not zerohour)
         _profileManagerMock.Verify(
             x => x.CreateProfileAsync(
-                It.Is<CreateProfileRequest>(req => req.GameClient != null && req.GameClient.Id == newGeneralsParams.Id.Value),
+                It.Is<CreateProfileRequest>(req => req.GameClient?.Id == newGeneralsParams.Id.Value),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should preserve the generals GameClient ID variant");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
@@ -304,7 +304,7 @@ public class ReconciliationIntegrationTests : IDisposable
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 profile.Id,
-                It.Is<UpdateProfileRequest>(r => r != null && r.EnabledContentIds != null && r.EnabledContentIds.Contains(newMapPack.Id.Value)),
+                It.Is<UpdateProfileRequest>(r => r.EnabledContentIds?.Contains(newMapPack.Id.Value) == true),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -385,7 +385,7 @@ public class ReconciliationIntegrationTests : IDisposable
         // Verify that the profile was updated with the generals GameClient ID (not zerohour)
         _profileManagerMock.Verify(
             x => x.CreateProfileAsync(
-                It.Is<CreateProfileRequest>(req => req.GameClient != null && req.GameClient.Id == newGeneralsParams.Id.Value),
+                It.Is<CreateProfileRequest>(req => req.GameClient?.Id == newGeneralsParams.Id.Value),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should preserve the generals GameClient ID variant");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ReconciliationIntegrationTests.cs
@@ -304,7 +304,7 @@ public class ReconciliationIntegrationTests : IDisposable
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 profile.Id,
-                It.Is<UpdateProfileRequest>(r => r.EnabledContentIds?.Contains(newMapPack.Id.Value) == true),
+                It.Is<UpdateProfileRequest>(r => MatchesEnabledContent(r, newMapPack.Id.Value)),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -385,11 +385,17 @@ public class ReconciliationIntegrationTests : IDisposable
         // Verify that the profile was updated with the generals GameClient ID (not zerohour)
         _profileManagerMock.Verify(
             x => x.CreateProfileAsync(
-                It.Is<CreateProfileRequest>(req => req.GameClient?.Id == newGeneralsParams.Id.Value),
+                It.Is<CreateProfileRequest>(req => MatchesGameClient(req, newGeneralsParams.Id.Value)),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should preserve the generals GameClient ID variant");
     }
+
+    private static bool MatchesEnabledContent(UpdateProfileRequest request, string contentId) =>
+        request.EnabledContentIds?.Contains(contentId) == true;
+
+    private static bool MatchesGameClient(CreateProfileRequest request, string gameClientId) =>
+        request.GameClient?.Id == gameClientId;
 
     private static ContentManifest CreateManifest(string id, string version, ContentType type, string publisher, GameType targetGame)
     {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/UserSettingsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/UserSettingsTests.cs
@@ -54,9 +54,11 @@ public class UserSettingsTests
 
         // Act
         settings.SkippedVersion = "2.0.0";
+        var firstCount = settings.SkippedVersions.Count;
         settings.SkippedVersion = "2.0.0";
 
         // Assert
+        Assert.Equal(1, firstCount);
         Assert.Single(settings.SkippedVersions);
         Assert.Equal("2.0.0", settings.SkippedVersion);
     }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/WorkspaceCasIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/WorkspaceCasIntegrationTests.cs
@@ -149,7 +149,7 @@ public class WorkspaceCasIntegrationTests : IDisposable
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
-    public async Task PrepareWorkspace_WithCasContent_CreatesCorrectLinks()
+    public async Task PrepareWorkspace_WithCasContent_CreatesCorrectLinksAsync()
     {
         // Skip test if running on non-Windows or without admin privileges
         bool isWindows = OperatingSystem.IsWindows();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Integration/ContentPipeline/ContentPipelineIntegrationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Integration/ContentPipeline/ContentPipelineIntegrationTests.cs
@@ -20,7 +20,7 @@ namespace GenHub.Tests.Integration.ContentPipeline;
 public class ContentPipelineIntegrationTests
 {
     [Fact]
-    public async Task GeneralsOnline_ManifestEndpoint_ShouldReturnValidManifests()
+    public async Task GeneralsOnline_ManifestEndpoint_ShouldReturnValidManifestsAsync()
     {
         // Arrange
         var discoverer = new GeneralsOnlineDiscoverer(
@@ -48,7 +48,7 @@ public class ContentPipelineIntegrationTests
     }
 
     [Fact]
-    public async Task GeneralsOnline_CreateDualManifests_ShouldGenerate30HzAnd60Hz()
+    public async Task GeneralsOnline_CreateDualManifests_ShouldGenerate30HzAnd60HzAsync()
     {
         // Arrange
         var discoverer = new GeneralsOnlineDiscoverer(
@@ -85,7 +85,7 @@ public class ContentPipelineIntegrationTests
     }
 
     [Fact(Skip = "Requires GitHub API client setup - manual verification at https://github.com/TheSuperHackers/GeneralsGameCode/releases")]
-    public async Task TheSuperHackers_GitHubReleases_ShouldFindWeeklyReleases()
+    public async Task TheSuperHackers_GitHubReleases_ShouldFindWeeklyReleasesAsync()
     {
         // This test requires actual GitHub API access with authentication
         // Skipped until proper test infrastructure is in place
@@ -93,7 +93,7 @@ public class ContentPipelineIntegrationTests
     }
 
     [Fact]
-    public async Task TheSuperHackers_ManifestFactory_ShouldCreateGeneralsAndZeroHourManifests()
+    public async Task TheSuperHackers_ManifestFactory_ShouldCreateGeneralsAndZeroHourManifestsAsync()
     {
         // Arrange
         var factory = new SuperHackersManifestFactory(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Linux/Gameinstallations/LinuxInstallationDetectorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Linux/Gameinstallations/LinuxInstallationDetectorTests.cs
@@ -33,7 +33,7 @@ public class LinuxInstallationDetectorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectInstallationsAsync_ReturnsDetectionResult()
+    public async Task DetectInstallationsAsync_ReturnsDetectionResultAsync()
     {
         var detector = new LinuxInstallationDetector(NullLogger<LinuxInstallationDetector>.Instance);
         var result = await detector.DetectInstallationsAsync();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Windows/Features/Workspace/WindowsFileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Windows/Features/Workspace/WindowsFileOperationsServiceTests.cs
@@ -37,7 +37,7 @@ public class WindowsFileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CreateHardLinkAsync_CreatesHardLink_OnWindows()
+    public async Task CreateHardLinkAsync_CreatesHardLink_OnWindowsAsync()
     {
         if (!OperatingSystem.IsWindows())
         {
@@ -72,7 +72,7 @@ public class WindowsFileOperationsServiceTests : IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CreateSymlinkAsync_CreatesSymlink_OnWindows()
+    public async Task CreateSymlinkAsync_CreatesSymlink_OnWindowsAsync()
     {
         if (!OperatingSystem.IsWindows())
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Windows/Gameinstallations/WindowsInstallationDetectorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Windows/Gameinstallations/WindowsInstallationDetectorTests.cs
@@ -33,7 +33,7 @@ public class WindowsInstallationDetectorTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task DetectInstallationsAsync_ReturnsDetectionResult()
+    public async Task DetectInstallationsAsync_ReturnsDetectionResultAsync()
     {
         var detector = new WindowsInstallationDetector(NullLogger<WindowsInstallationDetector>.Instance);
         var result = await detector.DetectInstallationsAsync();

--- a/GenHub/GenHub.Tests/Shared/CompositionRootAssertions.cs
+++ b/GenHub/GenHub.Tests/Shared/CompositionRootAssertions.cs
@@ -245,6 +245,7 @@ public static class CompositionRootAssertions
                 ValidateOnBuild = true,
                 ValidateScopes = true,
             });
+            _ = provider;
         }
         catch (AggregateException aggregate)
         {

--- a/GenHub/GenHub.Tools/CsvGenerator.cs
+++ b/GenHub/GenHub.Tools/CsvGenerator.cs
@@ -53,7 +53,7 @@ internal class CsvGenerator(Dictionary<string, string> arguments, ILogger logger
         var files = Directory.GetFiles(installationPath, "*", SearchOption.AllDirectories);
         var totalFiles = files.Length;
 
-        this.logger.LogInformation("Scanning {Count} files in {Path}", totalFiles, installationPath);
+        logger.LogInformation("Scanning {Count} files in {Path}", totalFiles, installationPath);
 
         for (var i = 0; i < totalFiles; i++)
         {

--- a/GenHub/GenHub.Tools/CsvGenerator.cs
+++ b/GenHub/GenHub.Tools/CsvGenerator.cs
@@ -11,42 +11,30 @@ namespace GenHub.Tools;
 /// <summary>
 /// Generates CSV files from game installations.
 /// </summary>
-internal class CsvGenerator
+/// <param name="arguments">The command line arguments.</param>
+/// <param name="logger">The logger.</param>
+internal class CsvGenerator(Dictionary<string, string> arguments, ILogger logger)
 {
-    private readonly Dictionary<string, string> arguments;
-    private readonly ILogger logger;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CsvGenerator"/> class.
-    /// </summary>
-    /// <param name="arguments">The command line arguments.</param>
-    /// <param name="logger">The logger.</param>
-    public CsvGenerator(Dictionary<string, string> arguments, ILogger logger)
-    {
-        this.arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
-
     /// <summary>
     /// Generates the CSV file based on arguments.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task GenerateCsvFileAsync()
     {
-        var installDir = this.arguments["installDir"];
-        var output = this.arguments["output"];
-        var gameType = this.arguments["gameType"];
-        var version = this.arguments["version"];
-        var language = this.arguments["language"];
+        var installDir = arguments["installDir"];
+        var output = arguments["output"];
+        var gameType = arguments["gameType"];
+        var version = arguments["version"];
+        var language = arguments["language"];
 
         if (!Directory.Exists(installDir))
         {
             throw new DirectoryNotFoundException($"Installation directory not found: {installDir}");
         }
 
-        this.logger.LogInformation("Scanning directory: {Path}", installDir);
+        logger.LogInformation("Scanning directory: {Path} for {GameType} {Version}", installDir, gameType, version);
 
-        var entries = await this.ScanInstallationAsync(installDir, gameType, language);
+        var entries = await ScanInstallationAsync(installDir, gameType, language);
 
         // Ensure output directory exists
         var outputDir = Path.GetDirectoryName(output);
@@ -55,8 +43,8 @@ internal class CsvGenerator
             Directory.CreateDirectory(outputDir);
         }
 
-        await this.WriteCsvFileAsync(entries, output);
-        this.logger.LogInformation("Generated CSV file: {Path} with {Count} entries", output, entries.Count);
+        await WriteCsvFileAsync(entries, output);
+        logger.LogInformation("Generated CSV file: {Path} with {Count} entries", output, entries.Count);
     }
 
     private async Task<List<CsvCatalogEntry>> ScanInstallationAsync(string installationPath, string gameType, string languageCode)
@@ -72,12 +60,12 @@ internal class CsvGenerator
             var file = files[i];
             if (i % 100 == 0)
             {
-                this.logger.LogInformation("Processed {Current}/{Total} files", i, totalFiles);
+                logger.LogInformation("Processed {Current}/{Total} files", i, totalFiles);
             }
 
             try
             {
-                var entry = await this.CreateCsvEntryAsync(file, installationPath, gameType, languageCode);
+                var entry = await CreateCsvEntryAsync(file, installationPath, gameType, languageCode);
                 if (entry != null)
                 {
                     entries.Add(entry);
@@ -85,7 +73,7 @@ internal class CsvGenerator
             }
             catch (Exception ex)
             {
-                this.logger.LogWarning(ex, "Failed to process file: {Path}", file);
+                logger.LogWarning(ex, "Failed to process file: {Path}", file);
             }
         }
 
@@ -102,8 +90,8 @@ internal class CsvGenerator
             return null; // Skip empty files
         }
 
-        var (md5, sha256) = await this.CalculateHashesAsync(filePath);
-        var isSpecific = this.IsLanguageSpecific(relativePath);
+        var (md5, sha256) = await CalculateHashesAsync(filePath);
+        var isSpecific = IsLanguageSpecific(relativePath);
 
         return new CsvCatalogEntry
         {
@@ -113,8 +101,8 @@ internal class CsvGenerator
             Sha256 = sha256,
             GameType = gameType,
             Language = isSpecific ? defaultLanguage : "All",
-            IsRequired = this.IsRequiredFile(relativePath),
-            Metadata = this.GetFileMetadata(relativePath),
+            IsRequired = IsRequiredFile(relativePath),
+            Metadata = GetFileMetadata(relativePath),
         };
     }
 
@@ -193,7 +181,7 @@ internal class CsvGenerator
         using var sha256 = SHA256.Create();
 
         var buffer = new byte[IoConstants.DefaultFileBufferSize];
-        int bytesRead;
+        int bytesRead = 0;
 
         while ((bytesRead = await stream.ReadAsync(buffer)) > 0)
         {
@@ -293,7 +281,7 @@ internal class CsvGenerator
         var config = new CsvConfiguration(System.Globalization.CultureInfo.InvariantCulture)
         {
             HasHeaderRecord = true,
-            PrepareHeaderForMatch = args => args.Header.ToLower(), // This is for reading
+            PrepareHeaderForMatch = args => args.Header.ToLower(System.Globalization.CultureInfo.InvariantCulture), // This is for reading
         };
 
         // Custom map for writing is better

--- a/GenHub/GenHub.Tools/CsvGenerator.cs
+++ b/GenHub/GenHub.Tools/CsvGenerator.cs
@@ -21,6 +21,9 @@ internal class CsvGenerator(Dictionary<string, string> arguments, ILogger logger
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task GenerateCsvFileAsync()
     {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(logger);
+
         var installDir = arguments["installDir"];
         var output = arguments["output"];
         var gameType = arguments["gameType"];

--- a/GenHub/GenHub.Tools/Program.cs
+++ b/GenHub/GenHub.Tools/Program.cs
@@ -11,8 +11,8 @@ internal static class Program
     /// Main entry point for the CSV Generation Utility.
     /// </summary>
     /// <param name="args">Command line arguments.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    private static async Task Main(string[] args)
+    /// <returns>A task representing the asynchronous operation with exit code.</returns>
+    private static async Task<int> Main(string[] args)
     {
         using var loggerFactory = LoggerFactory.Create(builder =>
         {
@@ -29,7 +29,7 @@ internal static class Program
                 logger.LogInformation("Usage: GenHub.Tools --installDir <path> --gameType <Generals|ZeroHour> --version <v> --output <file> [--language <code>]");
                 logger.LogInformation("  Default for --language: EN");
                 logger.LogInformation("Example: GenHub.Tools --installDir C:\\Games\\Generals --gameType Generals --version 1.08 --output docs/GameInstallationFilesRegistry/Generals-1.08.csv --language EN");
-                return;
+                return 0;
             }
 
             var arguments = ParseArguments(args);
@@ -47,11 +47,12 @@ internal static class Program
             await generator.GenerateCsvFileAsync();
 
             logger.LogInformation("CSV Generation Utility completed successfully");
+            return 0;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "CSV Generation Utility failed");
-            Environment.Exit(1);
+            return 1;
         }
     }
 
@@ -80,16 +81,9 @@ internal static class Program
             }
         }
 
-        if (!arguments.ContainsKey("language"))
-        {
-            arguments["language"] = "EN";
-        }
-
-        // make sure language code is uppercase
-        else
-        {
-            arguments["language"] = arguments["language"].ToUpperInvariant();
-        }
+        arguments["language"] = arguments.TryGetValue("language", out var lang)
+            ? lang.ToUpperInvariant()
+            : "EN";
 
         return arguments;
     }

--- a/GenHub/GenHub.Windows/Features/Workspace/WindowsSymlinkCapabilityProvider.cs
+++ b/GenHub/GenHub.Windows/Features/Workspace/WindowsSymlinkCapabilityProvider.cs
@@ -33,7 +33,7 @@ public sealed class WindowsSymlinkCapabilityProvider : ISymlinkCapabilityProvide
             File.CreateSymbolicLink(linkPath, targetPath);
             return new FileInfo(linkPath).LinkTarget is not null;
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return false;
         }
@@ -50,7 +50,7 @@ public sealed class WindowsSymlinkCapabilityProvider : ISymlinkCapabilityProvide
         {
             File.Delete(path);
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // Best-effort cleanup of a uniquely named temporary probe.
         }

--- a/GenHub/GenHub/Common/Services/StorageWritabilityProbe.cs
+++ b/GenHub/GenHub/Common/Services/StorageWritabilityProbe.cs
@@ -25,7 +25,7 @@ public class StorageWritabilityProbe(ILogger<StorageWritabilityProbe> logger) : 
             return false;
         }
 
-        string fullStoragePath;
+        string fullStoragePath = string.Empty;
 
         try
         {

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
@@ -9,6 +9,7 @@ using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Dialogs;
 using GenHub.Core.Models.Enums;
@@ -189,8 +190,8 @@ public class CommunityOutpostProfileReconciler(
     /// Builds a mapping from old manifest IDs to new manifest IDs.
     /// </summary>
     private static Dictionary<string, string> BuildManifestMapping(
-        List<ContentManifest> oldManifests,
-        List<ContentManifest> newManifests)
+        IReadOnlyList<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> newManifests)
     {
         var mapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -231,7 +232,7 @@ public class CommunityOutpostProfileReconciler(
     /// Acquires the latest Community Outpost version by searching and downloading.
     /// </summary>
     private async Task<OperationResult<List<ContentManifest>>> AcquireLatestVersionAsync(
-        List<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> oldManifests,
         CancellationToken cancellationToken)
     {
         try
@@ -299,8 +300,8 @@ public class CommunityOutpostProfileReconciler(
     /// Creates new profiles for the update instead of replacing existing ones.
     /// </summary>
     private async Task<OperationResult<int>> CreateNewProfilesForUpdateAsync(
-        List<ContentManifest> oldManifests,
-        List<ContentManifest> newManifests,
+        IReadOnlyList<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> newManifests,
         string newVersion,
         CancellationToken cancellationToken)
     {
@@ -375,7 +376,7 @@ public class CommunityOutpostProfileReconciler(
 
     private async Task<(bool ShouldProceed, UpdateStrategy Strategy, bool ShouldDeleteOldVersions)> PromptUserForUpdateStrategyAsync(
         UserSettings settings,
-        UpdateCheckResult updateResult)
+        ContentUpdateCheckResult updateResult)
     {
         var subscription = settings.GetSubscription(CommunityOutpostConstants.PublisherType);
         var strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
@@ -84,53 +84,14 @@ public class CommunityOutpostProfileReconciler(
             }
 
             // Determine strategy
-            var subscription = settings.GetSubscription(CommunityOutpostConstants.PublisherType);
-            UpdateStrategy strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
-            bool autoUpdate = subscription?.AutoUpdateEnabled == true;
-            bool shouldDeleteOldVersions = subscription?.DeleteOldVersions ?? true;
-
-            if (!autoUpdate)
+            var promptResult = await PromptUserForUpdateStrategyAsync(settings, updateResult);
+            if (!promptResult.ShouldProceed)
             {
-                var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
-                    "Community Patch Update Available",
-                    $"A new version of **Community Patch** is available (v{updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
-
-                if (dialogResult == null) return OperationResult<bool>.CreateSuccess(false);
-
-                if (dialogResult.Action == "Skip")
-                {
-                    logger.LogInformation("[CO Reconciler] User skipped version {Version}.", updateResult.LatestVersion);
-
-                    if (dialogResult.IsDoNotAskAgain)
-                    {
-                        await userSettingsService.TryUpdateAndSaveAsync(s =>
-                        {
-                            s.SkipVersion(CommunityOutpostConstants.PublisherType, updateResult.LatestVersion ?? string.Empty);
-                            return true;
-                        });
-                    }
-
-                    return OperationResult<bool>.CreateSuccess(false);
-                }
-
-                strategy = dialogResult.Strategy;
-
-                if (dialogResult.IsDoNotAskAgain)
-                {
-                    logger.LogInformation("[CO Reconciler] Saving user preference for Community Patch updates");
-                    await userSettingsService.TryUpdateAndSaveAsync(s =>
-                    {
-                        s.SetAutoUpdatePreference(CommunityOutpostConstants.PublisherType, true);
-                        var sub = s.GetSubscription(CommunityOutpostConstants.PublisherType);
-                        if (sub != null)
-                        {
-                            sub.PreferredUpdateStrategy = strategy;
-                        }
-
-                        return true;
-                    });
-                }
+                return OperationResult<bool>.CreateSuccess(false);
             }
+
+            var strategy = promptResult.Strategy;
+            var shouldDeleteOldVersions = promptResult.ShouldDeleteOldVersions;
 
             // Step 2: Notify user that update is being installed
             notificationService.ShowInfo(
@@ -168,53 +129,24 @@ public class CommunityOutpostProfileReconciler(
                 newManifests.Count);
 
             // Step 5: Update affected profiles based on strategy
-            int profilesUpdated = 0;
-            bool anyFailure = false;
+            var updateOutcome = await ApplyUpdateStrategyAsync(
+                strategy,
+                oldManifests,
+                newManifests,
+                updateResult.LatestVersion ?? "Unknown",
+                shouldDeleteOldVersions,
+                cancellationToken);
 
-            if (strategy == UpdateStrategy.CreateNewProfile)
+            if (!updateOutcome.Success)
             {
-                // Force keep old versions if creating new profiles
-                shouldDeleteOldVersions = false;
-
-                var createResult = await CreateNewProfilesForUpdateAsync(oldManifests, newManifests, updateResult.LatestVersion ?? "Unknown", cancellationToken);
-                if (createResult.Success)
-                {
-                    profilesUpdated = createResult.Data;
-                }
-                else
-                {
-                    anyFailure = true;
-                    notificationService.ShowWarning("Community Patch Update Partial", $"Failed to create some new profiles: {createResult.FirstError}");
-                }
+                return OperationResult<bool>.CreateFailure(updateOutcome.FirstError ?? "Update strategy execution failed");
             }
-            else
-            {
-                // ReplaceCurrent
-                var manifestMapping = BuildManifestMapping(oldManifests, newManifests);
-                var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(
-                    manifestMapping,
-                    shouldDeleteOldVersions,
-                    cancellationToken);
 
-                if (bulkUpdateResult.Success)
-                {
-                    profilesUpdated = bulkUpdateResult.Data.ProfilesUpdated;
-                    if (bulkUpdateResult.Data.FailedProfilesCount > 0)
-                    {
-                        anyFailure = true;
-                        notificationService.ShowWarning("Community Patch Update Partial", $"{bulkUpdateResult.Data.FailedProfilesCount} profiles could not be updated. Check logs for details.");
-                    }
-                }
-                else
-                {
-                    anyFailure = true;
-                    notificationService.ShowWarning("Community Patch Update Partial", $"Some profiles could not be updated: {bulkUpdateResult.FirstError}");
-                    return OperationResult<bool>.CreateFailure($"Bulk update failed: {bulkUpdateResult.FirstError}");
-                }
-            }
+            var profilesUpdated = updateOutcome.ProfilesUpdated;
+            var anyFailure = updateOutcome.AnyFailure;
+            shouldDeleteOldVersions = updateOutcome.ShouldDeleteOldVersions;
 
             // Step 6: Run garbage collection (only if old versions were deleted AND no failures occurred)
-            // If some profiles failed, GC could delete files they still rely on.
             if (shouldDeleteOldVersions && !anyFailure)
             {
                 await reconciliationService.ScheduleGarbageCollectionAsync(false, cancellationToken);
@@ -439,5 +371,119 @@ public class CommunityOutpostProfileReconciler(
         }
 
         return OperationResult<int>.CreateSuccess(createdCount);
+    }
+
+    private async Task<(bool ShouldProceed, UpdateStrategy Strategy, bool ShouldDeleteOldVersions)> PromptUserForUpdateStrategyAsync(
+        UserSettings settings,
+        UpdateCheckResult updateResult)
+    {
+        var subscription = settings.GetSubscription(CommunityOutpostConstants.PublisherType);
+        var strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
+        var autoUpdate = subscription?.AutoUpdateEnabled == true;
+        var shouldDeleteOldVersions = subscription?.DeleteOldVersions ?? true;
+
+        if (autoUpdate)
+        {
+            return (true, strategy, shouldDeleteOldVersions);
+        }
+
+        var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
+            "Community Patch Update Available",
+            $"A new version of **Community Patch** is available (v{updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
+
+        if (dialogResult == null)
+        {
+            return (false, strategy, shouldDeleteOldVersions);
+        }
+
+        if (dialogResult.Action == "Skip")
+        {
+            logger.LogInformation("[CO Reconciler] User skipped version {Version}.", updateResult.LatestVersion);
+
+            if (dialogResult.IsDoNotAskAgain)
+            {
+                await userSettingsService.TryUpdateAndSaveAsync(s =>
+                {
+                    s.SkipVersion(CommunityOutpostConstants.PublisherType, updateResult.LatestVersion ?? string.Empty);
+                    return true;
+                });
+            }
+
+            return (false, strategy, shouldDeleteOldVersions);
+        }
+
+        strategy = dialogResult.Strategy;
+
+        if (dialogResult.IsDoNotAskAgain)
+        {
+            logger.LogInformation("[CO Reconciler] Saving user preference for Community Patch updates");
+            await userSettingsService.TryUpdateAndSaveAsync(s =>
+            {
+                s.SetAutoUpdatePreference(CommunityOutpostConstants.PublisherType, true);
+                var sub = s.GetSubscription(CommunityOutpostConstants.PublisherType);
+                if (sub != null)
+                {
+                    sub.PreferredUpdateStrategy = strategy;
+                }
+
+                return true;
+            });
+        }
+
+        return (true, strategy, shouldDeleteOldVersions);
+    }
+
+    private async Task<(bool Success, string? FirstError, int ProfilesUpdated, bool AnyFailure, bool ShouldDeleteOldVersions)> ApplyUpdateStrategyAsync(
+        UpdateStrategy strategy,
+        IReadOnlyList<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> newManifests,
+        string latestVersion,
+        bool shouldDeleteOldVersions,
+        CancellationToken cancellationToken)
+    {
+        int profilesUpdated = 0;
+        bool anyFailure = false;
+
+        if (strategy == UpdateStrategy.CreateNewProfile)
+        {
+            // Force keep old versions if creating new profiles
+            shouldDeleteOldVersions = false;
+
+            var createResult = await CreateNewProfilesForUpdateAsync(oldManifests, newManifests, latestVersion, cancellationToken);
+            if (createResult.Success)
+            {
+                profilesUpdated = createResult.Data;
+            }
+            else
+            {
+                anyFailure = true;
+                notificationService.ShowWarning("Community Patch Update Partial", $"Failed to create some new profiles: {createResult.FirstError}");
+            }
+
+            return (true, null, profilesUpdated, anyFailure, shouldDeleteOldVersions);
+        }
+
+        // ReplaceCurrent
+        var manifestMapping = BuildManifestMapping(oldManifests, newManifests);
+        var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(
+            manifestMapping,
+            shouldDeleteOldVersions,
+            cancellationToken);
+
+        if (bulkUpdateResult.Success)
+        {
+            profilesUpdated = bulkUpdateResult.Data.ProfilesUpdated;
+            if (bulkUpdateResult.Data.FailedProfilesCount > 0)
+            {
+                anyFailure = true;
+                notificationService.ShowWarning("Community Patch Update Partial", $"{bulkUpdateResult.Data.FailedProfilesCount} profiles could not be updated. Check logs for details.");
+            }
+
+            return (true, null, profilesUpdated, anyFailure, shouldDeleteOldVersions);
+        }
+
+        anyFailure = true;
+        notificationService.ShowWarning("Community Patch Update Partial", $"Some profiles could not be updated: {bulkUpdateResult.FirstError}");
+        return (false, $"Bulk update failed: {bulkUpdateResult.FirstError}", profilesUpdated, anyFailure, shouldDeleteOldVersions);
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CompressedImageToTgaConverter.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CompressedImageToTgaConverter.cs
@@ -197,7 +197,7 @@ public class CompressedImageToTgaConverter(ILogger<CompressedImageToTgaConverter
                     }
                 }
 
-                Image image;
+                Image? image = null;
                 try
                 {
                     using var inputStream = File.OpenRead(sourcePath);

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/ProviderEndpointsExtensions.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/ProviderEndpointsExtensions.cs
@@ -23,7 +23,7 @@ public static class ProviderEndpointsExtensions
         // Check mirror preference from endpoints mirrors priority
         // NOTE: ProviderDefinition has MirrorPreference list, but ProviderEndpoints has Mirrors (list of EndpointMirror).
         // This extension simplifies access.
-        if (endpoints.Mirrors != null && endpoints.Mirrors.Count > 0)
+        if (endpoints.Mirrors is { Count: > 0 })
         {
             var orderedMirrors = endpoints.Mirrors.OrderBy(m => m.Priority).ToList();
             foreach (var mirrorEndpoint in orderedMirrors)

--- a/GenHub/GenHub/Features/Content/Services/ContentPipelineFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentPipelineFactory.cs
@@ -11,37 +11,19 @@ namespace GenHub.Features.Content.Services;
 /// Factory for obtaining content pipeline components by provider ID.
 /// Matches the providerId from JSON configuration to registered components.
 /// </summary>
-public class ContentPipelineFactory : IContentPipelineFactory
+/// <param name="discoverers">All registered content discoverers.</param>
+/// <param name="resolvers">All registered content resolvers.</param>
+/// <param name="deliverers">All registered content deliverers.</param>
+/// <param name="logger">Logger instance.</param>
+public class ContentPipelineFactory(
+    IEnumerable<IContentDiscoverer> discoverers,
+    IEnumerable<IContentResolver> resolvers,
+    IEnumerable<IContentDeliverer> deliverers,
+    ILogger<ContentPipelineFactory> logger) : IContentPipelineFactory
 {
-    private readonly IEnumerable<IContentDiscoverer> _discoverers;
-    private readonly IEnumerable<IContentResolver> _resolvers;
-    private readonly IEnumerable<IContentDeliverer> _deliverers;
-    private readonly ILogger<ContentPipelineFactory> _logger;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ContentPipelineFactory"/> class.
-    /// </summary>
-    /// <param name="discoverers">All registered content discoverers.</param>
-    /// <param name="resolvers">All registered content resolvers.</param>
-    /// <param name="deliverers">All registered content deliverers.</param>
-    /// <param name="logger">Logger instance.</param>
-    public ContentPipelineFactory(
-        IEnumerable<IContentDiscoverer> discoverers,
-        IEnumerable<IContentResolver> resolvers,
-        IEnumerable<IContentDeliverer> deliverers,
-        ILogger<ContentPipelineFactory> logger)
-    {
-        _discoverers = discoverers;
-        _resolvers = resolvers;
-        _deliverers = deliverers;
-        _logger = logger;
-
-        _logger.LogDebug(
-            "ContentPipelineFactory initialized with {DiscovererCount} discoverers, {ResolverCount} resolvers, {DelivererCount} deliverers",
-            _discoverers.Count(),
-            _resolvers.Count(),
-            _deliverers.Count());
-    }
+    private readonly IReadOnlyList<IContentDiscoverer> _discoverers = discoverers.ToList();
+    private readonly IReadOnlyList<IContentResolver> _resolvers = resolvers.ToList();
+    private readonly IReadOnlyList<IContentDeliverer> _deliverers = deliverers.ToList();
 
     /// <inheritdoc/>
     public IContentDiscoverer? GetDiscoverer(string providerId)
@@ -51,13 +33,14 @@ public class ContentPipelineFactory : IContentPipelineFactory
             return null;
         }
 
-        // Match by SourceName (case-insensitive)
+        var normalized = providerId.Replace("-", string.Empty);
         var discoverer = _discoverers.FirstOrDefault(d =>
-            d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase));
+            d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase) ||
+            d.SourceName.Equals(normalized, StringComparison.OrdinalIgnoreCase));
 
         if (discoverer == null)
         {
-            _logger.LogDebug("No discoverer found for provider ID '{ProviderId}'", providerId);
+            logger.LogDebug("No discoverer found for provider ID '{ProviderId}'", providerId);
         }
 
         return discoverer;
@@ -71,13 +54,14 @@ public class ContentPipelineFactory : IContentPipelineFactory
             return null;
         }
 
-        // Match by ResolverId (case-insensitive)
+        var normalized = providerId.Replace("-", string.Empty);
         var resolver = _resolvers.FirstOrDefault(r =>
-            r.ResolverId.Equals(providerId, StringComparison.OrdinalIgnoreCase));
+            r.ResolverId.Equals(providerId, StringComparison.OrdinalIgnoreCase) ||
+            r.ResolverId.Equals(normalized, StringComparison.OrdinalIgnoreCase));
 
         if (resolver == null)
         {
-            _logger.LogDebug("No resolver found for provider ID '{ProviderId}'", providerId);
+            logger.LogDebug("No resolver found for provider ID '{ProviderId}'", providerId);
         }
 
         return resolver;
@@ -91,13 +75,14 @@ public class ContentPipelineFactory : IContentPipelineFactory
             return null;
         }
 
-        // Match by SourceName (case-insensitive)
+        var normalized = providerId.Replace("-", string.Empty);
         var deliverer = _deliverers.FirstOrDefault(d =>
-            d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase));
+            d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase) ||
+            d.SourceName.Equals(normalized, StringComparison.OrdinalIgnoreCase));
 
         if (deliverer == null)
         {
-            _logger.LogDebug("No deliverer found for provider ID '{ProviderId}'", providerId);
+            logger.LogDebug("No deliverer found for provider ID '{ProviderId}'", providerId);
         }
 
         return deliverer;
@@ -120,13 +105,13 @@ public class ContentPipelineFactory : IContentPipelineFactory
 
         var providerId = provider.ProviderId;
 
-        _logger.LogDebug("Getting pipeline for provider '{ProviderId}'", providerId);
+        logger.LogDebug("Getting pipeline for provider '{ProviderId}'", providerId);
 
         var discoverer = GetDiscoverer(providerId);
         var resolver = GetResolver(providerId);
         var deliverer = GetDeliverer(providerId);
 
-        _logger.LogDebug(
+        logger.LogDebug(
             "Pipeline for '{ProviderId}': Discoverer={HasDiscoverer}, Resolver={HasResolver}, Deliverer={HasDeliverer}",
             providerId,
             discoverer != null,

--- a/GenHub/GenHub/Features/Content/Services/ContentPipelineFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentPipelineFactory.cs
@@ -34,9 +34,8 @@ public class ContentPipelineFactory(
         }
 
         var normalized = providerId.Replace("-", string.Empty);
-        var discoverer = _discoverers.FirstOrDefault(d =>
-            d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase) ||
-            d.SourceName.Equals(normalized, StringComparison.OrdinalIgnoreCase));
+        var discoverer = _discoverers.FirstOrDefault(d => d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase))
+            ?? _discoverers.FirstOrDefault(d => d.SourceName.Equals(normalized, StringComparison.OrdinalIgnoreCase));
 
         if (discoverer == null)
         {
@@ -55,9 +54,8 @@ public class ContentPipelineFactory(
         }
 
         var normalized = providerId.Replace("-", string.Empty);
-        var resolver = _resolvers.FirstOrDefault(r =>
-            r.ResolverId.Equals(providerId, StringComparison.OrdinalIgnoreCase) ||
-            r.ResolverId.Equals(normalized, StringComparison.OrdinalIgnoreCase));
+        var resolver = _resolvers.FirstOrDefault(r => r.ResolverId.Equals(providerId, StringComparison.OrdinalIgnoreCase))
+            ?? _resolvers.FirstOrDefault(r => r.ResolverId.Equals(normalized, StringComparison.OrdinalIgnoreCase));
 
         if (resolver == null)
         {
@@ -76,9 +74,8 @@ public class ContentPipelineFactory(
         }
 
         var normalized = providerId.Replace("-", string.Empty);
-        var deliverer = _deliverers.FirstOrDefault(d =>
-            d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase) ||
-            d.SourceName.Equals(normalized, StringComparison.OrdinalIgnoreCase));
+        var deliverer = _deliverers.FirstOrDefault(d => d.SourceName.Equals(providerId, StringComparison.OrdinalIgnoreCase))
+            ?? _deliverers.FirstOrDefault(d => d.SourceName.Equals(normalized, StringComparison.OrdinalIgnoreCase));
 
         if (deliverer == null)
         {

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
@@ -207,7 +207,6 @@ public class CNCLabsMapResolver(
         var fileSizeText = ExtractMetadataValue(document, "File Size:");
         var fileSize = FileSizeFormatter.ParseToBytes(fileSizeText);
 
-
         var submittedText = ExtractMetadataValue(document, "Submitted:");
         var submissionDate = DateTime.TryParse(submittedText, out var sd) ? sd : DateTime.MinValue;
 

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
@@ -189,12 +189,9 @@ public class CNCLabsMapResolver(
         var downloadUrl = downloadLink?.GetAttribute(CNCLabsConstants.HrefAttribute) ?? string.Empty;
 
         // Ensure absolute URL
-        if (!string.IsNullOrEmpty(downloadUrl))
+        if (!string.IsNullOrEmpty(downloadUrl) && !downloadUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
         {
-            if (!downloadUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-            {
-                downloadUrl = $"{CNCLabsConstants.PublisherWebsite.TrimEnd('/')}/{downloadUrl.TrimStart('/')}";
-            }
+            downloadUrl = $"{CNCLabsConstants.PublisherWebsite.TrimEnd('/')}/{downloadUrl.TrimStart('/')}";
         }
 
         // Rewrite downloader.aspx to fetch.aspx to bypass JS redirect

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
@@ -207,8 +207,6 @@ public class CNCLabsMapResolver(
         var fileSizeText = ExtractMetadataValue(document, "File Size:");
         var fileSize = FileSizeFormatter.ParseToBytes(fileSizeText);
 
-        var maxPlayersText = ExtractMetadataValue(document, "Max Players:");
-        var maxPlayers = int.TryParse(maxPlayersText?.Trim(), out var p) ? p : 0;
 
         var submittedText = ExtractMetadataValue(document, "Submitted:");
         var submissionDate = DateTime.TryParse(submittedText, out var sd) ? sd : DateTime.MinValue;

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/ModDBResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/ModDBResolver.cs
@@ -55,13 +55,9 @@ public class ModDBResolver(
 
         // Try finding "Added:" or "Posted:" labels
         var addedText = ExtractMetadataValue(document, "Added:", "Posted:", "Released:");
-        if (!string.IsNullOrEmpty(addedText))
+        if (!string.IsNullOrEmpty(addedText) && DateTime.TryParse(addedText, out var dt))
         {
-            // Try to parse various date formats
-            if (DateTime.TryParse(addedText, out var dt))
-            {
-                return dt;
-            }
+            return dt;
         }
 
         // Fallback: use current date

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/ModDBResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/ModDBResolver.cs
@@ -47,17 +47,17 @@ public class ModDBResolver(
         if (timeEl != null)
         {
             var dateTimeAttr = timeEl.GetAttribute("datetime");
-            if (DateTime.TryParse(dateTimeAttr, out var dt))
+            if (DateTime.TryParse(dateTimeAttr, out var parsedTime))
             {
-                return dt;
+                return parsedTime;
             }
         }
 
         // Try finding "Added:" or "Posted:" labels
         var addedText = ExtractMetadataValue(document, "Added:", "Posted:", "Released:");
-        if (!string.IsNullOrEmpty(addedText) && DateTime.TryParse(addedText, out var dt))
+        if (!string.IsNullOrEmpty(addedText) && DateTime.TryParse(addedText, out var parsedDate))
         {
-            return dt;
+            return parsedDate;
         }
 
         // Fallback: use current date

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -707,8 +707,8 @@ public class ContentStorageService : IContentStorageService
                 });
 
                 // Store file based on its SourceType
-                string hash;
-                long fileSize;
+                string hash = string.Empty;
+                long fileSize = 0;
 
                 if (manifestFile.SourceType == ContentSourceType.ContentAddressable)
                 {

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -47,7 +47,7 @@ public class ContentStorageService : IContentStorageService
                 try
                 {
                     var fullPath = Path.GetFullPath(Path.Combine(baseDirectory, file.RelativePath));
-                    if (!fullPath.StartsWith(normalizedBase, StringComparison.OrdinalIgnoreCase))
+                    if (!IsPathWithinDirectory(normalizedBase, fullPath))
                     {
                         return OperationResult<bool>.CreateFailure($"File {file.RelativePath} attempts path traversal outside base directory");
                     }
@@ -68,17 +68,11 @@ public class ContentStorageService : IContentStorageService
                     {
                         // If SourcePath is absolute, we strictly enforce it must be within baseDirectory
                         // If it is relative, we combine and check traversal
-                        string fullSource;
-                        if (Path.IsPathRooted(file.SourcePath))
-                        {
-                            fullSource = Path.GetFullPath(file.SourcePath);
-                        }
-                        else
-                        {
-                            fullSource = Path.GetFullPath(Path.Combine(baseDirectory, file.SourcePath));
-                        }
+                        var fullSource = Path.IsPathRooted(file.SourcePath)
+                            ? Path.GetFullPath(file.SourcePath)
+                            : Path.GetFullPath(Path.Combine(baseDirectory, file.SourcePath));
 
-                        if (!fullSource.StartsWith(normalizedBase, StringComparison.OrdinalIgnoreCase))
+                        if (!IsPathWithinDirectory(normalizedBase, fullSource))
                         {
                             return OperationResult<bool>.CreateFailure($"File {file.RelativePath} specifies SourcePath {file.SourcePath} which traverses outside base directory");
                         }
@@ -92,6 +86,15 @@ public class ContentStorageService : IContentStorageService
         }
 
         return OperationResult<bool>.CreateSuccess(true);
+    }
+
+    private static bool IsPathWithinDirectory(string normalizedBase, string fullPath)
+    {
+        var relative = Path.GetRelativePath(normalizedBase, fullPath);
+        return !relative.Equals("..", StringComparison.Ordinal) &&
+               !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+               !relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal) &&
+               !Path.IsPathRooted(relative);
     }
 
     private static async Task<string> CalculateFileHashAsync(string filePath, CancellationToken cancellationToken)

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -221,7 +221,7 @@ public class GeneralsOnlineDeliverer(
             return OperationResult<(string, string)>.CreateFailure("No ZIP file found in manifest");
         }
 
-        var zipPath = Path.Combine(targetDirectory, "GeneralsOnline.zip");
+        var zipPath = Path.Combine(targetDirectory, $"GeneralsOnline_{Guid.NewGuid():N}.zip");
         progress?.Report(new ContentAcquisitionProgress
         {
             Phase = ContentAcquisitionPhase.Downloading,
@@ -244,7 +244,7 @@ public class GeneralsOnlineDeliverer(
             return OperationResult<(string, string)>.CreateFailure($"Failed to download ZIP: {downloadResult.FirstError}");
         }
 
-        var extractPath = Path.Combine(targetDirectory, "extracted");
+        var extractPath = Path.Combine(targetDirectory, $"extracted_{Guid.NewGuid():N}");
         Directory.CreateDirectory(extractPath);
 
         progress?.Report(new ContentAcquisitionProgress

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -64,6 +64,7 @@ public class GeneralsOnlineDeliverer(
         try
         {
             logger.LogInformation("Starting Generals Online content delivery for {Version}", packageManifest.Version);
+            PruneStaleTempArtifacts(targetDirectory, logger);
 
             var downloadResult = await DownloadAndExtractPackageAsync(packageManifest, targetDirectory, progress, cancellationToken);
             if (!downloadResult.Success)
@@ -179,6 +180,47 @@ public class GeneralsOnlineDeliverer(
         {
             logger.LogError(ex, "Validation failed for Generals Online manifest {ManifestId}", manifest.Id);
             return Task.FromResult(OperationResult<bool>.CreateFailure($"Validation failed: {ex.Message}"));
+        }
+    }
+
+    private static void PruneStaleTempArtifacts(string targetDirectory, ILogger logger)
+    {
+        try
+        {
+            if (!Directory.Exists(targetDirectory))
+            {
+                return;
+            }
+
+            foreach (var staleZip in Directory.EnumerateFiles(targetDirectory, "GeneralsOnline_*.zip"))
+            {
+                try
+                {
+                    File.Delete(staleZip);
+                    logger.LogDebug("Pruned stale ZIP artifact: {Path}", staleZip);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogTrace(ex, "Failed to prune stale ZIP {Path}", staleZip);
+                }
+            }
+
+            foreach (var staleDir in Directory.EnumerateDirectories(targetDirectory, "extracted_*"))
+            {
+                try
+                {
+                    Directory.Delete(staleDir, recursive: true);
+                    logger.LogDebug("Pruned stale extraction directory: {Path}", staleDir);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogTrace(ex, "Failed to prune stale extraction dir {Path}", staleDir);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogTrace(ex, "Error while pruning stale artifacts in {Directory}", targetDirectory);
         }
     }
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDiscoverer.cs
@@ -115,8 +115,8 @@ public class GeneralsOnlineDiscoverer(
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
                 results = results.Where(r =>
-                    (r.Version?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (r.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) ?? false));
+                    r.Version?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
+                    r.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true);
             }
 
             var list = results.ToList();

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -617,6 +617,8 @@ public class GeneralsOnlineProfileReconciler(
             return OperationResult<int>.CreateFailure("Failed to retrieve profiles for creating new profiles");
         }
 
+        var existingProfileNames = allProfiles.Data.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         foreach (var profile in allProfiles.Data)
         {
             // Check if profile is relevant (uses any Old GeneralsOnline manifest)
@@ -626,7 +628,7 @@ public class GeneralsOnlineProfileReconciler(
             if (!isRelevant) continue;
 
             var targetProfileName = $"{profile.Name} (v{newVersion})";
-            if (allProfiles.Data.Any(p => string.Equals(p.Name, targetProfileName, StringComparison.OrdinalIgnoreCase)))
+            if (existingProfileNames.Contains(targetProfileName))
             {
                 logger.LogInformation("[GO Reconciler] Profile '{Name}' already exists, skipping clone", targetProfileName);
                 continue;
@@ -689,6 +691,7 @@ public class GeneralsOnlineProfileReconciler(
                 if (createResult.Success)
                 {
                     createdCount++;
+                    existingProfileNames.Add(targetProfileName);
                     logger.LogInformation("[GO Reconciler] Created new profile '{Name}' for update", cloneRequest.Name);
                 }
                 else

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -38,6 +38,8 @@ public class GeneralsOnlineProfileReconciler(
     IContentVersionComparer versionComparer)
     : IGeneralsOnlineProfileReconciler, IPublisherReconciler
 {
+    private readonly SemaphoreSlim _reconcileLock = new(1, 1);
+
     /// <inheritdoc/>
     public string PublisherType => GeneralsOnlineConstants.PublisherType;
 
@@ -46,6 +48,7 @@ public class GeneralsOnlineProfileReconciler(
         string triggeringProfileId,
         CancellationToken cancellationToken = default)
     {
+        await _reconcileLock.WaitAsync(cancellationToken);
         try
         {
             logger.LogInformation(
@@ -140,6 +143,10 @@ public class GeneralsOnlineProfileReconciler(
 
             return OperationResult<bool>.CreateFailure(
                 $"GeneralsOnline update reconciliation failed: {ex.Message}");
+        }
+        finally
+        {
+            _reconcileLock.Release();
         }
     }
 
@@ -618,15 +625,40 @@ public class GeneralsOnlineProfileReconciler(
 
             if (!isRelevant) continue;
 
+            var targetProfileName = $"{profile.Name} (v{newVersion})";
+            if (allProfiles.Data.Any(p => string.Equals(p.Name, targetProfileName, StringComparison.OrdinalIgnoreCase)))
+            {
+                logger.LogInformation("[GO Reconciler] Profile '{Name}' already exists, skipping clone", targetProfileName);
+                continue;
+            }
+
             try
             {
+                // Resolve updated game client reference if applicable
+                var updatedGameClient = profile.GameClient;
+                if (profile.GameClient != null && manifestMapping.TryGetValue(profile.GameClient.Id, out var newGameClientId))
+                {
+                    var newManifest = newManifests.FirstOrDefault(m => string.Equals(m.Id.Value, newGameClientId, StringComparison.OrdinalIgnoreCase));
+                    if (newManifest != null)
+                    {
+                        updatedGameClient = new Core.Models.GameClients.GameClient
+                        {
+                            Id = newManifest.Id.Value,
+                            Name = newManifest.Name,
+                            Version = newManifest.Version.Value,
+                            ExecutablePath = newManifest.EntryPoints.FirstOrDefault()?.RelativePath ?? profile.GameClient.ExecutablePath,
+                            Publisher = newManifest.Publisher?.Name ?? profile.GameClient.Publisher,
+                        };
+                    }
+                }
+
                 // Clone the profile
                 var cloneRequest = new Core.Models.GameProfile.CreateProfileRequest
                 {
-                   Name = $"{profile.Name} (v{newVersion})",
+                   Name = targetProfileName,
                    GameInstallationId = profile.GameInstallationId,
                    WorkspaceStrategy = profile.WorkspaceStrategy,
-                   GameClient = profile.GameClient,
+                   GameClient = updatedGameClient,
                 };
 
                 // Calculate new content IDs

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -645,9 +645,13 @@ public class GeneralsOnlineProfileReconciler(
                         {
                             Id = newManifest.Id.Value,
                             Name = newManifest.Name,
-                            Version = newManifest.Version.Value,
-                            ExecutablePath = newManifest.EntryPoints.FirstOrDefault()?.RelativePath ?? profile.GameClient.ExecutablePath,
-                            Publisher = newManifest.Publisher?.Name ?? profile.GameClient.Publisher,
+                            Version = newManifest.Version ?? string.Empty,
+                            GameType = newManifest.TargetGame,
+                            SourceType = newManifest.ContentType,
+                            PublisherType = newManifest.Publisher?.PublisherType ?? profile.GameClient.PublisherType,
+                            InstallationId = profile.GameClient.InstallationId,
+                            ExecutablePath = profile.GameClient.ExecutablePath,
+                            WorkingDirectory = profile.GameClient.WorkingDirectory,
                         };
                     }
                 }

--- a/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
@@ -245,6 +245,17 @@ public class GitHubContentDeliverer(
                ext == FileTypes.RarFileExtension;
     }
 
+    private static bool IsPathWithinDirectory(string normalizedBase, string fullPath)
+    {
+        var normalizedRoot = Path.GetFullPath(normalizedBase);
+        var normalizedTarget = Path.GetFullPath(fullPath);
+        var relative = Path.GetRelativePath(normalizedRoot, normalizedTarget);
+        return !relative.Equals("..", StringComparison.Ordinal) &&
+               !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+               !relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal) &&
+               !Path.IsPathRooted(relative);
+    }
+
     /// <summary>
     /// Handles extracted content by using publisher-specific factories to create manifests.
     /// May return multiple manifests if the publisher factory detects multi-variant content.
@@ -381,7 +392,12 @@ public class GitHubContentDeliverer(
                         break;
                     }
 
-                    var destinationPath = Path.Combine(targetDirectory, entry.Key ?? string.Empty);
+                    var destinationPath = Path.GetFullPath(Path.Combine(targetDirectory, entry.Key ?? string.Empty));
+                    if (!IsPathWithinDirectory(targetDirectory, destinationPath))
+                    {
+                        throw new InvalidOperationException($"Zip slip vulnerability detected: entry '{entry.Key}' attempts to extract outside target directory.");
+                    }
+
                     var destinationDir = Path.GetDirectoryName(destinationPath);
                     if (!string.IsNullOrEmpty(destinationDir))
                     {

--- a/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
@@ -139,7 +139,7 @@ public class GitHubContentDeliverer(
 
             // Check if this is content with archive files (ZIP, 7z, tar.gz, etc.)
             var archiveFiles = downloadedFiles
-                .Where(f => IsArchiveFile(f))
+                .Where(IsArchiveFile)
                 .ToList();
 
             if (archiveFiles.Count > 0)
@@ -370,52 +370,50 @@ public class GitHubContentDeliverer(
         await Task.Run(
             () =>
             {
-                using (var archive = ArchiveFactory.Open(archiveFile))
+                using var archive = ArchiveFactory.Open(archiveFile);
+                int totalEntries = archive.Entries.Count(e => !e.IsDirectory);
+                int currentEntry = 0;
+
+                foreach (var entry in archive.Entries.Where(e => !e.IsDirectory))
                 {
-                    int totalEntries = archive.Entries.Count(e => !e.IsDirectory);
-                    int currentEntry = 0;
-
-                    foreach (var entry in archive.Entries.Where(e => !e.IsDirectory))
+                    if (cancellationToken.IsCancellationRequested)
                     {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            break;
-                        }
-
-                        var destinationPath = Path.Combine(targetDirectory, entry.Key ?? string.Empty);
-                        var destinationDir = Path.GetDirectoryName(destinationPath);
-                        if (!string.IsNullOrEmpty(destinationDir))
-                        {
-                            Directory.CreateDirectory(destinationDir);
-                        }
-
-                        entry.WriteToFile(
-                            destinationPath,
-                            new ExtractionOptions
-                            {
-                                ExtractFullPath = true,
-                                Overwrite = true,
-                            });
-
-                        currentEntry++;
-
-                        // Map extraction progress from ProgressStepValidatingFiles to ProgressStepExtracting
-                        double extractStart = ContentConstants.ProgressStepValidatingFiles;
-                        double extractEnd = ContentConstants.ProgressStepExtracting;
-                        double progressRange = extractEnd - extractStart;
-                        double currentPercentage = extractStart + ((double)currentEntry / totalEntries * progressRange);
-
-                        progress?.Report(
-                            new ContentAcquisitionProgress
-                            {
-                                Phase = ContentAcquisitionPhase.Extracting,
-                                ProgressPercentage = currentPercentage,
-                                CurrentOperation = $"{Path.GetFileName(entry.Key)} ({currentEntry}/{totalEntries})",
-                                FilesProcessed = currentEntry,
-                                TotalFiles = totalEntries,
-                                CurrentFile = Path.GetFileName(entry.Key) ?? string.Empty,
-                            });
+                        break;
                     }
+
+                    var destinationPath = Path.Combine(targetDirectory, entry.Key ?? string.Empty);
+                    var destinationDir = Path.GetDirectoryName(destinationPath);
+                    if (!string.IsNullOrEmpty(destinationDir))
+                    {
+                        Directory.CreateDirectory(destinationDir);
+                    }
+
+                    entry.WriteToFile(
+                        destinationPath,
+                        new ExtractionOptions
+                        {
+                            ExtractFullPath = true,
+                            Overwrite = true,
+                        });
+
+                    currentEntry++;
+
+                    // Map extraction progress from ProgressStepValidatingFiles to ProgressStepExtracting
+                    double extractStart = ContentConstants.ProgressStepValidatingFiles;
+                    double extractEnd = ContentConstants.ProgressStepExtracting;
+                    double progressRange = extractEnd - extractStart;
+                    double currentPercentage = extractStart + ((double)currentEntry / totalEntries * progressRange);
+
+                    progress?.Report(
+                        new ContentAcquisitionProgress
+                        {
+                            Phase = ContentAcquisitionPhase.Extracting,
+                            ProgressPercentage = currentPercentage,
+                            CurrentOperation = $"{Path.GetFileName(entry.Key)} ({currentEntry}/{totalEntries})",
+                            FilesProcessed = currentEntry,
+                            TotalFiles = totalEntries,
+                            CurrentFile = Path.GetFileName(entry.Key) ?? string.Empty,
+                        });
                 }
             },
             cancellationToken);

--- a/GenHub/GenHub/Features/Content/Services/GitHub/GitHubResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/GitHub/GitHubResolver.cs
@@ -335,10 +335,6 @@ public partial class GitHubResolver(
             // Extract variant from asset name (e.g., "English" from "0_ImprovedMenusEnglish.big")
             var variant = ExtractAssetVariant(asset.Name);
 
-            // Generate manifest ID matching the discoverer format
-            // Publisher = owner
-            var publisherId = owner;
-
             // Extract version from tag (Restored)
             var userVersion = ExtractVersionFromReleaseTag(tag);
 

--- a/GenHub/GenHub/Features/Content/Services/Helpers/CNCLabsHelper.cs
+++ b/GenHub/GenHub/Features/Content/Services/Helpers/CNCLabsHelper.cs
@@ -84,7 +84,7 @@ public static partial class CNCLabsHelper
                   .Append(query.NumberOfPlayers.Value.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (query.CNCLabsMapTags != null && query.CNCLabsMapTags.Count > 0)
+            if (query.CNCLabsMapTags is { Count: > 0 })
             {
                 sb.Append('&')
                   .Append(CNCLabsConstants.TagsQueryParam)

--- a/GenHub/GenHub/Features/Content/Services/MemoryDynamicContentCache.cs
+++ b/GenHub/GenHub/Features/Content/Services/MemoryDynamicContentCache.cs
@@ -59,7 +59,7 @@ public class MemoryDynamicContentCache(IMemoryCache memoryCache) : IDynamicConte
 
         lock (_keys)
         {
-            keysToRemove = [.._keys.Where(k => regex.IsMatch(k))];
+            keysToRemove = [.._keys.Where(regex.IsMatch)];
         }
 
         foreach (var key in keysToRemove)

--- a/GenHub/GenHub/Features/Content/Services/MemoryDynamicContentCache.cs
+++ b/GenHub/GenHub/Features/Content/Services/MemoryDynamicContentCache.cs
@@ -54,11 +54,11 @@ public class MemoryDynamicContentCache(IMemoryCache memoryCache) : IDynamicConte
     /// <inheritdoc/>
     public Task InvalidateAsync(string pattern, CancellationToken cancellationToken = default)
     {
-        var regex = new Regex(pattern.Replace("*", ".*"));
-        List<string> keysToRemove;
+        var regex = new Regex(pattern.Replace("*", ".*"), RegexOptions.None, TimeSpan.FromSeconds(1));
+        List<string> keysToRemove = [];
         lock (_keys)
         {
-            keysToRemove = _keys.FindAll(k => regex.IsMatch(k));
+            keysToRemove = _keys.FindAll(regex.IsMatch);
         }
 
         foreach (var key in keysToRemove)

--- a/GenHub/GenHub/Features/Content/Services/MemoryDynamicContentCache.cs
+++ b/GenHub/GenHub/Features/Content/Services/MemoryDynamicContentCache.cs
@@ -56,10 +56,9 @@ public class MemoryDynamicContentCache(IMemoryCache memoryCache) : IDynamicConte
     {
         var regex = new Regex(pattern.Replace("*", ".*"));
         List<string> keysToRemove;
-
         lock (_keys)
         {
-            keysToRemove = [.._keys.Where(regex.IsMatch)];
+            keysToRemove = _keys.FindAll(k => regex.IsMatch(k));
         }
 
         foreach (var key in keysToRemove)

--- a/GenHub/GenHub/Features/Content/Services/Publishers/AODMapsManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/AODMapsManifestFactory.cs
@@ -79,7 +79,7 @@ public partial class AODMapsManifestFactory(
 
         // 3. Format release date
         var releaseDate = details.SubmissionDate.ToString("yyyyMMdd");
-        if (releaseDate == "00010101") releaseDate = DateTime.Now.ToString("yyyyMMdd");
+        if (releaseDate == "00010101") releaseDate = DateTime.UtcNow.ToString("yyyyMMdd");
 
         // 4. Generate manifest ID
         // User requested Version 0 for downloaded content

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -79,16 +79,14 @@ public class SuperHackersProvider(
                 SuperHackersConstants.GeneralsGameCodeRepo,
                 cancellationToken);
 
-            if (latestRelease != null)
+            if (latestRelease != null &&
+                (string.IsNullOrWhiteSpace(query.AuthorName) ||
+                 query.AuthorName.Equals(SuperHackersConstants.GeneralsGameCodeOwner, StringComparison.OrdinalIgnoreCase)) &&
+                (string.IsNullOrWhiteSpace(query.SearchTerm) ||
+                 latestRelease.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
+                 SuperHackersConstants.GeneralsGameCodeRepo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
             {
-                // Verify it matches the search query if provided
-                if ((string.IsNullOrWhiteSpace(query.AuthorName) ||
-                     query.AuthorName.Equals(SuperHackersConstants.GeneralsGameCodeOwner, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrWhiteSpace(query.SearchTerm) ||
-                     latestRelease.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
-                     SuperHackersConstants.GeneralsGameCodeRepo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
-                {
-                    // Generate manifest ID
+                // Generate manifest ID
                     var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
                         SuperHackersConstants.GeneralsGameCodeOwner,
                         SuperHackersConstants.GeneralsGameCodeRepo,

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -124,7 +124,7 @@ public class SuperHackersProvider(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to search SuperHackers content");
+            Logger.LogError(ex, "Failed to search SuperHackers content");
             return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure($"Search failed: {ex.Message}");
         }
     }

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -39,7 +39,7 @@ public class SuperHackersProvider(
             d.SourceName?.Equals(ContentSourceNames.GitHubDeliverer, StringComparison.OrdinalIgnoreCase) == true)
         ?? throw new InvalidOperationException("No GitHub deliverer found for SuperHackers");
 
-    private ProviderDefinition? _cachedProviderDefinition;
+    private readonly ProviderDefinition? _cachedProviderDefinition = providerDefinitionLoader.GetProvider(SuperHackersConstants.PublisherId);
 
     /// <inheritdoc/>
     public override string SourceName => PublisherTypeConstants.TheSuperHackers;
@@ -87,38 +87,37 @@ public class SuperHackersProvider(
                  SuperHackersConstants.GeneralsGameCodeRepo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
             {
                 // Generate manifest ID
-                    var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
-                        SuperHackersConstants.GeneralsGameCodeOwner,
-                        SuperHackersConstants.GeneralsGameCodeRepo,
-                        ContentType.GameClient,
-                        latestRelease.TagName);
+                var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
+                    SuperHackersConstants.GeneralsGameCodeOwner,
+                    SuperHackersConstants.GeneralsGameCodeRepo,
+                    ContentType.GameClient,
+                    latestRelease.TagName);
 
-                    var result = new ContentSearchResult
+                var result = new ContentSearchResult
+                {
+                    Id = manifestId,
+                    Name = latestRelease.Name ?? $"{SuperHackersConstants.PublisherName} {latestRelease.TagName}",
+                    Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
+                    Version = latestRelease.TagName ?? "latest",
+                    AuthorName = SuperHackersConstants.GeneralsGameCodeOwner,
+                    ContentType = ContentType.GameClient,
+                    TargetGame = GameType.Generals, // Simplification, could infer
+                    IsInferred = false,
+                    ProviderName = SourceName,
+                    RequiresResolution = true,
+                    ResolverId = SuperHackersConstants.ResolverId,
+                    SourceUrl = latestRelease.HtmlUrl,
+                    LastUpdated = latestRelease.PublishedAt?.DateTime ?? latestRelease.CreatedAt.DateTime,
+                    ResolverMetadata =
                     {
-                        Id = manifestId,
-                        Name = latestRelease.Name ?? $"{SuperHackersConstants.PublisherName} {latestRelease.TagName}",
-                        Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
-                        Version = latestRelease.TagName ?? "latest",
-                        AuthorName = SuperHackersConstants.GeneralsGameCodeOwner,
-                        ContentType = ContentType.GameClient,
-                        TargetGame = GameType.Generals, // Simplification, could infer
-                        IsInferred = false,
-                        ProviderName = SourceName,
-                        RequiresResolution = true,
-                        ResolverId = SuperHackersConstants.ResolverId,
-                        SourceUrl = latestRelease.HtmlUrl,
-                        LastUpdated = latestRelease.PublishedAt?.DateTime ?? latestRelease.CreatedAt.DateTime,
-                        ResolverMetadata =
-                        {
-                            [GitHubConstants.OwnerMetadataKey] = SuperHackersConstants.GeneralsGameCodeOwner,
-                            [GitHubConstants.RepoMetadataKey] = SuperHackersConstants.GeneralsGameCodeRepo,
-                            [GitHubConstants.TagMetadataKey] = latestRelease.TagName ?? "latest",
-                        },
-                    };
+                        [GitHubConstants.OwnerMetadataKey] = SuperHackersConstants.GeneralsGameCodeOwner,
+                        [GitHubConstants.RepoMetadataKey] = SuperHackersConstants.GeneralsGameCodeRepo,
+                        [GitHubConstants.TagMetadataKey] = latestRelease.TagName ?? "latest",
+                    },
+                };
 
-                    result.SetData(latestRelease);
-                    results.Add(result);
-                }
+                result.SetData(latestRelease);
+                results.Add(result);
             }
 
             return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(results);
@@ -175,15 +174,6 @@ public class SuperHackersProvider(
     /// </remarks>
     protected override ProviderDefinition? GetProviderDefinition()
     {
-        // Use cached definition if available
-        if (_cachedProviderDefinition != null)
-        {
-            return _cachedProviderDefinition;
-        }
-
-        // Try to get from the loader (it should already be loaded at startup)
-        _cachedProviderDefinition = providerDefinitionLoader.GetProvider(SuperHackersConstants.PublisherId);
-
         if (_cachedProviderDefinition == null)
         {
             Logger.LogWarning(

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -39,7 +39,7 @@ public class SuperHackersProvider(
             d.SourceName?.Equals(ContentSourceNames.GitHubDeliverer, StringComparison.OrdinalIgnoreCase) == true)
         ?? throw new InvalidOperationException("No GitHub deliverer found for SuperHackers");
 
-    private readonly ProviderDefinition? _cachedProviderDefinition = providerDefinitionLoader.GetProvider(SuperHackersConstants.PublisherId);
+    private ProviderDefinition? _cachedProviderDefinition;
 
     /// <inheritdoc/>
     public override string SourceName => PublisherTypeConstants.TheSuperHackers;
@@ -174,6 +174,12 @@ public class SuperHackersProvider(
     /// </remarks>
     protected override ProviderDefinition? GetProviderDefinition()
     {
+        if (_cachedProviderDefinition != null)
+        {
+            return _cachedProviderDefinition;
+        }
+
+        _cachedProviderDefinition = providerDefinitionLoader.GetProvider(SuperHackersConstants.PublisherId);
         if (_cachedProviderDefinition == null)
         {
             Logger.LogWarning(

--- a/GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/Reconciliation/ContentReconciliationOrchestrator.cs
@@ -55,114 +55,37 @@ public class ContentReconciliationOrchestrator(
         try
         {
             // STEP 1: Update all profiles with new manifest references
-            logger.LogDebug("[Orchestrator:{OpId}] Step 1: Updating profiles", operationId);
-            var profileResult = await reconciliationService.OrchestrateBulkUpdateAsync(
+            var (profilesUpdated, workspacesInvalidated) = await ExecuteStep1UpdateProfilesAsync(
                 request.ManifestMapping,
-                false, // GC handled in Step 4
+                operationId,
+                warnings,
+                () => criticalFailureOccurred = true,
                 cancellationToken);
 
-            int profilesUpdated = profileResult.Data?.ProfilesUpdated ?? 0;
-            int workspacesInvalidated = profileResult.Data?.WorkspacesInvalidated ?? 0;
-            if (!profileResult.Success)
-            {
-                warnings.Add($"Profile update failure: {profileResult.FirstError}");
-                criticalFailureOccurred = true;
-            }
-            else if (profileResult.Data != null && profileResult.Data.FailedProfilesCount > 0)
-            {
-                warnings.Add($"Partial failure: {profileResult.Data!.FailedProfilesCount} profiles failed to update");
-                criticalFailureOccurred = true;
-            }
-
             // STEP 2: Untrack old manifests (MUST happen before GC)
-            int manifestsRemoved = 0;
-            if (request.RemoveOldManifests)
-            {
-                logger.LogDebug("[Orchestrator:{OpId}] Step 2: Untracking old manifests", operationId);
-
-                // Untrack CAS references before removal
-                var untrackResult = await casLifecycleManager.UntrackManifestsAsync([.. request.ManifestMapping.Keys], cancellationToken);
-
-                // CasLifecycleManager returns Success=false if ANY manifest fails to untrack
-                if (!untrackResult.Success)
-                {
-                    warnings.Add($"Manifest untracking failed: {untrackResult.FirstError}");
-                    criticalFailureOccurred = true;
-                }
-
-                // Note: Success=true guarantees all manifests were untracked (UntrackManifestsAsync contract)
-
-                // Publish removing events for each manifest
-                foreach (var oldId in request.ManifestMapping.Keys)
-                {
-                    WeakReferenceMessenger.Default.Send(new ContentRemovingEvent(oldId, null, "Replacement"));
-                }
-            }
+            await ExecuteStep2UntrackManifestsAsync(
+                request,
+                operationId,
+                warnings,
+                () => criticalFailureOccurred = true,
+                cancellationToken);
 
             // STEP 3: Remove old manifest files from pool
-            logger.LogDebug("[Orchestrator:{OpId}] Step 3: Removing old manifests from pool", operationId);
-            if (request.RemoveOldManifests)
-            {
-                if (criticalFailureOccurred)
-                {
-                    logger.LogWarning("[Orchestrator:{OpId}] Skipping manifest removal step due to previous errors", operationId);
-                    warnings.Add("Manifest removal step skipped due to previous errors in profile update or untracking.");
-                }
-                else
-                {
-                    foreach (var oldId in request.ManifestMapping.Keys)
-                    {
-                        try
-                        {
-                            // Use helper for optimized removal
-                            // Only skip untracking if we are sure everything went well so far
-                            var removeResult = await RemoveManifestWithOptimizedUntrackingAsync(oldId, skipUntrack: true, cancellationToken);
-                            if (removeResult.Success)
-                            {
-                                manifestsRemoved++;
-                            }
-                            else
-                            {
-                                warnings.Add(removeResult.FirstError ?? "Manifest removal failed with unknown error");
-                                criticalFailureOccurred = true;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            warnings.Add($"Error removing manifest {oldId}: {ex.Message}");
-                            criticalFailureOccurred = true;
-                        }
-                    }
-                }
-            }
+            int manifestsRemoved = await ExecuteStep3RemoveManifestsAsync(
+                request,
+                operationId,
+                criticalFailureOccurred,
+                warnings,
+                () => criticalFailureOccurred = true,
+                cancellationToken);
 
             // STEP 4: Run GC (now safe - .refs files are gone)
-            int casObjectsCollected = 0;
-            long bytesFreed = 0;
-            if (request.RunGarbageCollection)
-            {
-                if (criticalFailureOccurred)
-                {
-                    logger.LogWarning("[Orchestrator:{OpId}] Skipping GC due to previous manifest removal failures", operationId);
-                    warnings.Add("Garbage collection skipped due to failures in manifest untracking or removal");
-                }
-                else
-                {
-                    logger.LogDebug("[Orchestrator:{OpId}] Step 4: Running garbage collection", operationId);
-                    var gcResult = await casLifecycleManager.RunGarbageCollectionAsync(force: false, cancellationToken: cancellationToken);
-                    if (gcResult.Success && gcResult.Data != null)
-                    {
-                        casObjectsCollected = gcResult.Data.ObjectsDeleted;
-                        bytesFreed = gcResult.Data.BytesFreed;
-                    }
-                    else
-                    {
-                        var warning = gcResult.FirstError ?? "Garbage collection did not run";
-                        warnings.Add(warning);
-                        logger.LogWarning("[Orchestrator:{OpId}] {Warning}", operationId, warning);
-                    }
-                }
-            }
+            var (casObjectsCollected, bytesFreed) = await ExecuteStep4GarbageCollectionAsync(
+                request,
+                operationId,
+                criticalFailureOccurred,
+                warnings,
+                cancellationToken);
 
             stopwatch.Stop();
 
@@ -635,5 +558,148 @@ public class ContentReconciliationOrchestrator(
         {
             return OperationResult<bool>.CreateFailure($"Error removing manifest {manifestId}: {ex.Message}");
         }
+    }
+
+    private async Task<(int ProfilesUpdated, int WorkspacesInvalidated)> ExecuteStep1UpdateProfilesAsync(
+        IReadOnlyDictionary<string, string> manifestMapping,
+        string operationId,
+        List<string> warnings,
+        Action onCriticalFailure,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("[Orchestrator:{OpId}] Step 1: Updating profiles", operationId);
+        var profileResult = await reconciliationService.OrchestrateBulkUpdateAsync(
+            manifestMapping,
+            false, // GC handled in Step 4
+            cancellationToken);
+
+        int profilesUpdated = profileResult.Data?.ProfilesUpdated ?? 0;
+        int workspacesInvalidated = profileResult.Data?.WorkspacesInvalidated ?? 0;
+
+        if (!profileResult.Success)
+        {
+            warnings.Add($"Profile update failure: {profileResult.FirstError}");
+            onCriticalFailure();
+        }
+        else if (profileResult.Data?.FailedProfilesCount > 0)
+        {
+            warnings.Add($"Partial failure: {profileResult.Data.FailedProfilesCount} profiles failed to update");
+            onCriticalFailure();
+        }
+
+        return (profilesUpdated, workspacesInvalidated);
+    }
+
+    private async Task ExecuteStep2UntrackManifestsAsync(
+        ContentReplacementRequest request,
+        string operationId,
+        List<string> warnings,
+        Action onCriticalFailure,
+        CancellationToken cancellationToken)
+    {
+        if (!request.RemoveOldManifests)
+        {
+            return;
+        }
+
+        logger.LogDebug("[Orchestrator:{OpId}] Step 2: Untracking old manifests", operationId);
+        var untrackResult = await casLifecycleManager.UntrackManifestsAsync([.. request.ManifestMapping.Keys], cancellationToken);
+
+        if (!untrackResult.Success)
+        {
+            warnings.Add($"Manifest untracking failed: {untrackResult.FirstError}");
+            onCriticalFailure();
+        }
+
+        foreach (var oldId in request.ManifestMapping.Keys)
+        {
+            WeakReferenceMessenger.Default.Send(new ContentRemovingEvent(oldId, null, "Replacement"));
+        }
+    }
+
+    private async Task<int> ExecuteStep3RemoveManifestsAsync(
+        ContentReplacementRequest request,
+        string operationId,
+        bool criticalFailureOccurred,
+        List<string> warnings,
+        Action onCriticalFailure,
+        CancellationToken cancellationToken)
+    {
+        int manifestsRemoved = 0;
+        if (!request.RemoveOldManifests)
+        {
+            return manifestsRemoved;
+        }
+
+        logger.LogDebug("[Orchestrator:{OpId}] Step 3: Removing old manifests from pool", operationId);
+        if (criticalFailureOccurred)
+        {
+            logger.LogWarning("[Orchestrator:{OpId}] Skipping manifest removal step due to previous errors", operationId);
+            warnings.Add("Manifest removal step skipped due to previous errors in profile update or untracking.");
+            return manifestsRemoved;
+        }
+
+        foreach (var oldId in request.ManifestMapping.Keys)
+        {
+            try
+            {
+                var removeResult = await RemoveManifestWithOptimizedUntrackingAsync(oldId, skipUntrack: true, cancellationToken);
+                if (removeResult.Success)
+                {
+                    manifestsRemoved++;
+                }
+                else
+                {
+                    warnings.Add(removeResult.FirstError ?? "Manifest removal failed with unknown error");
+                    onCriticalFailure();
+                }
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Error removing manifest {oldId}: {ex.Message}");
+                onCriticalFailure();
+            }
+        }
+
+        return manifestsRemoved;
+    }
+
+    private async Task<(int CasObjectsCollected, long BytesFreed)> ExecuteStep4GarbageCollectionAsync(
+        ContentReplacementRequest request,
+        string operationId,
+        bool criticalFailureOccurred,
+        List<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        int casObjectsCollected = 0;
+        long bytesFreed = 0;
+
+        if (!request.RunGarbageCollection)
+        {
+            return (casObjectsCollected, bytesFreed);
+        }
+
+        if (criticalFailureOccurred)
+        {
+            logger.LogWarning("[Orchestrator:{OpId}] Skipping GC due to previous manifest removal failures", operationId);
+            warnings.Add("Garbage collection skipped due to failures in manifest untracking or removal");
+            return (casObjectsCollected, bytesFreed);
+        }
+
+        logger.LogDebug("[Orchestrator:{OpId}] Step 4: Running garbage collection", operationId);
+        var gcResult = await casLifecycleManager.RunGarbageCollectionAsync(force: false, cancellationToken: cancellationToken);
+        if (gcResult.Success && gcResult.Data != null)
+        {
+            casObjectsCollected = gcResult.Data.ObjectsDeleted;
+            bytesFreed = gcResult.Data.BytesFreed;
+        }
+        else
+        {
+            var warning = gcResult.FirstError ?? "Garbage collection did not run";
+            warnings.Add(warning);
+            logger.LogWarning("[Orchestrator:{OpId}] {Warning}", operationId, warning);
+        }
+
+        return (casObjectsCollected, bytesFreed);
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
@@ -82,53 +82,14 @@ public class SuperHackersProfileReconciler(
             }
 
             // Determine strategy
-            var subscription = settings.GetSubscription(PublisherTypeConstants.TheSuperHackers);
-            UpdateStrategy strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
-            bool autoUpdate = subscription?.AutoUpdateEnabled == true;
-            bool shouldDeleteOldVersions = subscription?.DeleteOldVersions ?? true;
-
-            if (!autoUpdate)
+            var promptResult = await PromptUserForUpdateStrategyAsync(settings, updateResult);
+            if (!promptResult.ShouldProceed)
             {
-                var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
-                    "SuperHackers Update Available",
-                    $"A new version of **The Super Hackers** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
-
-                if (dialogResult == null) return OperationResult<bool>.CreateSuccess(false);
-
-                if (dialogResult.Action == "Skip")
-                {
-                    logger.LogInformation("[SH Reconciler] User skipped version {Version}.", updateResult.LatestVersion);
-
-                    if (dialogResult.IsDoNotAskAgain)
-                    {
-                         await userSettingsService.TryUpdateAndSaveAsync(s =>
-                         {
-                             s.SkipVersion(PublisherTypeConstants.TheSuperHackers, updateResult.LatestVersion ?? string.Empty);
-                             return true;
-                         });
-                    }
-
-                    return OperationResult<bool>.CreateSuccess(false);
-                }
-
-                strategy = dialogResult.Strategy;
-
-                if (dialogResult.IsDoNotAskAgain)
-                {
-                    logger.LogInformation("[SH Reconciler] Saving user preference for SuperHackers updates");
-                    await userSettingsService.TryUpdateAndSaveAsync(s =>
-                    {
-                        s.SetAutoUpdatePreference(PublisherTypeConstants.TheSuperHackers, true);
-                        var sub = s.GetSubscription(PublisherTypeConstants.TheSuperHackers);
-                        if (sub != null)
-                        {
-                            sub.PreferredUpdateStrategy = strategy;
-                        }
-
-                        return true;
-                    });
-                }
+                return OperationResult<bool>.CreateSuccess(false);
             }
+
+            var strategy = promptResult.Strategy;
+            var shouldDeleteOldVersions = promptResult.ShouldDeleteOldVersions;
 
             // Notify user that update is being installed
             notificationService.ShowInfo(
@@ -159,52 +120,24 @@ public class SuperHackersProfileReconciler(
             var newManifests = acquireResult.Data!;
 
             // Update profiles based on strategy
-            int profilesUpdated = 0;
-            bool anyFailure = false;
+            var updateOutcome = await ApplyUpdateStrategyAsync(
+                strategy,
+                oldManifests,
+                newManifests,
+                updateResult.LatestVersion ?? "Unknown",
+                shouldDeleteOldVersions,
+                cancellationToken);
 
-            if (strategy == UpdateStrategy.CreateNewProfile)
+            if (!updateOutcome.Success)
             {
-                // keep old versions when creating new profiles
-                shouldDeleteOldVersions = false;
-
-                var createResult = await CreateNewProfilesForUpdateAsync(oldManifests, newManifests, updateResult.LatestVersion ?? "Unknown", cancellationToken);
-                if (createResult.Success)
-                {
-                    profilesUpdated = createResult.Data;
-                }
-                else
-                {
-                    anyFailure = true;
-                    notificationService.ShowWarning("SuperHackers Update Partial", $"Failed to create some new profiles: {createResult.FirstError}");
-                }
+                return OperationResult<bool>.CreateFailure(updateOutcome.FirstError ?? "Update strategy execution failed");
             }
-            else
-            {
-                var manifestMapping = BuildManifestMapping(oldManifests, newManifests);
-                var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(
-                    manifestMapping,
-                    shouldDeleteOldVersions,
-                    cancellationToken);
 
-                if (bulkUpdateResult.Success)
-                {
-                    profilesUpdated = bulkUpdateResult.Data.ProfilesUpdated;
-                    if (bulkUpdateResult.Data.FailedProfilesCount > 0)
-                    {
-                        anyFailure = true;
-                        notificationService.ShowWarning("SuperHackers Update Partial", $"{bulkUpdateResult.Data.FailedProfilesCount} profiles could not be updated.", NotificationDurations.VeryLong);
-                    }
-                }
-                else
-                {
-                    anyFailure = true;
-                    notificationService.ShowWarning("SuperHackers Update Partial", $"Some profiles could not be updated: {bulkUpdateResult.FirstError}", NotificationDurations.VeryLong);
-                    return OperationResult<bool>.CreateFailure($"Bulk update failed: {bulkUpdateResult.FirstError}");
-                }
-            }
+            var profilesUpdated = updateOutcome.ProfilesUpdated;
+            var anyFailure = updateOutcome.AnyFailure;
+            shouldDeleteOldVersions = updateOutcome.ShouldDeleteOldVersions;
 
             // Run garbage collection only if old versions were deleted AND no failures occurred
-            // If some profiles failed, GC could delete files they still rely on.
             if (shouldDeleteOldVersions && !anyFailure)
             {
                 await reconciliationService.ScheduleGarbageCollectionAsync(false, cancellationToken);
@@ -471,5 +404,118 @@ public class SuperHackersProfileReconciler(
         }
 
         return OperationResult<int>.CreateSuccess(createdCount);
+    }
+
+    private async Task<(bool ShouldProceed, UpdateStrategy Strategy, bool ShouldDeleteOldVersions)> PromptUserForUpdateStrategyAsync(
+        UserSettings settings,
+        UpdateCheckResult updateResult)
+    {
+        var subscription = settings.GetSubscription(PublisherTypeConstants.TheSuperHackers);
+        var strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
+        var autoUpdate = subscription?.AutoUpdateEnabled == true;
+        var shouldDeleteOldVersions = subscription?.DeleteOldVersions ?? true;
+
+        if (autoUpdate)
+        {
+            return (true, strategy, shouldDeleteOldVersions);
+        }
+
+        var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
+            "SuperHackers Update Available",
+            $"A new version of **The Super Hackers** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
+
+        if (dialogResult == null)
+        {
+            return (false, strategy, shouldDeleteOldVersions);
+        }
+
+        if (dialogResult.Action == "Skip")
+        {
+            logger.LogInformation("[SH Reconciler] User skipped version {Version}.", updateResult.LatestVersion);
+
+            if (dialogResult.IsDoNotAskAgain)
+            {
+                await userSettingsService.TryUpdateAndSaveAsync(s =>
+                {
+                    s.SkipVersion(PublisherTypeConstants.TheSuperHackers, updateResult.LatestVersion ?? string.Empty);
+                    return true;
+                });
+            }
+
+            return (false, strategy, shouldDeleteOldVersions);
+        }
+
+        strategy = dialogResult.Strategy;
+
+        if (dialogResult.IsDoNotAskAgain)
+        {
+            logger.LogInformation("[SH Reconciler] Saving user preference for SuperHackers updates");
+            await userSettingsService.TryUpdateAndSaveAsync(s =>
+            {
+                s.SetAutoUpdatePreference(PublisherTypeConstants.TheSuperHackers, true);
+                var sub = s.GetSubscription(PublisherTypeConstants.TheSuperHackers);
+                if (sub != null)
+                {
+                    sub.PreferredUpdateStrategy = strategy;
+                }
+
+                return true;
+            });
+        }
+
+        return (true, strategy, shouldDeleteOldVersions);
+    }
+
+    private async Task<(bool Success, string? FirstError, int ProfilesUpdated, bool AnyFailure, bool ShouldDeleteOldVersions)> ApplyUpdateStrategyAsync(
+        UpdateStrategy strategy,
+        IReadOnlyList<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> newManifests,
+        string latestVersion,
+        bool shouldDeleteOldVersions,
+        CancellationToken cancellationToken)
+    {
+        int profilesUpdated = 0;
+        bool anyFailure = false;
+
+        if (strategy == UpdateStrategy.CreateNewProfile)
+        {
+            // keep old versions when creating new profiles
+            shouldDeleteOldVersions = false;
+
+            var createResult = await CreateNewProfilesForUpdateAsync(oldManifests, newManifests, latestVersion, cancellationToken);
+            if (createResult.Success)
+            {
+                profilesUpdated = createResult.Data;
+            }
+            else
+            {
+                anyFailure = true;
+                notificationService.ShowWarning("SuperHackers Update Partial", $"Failed to create some new profiles: {createResult.FirstError}");
+            }
+
+            return (true, null, profilesUpdated, anyFailure, shouldDeleteOldVersions);
+        }
+
+        var manifestMapping = BuildManifestMapping(oldManifests, newManifests);
+        var bulkUpdateResult = await reconciliationService.OrchestrateBulkUpdateAsync(
+            manifestMapping,
+            shouldDeleteOldVersions,
+            cancellationToken);
+
+        if (bulkUpdateResult.Success)
+        {
+            profilesUpdated = bulkUpdateResult.Data.ProfilesUpdated;
+            if (bulkUpdateResult.Data.FailedProfilesCount > 0)
+            {
+                anyFailure = true;
+                notificationService.ShowWarning("SuperHackers Update Partial", $"{bulkUpdateResult.Data.FailedProfilesCount} profiles could not be updated.", NotificationDurations.VeryLong);
+            }
+
+            return (true, null, profilesUpdated, anyFailure, shouldDeleteOldVersions);
+        }
+
+        anyFailure = true;
+        notificationService.ShowWarning("SuperHackers Update Partial", $"Some profiles could not be updated: {bulkUpdateResult.FirstError}", NotificationDurations.VeryLong);
+        return (false, $"Bulk update failed: {bulkUpdateResult.FirstError}", profilesUpdated, anyFailure, shouldDeleteOldVersions);
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
@@ -10,6 +10,7 @@ using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Dialogs;
 using GenHub.Core.Models.Enums;
@@ -176,8 +177,8 @@ public class SuperHackersProfileReconciler(
     }
 
     private static Dictionary<string, string> BuildManifestMapping(
-        List<ContentManifest> oldManifests,
-        List<ContentManifest> newManifests)
+        IReadOnlyList<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> newManifests)
     {
         var mapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -240,7 +241,7 @@ public class SuperHackersProfileReconciler(
     }
 
     private async Task<OperationResult<List<ContentManifest>>> AcquireLatestVersionAsync(
-        List<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> oldManifests,
         CancellationToken cancellationToken)
     {
         try
@@ -309,8 +310,8 @@ public class SuperHackersProfileReconciler(
     /// Creates new profiles for the update instead of replacing existing ones.
     /// </summary>
     private async Task<OperationResult<int>> CreateNewProfilesForUpdateAsync(
-        List<ContentManifest> oldManifests,
-        List<ContentManifest> newManifests,
+        IReadOnlyList<ContentManifest> oldManifests,
+        IReadOnlyList<ContentManifest> newManifests,
         string newVersion,
         CancellationToken cancellationToken)
     {
@@ -408,7 +409,7 @@ public class SuperHackersProfileReconciler(
 
     private async Task<(bool ShouldProceed, UpdateStrategy Strategy, bool ShouldDeleteOldVersions)> PromptUserForUpdateStrategyAsync(
         UserSettings settings,
-        UpdateCheckResult updateResult)
+        ContentUpdateCheckResult updateResult)
     {
         var subscription = settings.GetSubscription(PublisherTypeConstants.TheSuperHackers);
         var strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;

--- a/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
@@ -548,25 +548,6 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
     }
 
     /// <summary>
-    /// Extracts numeric date from version strings like "weekly-2025-11-21" or "20251121".
-    /// </summary>
-    private static string ExtractDateFromVersion(string version)
-    {
-        if (string.IsNullOrEmpty(version))
-        {
-            return string.Empty;
-        }
-
-        var match = System.Text.RegularExpressions.Regex.Match(version, @"\d{4}-?\d{2}-?\d{2}|\d{8}");
-        if (match.Success)
-        {
-            return match.Value.Replace("-", string.Empty);
-        }
-
-        return string.Empty;
-    }
-
-    /// <summary>
     /// Finds all installed content manifest variants that match the given content item.
     /// Used to populate <see cref="ContentItemViewModel.AvailableVariants"/>.
     /// </summary>

--- a/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
@@ -354,7 +354,7 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
             item.RequiredDependencyNames.Count);
     }
 
-    private static void UpdateItemVariants(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
+    private void UpdateItemVariants(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
     {
         if (variants.Count > 0)
         {
@@ -412,7 +412,7 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
         }
     }
 
-    private static void UpdateItemResolutionVariants(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
+    private void UpdateItemResolutionVariants(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
     {
         if (variants.Count == 1)
         {
@@ -444,7 +444,7 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
         }
     }
 
-    private static void UpdateItemDependencies(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
+    private void UpdateItemDependencies(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
     {
         List<string> requiredDependencies;
         if (variants.Count > 0)

--- a/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
@@ -94,12 +94,6 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
     [ObservableProperty]
     private ObservableCollection<ContentTypeGroup> _contentTypes = [];
 
-    private void ContentTypes_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-    {
-        OnPropertyChanged(nameof(HasContent));
-        OnPropertyChanged(nameof(ContentSummary));
-    }
-
     [ObservableProperty]
     private bool _showContentSummary = true;
 
@@ -331,6 +325,165 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
         }
     }
 
+    /// <summary>
+    /// Extracts numeric date from version strings like "weekly-2025-11-21" or "20251121".
+    /// </summary>
+    private static string ExtractDateFromVersion(string version)
+    {
+        if (string.IsNullOrEmpty(version))
+        {
+            return string.Empty;
+        }
+
+        var numericVersion = GameVersionHelper.ExtractVersionFromVersionString(version);
+        return numericVersion > 0 ? numericVersion.ToString() : string.Empty;
+    }
+
+    /// <summary>
+    /// Formats a user-friendly progress status message.
+    /// </summary>
+    private static string FormatProgressStatus(GenHub.Core.Models.Content.ContentAcquisitionProgress progress)
+    {
+        var phaseName = progress.Phase switch
+        {
+            Core.Models.Content.ContentAcquisitionPhase.Downloading => "Downloading",
+            Core.Models.Content.ContentAcquisitionPhase.Extracting => "Extracting",
+            Core.Models.Content.ContentAcquisitionPhase.Copying => "Copying",
+            Core.Models.Content.ContentAcquisitionPhase.ValidatingManifest => "Validating manifest",
+            Core.Models.Content.ContentAcquisitionPhase.ValidatingFiles => "Validating files",
+            Core.Models.Content.ContentAcquisitionPhase.Delivering => "Installing",
+            Core.Models.Content.ContentAcquisitionPhase.Completed => "Complete",
+            _ => "Processing",
+        };
+
+        if (!string.IsNullOrEmpty(progress.CurrentOperation))
+        {
+            return $"{phaseName}: {progress.CurrentOperation}";
+        }
+
+        // Format with percentage and phase
+        var percentText = progress.ProgressPercentage > 0 ? $"{progress.ProgressPercentage:F0}%" : string.Empty;
+
+        // Add file/bytes info if available
+        if (progress.TotalBytes > 0 && progress.Phase == Core.Models.Content.ContentAcquisitionPhase.Downloading)
+        {
+            var downloaded = ByteFormatHelper.FormatBytes(progress.BytesProcessed);
+            var total = ByteFormatHelper.FormatBytes(progress.TotalBytes);
+            return $"{phaseName}: {downloaded} / {total} ({percentText})";
+        }
+
+        if (progress.TotalFiles > 0)
+        {
+            var phasePercent = (int)((double)progress.FilesProcessed / progress.TotalFiles * 100);
+            return $"{phaseName}: {progress.FilesProcessed}/{progress.TotalFiles} files ({phasePercent}%)";
+        }
+
+        return !string.IsNullOrEmpty(percentText) ? $"{phaseName}... {percentText}" : $"{phaseName}...";
+    }
+
+    /// <summary>
+    /// Finds all installed content manifest variants that match the given content item.
+    /// Used to populate <see cref="ContentItemViewModel.AvailableVariants"/>.
+    /// </summary>
+    private static List<Core.Models.Manifest.ContentManifest> FindContentVariants(
+        ContentItemViewModel item,
+        List<Core.Models.Manifest.ContentManifest> allManifests,
+        string publisherId)
+    {
+        var variants = new List<Core.Models.Manifest.ContentManifest>();
+        var itemId = item.Model.Id ?? string.Empty;
+        var itemVersion = item.Version ?? string.Empty;
+        var itemDatePart = ExtractDateFromVersion(itemVersion);
+
+        foreach (var manifest in allManifests)
+        {
+            if (IsManifestVariantMatch(item, manifest, publisherId, itemId, itemVersion, itemDatePart))
+            {
+                variants.Add(manifest);
+            }
+        }
+
+        return [.. variants.OrderBy(v => v.Name)];
+    }
+
+    private static bool IsManifestVariantMatch(
+        ContentItemViewModel item,
+        Core.Models.Manifest.ContentManifest manifest,
+        string publisherId,
+        string itemId,
+        string itemVersion,
+        string itemDatePart)
+    {
+        if (item.Model.ContentType != manifest.ContentType)
+        {
+            return false;
+        }
+
+        var manifestIdParts = manifest.Id.Value.Split('.');
+        if (manifestIdParts.Length >= 2 && manifestIdParts[1] == "0" && manifest.ContentType == ContentType.GameClient)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(itemId) && manifest.Id.Value.Equals(itemId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var hasPublisherInId = manifestIdParts.Length > 2 &&
+            manifestIdParts[2].Equals(publisherId, StringComparison.OrdinalIgnoreCase);
+        var publisherMatch = hasPublisherInId ||
+            (manifest.Publisher?.PublisherType?.Equals(publisherId, StringComparison.OrdinalIgnoreCase) == true);
+
+        if (!publisherMatch)
+        {
+            return false;
+        }
+
+        var nameMatch = IsNameMatch(item.Name, manifest.Name);
+        var manifestVersion = manifest.Version ?? string.Empty;
+        var manifestDatePart = ExtractDateFromVersion(manifestVersion);
+        var versionMatch = IsVersionMatch(itemVersion, manifestVersion, itemDatePart, manifestDatePart);
+
+        var isGameClient = item.Model.ContentType == ContentType.GameClient;
+        return nameMatch || (versionMatch && isGameClient);
+    }
+
+    private static bool IsNameMatch(string? itemName, string? manifestName)
+    {
+        var itemStr = itemName?.ToLowerInvariant() ?? string.Empty;
+        var manifestStr = manifestName?.ToLowerInvariant() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(itemStr) || string.IsNullOrEmpty(manifestStr))
+        {
+            return false;
+        }
+
+        var normalizedItemName = itemStr.Replace(" ", string.Empty).Replace("-", string.Empty);
+        var normalizedManifestName = manifestStr.Replace(" ", string.Empty).Replace("-", string.Empty);
+
+        return normalizedManifestName.Contains(normalizedItemName, StringComparison.OrdinalIgnoreCase) ||
+               normalizedItemName.Contains(normalizedManifestName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsVersionMatch(string itemVersion, string manifestVersion, string itemDatePart, string manifestDatePart)
+    {
+        if (manifestVersion.Equals(itemVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrEmpty(itemDatePart) &&
+               !string.IsNullOrEmpty(manifestDatePart) &&
+               itemDatePart.Equals(manifestDatePart, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void ContentTypes_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasContent));
+        OnPropertyChanged(nameof(ContentSummary));
+    }
+
     private void UpdateItemInstallationStatus(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> allManifests)
     {
         var variants = FindContentVariants(item, allManifests, PublisherId);
@@ -483,159 +636,6 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
                 item.RequiredDependencyNames.Add(dep);
             }
         }
-    }
-
-    /// <summary>
-    /// Extracts numeric date from version strings like "weekly-2025-11-21" or "20251121".
-    /// </summary>
-    private static string ExtractDateFromVersion(string version)
-    {
-        if (string.IsNullOrEmpty(version))
-        {
-            return string.Empty;
-        }
-
-        var numericVersion = GameVersionHelper.ExtractVersionFromVersionString(version);
-        return numericVersion > 0 ? numericVersion.ToString() : string.Empty;
-    }
-
-    /// <summary>
-    /// Formats a user-friendly progress status message.
-    /// </summary>
-    private static string FormatProgressStatus(GenHub.Core.Models.Content.ContentAcquisitionProgress progress)
-    {
-        var phaseName = progress.Phase switch
-        {
-            Core.Models.Content.ContentAcquisitionPhase.Downloading => "Downloading",
-            Core.Models.Content.ContentAcquisitionPhase.Extracting => "Extracting",
-            Core.Models.Content.ContentAcquisitionPhase.Copying => "Copying",
-            Core.Models.Content.ContentAcquisitionPhase.ValidatingManifest => "Validating manifest",
-            Core.Models.Content.ContentAcquisitionPhase.ValidatingFiles => "Validating files",
-            Core.Models.Content.ContentAcquisitionPhase.Delivering => "Installing",
-            Core.Models.Content.ContentAcquisitionPhase.Completed => "Complete",
-            _ => "Processing",
-        };
-
-        if (!string.IsNullOrEmpty(progress.CurrentOperation))
-        {
-            return $"{phaseName}: {progress.CurrentOperation}";
-        }
-
-        // Format with percentage and phase
-        var percentText = progress.ProgressPercentage > 0 ? $"{progress.ProgressPercentage:F0}%" : string.Empty;
-
-        // Add file/bytes info if available
-        if (progress.TotalBytes > 0 && progress.Phase == Core.Models.Content.ContentAcquisitionPhase.Downloading)
-        {
-            var downloaded = ByteFormatHelper.FormatBytes(progress.BytesProcessed);
-            var total = ByteFormatHelper.FormatBytes(progress.TotalBytes);
-            return $"{phaseName}: {downloaded} / {total} ({percentText})";
-        }
-
-        if (progress.TotalFiles > 0)
-        {
-            var phasePercent = (int)((double)progress.FilesProcessed / progress.TotalFiles * 100);
-            return $"{phaseName}: {progress.FilesProcessed}/{progress.TotalFiles} files ({phasePercent}%)";
-        }
-
-        return !string.IsNullOrEmpty(percentText) ? $"{phaseName}... {percentText}" : $"{phaseName}...";
-    }
-
-    /// <summary>
-    /// Finds all installed content manifest variants that match the given content item.
-    /// Used to populate <see cref="ContentItemViewModel.AvailableVariants"/>.
-    /// </summary>
-    private static List<Core.Models.Manifest.ContentManifest> FindContentVariants(
-        ContentItemViewModel item,
-        List<Core.Models.Manifest.ContentManifest> allManifests,
-        string publisherId)
-    {
-        var variants = new List<Core.Models.Manifest.ContentManifest>();
-        var itemId = item.Model.Id ?? string.Empty;
-        var itemVersion = item.Version ?? string.Empty;
-        var itemDatePart = ExtractDateFromVersion(itemVersion);
-
-        foreach (var manifest in allManifests)
-        {
-            if (IsManifestVariantMatch(item, manifest, publisherId, itemId, itemVersion, itemDatePart))
-            {
-                variants.Add(manifest);
-            }
-        }
-
-        return [.. variants.OrderBy(v => v.Name)];
-    }
-
-    private static bool IsManifestVariantMatch(
-        ContentItemViewModel item,
-        Core.Models.Manifest.ContentManifest manifest,
-        string publisherId,
-        string itemId,
-        string itemVersion,
-        string itemDatePart)
-    {
-        if (item.Model.ContentType != manifest.ContentType)
-        {
-            return false;
-        }
-
-        var manifestIdParts = manifest.Id.Value.Split('.');
-        if (manifestIdParts.Length >= 2 && manifestIdParts[1] == "0" && manifest.ContentType == ContentType.GameClient)
-        {
-            return false;
-        }
-
-        if (!string.IsNullOrEmpty(itemId) && manifest.Id.Value.Equals(itemId, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        var hasPublisherInId = manifestIdParts.Length > 2 &&
-            manifestIdParts[2].Equals(publisherId, StringComparison.OrdinalIgnoreCase);
-        var publisherMatch = hasPublisherInId ||
-            (manifest.Publisher?.PublisherType?.Equals(publisherId, StringComparison.OrdinalIgnoreCase) == true);
-
-        if (!publisherMatch)
-        {
-            return false;
-        }
-
-        var nameMatch = IsNameMatch(item.Name, manifest.Name);
-        var manifestVersion = manifest.Version ?? string.Empty;
-        var manifestDatePart = ExtractDateFromVersion(manifestVersion);
-        var versionMatch = IsVersionMatch(itemVersion, manifestVersion, itemDatePart, manifestDatePart);
-
-        var isGameClient = item.Model.ContentType == ContentType.GameClient;
-        return nameMatch || (versionMatch && isGameClient);
-    }
-
-    private static bool IsNameMatch(string? itemName, string? manifestName)
-    {
-        var itemStr = itemName?.ToLowerInvariant() ?? string.Empty;
-        var manifestStr = manifestName?.ToLowerInvariant() ?? string.Empty;
-
-        if (string.IsNullOrEmpty(itemStr) || string.IsNullOrEmpty(manifestStr))
-        {
-            return false;
-        }
-
-        var normalizedItemName = itemStr.Replace(" ", string.Empty).Replace("-", string.Empty);
-        var normalizedManifestName = manifestStr.Replace(" ", string.Empty).Replace("-", string.Empty);
-
-        return normalizedManifestName.Contains(normalizedItemName, StringComparison.OrdinalIgnoreCase) ||
-               normalizedItemName.Contains(normalizedManifestName, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsVersionMatch(string itemVersion, string manifestVersion, string itemDatePart, string manifestDatePart)
-    {
-        if (manifestVersion.Equals(itemVersion, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return !string.IsNullOrEmpty(itemDatePart) &&
-               !string.IsNullOrEmpty(manifestDatePart) &&
-               itemDatePart.Equals(manifestDatePart, StringComparison.OrdinalIgnoreCase);
     }
 
     [RelayCommand]

--- a/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
@@ -543,13 +543,30 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
 
         if (progress.TotalFiles > 0)
         {
-            var phasePercent = progress.TotalFiles > 0
-                ? (int)((double)progress.FilesProcessed / progress.TotalFiles * 100)
-                : 0;
+            var phasePercent = (int)((double)progress.FilesProcessed / progress.TotalFiles * 100);
             return $"{phaseName}: {progress.FilesProcessed}/{progress.TotalFiles} files ({phasePercent}%)";
         }
 
         return !string.IsNullOrEmpty(percentText) ? $"{phaseName}... {percentText}" : $"{phaseName}...";
+    }
+
+    /// <summary>
+    /// Extracts numeric date from version strings like "weekly-2025-11-21" or "20251121".
+    /// </summary>
+    private static string ExtractDateFromVersion(string version)
+    {
+        if (string.IsNullOrEmpty(version))
+        {
+            return string.Empty;
+        }
+
+        var match = System.Text.RegularExpressions.Regex.Match(version, @"\d{4}-?\d{2}-?\d{2}|\d{8}");
+        if (match.Success)
+        {
+            return match.Value.Replace("-", string.Empty);
+        }
+
+        return string.Empty;
     }
 
     /// <summary>
@@ -568,100 +585,85 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
 
         foreach (var manifest in allManifests)
         {
-            // SKIP MAP PACKS if the item is a GameClient
-            // We want to associate MapPacks with GameClients only via dependencies,
-            // not as "variants" of the GameClient itself in this context,
-            // UNLESS the item itself IS a MapPack.
-            if (item.Model.ContentType != manifest.ContentType)
-            {
-                continue;
-            }
-
-            // SKIP detected local game clients (userVersion 0)
-            // Detected clients have ID like: 1.0.generalsonline.gameclient.zerohour30hz
-            // Downloaded content has ID like: 1.1215251.generalsonline.gameclient.30hz
-            // We only want downloaded content as variants for the add-to-profile dropdown
-            var manifestIdParts = manifest.Id.Value.Split('.');
-            if (manifestIdParts.Length >= 2 && manifestIdParts[1] == "0" && manifest.ContentType == ContentType.GameClient)
-            {
-                continue;
-            }
-
-            // Direct ID match
-            if (!string.IsNullOrEmpty(itemId) &&
-                manifest.Id.Value.Equals(itemId, StringComparison.OrdinalIgnoreCase))
-            {
-                variants.Add(manifest);
-                continue;
-            }
-
-            // Publisher Check
-            var hasPublisherInId = manifestIdParts.Length > 2 &&
-                manifestIdParts[2].Equals(publisherId, StringComparison.OrdinalIgnoreCase);
-            var publisherMatch = hasPublisherInId ||
-                (manifest.Publisher?.PublisherType?.Equals(publisherId, StringComparison.OrdinalIgnoreCase) == true);
-
-            if (!publisherMatch)
-            {
-                continue;
-            }
-
-            // Name Match check
-            // For variants, the name often contains the variant suffix (e.g. "Generals", "Zero Hour", "30Hz").
-            // But strict name matching might filter out variants if their names differ too much.
-            // For SuperHackers: Item="weekly-2025-12-12", Manifest="TheSuperHackers-GeneralsGameCode - Generals"
-            //   -> Names don't match, but they are the same release (same publisher + version).
-            // So we check names, but if names don't match, we still proceed to version check.
-            // If publisher matches AND version matches, that's sufficient for variant detection.
-            var itemName = item.Name?.ToLowerInvariant() ?? string.Empty;
-            var manifestName = manifest.Name?.ToLowerInvariant() ?? string.Empty;
-
-            var nameMatch = false;
-            if (!string.IsNullOrEmpty(itemName) && !string.IsNullOrEmpty(manifestName))
-            {
-                var normalizedItemName = itemName.Replace(" ", string.Empty).Replace("-", string.Empty);
-                var normalizedManifestName = manifestName.Replace(" ", string.Empty).Replace("-", string.Empty);
-
-                if (normalizedManifestName.Contains(normalizedItemName, StringComparison.OrdinalIgnoreCase) ||
-                    normalizedItemName.Contains(normalizedManifestName, StringComparison.OrdinalIgnoreCase))
-                {
-                    nameMatch = true;
-                }
-            }
-
-            // Version Match check
-            var manifestVersion = manifest.Version ?? string.Empty;
-            var manifestDatePart = ExtractDateFromVersion(manifestVersion);
-
-            var versionMatch = false;
-
-            // Direct version match
-            if (manifestVersion.Equals(itemVersion, StringComparison.OrdinalIgnoreCase))
-            {
-                versionMatch = true;
-            }
-
-            // Date part match (e.g., "weekly-2025-12-12" vs "20251212")
-            else if (!string.IsNullOrEmpty(itemDatePart) &&
-                !string.IsNullOrEmpty(manifestDatePart) &&
-                itemDatePart.Equals(manifestDatePart, StringComparison.OrdinalIgnoreCase))
-            {
-                versionMatch = true;
-            }
-
-            // If publisher matches AND (names match OR versions match), it's a variant
-            // RESTRICTION: strict version matching without name matching is ONLY allowed for GameClient content.
-            // This prevents "Addon A v1.0" being identified as a variant of "Addon B v1.0".
-            var isGameClient = item.Model.ContentType == ContentType.GameClient;
-
-            if (nameMatch || (versionMatch && isGameClient))
+            if (IsManifestVariantMatch(item, manifest, publisherId, itemId, itemVersion, itemDatePart))
             {
                 variants.Add(manifest);
             }
         }
 
-        // Sort variants by name for consistent UI display
         return [.. variants.OrderBy(v => v.Name)];
+    }
+
+    private static bool IsManifestVariantMatch(
+        ContentItemViewModel item,
+        Core.Models.Manifest.ContentManifest manifest,
+        string publisherId,
+        string itemId,
+        string itemVersion,
+        string itemDatePart)
+    {
+        if (item.Model.ContentType != manifest.ContentType)
+        {
+            return false;
+        }
+
+        var manifestIdParts = manifest.Id.Value.Split('.');
+        if (manifestIdParts.Length >= 2 && manifestIdParts[1] == "0" && manifest.ContentType == ContentType.GameClient)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(itemId) && manifest.Id.Value.Equals(itemId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var hasPublisherInId = manifestIdParts.Length > 2 &&
+            manifestIdParts[2].Equals(publisherId, StringComparison.OrdinalIgnoreCase);
+        var publisherMatch = hasPublisherInId ||
+            (manifest.Publisher?.PublisherType?.Equals(publisherId, StringComparison.OrdinalIgnoreCase) == true);
+
+        if (!publisherMatch)
+        {
+            return false;
+        }
+
+        var nameMatch = IsNameMatch(item.Name, manifest.Name);
+        var manifestVersion = manifest.Version ?? string.Empty;
+        var manifestDatePart = ExtractDateFromVersion(manifestVersion);
+        var versionMatch = IsVersionMatch(itemVersion, manifestVersion, itemDatePart, manifestDatePart);
+
+        var isGameClient = item.Model.ContentType == ContentType.GameClient;
+        return nameMatch || (versionMatch && isGameClient);
+    }
+
+    private static bool IsNameMatch(string? itemName, string? manifestName)
+    {
+        var itemStr = itemName?.ToLowerInvariant() ?? string.Empty;
+        var manifestStr = manifestName?.ToLowerInvariant() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(itemStr) || string.IsNullOrEmpty(manifestStr))
+        {
+            return false;
+        }
+
+        var normalizedItemName = itemStr.Replace(" ", string.Empty).Replace("-", string.Empty);
+        var normalizedManifestName = manifestStr.Replace(" ", string.Empty).Replace("-", string.Empty);
+
+        return normalizedManifestName.Contains(normalizedItemName, StringComparison.OrdinalIgnoreCase) ||
+               normalizedItemName.Contains(normalizedManifestName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsVersionMatch(string itemVersion, string manifestVersion, string itemDatePart, string manifestDatePart)
+    {
+        if (manifestVersion.Equals(itemVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrEmpty(itemDatePart) &&
+               !string.IsNullOrEmpty(manifestDatePart) &&
+               itemDatePart.Equals(manifestDatePart, StringComparison.OrdinalIgnoreCase);
     }
 
     [RelayCommand]

--- a/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
@@ -321,173 +321,167 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
             {
                 foreach (var item in group.Items)
                 {
-                    // Find all matching manifests for this item to populate variants
-                    var variants = FindContentVariants(item, allManifests, PublisherId);
-
-                    // Update variants collection
-                    if (variants.Count > 0)
-                    {
-                        // Only update if changed to avoid unnecessary UI updates
-                        // Check if counts differ or if any IDs differ
-                        var currentIds = item.AvailableVariants.Select(v => v.Id.Value).ToHashSet();
-                        var newIds = variants.Select(v => v.Id.Value).ToHashSet();
-
-                        if (!currentIds.SetEquals(newIds))
-                        {
-                            item.AvailableVariants.Clear();
-                            foreach (var variant in variants)
-                            {
-                                item.AvailableVariants.Add(variant);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        item.AvailableVariants.Clear();
-                    }
-
-                    var isDownloaded = variants.Count > 0;
-                    item.IsDownloaded = isDownloaded;
-                    item.IsInstalled = isDownloaded;
-
-                    // Check if a newer version is available
-                    if (isDownloaded && !string.IsNullOrEmpty(item.Version))
-                    {
-                        // Find the highest version among installed variants
-                        var highestInstalledVersion = variants
-                            .Select(v => v.Version ?? string.Empty)
-                            .OrderByDescending(v => v, _versionComparer.GetScheme(PublisherId))
-                            .FirstOrDefault();
-
-                        if (!string.IsNullOrEmpty(highestInstalledVersion))
-                        {
-                            var isNewer = _versionComparer.IsNewer(item.Version, highestInstalledVersion, PublisherId);
-                            item.IsUpdateAvailable = isNewer;
-
-                            if (isNewer)
-                            {
-                                item.UpdateAvailableVersion = item.Version;
-                                _logger.LogDebug(
-                                    "Update available for {Name}: installed={InstalledVersion}, available={AvailableVersion}",
-                                    item.Name,
-                                    highestInstalledVersion,
-                                    item.Version);
-                            }
-                            else
-                            {
-                                item.UpdateAvailableVersion = null;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        item.IsUpdateAvailable = false;
-                        item.UpdateAvailableVersion = null;
-                    }
-
-                    // If we have a single variant, ensure the Model ID matches it
-                    if (variants.Count == 1)
-                    {
-                        var variant = variants[0];
-                        item.Model.Id = variant.Id.Value;
-
-                        // Populate resolution variants from the manifest metadata
-                        if (variant.Metadata?.Variants != null && variant.Metadata.Variants.Count > 0)
-                        {
-                            if (!item.ResolutionVariants.SequenceEqual(variant.Metadata.Variants))
-                            {
-                                item.ResolutionVariants.Clear();
-                                foreach (var resVariant in variant.Metadata.Variants)
-                                {
-                                    item.ResolutionVariants.Add(resVariant);
-                                }
-                            }
-
-                            // Set default variant if not already selected (even if list already matched)
-                            if (string.IsNullOrEmpty(item.SelectedVariantId))
-                            {
-                                var defaultVariant = variant.Metadata.Variants.FirstOrDefault(v => v.IsDefault);
-                                item.SelectedVariantId = defaultVariant?.Id ?? variant.Metadata.Variants.FirstOrDefault()?.Id;
-                            }
-                        }
-                        else
-                        {
-                            item.ResolutionVariants.Clear();
-                            item.SelectedVariantId = null;
-                        }
-                    }
-
-                    // If we have multiple variants, we don't change the Model.Id arbitrarily
-                    // The UI will force the user to choose one from AvailableVariants
-
-                    // Populate dependency information for the item
-                    if (variants.Count > 0)
-                    {
-                        // Get dependencies from the first variant (all variants should have same dependencies)
-                        var manifest = variants[0];
-
-                        // Filter out auto-bundled dependencies and installation/client dependencies
-                        // Only show manual dependencies (e.g., GenTool) that users must explicitly download
-                        var requiredDependencies = manifest.Dependencies?
-                            .Where(d => !d.IsOptional)
-                            .Where(d => d.DependencyType != Core.Models.Enums.ContentType.GameInstallation &&
-                                       d.DependencyType != Core.Models.Enums.ContentType.GameClient)
-                            .Where(d => d.InstallBehavior != Core.Models.Enums.DependencyInstallBehavior.AutoInstall)
-                            .Select(d => d.Name ?? string.Empty)
-                            .Where(n => !string.IsNullOrEmpty(n))
-                            .ToList() ?? [];
-
-                        // Update dependency names only if they've changed (notifications fire automatically via NotifyPropertyChangedFor)
-                        if (!item.RequiredDependencyNames.SequenceEqual(requiredDependencies))
-                        {
-                            item.RequiredDependencyNames.Clear();
-                            foreach (var dep in requiredDependencies)
-                            {
-                                item.RequiredDependencyNames.Add(dep);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Try to get dependencies from manifest data if available
-                        if (item.Model.Data is Core.Models.Manifest.ContentManifest dataManifest)
-                        {
-                            // Filter out auto-bundled dependencies and installation/client dependencies
-                            // Only show manual dependencies (e.g., GenTool) that users must explicitly download
-                            var requiredDependencies = dataManifest.Dependencies?
-                                .Where(d => !d.IsOptional)
-                                .Where(d => d.DependencyType != Core.Models.Enums.ContentType.GameInstallation &&
-                                           d.DependencyType != Core.Models.Enums.ContentType.GameClient)
-                                .Where(d => d.InstallBehavior != Core.Models.Enums.DependencyInstallBehavior.AutoInstall)
-                                .Select(d => d.Name ?? string.Empty)
-                                .Where(n => !string.IsNullOrEmpty(n))
-                                .ToList() ?? [];
-
-                            if (!item.RequiredDependencyNames.SequenceEqual(requiredDependencies))
-                            {
-                                item.RequiredDependencyNames.Clear();
-                                foreach (var dep in requiredDependencies)
-                                {
-                                    item.RequiredDependencyNames.Add(dep);
-                                }
-                            }
-                        }
-                    }
-
-                    _logger.LogDebug(
-                        "Content item: {Name} v{Version} ({ContentType}) - Downloaded: {IsDownloaded}, Variants: {VariantCount}, Dependencies: {DependencyCount}",
-                        item.Name,
-                        item.Version,
-                        item.Model.ContentType,
-                        item.IsDownloaded,
-                        item.AvailableVariants.Count,
-                        item.RequiredDependencyNames.Count);
+                    UpdateItemInstallationStatus(item, allManifests);
                 }
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to refresh installation status for {PublisherId}", PublisherId);
+        }
+    }
+
+    private void UpdateItemInstallationStatus(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> allManifests)
+    {
+        var variants = FindContentVariants(item, allManifests, PublisherId);
+        UpdateItemVariants(item, variants);
+
+        var isDownloaded = variants.Count > 0;
+        item.IsDownloaded = isDownloaded;
+        item.IsInstalled = isDownloaded;
+
+        UpdateItemUpdateAvailability(item, variants, isDownloaded);
+        UpdateItemResolutionVariants(item, variants);
+        UpdateItemDependencies(item, variants);
+
+        _logger.LogDebug(
+            "Content item: {Name} v{Version} ({ContentType}) - Downloaded: {IsDownloaded}, Variants: {VariantCount}, Dependencies: {DependencyCount}",
+            item.Name,
+            item.Version,
+            item.Model.ContentType,
+            item.IsDownloaded,
+            item.AvailableVariants.Count,
+            item.RequiredDependencyNames.Count);
+    }
+
+    private static void UpdateItemVariants(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
+    {
+        if (variants.Count > 0)
+        {
+            var currentIds = item.AvailableVariants.Select(v => v.Id.Value).ToHashSet();
+            var newIds = variants.Select(v => v.Id.Value).ToHashSet();
+
+            if (!currentIds.SetEquals(newIds))
+            {
+                item.AvailableVariants.Clear();
+                foreach (var variant in variants)
+                {
+                    item.AvailableVariants.Add(variant);
+                }
+            }
+        }
+        else
+        {
+            item.AvailableVariants.Clear();
+        }
+    }
+
+    private void UpdateItemUpdateAvailability(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants, bool isDownloaded)
+    {
+        if (isDownloaded && !string.IsNullOrEmpty(item.Version))
+        {
+            var highestInstalledVersion = variants
+                .Select(v => v.Version ?? string.Empty)
+                .OrderByDescending(v => v, _versionComparer.GetScheme(PublisherId))
+                .FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(highestInstalledVersion))
+            {
+                var isNewer = _versionComparer.IsNewer(item.Version, highestInstalledVersion, PublisherId);
+                item.IsUpdateAvailable = isNewer;
+
+                if (isNewer)
+                {
+                    item.UpdateAvailableVersion = item.Version;
+                    _logger.LogDebug(
+                        "Update available for {Name}: installed={InstalledVersion}, available={AvailableVersion}",
+                        item.Name,
+                        highestInstalledVersion,
+                        item.Version);
+                }
+                else
+                {
+                    item.UpdateAvailableVersion = null;
+                }
+            }
+        }
+        else
+        {
+            item.IsUpdateAvailable = false;
+            item.UpdateAvailableVersion = null;
+        }
+    }
+
+    private static void UpdateItemResolutionVariants(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
+    {
+        if (variants.Count == 1)
+        {
+            var variant = variants[0];
+            item.Model.Id = variant.Id.Value;
+
+            if (variant.Metadata?.Variants != null && variant.Metadata.Variants.Count > 0)
+            {
+                if (!item.ResolutionVariants.SequenceEqual(variant.Metadata.Variants))
+                {
+                    item.ResolutionVariants.Clear();
+                    foreach (var resVariant in variant.Metadata.Variants)
+                    {
+                        item.ResolutionVariants.Add(resVariant);
+                    }
+                }
+
+                if (string.IsNullOrEmpty(item.SelectedVariantId))
+                {
+                    var defaultVariant = variant.Metadata.Variants.FirstOrDefault(v => v.IsDefault);
+                    item.SelectedVariantId = defaultVariant?.Id ?? variant.Metadata.Variants.FirstOrDefault()?.Id;
+                }
+            }
+            else
+            {
+                item.ResolutionVariants.Clear();
+                item.SelectedVariantId = null;
+            }
+        }
+    }
+
+    private static void UpdateItemDependencies(ContentItemViewModel item, List<Core.Models.Manifest.ContentManifest> variants)
+    {
+        List<string> requiredDependencies;
+        if (variants.Count > 0)
+        {
+            var manifest = variants[0];
+            requiredDependencies = manifest.Dependencies?
+                .Where(d => !d.IsOptional)
+                .Where(d => d.DependencyType != Core.Models.Enums.ContentType.GameInstallation &&
+                           d.DependencyType != Core.Models.Enums.ContentType.GameClient)
+                .Where(d => d.InstallBehavior != Core.Models.Enums.DependencyInstallBehavior.AutoInstall)
+                .Select(d => d.Name ?? string.Empty)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .ToList() ?? [];
+        }
+        else if (item.Model.Data is Core.Models.Manifest.ContentManifest dataManifest)
+        {
+            requiredDependencies = dataManifest.Dependencies?
+                .Where(d => !d.IsOptional)
+                .Where(d => d.DependencyType != Core.Models.Enums.ContentType.GameInstallation &&
+                           d.DependencyType != Core.Models.Enums.ContentType.GameClient)
+                .Where(d => d.InstallBehavior != Core.Models.Enums.DependencyInstallBehavior.AutoInstall)
+                .Select(d => d.Name ?? string.Empty)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .ToList() ?? [];
+        }
+        else
+        {
+            return;
+        }
+
+        if (!item.RequiredDependencyNames.SequenceEqual(requiredDependencies))
+        {
+            item.RequiredDependencyNames.Clear();
+            foreach (var dep in requiredDependencies)
+            {
+                item.RequiredDependencyNames.Add(dep);
+            }
         }
     }
 

--- a/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/PublisherCardViewModel.cs
@@ -389,10 +389,7 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
                     if (variants.Count == 1)
                     {
                         var variant = variants[0];
-                        if (item.Model.Id != variant.Id.Value)
-                        {
-                            item.Model.Id = variant.Id.Value;
-                        }
+                        item.Model.Id = variant.Id.Value;
 
                         // Populate resolution variants from the manifest metadata
                         if (variant.Metadata?.Variants != null && variant.Metadata.Variants.Count > 0)
@@ -843,8 +840,8 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
             return;
         }
 
-        string contentId;
-        string contentName;
+        string contentId = string.Empty;
+        string contentName = string.Empty;
         bool isDownloading = false;
 
         if (parameters[0] is ContentItemViewModel item)
@@ -986,8 +983,8 @@ public partial class PublisherCardViewModel : ObservableObject, IRecipient<Profi
             return;
         }
 
-        string contentId;
-        string contentName;
+        string contentId = string.Empty;
+        string contentName = string.Empty;
         ContentItemViewModel? itemForStatus = null;
 
         if (parameter is ContentItemViewModel item)

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -240,8 +240,8 @@ public class GameClientDetector(
             // Try to detect version for both game types
             var generalsVersion = hashRegistry.GetVersionFromHash(hash, GameType.Generals);
             var zeroHourVersion = hashRegistry.GetVersionFromHash(hash, GameType.ZeroHour);
-            GameType detectedGameType;
-            string detectedVersion;
+            var detectedGameType = GameType.Unknown;
+            var detectedVersion = GameClientConstants.UnknownVersion;
             if (!string.Equals(generalsVersion, GameClientConstants.UnknownVersion, StringComparison.OrdinalIgnoreCase))
             {
                 detectedGameType = GameType.Generals;
@@ -958,7 +958,7 @@ public class GameClientDetector(
             // Find the executable file in the manifest
             var executableFile = manifest.Files?.FirstOrDefault(f =>
                 f.IsExecutable ||
-                (f.RelativePath?.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ?? false));
+                (f.RelativePath?.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) == true));
 
             if (executableFile == null)
             {

--- a/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
+++ b/GenHub/GenHub/Features/GameClients/GameClientDetector.cs
@@ -211,7 +211,11 @@ public class GameClientDetector(
             return ResolveGeneralsOnlineEntryPoint(
                 Directory.EnumerateFiles(directory).Select(Path.GetFileName).OfType<string>());
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
         {
             return null;
         }
@@ -472,16 +476,43 @@ public class GameClientDetector(
     /// <returns>A tuple containing the detected version string and the actual executable path found, or (GameClientConstants.UnknownVersion, original path) if not recognized.</returns>
     private async Task<(string Version, string ExecutablePath)> DetectVersionFromInstallationAsync(string installationPath, GameType gameType, CancellationToken cancellationToken)
     {
-        // Use the possible executable names from the registry
+        var hashResult = await DetectVersionFromHashAsync(installationPath, gameType, cancellationToken);
+        if (hashResult.HasValue)
+        {
+            return hashResult.Value;
+        }
+
+        var defaultExecutableName = gameType == GameType.Generals
+            ? GameClientConstants.GeneralsExecutable
+            : GameClientConstants.ZeroHourExecutable;
+        var defaultPath = Path.Combine(installationPath, defaultExecutableName);
+
+        var fallbackVersion = DetectVersionFromFileVersionInfo(defaultPath, defaultExecutableName, gameType);
+        fallbackVersion = NormalizeGenericVersion(fallbackVersion, gameType);
+
+        logger.LogInformation(
+            "Using {ExecutableName} with version {Version} for {GameType}",
+            defaultExecutableName,
+            fallbackVersion,
+            gameType);
+        return (fallbackVersion, defaultPath);
+    }
+
+    private async Task<(string Version, string ExecutablePath)?> DetectVersionFromHashAsync(
+        string installationPath,
+        GameType gameType,
+        CancellationToken cancellationToken)
+    {
         foreach (var executableName in hashRegistry.PossibleExecutableNames)
         {
             var executablePath = Path.Combine(installationPath, executableName);
             if (!File.Exists(executablePath))
+            {
                 continue;
+            }
 
             try
             {
-                // Get the actual filename with correct casing from the filesystem
                 var actualFileName = Path.GetFileName(new FileInfo(executablePath).FullName);
                 var actualExecutablePath = Path.Combine(installationPath, actualFileName);
 
@@ -493,7 +524,6 @@ public class GameClientDetector(
                 }
 
                 var version = hashRegistry.GetVersionFromHash(hash, gameType);
-
                 if (!string.Equals(version, GameClientConstants.UnknownVersion, StringComparison.OrdinalIgnoreCase))
                 {
                     logger.LogInformation(
@@ -504,14 +534,12 @@ public class GameClientDetector(
                         hash);
                     return (version, actualExecutablePath);
                 }
-                else
-                {
-                    logger.LogDebug(
-                        "Unknown hash for {GameType} in {ExecutableName}: {Hash}",
-                        gameType,
-                        actualFileName,
-                        hash);
-                }
+
+                logger.LogDebug(
+                    "Unknown hash for {GameType} in {ExecutableName}: {Hash}",
+                    gameType,
+                    actualFileName,
+                    hash);
             }
             catch (Exception ex)
             {
@@ -519,54 +547,57 @@ public class GameClientDetector(
             }
         }
 
-        // Fallback: try to detect version from the default executable's file info
-        var defaultExecutableName = gameType == GameType.Generals
-            ? GameClientConstants.GeneralsExecutable
-            : GameClientConstants.ZeroHourExecutable;
-        var defaultPath = Path.Combine(installationPath, defaultExecutableName);
+        return null;
+    }
 
-        var fallbackVersion = GameClientConstants.UnknownVersion;
-
-        if (File.Exists(defaultPath))
+    private string DetectVersionFromFileVersionInfo(string defaultPath, string defaultExecutableName, GameType gameType)
+    {
+        if (!File.Exists(defaultPath))
         {
-            try
-            {
-                var versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(defaultPath);
-                var rawVersion = versionInfo.ProductVersion ?? versionInfo.FileVersion;
-
-                if (!string.IsNullOrWhiteSpace(rawVersion))
-                {
-                    var cleanVersion = rawVersion.Split('+')[0].Split('-')[0].Trim();
-                    cleanVersion = cleanVersion.Replace(", ", ".").Replace(",", ".");
-                    var components = cleanVersion.Split('.');
-
-                    if (components.Length > 2)
-                    {
-                        if (components.Length >= 3 && components[0] == "1" && components[1] == "0" && components[2] != "0")
-                        {
-                            cleanVersion = $"1.0{components[2]}"; // 1.0.4 -> 1.04
-                        }
-                        else if (components.Length >= 2)
-                        {
-                            cleanVersion = $"{components[0]}.{components[1]}"; // 1.0.0.0 -> 1.0
-                        }
-                    }
-
-                    fallbackVersion = cleanVersion;
-                    logger.LogInformation(
-                        "Detected {GameType} version {Version} from FileVersionInfo for {ExecutableName}",
-                        gameType,
-                        cleanVersion,
-                        defaultExecutableName);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to read FileVersionInfo from {ExecutablePath}", defaultPath);
-            }
+            return GameClientConstants.UnknownVersion;
         }
 
-        // Apply smart defaults for generic/unknown versions
+        try
+        {
+            var versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(defaultPath);
+            var rawVersion = versionInfo.ProductVersion ?? versionInfo.FileVersion;
+
+            if (!string.IsNullOrWhiteSpace(rawVersion))
+            {
+                var cleanVersion = rawVersion.Split('+')[0].Split('-')[0].Trim();
+                cleanVersion = cleanVersion.Replace(", ", ".").Replace(",", ".");
+                var components = cleanVersion.Split('.');
+
+                if (components.Length > 2)
+                {
+                    if (components.Length >= 3 && components[0] == "1" && components[1] == "0" && components[2] != "0")
+                    {
+                        cleanVersion = $"1.0{components[2]}"; // 1.0.4 -> 1.04
+                    }
+                    else if (components.Length >= 2)
+                    {
+                        cleanVersion = $"{components[0]}.{components[1]}"; // 1.0.0.0 -> 1.0
+                    }
+                }
+
+                logger.LogInformation(
+                    "Detected {GameType} version {Version} from FileVersionInfo for {ExecutableName}",
+                    gameType,
+                    cleanVersion,
+                    defaultExecutableName);
+                return cleanVersion;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read FileVersionInfo from {ExecutablePath}", defaultPath);
+        }
+
+        return GameClientConstants.UnknownVersion;
+    }
+
+    private string NormalizeGenericVersion(string fallbackVersion, GameType gameType)
+    {
         if (fallbackVersion == GameClientConstants.UnknownVersion || fallbackVersion == "1.0" || fallbackVersion == "1.00" || fallbackVersion == "0.0" || fallbackVersion == "0.0.0.0")
         {
             var oldVersion = fallbackVersion;
@@ -582,12 +613,7 @@ public class GameClientDetector(
             }
         }
 
-        logger.LogInformation(
-            "Using {ExecutableName} with version {Version} for {GameType}",
-            defaultExecutableName,
-            fallbackVersion,
-            gameType);
-        return (fallbackVersion, defaultPath);
+        return fallbackVersion;
     }
 
     /// <returns>A list of detected publisher game clients.</returns>

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -545,8 +545,8 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
         CancellationToken cancellationToken)
     {
         var detectedVersion = gameClient?.Version;
-        int versionForId;
-        string versionForManifest;
+        int versionForId = 0;
+        string versionForManifest = string.Empty;
 
         if (string.IsNullOrEmpty(detectedVersion) ||
             detectedVersion.Equals("Unknown", StringComparison.OrdinalIgnoreCase))

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -84,13 +84,9 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
         try
         {
             var initResult = await TryInitializeCacheAsync(cancellationToken);
-            if (!initResult.Success)
+            if (!initResult.Success && _cachedInstallations == null)
             {
-                // If TryInitializeCacheAsync failed and cache is null, return failure
-                if (_cachedInstallations == null)
-                {
-                    return OperationResult<IReadOnlyList<GameInstallation>>.CreateFailure(initResult.Errors[0]);
-                }
+                return OperationResult<IReadOnlyList<GameInstallation>>.CreateFailure(initResult.Errors[0]);
             }
 
             if (_cachedInstallations == null)
@@ -748,7 +744,7 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
             var detectionResult = await detectionOrchestrator.DetectAllInstallationsAsync(cancellationToken);
 
             // Start with auto-detected installations if successful, otherwise empty list
-            List<GameInstallation> installations;
+            List<GameInstallation> installations = [];
             bool detectionHadError = !detectionResult.Success;
             if (detectionResult.Success)
             {

--- a/GenHub/GenHub/Features/GameInstallations/InstallationPathResolver.cs
+++ b/GenHub/GenHub/Features/GameInstallations/InstallationPathResolver.cs
@@ -198,7 +198,7 @@ public class InstallationPathResolver(
             installation.InstallationType);
 
         return OperationResult<string>.CreateFailure(
-            $"Installation not found in common locations");
+            "Installation not found in common locations");
     }
 
     private static List<string> GetSearchPaths(GameInstallationType installationType)

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -889,6 +889,15 @@ public class GameProcessManager(
         ProcessExited?.Invoke(this, args);
 
         logger.LogInformation("Process {ProcessId} exited with code {ExitCode}", processId, exitCode);
+
+        try
+        {
+            process.Dispose();
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to dispose process {ProcessId}", processId);
+        }
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -889,15 +889,6 @@ public class GameProcessManager(
         ProcessExited?.Invoke(this, args);
 
         logger.LogInformation("Process {ProcessId} exited with code {ExitCode}", processId, exitCode);
-
-        try
-        {
-            process.Dispose();
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "Failed to dispose process {ProcessId}", processId);
-        }
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -200,53 +200,8 @@ public class GameProfileManager(
                 profile.Name = request.Name;
             }
 
-            profile.Description = request.Description ?? profile.Description;
-            profile.EnabledContentIds = request.EnabledContentIds ?? profile.EnabledContentIds ?? [];
-            profile.GameClient = request.GameClient ?? profile.GameClient;
-            profile.WorkspaceStrategy = request.WorkspaceStrategy ?? profile.WorkspaceStrategy;
-            profile.LaunchOptions = request.LaunchArguments ?? profile.LaunchOptions ?? [];
-            profile.CustomExecutablePath = request.CustomExecutablePath ?? profile.CustomExecutablePath;
-            profile.WorkingDirectory = request.WorkingDirectory ?? profile.WorkingDirectory;
-            profile.IconPath = request.IconPath ?? profile.IconPath;
-            profile.CoverPath = request.CoverPath ?? profile.CoverPath;
-            profile.ThemeColor = request.ThemeColor ?? profile.ThemeColor;
-            profile.GameInstallationId = request.GameInstallationId ?? profile.GameInstallationId;
-            profile.ToolContentId = request.ToolContentId ?? profile.ToolContentId;
-            profile.CommandLineArguments = request.CommandLineArguments ?? profile.CommandLineArguments;
-
-            // Detect if content changed and invalidate workspace if needed
-            bool contentChanged = false;
-            if (request.EnabledContentIds != null)
-            {
-                var newContentIds = request.EnabledContentIds.ToList();
-                contentChanged = !previousEnabledContentIds.SequenceEqual(newContentIds, StringComparer.OrdinalIgnoreCase);
-            }
-
-            if (request.GameClient != null)
-            {
-                var newGameClientId = request.GameClient.Id;
-                contentChanged = contentChanged || !string.Equals(previousGameClientId, newGameClientId, StringComparison.OrdinalIgnoreCase);
-            }
-
-            // If content changed, clear the ActiveWorkspaceId to force workspace rebuild on next launch
-            // This is critical - without this, the workspace will continue using the old content
-            if (contentChanged && !string.IsNullOrEmpty(profile.ActiveWorkspaceId))
-            {
-                logger.LogDebug(
-                    "Profile '{ProfileName}' content changed - clearing ActiveWorkspaceId '{WorkspaceId}' to force workspace rebuild on next launch",
-                    profile.Name,
-                    profile.ActiveWorkspaceId);
-                profile.ActiveWorkspaceId = string.Empty;
-            }
-
-            // Only update ActiveWorkspaceId if explicitly provided (not null)
-            // We allow empty strings because that's how we clear the active workspace to force a rebuild
-            if (request.ActiveWorkspaceId != null)
-            {
-                profile.ActiveWorkspaceId = request.ActiveWorkspaceId;
-            }
-
-            // Update game settings
+            ApplyUpdateRequestToProfile(profile, request);
+            CheckAndHandleContentChanges(profile, request, previousEnabledContentIds, previousGameClientId);
             GameSettingsMapper.UpdateFromRequest(profile, request);
 
             var saveResult = await profileRepository.SaveProfileAsync(profile, cancellationToken);
@@ -417,6 +372,57 @@ public class GameProfileManager(
         {
             // Don't fail profile creation if settings loading fails
             logger.LogWarning(ex, "Failed to load existing Options.ini for profile {ProfileName}, using defaults", profile.Name);
+        }
+    }
+
+    private static void ApplyUpdateRequestToProfile(GameProfile profile, UpdateProfileRequest request)
+    {
+        profile.Description = request.Description ?? profile.Description;
+        profile.EnabledContentIds = request.EnabledContentIds ?? profile.EnabledContentIds ?? [];
+        profile.GameClient = request.GameClient ?? profile.GameClient;
+        profile.WorkspaceStrategy = request.WorkspaceStrategy ?? profile.WorkspaceStrategy;
+        profile.LaunchOptions = request.LaunchArguments ?? profile.LaunchOptions ?? [];
+        profile.CustomExecutablePath = request.CustomExecutablePath ?? profile.CustomExecutablePath;
+        profile.WorkingDirectory = request.WorkingDirectory ?? profile.WorkingDirectory;
+        profile.IconPath = request.IconPath ?? profile.IconPath;
+        profile.CoverPath = request.CoverPath ?? profile.CoverPath;
+        profile.ThemeColor = request.ThemeColor ?? profile.ThemeColor;
+        profile.GameInstallationId = request.GameInstallationId ?? profile.GameInstallationId;
+        profile.ToolContentId = request.ToolContentId ?? profile.ToolContentId;
+        profile.CommandLineArguments = request.CommandLineArguments ?? profile.CommandLineArguments;
+
+        if (request.ActiveWorkspaceId != null)
+        {
+            profile.ActiveWorkspaceId = request.ActiveWorkspaceId;
+        }
+    }
+
+    private void CheckAndHandleContentChanges(
+        GameProfile profile,
+        UpdateProfileRequest request,
+        List<string> previousEnabledContentIds,
+        string? previousGameClientId)
+    {
+        bool contentChanged = false;
+        if (request.EnabledContentIds != null)
+        {
+            var newContentIds = request.EnabledContentIds.ToList();
+            contentChanged = !previousEnabledContentIds.SequenceEqual(newContentIds, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (request.GameClient != null)
+        {
+            var newGameClientId = request.GameClient.Id;
+            contentChanged = contentChanged || !string.Equals(previousGameClientId, newGameClientId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (contentChanged && !string.IsNullOrEmpty(profile.ActiveWorkspaceId))
+        {
+            logger.LogDebug(
+                "Profile '{ProfileName}' content changed - clearing ActiveWorkspaceId '{WorkspaceId}' to force workspace rebuild on next launch",
+                profile.Name,
+                profile.ActiveWorkspaceId);
+            profile.ActiveWorkspaceId = string.Empty;
         }
     }
 }

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -373,7 +373,7 @@ public class GameProfileManager(
         }
     }
 
-    private static void ApplyUpdateRequestToProfile(GameProfile profile, UpdateProfileRequest request)
+    private void ApplyUpdateRequestToProfile(GameProfile profile, UpdateProfileRequest request)
     {
         profile.Description = request.Description ?? profile.Description;
         profile.EnabledContentIds = request.EnabledContentIds ?? profile.EnabledContentIds ?? [];

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -243,11 +243,9 @@ public class GameProfileManager(
                 logger.LogInformation("Successfully deleted game profile with ID: {ProfileId}", profileId);
                 return OperationResult<bool>.CreateSuccess(true);
             }
-            else
-            {
-                logger.LogError("Failed to delete game profile with ID: {ProfileId}", profileId);
-                return OperationResult<bool>.CreateFailure(deleteResult.Errors);
-            }
+
+            logger.LogError("Failed to delete game profile with ID: {ProfileId}", profileId);
+            return OperationResult<bool>.CreateFailure(deleteResult.Errors);
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -200,8 +200,8 @@ public class GameProfileManager(
                 profile.Name = request.Name;
             }
 
-            ApplyUpdateRequestToProfile(profile, request);
             CheckAndHandleContentChanges(profile, request, previousEnabledContentIds, previousGameClientId);
+            ApplyUpdateRequestToProfile(profile, request);
             GameSettingsMapper.UpdateFromRequest(profile, request);
 
             var saveResult = await profileRepository.SaveProfileAsync(profile, cancellationToken);

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileContentLoader.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileContentLoader.cs
@@ -106,8 +106,6 @@ public class ProfileContentLoader(
                 return result;
             }
 
-            var includedManifestIds = new HashSet<string>();
-
             await AddCasStoredGameClientsAsync(result, []);
 
             logger.LogInformation("Loaded {Count} game client options", result.Count);

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileContentService.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileContentService.cs
@@ -85,26 +85,7 @@ public sealed class ProfileContentService(
 
             // Build new enabled content list
             List<string> enabledContentIds = [.. profile.EnabledContentIds ?? []];
-            string? swappedContentId = null;
-            string? swappedContentName = null;
-            ContentType swappedContentType = ContentType.UnknownContentType;
-
-            if (conflictInfo.HasConflict && conflictInfo.CanAutoResolve)
-            {
-                // Remove the conflicting content
-                if (!string.IsNullOrEmpty(conflictInfo.ConflictingContentId))
-                {
-                    enabledContentIds.Remove(conflictInfo.ConflictingContentId);
-                    swappedContentId = conflictInfo.ConflictingContentId;
-                    swappedContentName = conflictInfo.ConflictingContentName;
-                    swappedContentType = conflictInfo.ConflictingContentType;
-
-                    logger.LogInformation(
-                        "Swapping content: removing {OldContent} to add {NewContent}",
-                        swappedContentId,
-                        manifestId);
-                }
-            }
+            var swapResult = HandleContentConflictSwap(conflictInfo, manifestId, enabledContentIds);
 
             // Add the new content if not already present
             if (!enabledContentIds.Contains(manifestId, StringComparer.OrdinalIgnoreCase))
@@ -113,72 +94,11 @@ public sealed class ProfileContentService(
             }
 
             // Resolve dependencies
-            var previousIds = new HashSet<string>(enabledContentIds, StringComparer.OrdinalIgnoreCase);
-            try
-            {
-                var resolvedIds = await dependencyResolver.ResolveDependenciesAsync(enabledContentIds, cancellationToken);
-                enabledContentIds = [.. resolvedIds];
-
-                // Ensure the target manifest is included (may have been added by resolution)
-                if (!enabledContentIds.Contains(manifestId, StringComparer.OrdinalIgnoreCase))
-                {
-                    enabledContentIds.Add(manifestId);
-                }
-
-                // Notify user if dependencies were auto-installed
-                var newlyAdded = enabledContentIds
-                    .Where(id => !previousIds.Contains(id))
-                    .ToList();
-
-                if (newlyAdded.Count > 0)
-                {
-                    var dependencyNames = new List<string>();
-                    foreach (var id in newlyAdded)
-                    {
-                        try
-                        {
-                            // Auto-acquire missing dependencies when possible
-                            if (!await TryAcquireDependencyAsync(id, cancellationToken))
-                            {
-                                logger.LogWarning("Dependency {DependencyId} could not be auto-acquired", id);
-                            }
-
-                            var depManifest = await manifestPool.GetManifestAsync(
-                                Core.Models.Manifest.ManifestId.Create(id),
-                                cancellationToken);
-
-                            if (depManifest.Success && depManifest.Data != null)
-                            {
-                                dependencyNames.Add(depManifest.Data.Name ?? "Required dependency");
-                            }
-                            else if (TryParseCommunityOutpostContentCode(id, out var contentCode))
-                            {
-                                var metadata = Core.Models.CommunityOutpost.GenPatcherContentRegistry.GetMetadata(contentCode);
-                                dependencyNames.Add(!string.IsNullOrEmpty(metadata.DisplayName)
-                                    ? metadata.DisplayName
-                                    : "Required dependency");
-                            }
-                            else
-                            {
-                                dependencyNames.Add("Required dependency");
-                            }
-                        }
-                        catch
-                        {
-                            dependencyNames.Add("Required dependency");
-                        }
-                    }
-
-                    logger.LogInformation("Auto-installed {Count} dependencies for {ManifestId}", newlyAdded.Count, manifestId);
-                    notificationService.ShowInfo(
-                        "Dependencies Added",
-                        $"Added required dependencies for '{contentName}': {string.Join(", ", dependencyNames)}");
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to resolve dependencies, proceeding with original list");
-            }
+            enabledContentIds = await ResolveAndAcquireDependenciesAsync(
+                enabledContentIds,
+                manifestId,
+                contentName,
+                cancellationToken);
 
             // Update the profile
             var updateRequest = new UpdateProfileRequest
@@ -195,24 +115,24 @@ public sealed class ProfileContentService(
             }
 
             // Show notification for swap
-            if (!string.IsNullOrEmpty(swappedContentId))
+            if (!string.IsNullOrEmpty(swapResult.SwappedContentId))
             {
                 notificationService.ShowInfo(
                     "Content Replaced",
-                    $"Replaced '{swappedContentName ?? swappedContentId}' with '{contentName}'");
+                    $"Replaced '{swapResult.SwappedContentName ?? swapResult.SwappedContentId}' with '{contentName}'");
 
                 logger.LogInformation(
                     "Content swap complete: {OldContent} → {NewContent} in profile {ProfileId}",
-                    swappedContentId,
+                    swapResult.SwappedContentId,
                     manifestId,
                     profileId);
 
                 return AddToProfileResult.CreateSuccessWithSwap(
                     manifestId,
                     contentName,
-                    swappedContentId,
-                    swappedContentName,
-                    swappedContentType,
+                    swapResult.SwappedContentId,
+                    swapResult.SwappedContentName,
+                    swapResult.SwappedContentType,
                     sw.Elapsed);
             }
 
@@ -707,5 +627,109 @@ public sealed class ProfileContentService(
             logger.LogWarning(ex, "Failed to auto-acquire dependency {ManifestId}", manifestId);
             return false;
         }
+    }
+
+    private (string? SwappedContentId, string? SwappedContentName, ContentType SwappedContentType) HandleContentConflictSwap(
+        ContentConflictInfo conflictInfo,
+        string manifestId,
+        List<string> enabledContentIds)
+    {
+        string? swappedContentId = null;
+        string? swappedContentName = null;
+        ContentType swappedContentType = ContentType.UnknownContentType;
+
+        if (conflictInfo.HasConflict && conflictInfo.CanAutoResolve && !string.IsNullOrEmpty(conflictInfo.ConflictingContentId))
+        {
+            enabledContentIds.Remove(conflictInfo.ConflictingContentId);
+            swappedContentId = conflictInfo.ConflictingContentId;
+            swappedContentName = conflictInfo.ConflictingContentName;
+            swappedContentType = conflictInfo.ConflictingContentType;
+
+            logger.LogInformation(
+                "Swapping content: removing {OldContent} to add {NewContent}",
+                swappedContentId,
+                manifestId);
+        }
+
+        return (swappedContentId, swappedContentName, swappedContentType);
+    }
+
+    private async Task<List<string>> ResolveAndAcquireDependenciesAsync(
+        List<string> enabledContentIds,
+        string manifestId,
+        string contentName,
+        CancellationToken cancellationToken)
+    {
+        var previousIds = new HashSet<string>(enabledContentIds, StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            var resolvedIds = await dependencyResolver.ResolveDependenciesAsync(enabledContentIds, cancellationToken);
+            enabledContentIds = [.. resolvedIds];
+
+            if (!enabledContentIds.Contains(manifestId, StringComparer.OrdinalIgnoreCase))
+            {
+                enabledContentIds.Add(manifestId);
+            }
+
+            var newlyAdded = enabledContentIds
+                .Where(id => !previousIds.Contains(id))
+                .ToList();
+
+            if (newlyAdded.Count > 0)
+            {
+                var dependencyNames = new List<string>();
+                foreach (var id in newlyAdded)
+                {
+                    var depName = await ResolveDependencyDisplayNameAsync(id, cancellationToken);
+                    dependencyNames.Add(depName);
+                }
+
+                logger.LogInformation("Auto-installed {Count} dependencies for {ManifestId}", newlyAdded.Count, manifestId);
+                notificationService.ShowInfo(
+                    "Dependencies Added",
+                    $"Added required dependencies for '{contentName}': {string.Join(", ", dependencyNames)}");
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to resolve dependencies, proceeding with original list");
+        }
+
+        return enabledContentIds;
+    }
+
+    private async Task<string> ResolveDependencyDisplayNameAsync(string id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!await TryAcquireDependencyAsync(id, cancellationToken))
+            {
+                logger.LogWarning("Dependency {DependencyId} could not be auto-acquired", id);
+            }
+
+            var depManifest = await manifestPool.GetManifestAsync(
+                Core.Models.Manifest.ManifestId.Create(id),
+                cancellationToken);
+
+            if (depManifest.Success && depManifest.Data != null)
+            {
+                return depManifest.Data.Name ?? "Required dependency";
+            }
+
+            if (TryParseCommunityOutpostContentCode(id, out var contentCode))
+            {
+                var metadata = Core.Models.CommunityOutpost.GenPatcherContentRegistry.GetMetadata(contentCode);
+                return !string.IsNullOrEmpty(metadata.DisplayName)
+                    ? metadata.DisplayName
+                    : "Required dependency";
+            }
+        }
+        catch
+        {
+            // Ignore error and return fallback
+        }
+
+        return "Required dependency";
     }
 }

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileEditorFacade.cs
@@ -125,7 +125,7 @@ public class ProfileEditorFacade(
                 workspaceConfig.WorkspaceRootPath = _storageLocationService.GetWorkspacePath(install.Data);
 
                 // Build manifests from enabled content IDs
-                if (profile.EnabledContentIds != null && profile.EnabledContentIds.Count > 0)
+                if (profile.EnabledContentIds is { Count: > 0 })
                 {
                     var resolutionResult = await _dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds, cancellationToken);
                     if (!resolutionResult.Success)
@@ -311,7 +311,7 @@ public class ProfileEditorFacade(
             }
 
             // Validate content manifests exist
-            if (profile.EnabledContentIds != null && profile.EnabledContentIds.Count > 0)
+            if (profile.EnabledContentIds is { Count: > 0 })
             {
                 var manifestsResult = await _manifestPool.GetAllManifestsAsync(cancellationToken);
                 if (manifestsResult.Success && manifestsResult.Data != null)

--- a/GenHub/GenHub/Features/GameProfiles/Services/SetupWizardService.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/SetupWizardService.cs
@@ -86,11 +86,9 @@ public class SetupWizardService(
                     // Everything is perfect. Skip wizard, no action.
                     return (true, GameClientConstants.WizardActionTypes.Decline);
                 }
-                else
-                {
-                    // Content is there, just needs a profile. Skip wizard, auto-accept.
-                    return (true, GameClientConstants.WizardActionTypes.CreateProfile);
-                }
+
+                // Content is there, just needs a profile. Skip wizard, auto-accept.
+                return (true, GameClientConstants.WizardActionTypes.CreateProfile);
             }
 
             // If we reach here, we don't have a managed up-to-date client.
@@ -104,7 +102,6 @@ public class SetupWizardService(
                 }
             }
 
-            var detectedVersion = componentGlobal.Select(x => x.Client?.Version).FirstOrDefault() ?? GameClientConstants.UnknownVersion;
             var isDetected = componentGlobal.Count > 0;
 
             // Construct Wizard Item

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoGameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoGameProfileSettingsViewModel.cs
@@ -179,6 +179,8 @@ public partial class DemoGameProfileSettingsViewModel : GameProfileSettingsViewM
                 list.Add(new ContentDisplayItem { DisplayName = "WNDEditor", ContentType = ContentType.ModdingTool, GameType = Core.Models.Enums.GameType.ZeroHour, Publisher = "Community", Version = "0.4", ManifestId = ManifestId.Create("0.4.community.tool.wndeditor"), InstallationType = GameInstallationType.Unknown });
                 list.Add(new ContentDisplayItem { DisplayName = "FinalBig", ContentType = ContentType.ModdingTool, GameType = Core.Models.Enums.GameType.ZeroHour, Publisher = "Community", Version = "0.4", ManifestId = ManifestId.Create("0.4.community.tool.finalbig"), InstallationType = GameInstallationType.Unknown });
                 break;
+            default:
+                break;
         }
 
         AvailableContent = list;
@@ -259,7 +261,7 @@ public partial class DemoGameProfileSettingsViewModel : GameProfileSettingsViewM
     public new bool IsAddLocalContentDialogOpen
     {
         get => false; // Always return false in demo mode
-        set { } // Ignore all attempts to set this property
+        set { _ = value; } // Ignore all attempts to set this property
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoGameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoGameProfileSettingsViewModel.cs
@@ -180,6 +180,7 @@ public partial class DemoGameProfileSettingsViewModel : GameProfileSettingsViewM
                 list.Add(new ContentDisplayItem { DisplayName = "FinalBig", ContentType = ContentType.ModdingTool, GameType = Core.Models.Enums.GameType.ZeroHour, Publisher = "Community", Version = "0.4", ManifestId = ManifestId.Create("0.4.community.tool.finalbig"), InstallationType = GameInstallationType.Unknown });
                 break;
             default:
+                // No additional mock items for other content types
                 break;
         }
 
@@ -261,7 +262,7 @@ public partial class DemoGameProfileSettingsViewModel : GameProfileSettingsViewM
     public new bool IsAddLocalContentDialogOpen
     {
         get => false; // Always return false in demo mode
-        set { _ = value; } // Ignore all attempts to set this property
+        set => _ = value; // Ignore all attempts to set this property
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -718,6 +718,29 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
         _logger.LogInformation("Loading settings from profile {ProfileId}", _currentProfileId);
 
+        LoadVideoAudioSettingsFromProfile(profile);
+        LoadTshSettingsFromProfile(profile);
+        LoadGeneralsOnlineSettingsFromProfile(profile);
+
+        if (profile.GameSpyIPAddress != null) GameSpyIPAddress = profile.GameSpyIPAddress;
+
+        // Update selected preset if it matches
+        var currentRes = $"{ResolutionWidth}x{ResolutionHeight}";
+        SelectedResolutionPreset = ResolutionPresets.Contains(currentRes) ? currentRes : null;
+
+        var gameType = profile.GameClient?.GameType;
+        StatusMessage = gameType != null
+            ? $"Loaded profile settings for {gameType}"
+            : "Loaded profile settings (no game client configured)";
+        _logger.LogInformation(
+            "Loaded profile settings - Windowed={Windowed}, Resolution={Width}x{Height}",
+            Windowed,
+            ResolutionWidth,
+            ResolutionHeight);
+    }
+
+    private void LoadVideoAudioSettingsFromProfile(Core.Models.GameProfile.GameProfile profile)
+    {
         if (profile.VideoResolutionWidth.HasValue) ResolutionWidth = profile.VideoResolutionWidth.Value;
         if (profile.VideoResolutionHeight.HasValue) ResolutionHeight = profile.VideoResolutionHeight.Value;
         if (profile.VideoWindowed.HasValue) Windowed = profile.VideoWindowed.Value;
@@ -757,8 +780,10 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (profile.AudioMusicVolume.HasValue) MusicVolume = profile.AudioMusicVolume.Value;
         if (profile.AudioEnabled.HasValue) AudioEnabled = profile.AudioEnabled.Value;
         if (profile.AudioNumSounds.HasValue) NumSounds = profile.AudioNumSounds.Value;
+    }
 
-        // TheSuperHackers settings
+    private void LoadTshSettingsFromProfile(Core.Models.GameProfile.GameProfile profile)
+    {
         if (profile.TshArchiveReplays.HasValue) TshArchiveReplays = profile.TshArchiveReplays.Value;
         if (profile.TshShowMoneyPerMinute.HasValue) TshShowMoneyPerMinute = profile.TshShowMoneyPerMinute.Value;
         if (profile.TshPlayerObserverEnabled.HasValue) TshPlayerObserverEnabled = profile.TshPlayerObserverEnabled.Value;
@@ -773,8 +798,10 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) TshScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value;
         if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) TshScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp.Value;
         if (profile.TshMoneyTransactionVolume.HasValue) TshMoneyTransactionVolume = profile.TshMoneyTransactionVolume.Value;
+    }
 
-        // GeneralsOnline settings
+    private void LoadGeneralsOnlineSettingsFromProfile(Core.Models.GameProfile.GameProfile profile)
+    {
         if (profile.GoShowFps.HasValue) GoShowFps = profile.GoShowFps.Value;
         if (profile.GoShowPing.HasValue) GoShowPing = profile.GoShowPing.Value;
         if (profile.GoShowPlayerRanks.HasValue) GoShowPlayerRanks = profile.GoShowPlayerRanks.Value;
@@ -809,22 +836,6 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (profile.GoSocialNotificationPlayerAcceptsRequestMenus.HasValue) GoSocialNotificationPlayerAcceptsRequestMenus = profile.GoSocialNotificationPlayerAcceptsRequestMenus.Value;
         if (profile.GoSocialNotificationPlayerSendsRequestGameplay.HasValue) GoSocialNotificationPlayerSendsRequestGameplay = profile.GoSocialNotificationPlayerSendsRequestGameplay.Value;
         if (profile.GoSocialNotificationPlayerSendsRequestMenus.HasValue) GoSocialNotificationPlayerSendsRequestMenus = profile.GoSocialNotificationPlayerSendsRequestMenus.Value;
-
-        if (profile.GameSpyIPAddress != null) GameSpyIPAddress = profile.GameSpyIPAddress;
-
-        // Update selected preset if it matches
-        var currentRes = $"{ResolutionWidth}x{ResolutionHeight}";
-        SelectedResolutionPreset = ResolutionPresets.Contains(currentRes) ? currentRes : null;
-
-        var gameType = profile.GameClient?.GameType;
-        StatusMessage = gameType != null
-            ? $"Loaded profile settings for {gameType}"
-            : "Loaded profile settings (no game client configured)";
-        _logger.LogInformation(
-            "Loaded profile settings - Windowed={Windowed}, Resolution={Width}x{Height}",
-            Windowed,
-            ResolutionWidth,
-            ResolutionHeight);
     }
 
     /// <summary>
@@ -975,63 +986,9 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         BuildingOcclusion = options.Video.BuildingOcclusion;
         ShowProps = options.Video.ShowProps;
 
-        // Load GenHub custom properties
-        if (options.Video.AdditionalProperties.TryGetValue("GenHubParticleEffects", out var particleEffects))
-            ParticleEffects = ParseBool(particleEffects);
-        if (options.Video.AdditionalProperties.TryGetValue("GenHubBuildingAnimations", out var buildingAnimations))
-            BuildingAnimations = ParseBool(buildingAnimations);
-
-        // Load additional video settings
-        if (options.Video.AdditionalProperties.TryGetValue("StaticGameLOD", out var staticLOD))
-            StaticGameLOD = staticLOD;
-        if (options.Video.AdditionalProperties.TryGetValue("IdealStaticGameLOD", out var idealLOD))
-            IdealStaticGameLOD = idealLOD;
-
-        // Graphics Settings
-        if (options.Video.AdditionalProperties.TryGetValue("ShowSoftWaterEdge", out var swe)) ShowSoftWaterEdge = ParseBool(swe);
-        if (options.Video.AdditionalProperties.TryGetValue("ShowTrees", out var st)) ShowTrees = ParseBool(st);
-        if (options.Video.AdditionalProperties.TryGetValue("UseCloudMap", out var ucm)) UseCloudMap = ParseBool(ucm);
-        if (options.Video.AdditionalProperties.TryGetValue("UseLightMap", out var ulm)) UseLightMap = ParseBool(ulm);
-
-        // Control/Misc Settings
-        if (options.Video.AdditionalProperties.TryGetValue("DrawScrollAnchor", out var draws)) DrawScrollAnchor = ParseBool(draws);
-        if (options.Video.AdditionalProperties.TryGetValue("MoveScrollAnchor", out var moves)) MoveScrollAnchor = ParseBool(moves);
-        if (options.Video.AdditionalProperties.TryGetValue("GameTimeFontSize", out var gtfs) && int.TryParse(gtfs, out var gtfsVal)) GameTimeFontSize = gtfsVal;
-        if (options.Video.AdditionalProperties.TryGetValue("LanguageFilter", out var lf)) LanguageFilter = ParseBool(lf);
-        if (options.Video.AdditionalProperties.TryGetValue("SendDelay", out var sd)) SendDelay = ParseBool(sd);
-        if (options.Video.AdditionalProperties.TryGetValue("SkipEALogo", out var sel)) SkipEALogo = ParseBool(sel);
-
+        ApplyVideoAdditionalProperties(options);
         AntiAliasing = options.Video.AntiAliasing;
-
-        // Load TSH-specific settings from the [TheSuperHackers] section
-        if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var tsh))
-        {
-            if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
-                UseDoubleClickAttackMove = ParseBool(doubleClick);
-            if (tsh.TryGetValue("ScrollFactor", out var scroll) && int.TryParse(scroll, out var scrollVal))
-                ScrollFactor = scrollVal;
-            if (tsh.TryGetValue("Retaliation", out var retaliation))
-                Retaliation = ParseBool(retaliation);
-            if (tsh.TryGetValue("DynamicLOD", out var dynLOD))
-                DynamicLOD = ParseBool(dynLOD);
-            if (tsh.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
-                MaxParticleCount = particleVal;
-
-            if (tsh.TryGetValue("ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
-            if (tsh.TryGetValue("ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
-            if (tsh.TryGetValue("PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
-            if (tsh.TryGetValue("SystemTimeFontSize", out var stfs) && int.TryParse(stfs, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
-            if (tsh.TryGetValue("NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
-            if (tsh.TryGetValue("RenderFpsFontSize", out var rffs) && int.TryParse(rffs, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
-            if (tsh.TryGetValue("ResolutionFontAdjustment", out var rfa) && int.TryParse(rfa, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
-            if (tsh.TryGetValue("CursorCaptureEnabledInFullscreenGame", out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
-            if (tsh.TryGetValue("CursorCaptureEnabledInFullscreenMenu", out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
-            if (tsh.TryGetValue("CursorCaptureEnabledInWindowedGame", out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
-            if (tsh.TryGetValue("CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
-            if (tsh.TryGetValue("ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
-            if (tsh.TryGetValue("ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
-            if (tsh.TryGetValue("MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
-        }
+        ApplyTshAdditionalProperties(options);
 
         ExtraAnimations = options.Video.ExtraAnimations;
         Gamma = options.Video.Gamma;
@@ -1043,6 +1000,65 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         // Update selected preset if it matches
         var currentRes = $"{ResolutionWidth}x{ResolutionHeight}";
         SelectedResolutionPreset = ResolutionPresets.Contains(currentRes) ? currentRes : null;
+    }
+
+    private void ApplyVideoAdditionalProperties(IniOptions options)
+    {
+        if (options.Video.AdditionalProperties.TryGetValue("GenHubParticleEffects", out var particleEffects))
+            ParticleEffects = ParseBool(particleEffects);
+        if (options.Video.AdditionalProperties.TryGetValue("GenHubBuildingAnimations", out var buildingAnimations))
+            BuildingAnimations = ParseBool(buildingAnimations);
+
+        if (options.Video.AdditionalProperties.TryGetValue("StaticGameLOD", out var staticLOD))
+            StaticGameLOD = staticLOD;
+        if (options.Video.AdditionalProperties.TryGetValue("IdealStaticGameLOD", out var idealLOD))
+            IdealStaticGameLOD = idealLOD;
+
+        if (options.Video.AdditionalProperties.TryGetValue("ShowSoftWaterEdge", out var swe)) ShowSoftWaterEdge = ParseBool(swe);
+        if (options.Video.AdditionalProperties.TryGetValue("ShowTrees", out var st)) ShowTrees = ParseBool(st);
+        if (options.Video.AdditionalProperties.TryGetValue("UseCloudMap", out var ucm)) UseCloudMap = ParseBool(ucm);
+        if (options.Video.AdditionalProperties.TryGetValue("UseLightMap", out var ulm)) UseLightMap = ParseBool(ulm);
+
+        if (options.Video.AdditionalProperties.TryGetValue("DrawScrollAnchor", out var draws)) DrawScrollAnchor = ParseBool(draws);
+        if (options.Video.AdditionalProperties.TryGetValue("MoveScrollAnchor", out var moves)) MoveScrollAnchor = ParseBool(moves);
+        if (options.Video.AdditionalProperties.TryGetValue("GameTimeFontSize", out var gtfs) && int.TryParse(gtfs, out var gtfsVal)) GameTimeFontSize = gtfsVal;
+        if (options.Video.AdditionalProperties.TryGetValue("LanguageFilter", out var lf)) LanguageFilter = ParseBool(lf);
+        if (options.Video.AdditionalProperties.TryGetValue("SendDelay", out var sd)) SendDelay = ParseBool(sd);
+        if (options.Video.AdditionalProperties.TryGetValue("SkipEALogo", out var sel)) SkipEALogo = ParseBool(sel);
+    }
+
+    private void ApplyTshAdditionalProperties(IniOptions options)
+    {
+        if (!options.AdditionalSections.TryGetValue("TheSuperHackers", out var tsh))
+        {
+            return;
+        }
+
+        if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
+            UseDoubleClickAttackMove = ParseBool(doubleClick);
+        if (tsh.TryGetValue("ScrollFactor", out var scroll) && int.TryParse(scroll, out var scrollVal))
+            ScrollFactor = scrollVal;
+        if (tsh.TryGetValue("Retaliation", out var retaliation))
+            Retaliation = ParseBool(retaliation);
+        if (tsh.TryGetValue("DynamicLOD", out var dynLOD))
+            DynamicLOD = ParseBool(dynLOD);
+        if (tsh.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
+            MaxParticleCount = particleVal;
+
+        if (tsh.TryGetValue("ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
+        if (tsh.TryGetValue("ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
+        if (tsh.TryGetValue("PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
+        if (tsh.TryGetValue("SystemTimeFontSize", out var stfs) && int.TryParse(stfs, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
+        if (tsh.TryGetValue("NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
+        if (tsh.TryGetValue("RenderFpsFontSize", out var rffs) && int.TryParse(rffs, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
+        if (tsh.TryGetValue("ResolutionFontAdjustment", out var rfa) && int.TryParse(rfa, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
+        if (tsh.TryGetValue("CursorCaptureEnabledInFullscreenGame", out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
+        if (tsh.TryGetValue("CursorCaptureEnabledInFullscreenMenu", out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
+        if (tsh.TryGetValue("CursorCaptureEnabledInWindowedGame", out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
+        if (tsh.TryGetValue("CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
+        if (tsh.TryGetValue("ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
+        if (tsh.TryGetValue("ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
+        if (tsh.TryGetValue("MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
     }
 
     private IniOptions CreateOptionsFromViewModel()

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -455,7 +455,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             }
 
             // If profile has settings, load them
-            if (profile != null && profile.HasCustomSettings())
+            if (profile?.HasCustomSettings() == true)
             {
                 LoadSettingsFromProfile(profile);
             }
@@ -741,6 +741,13 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void LoadVideoAudioSettingsFromProfile(Core.Models.GameProfile.GameProfile profile)
     {
+        LoadVideoBasicSettingsFromProfile(profile);
+        LoadVideoAdvancedSettingsFromProfile(profile);
+        LoadAudioSettingsFromProfile(profile);
+    }
+
+    private void LoadVideoBasicSettingsFromProfile(Core.Models.GameProfile.GameProfile profile)
+    {
         if (profile.VideoResolutionWidth.HasValue) ResolutionWidth = profile.VideoResolutionWidth.Value;
         if (profile.VideoResolutionHeight.HasValue) ResolutionHeight = profile.VideoResolutionHeight.Value;
         if (profile.VideoWindowed.HasValue) Windowed = profile.VideoWindowed.Value;
@@ -755,6 +762,10 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (profile.VideoUseShadowDecals.HasValue) UseShadowDecals = profile.VideoUseShadowDecals.Value;
         if (profile.VideoBuildingOcclusion.HasValue) BuildingOcclusion = profile.VideoBuildingOcclusion.Value;
         if (profile.VideoShowProps.HasValue) ShowProps = profile.VideoShowProps.Value;
+    }
+
+    private void LoadVideoAdvancedSettingsFromProfile(Core.Models.GameProfile.GameProfile profile)
+    {
         if (profile.VideoStaticGameLOD != null) StaticGameLOD = profile.VideoStaticGameLOD;
         if (profile.VideoIdealStaticGameLOD != null) IdealStaticGameLOD = profile.VideoIdealStaticGameLOD;
         if (profile.VideoUseDoubleClickAttackMove.HasValue) UseDoubleClickAttackMove = profile.VideoUseDoubleClickAttackMove.Value;
@@ -773,7 +784,10 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (profile.VideoUseCloudMap.HasValue) UseCloudMap = profile.VideoUseCloudMap.Value;
         if (profile.VideoUseLightMap.HasValue) UseLightMap = profile.VideoUseLightMap.Value;
         if (profile.VideoSkipEALogo.HasValue) SkipEALogo = profile.VideoSkipEALogo.Value;
+    }
 
+    private void LoadAudioSettingsFromProfile(Core.Models.GameProfile.GameProfile profile)
+    {
         if (profile.AudioSoundVolume.HasValue) SoundVolume = profile.AudioSoundVolume.Value;
         if (profile.AudioThreeDSoundVolume.HasValue) ThreeDSoundVolume = profile.AudioThreeDSoundVolume.Value;
         if (profile.AudioSpeechVolume.HasValue) SpeechVolume = profile.AudioSpeechVolume.Value;
@@ -1034,6 +1048,12 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             return;
         }
 
+        ApplyTshGameplayProperties(tsh);
+        ApplyTshUiCursorProperties(tsh);
+    }
+
+    private void ApplyTshGameplayProperties(Dictionary<string, string> tsh)
+    {
         if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
             UseDoubleClickAttackMove = ParseBool(doubleClick);
         if (tsh.TryGetValue("ScrollFactor", out var scroll) && int.TryParse(scroll, out var scrollVal))
@@ -1044,10 +1064,14 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             DynamicLOD = ParseBool(dynLOD);
         if (tsh.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
             MaxParticleCount = particleVal;
-
         if (tsh.TryGetValue("ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
         if (tsh.TryGetValue("ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
         if (tsh.TryGetValue("PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
+        if (tsh.TryGetValue("MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
+    }
+
+    private void ApplyTshUiCursorProperties(Dictionary<string, string> tsh)
+    {
         if (tsh.TryGetValue("SystemTimeFontSize", out var stfs) && int.TryParse(stfs, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
         if (tsh.TryGetValue("NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
         if (tsh.TryGetValue("RenderFpsFontSize", out var rffs) && int.TryParse(rffs, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
@@ -1058,7 +1082,6 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (tsh.TryGetValue("CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
         if (tsh.TryGetValue("ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
         if (tsh.TryGetValue("ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
-        if (tsh.TryGetValue("MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
     }
 
     private IniOptions CreateOptionsFromViewModel()

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml.cs
@@ -92,14 +92,7 @@ public partial class AddLocalContentView : UserControl
     // Drag & Drop handlers
     private void OnDragOver(object? sender, DragEventArgs e)
     {
-        if (e.Data.Contains(DataFormats.Files))
-        {
-            e.DragEffects = DragDropEffects.Copy;
-        }
-        else
-        {
-            e.DragEffects = DragDropEffects.None;
-        }
+        e.DragEffects = e.Data.Contains(DataFormats.Files) ? DragDropEffects.Copy : DragDropEffects.None;
     }
 
     private async void OnDrop(object? sender, DragEventArgs e)

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
@@ -73,17 +73,21 @@ public partial class AddLocalContentWindow : Window
         }
     }
 
-    private void OnAdminDrop(string[] files)
+    private async void OnAdminDrop(string[] files)
     {
         if (DataContext is not AddLocalContentViewModel vm) return;
 
-        _ = Task.Run(async () =>
+        try
         {
             foreach (var file in files)
             {
                 await vm.ImportContentAsync(file);
             }
-        });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error during admin drop import: {ex.Message}");
+        }
     }
 
     private void InitializeComponent()

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
@@ -72,14 +72,17 @@ public partial class AddLocalContentWindow : Window
         }
     }
 
-    private async void OnAdminDrop(string[] files)
+    private void OnAdminDrop(string[] files)
     {
         if (DataContext is not AddLocalContentViewModel vm) return;
 
-        foreach (var file in files)
+        _ = Task.Run(async () =>
         {
-            await vm.ImportContentAsync(file);
-        }
+            foreach (var file in files)
+            {
+                await vm.ImportContentAsync(file);
+            }
+        });
     }
 
     private void InitializeComponent()
@@ -90,14 +93,7 @@ public partial class AddLocalContentWindow : Window
     // Drag & Drop handlers
     private void OnDragOver(object? sender, DragEventArgs e)
     {
-        if (e.Data.Contains(DataFormats.Files))
-        {
-            e.DragEffects = DragDropEffects.Copy;
-        }
-        else
-        {
-            e.DragEffects = DragDropEffects.None;
-        }
+        e.DragEffects = e.Data.Contains(DataFormats.Files) ? DragDropEffects.Copy : DragDropEffects.None;
     }
 
     private async void OnDrop(object? sender, DragEventArgs e)

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
@@ -73,9 +73,17 @@ public partial class AddLocalContentWindow : Window
         }
     }
 
-    private async void OnAdminDrop(string[] files)
+    private void OnAdminDrop(string[] files)
     {
-        if (DataContext is not AddLocalContentViewModel vm) return;
+        _ = ProcessAdminDropAsync(files);
+    }
+
+    private async Task ProcessAdminDropAsync(string[] files)
+    {
+        if (DataContext is not AddLocalContentViewModel vm)
+        {
+            return;
+        }
 
         try
         {

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;

--- a/GenHub/GenHub/Features/GameProfiles/Views/GameProfileContentEditorView.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameProfileContentEditorView.axaml.cs
@@ -27,7 +27,7 @@ public partial class GameProfileContentEditorView : UserControl
 
     // Animation state
     private DispatcherTimer? _animationTimer;
-    private Stopwatch _animationStopwatch = new();
+    private readonly Stopwatch _animationStopwatch = new();
     private double _animStartOffset;
     private double _animTargetOffset;
 

--- a/GenHub/GenHub/Features/GameProfiles/Views/GameProfileContentEditorView.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameProfileContentEditorView.axaml.cs
@@ -20,6 +20,7 @@ public partial class GameProfileContentEditorView : UserControl
     private static readonly TimeSpan FrameInterval = TimeSpan.FromMilliseconds(16); // ~60fps
 
     private readonly List<(string Name, Control Control, ContentEditorCategory Category)> _sections = [];
+    private readonly Stopwatch _animationStopwatch = new();
 
     private ScrollViewer? _scrollViewer;
     private GameProfileSettingsViewModel? _subscribedViewModel;
@@ -27,7 +28,6 @@ public partial class GameProfileContentEditorView : UserControl
 
     // Animation state
     private DispatcherTimer? _animationTimer;
-    private readonly Stopwatch _animationStopwatch = new();
     private double _animStartOffset;
     private double _animTargetOffset;
 

--- a/GenHub/GenHub/Features/GameProfiles/Views/GameProfileContentSettingsView.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/GameProfileContentSettingsView.axaml.cs
@@ -33,15 +33,6 @@ public partial class GameProfileContentSettingsView : UserControl
         _scrollViewer = this.FindControl<ScrollViewer>("ContentSettingsScrollViewer");
     }
 
-    /// <summary>
-    /// Handles the unloaded event to clean up subscriptions.
-    /// </summary>
-    /// <param name="e">The event args.</param>
-    protected override void OnUnloaded(RoutedEventArgs e)
-    {
-        base.OnUnloaded(e);
-    }
-
     private void MapSection(string name)
     {
         var control = this.FindControl<Control>(name);

--- a/GenHub/GenHub/Features/GitHub/Services/GitHubRateLimitTracker.cs
+++ b/GenHub/GenHub/Features/GitHub/Services/GitHubRateLimitTracker.cs
@@ -122,13 +122,12 @@ public class GitHubRateLimitTracker(ILogger<GitHubRateLimitTracker> logger)
         {
             return $"{span.Minutes}m";
         }
-        else if (span.TotalHours < 24)
+
+        if (span.TotalHours < 24)
         {
             return $"{span.Hours}h {span.Minutes}m";
         }
-        else
-        {
-            return $"{span.Days}d {span.Hours}h";
-        }
+
+        return $"{span.Days}d {span.Hours}h";
     }
 }

--- a/GenHub/GenHub/Features/Info/Services/GeneralsOnlinePatchNotesService.cs
+++ b/GenHub/GenHub/Features/Info/Services/GeneralsOnlinePatchNotesService.cs
@@ -48,13 +48,10 @@ public class GeneralsOnlinePatchNotesService(IHttpClientFactory httpClientFactor
                 patchNote.Summary = summaryElement?.TextContent.Trim() ?? string.Empty;
                 patchNote.DetailsUrl = titleElement?.GetAttribute("href") ?? string.Empty;
 
-                if (!string.IsNullOrEmpty(patchNote.DetailsUrl))
+                if (!string.IsNullOrEmpty(patchNote.DetailsUrl) && !patchNote.DetailsUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (!patchNote.DetailsUrl.StartsWith("http"))
-                    {
-                        patchNote.Id = patchNote.DetailsUrl.Split('/').LastOrDefault() ?? string.Empty;
-                        patchNote.DetailsUrl = BaseUrl + patchNote.DetailsUrl;
-                    }
+                    patchNote.Id = patchNote.DetailsUrl.Split('/').LastOrDefault() ?? string.Empty;
+                    patchNote.DetailsUrl = BaseUrl + patchNote.DetailsUrl;
                 }
 
                 patchNotes.Add(patchNote);

--- a/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
+++ b/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
@@ -732,6 +732,7 @@ public class MockProfileContentLoader : IProfileContentLoader
                 break;
 
             default:
+                // No additional mock content for other content types
                 break;
         }
 

--- a/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
+++ b/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
@@ -122,7 +122,7 @@ public class MockUploadHistoryService : IUploadHistoryService
     public Task<UsageInfo> GetUsageInfoAsync()
     {
         // UsageInfo is a record struct with (UsedBytes, LimitBytes, ResetDate)
-        return Task.FromResult(new UsageInfo(1024 * 1024 * 5, 1024 * 1024 * 50, DateTime.Now.AddDays(1)));
+        return Task.FromResult(new UsageInfo(1024 * 1024 * 5, 1024 * 1024 * 50, DateTime.UtcNow.AddDays(1)));
     }
 
     /// <inheritdoc/>
@@ -179,7 +179,7 @@ public class MockReplayDirectoryService : IReplayDirectoryService
                 FileName = "Demo Replay 1.rep",
                 FullPath = "C:\\Mock\\Demo1.rep",
                 SizeInBytes = 1024 * 500,
-                LastModified = DateTime.Now.AddDays(-1),
+                LastModified = DateTime.UtcNow.AddDays(-1),
                 GameVersion = gameType, // Use requested type so it appears valid
             },
             new()
@@ -187,7 +187,7 @@ public class MockReplayDirectoryService : IReplayDirectoryService
                 FileName = "Pro Match vs AI.rep",
                 FullPath = "C:\\Mock\\Demo2.rep",
                 SizeInBytes = 1024 * 1200,
-                LastModified = DateTime.Now.AddHours(-5),
+                LastModified = DateTime.UtcNow.AddHours(-5),
                 GameVersion = gameType, // Use requested type so it appears valid
             },
         };
@@ -292,7 +292,7 @@ public class MockMapDirectoryService : IMapDirectoryService
                 GameType = GameType.ZeroHour,
                 IsDirectory = true,
                 SizeBytes = 250000,
-                LastModified = DateTime.Now,
+                LastModified = DateTime.UtcNow,
                 DirectoryName = "Tournament Desert",
                 AssetFiles = ["map.ini", "map.str", "map.tga"],
             },
@@ -304,7 +304,7 @@ public class MockMapDirectoryService : IMapDirectoryService
                 GameType = GameType.ZeroHour,
                 IsDirectory = false,
                 SizeBytes = 150000,
-                LastModified = DateTime.Now.AddDays(-10),
+                LastModified = DateTime.UtcNow.AddDays(-10),
                 DirectoryName = "Twilight Flame",
                 AssetFiles = ["map.ini", "map.str", "map.tga"],
             },
@@ -316,7 +316,7 @@ public class MockMapDirectoryService : IMapDirectoryService
                 GameType = GameType.Generals,
                 IsDirectory = true,
                 SizeBytes = 180000,
-                LastModified = DateTime.Now.AddDays(-5),
+                LastModified = DateTime.UtcNow.AddDays(-5),
                 DirectoryName = "Alpine Assault",
                 AssetFiles = ["map.ini", "map.str", "map.tga"],
             },
@@ -328,7 +328,7 @@ public class MockMapDirectoryService : IMapDirectoryService
                 GameType = GameType.Generals,
                 IsDirectory = false,
                 SizeBytes = 120000,
-                LastModified = DateTime.Now.AddDays(-20),
+                LastModified = DateTime.UtcNow.AddDays(-20),
                 DirectoryName = "Flash Fire",
                 AssetFiles = ["map.ini", "map.str", "map.tga"],
             },
@@ -729,6 +729,9 @@ public class MockProfileContentLoader : IProfileContentLoader
             case ContentType.ModdingTool:
                 list.Add(new ContentDisplayItem { Id = "wb", DisplayName = "World Builder", ContentType = ContentType.ModdingTool, GameType = GameType.ZeroHour, Publisher = "EA", Version = "1.0", ManifestId = ManifestId.Create("wb"), InstallationType = GameInstallationType.Unknown });
                 list.Add(new ContentDisplayItem { Id = "finalbig", DisplayName = "FinalBig", ContentType = ContentType.ModdingTool, GameType = GameType.ZeroHour, Publisher = "Community", Version = "0.4", ManifestId = ManifestId.Create("finalbig"), InstallationType = GameInstallationType.Unknown });
+                break;
+
+            default:
                 break;
         }
 

--- a/GenHub/GenHub/Features/Info/Services/MockVelopackUpdateManager.cs
+++ b/GenHub/GenHub/Features/Info/Services/MockVelopackUpdateManager.cs
@@ -97,8 +97,8 @@ public class MockVelopackUpdateManager(INotificationService? notificationService
     {
         var artifacts = new List<ArtifactUpdateInfo>
         {
-            new("1.2.0", "abcdefg", null, 123456, "https://github.com", 7890, $"GenHub-win-x64-{branchName}", DateTime.Now.AddDays(-1), "https://github.com/download", 50 * 1024 * 1024),
-            new("1.1.9", "7654321", null, 123455, "https://github.com", 7889, $"GenHub-win-x64-{branchName}", DateTime.Now.AddDays(-3), "https://github.com/download", 50 * 1024 * 1024),
+            new("1.2.0", "abcdefg", null, 123456, "https://github.com", 7890, $"GenHub-win-x64-{branchName}", DateTime.UtcNow.AddDays(-1), "https://github.com/download", 50 * 1024 * 1024),
+            new("1.1.9", "7654321", null, 123455, "https://github.com", 7889, $"GenHub-win-x64-{branchName}", DateTime.UtcNow.AddDays(-3), "https://github.com/download", 50 * 1024 * 1024),
         };
         return Task.FromResult<IReadOnlyList<ArtifactUpdateInfo>>(artifacts);
     }
@@ -108,8 +108,8 @@ public class MockVelopackUpdateManager(INotificationService? notificationService
     {
         var artifacts = new List<ArtifactUpdateInfo>
         {
-            new("1.2.0", "abc1234", prNumber, 112233, "https://github.com", 4455, $"GenHub-win-x64-PR{prNumber}", DateTime.Now.AddHours(-2), "https://github.com/download", 52 * 1024 * 1024),
-            new("1.2.0", "def5678", prNumber, 112232, "https://github.com", 4454, $"GenHub-win-x64-PR{prNumber}", DateTime.Now.AddDays(-1), "https://github.com/download", 51 * 1024 * 1024),
+            new("1.2.0", "abc1234", prNumber, 112233, "https://github.com", 4455, $"GenHub-win-x64-PR{prNumber}", DateTime.UtcNow.AddHours(-2), "https://github.com/download", 52 * 1024 * 1024),
+            new("1.2.0", "def5678", prNumber, 112232, "https://github.com", 4454, $"GenHub-win-x64-PR{prNumber}", DateTime.UtcNow.AddDays(-1), "https://github.com/download", 51 * 1024 * 1024),
         };
         return Task.FromResult<IReadOnlyList<ArtifactUpdateInfo>>(artifacts);
     }

--- a/GenHub/GenHub/Features/Info/ViewModels/DemoViewModelFactory.cs
+++ b/GenHub/GenHub/Features/Info/ViewModels/DemoViewModelFactory.cs
@@ -198,8 +198,10 @@ public static class DemoViewModelFactory
 
             return vm;
         }
-        catch (InvalidOperationException)
+        catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"Failed to create full demo game settings view model: {ex}");
+
             // Fallback
             var mockService = new MockGameSettingsService();
             var mockLogger = new MockLogger<GameSettingsViewModel>();

--- a/GenHub/GenHub/Features/Info/ViewModels/DemoViewModelFactory.cs
+++ b/GenHub/GenHub/Features/Info/ViewModels/DemoViewModelFactory.cs
@@ -198,7 +198,7 @@ public static class DemoViewModelFactory
 
             return vm;
         }
-        catch (Exception)
+        catch (InvalidOperationException)
         {
             // Fallback
             var mockService = new MockGameSettingsService();

--- a/GenHub/GenHub/Features/Info/ViewModels/FaqSectionViewModel.cs
+++ b/GenHub/GenHub/Features/Info/ViewModels/FaqSectionViewModel.cs
@@ -60,7 +60,7 @@ public partial class FaqSectionViewModel(IFaqService faqService, ILogger<FaqSect
     ];
 
     [ObservableProperty]
-    private LanguageOption _selectedLanguageOption = new LanguageOption("English", "en", "avares://GenHub/Assets/Images/Flags/en.png"); // Default, updated in constructor logic if needed but simpler to just init here or OnActivated
+    private LanguageOption _selectedLanguageOption = new("English", "en", "avares://GenHub/Assets/Images/Flags/en.png"); // Default, updated in constructor logic if needed but simpler to just init here or OnActivated
 
     [ObservableProperty]
     private FaqCategoryViewModel? _selectedCategory;
@@ -87,9 +87,9 @@ public partial class FaqSectionViewModel(IFaqService faqService, ILogger<FaqSect
         }
     }
 
-    async partial void OnSelectedLanguageOptionChanged(LanguageOption value)
+    partial void OnSelectedLanguageOptionChanged(LanguageOption value)
     {
-        await LoadFaqAsync();
+        _ = LoadFaqAsync();
     }
 
     [RelayCommand]

--- a/GenHub/GenHub/Features/Info/ViewModels/GenHubInfoSectionViewModel.cs
+++ b/GenHub/GenHub/Features/Info/ViewModels/GenHubInfoSectionViewModel.cs
@@ -83,7 +83,7 @@ public partial class GenHubInfoSectionViewModel(
     /// <summary>
     /// Gets the FAQ cards for the right column.
     /// </summary>
-    public IEnumerable<InfoCardViewModel> FaqCardsRight => SelectedSection?.Cards.Where((_, i) => i % 2 == 1) ?? [];
+    public IEnumerable<InfoCardViewModel> FaqCardsRight => SelectedSection?.Cards.Where((_, i) => i % 2 != 0) ?? [];
 
     // Tools section expandable state
     [ObservableProperty]
@@ -214,19 +214,9 @@ public partial class GenHubInfoSectionViewModel(
     {
         Sections.Clear();
 
-        IEnumerable<InfoSectionViewModel> filtered;
-
-        if (_currentModule == GeneralsHubModule.GeneralsOnline)
-        {
-            // For GeneralsOnline, show FAQ and Changelog (and any others tagged for it)
-            // Assuming IDs: "faq", "go-changelog" (from DefaultInfoContentProvider)
-            filtered = _allSections.Where(s => s.Id == "faq" || s.Id == "go-changelog");
-        }
-        else
-        {
-            // For Guide, show everything ELSE
-            filtered = _allSections.Where(s => s.Id != "faq" && s.Id != "go-changelog");
-        }
+        var filtered = _currentModule == GeneralsHubModule.GeneralsOnline
+            ? _allSections.Where(s => s.Id == "faq" || s.Id == "go-changelog")
+            : _allSections.Where(s => s.Id != "faq" && s.Id != "go-changelog");
 
         foreach (var section in filtered)
         {

--- a/GenHub/GenHub/Features/Info/ViewModels/InfoViewModel.cs
+++ b/GenHub/GenHub/Features/Info/ViewModels/InfoViewModel.cs
@@ -42,17 +42,10 @@ public partial class InfoViewModel : ViewModelBase, IDisposable, IRecipient<Open
     /// <param name="sectionId">The ID of the section to open.</param>
     public void OpenSection(string sectionId)
     {
-        // 1. Check if it's a known GeneralsOnline section
-        if (sectionId.Equals("faq", StringComparison.OrdinalIgnoreCase) ||
-            sectionId.Equals("go-changelog", StringComparison.OrdinalIgnoreCase))
-        {
-            SelectedModule = "GeneralsOnline";
-        }
-        else
-        {
-            // Default to Guide for everything else
-            SelectedModule = "GenHub Guide";
-        }
+        SelectedModule = (sectionId.Equals("faq", StringComparison.OrdinalIgnoreCase) ||
+                          sectionId.Equals("go-changelog", StringComparison.OrdinalIgnoreCase))
+            ? "GeneralsOnline"
+            : "GenHub Guide";
 
         // 2. Force update sections context to ensure the list is populated for the target module
         // (SelectedModule setter calls UpdateSidebarItems, but we need to be sure before searching)
@@ -217,12 +210,9 @@ public partial class InfoViewModel : ViewModelBase, IDisposable, IRecipient<Open
 
     private void OnFaqSectionPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(FaqSectionViewModel.SelectedCategory))
+        if (e.PropertyName == nameof(FaqSectionViewModel.SelectedCategory) && sender is FaqSectionViewModel faqSection)
         {
-            if (sender is FaqSectionViewModel faqSection)
-            {
-                SelectedSidebarItem = faqSection.SelectedCategory;
-            }
+            SelectedSidebarItem = faqSection.SelectedCategory;
         }
     }
 

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -874,7 +874,7 @@ public class GameLauncher(
         }
     }
 
-    private async Task<OperationResult<(WorkspaceInfo, IDisposable?)>> SetupAndAcquireWorkspaceAsync(
+    private async Task<OperationResult<(WorkspaceInfo Workspace, IDisposable? SteamLock)>> SetupAndAcquireWorkspaceAsync(
         GameProfile profile,
         List<ContentManifest> manifests,
         GenHub.Core.Models.GameClients.GameClient gameClient,

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -771,7 +771,7 @@ public class GameLauncher(
                 progress,
                 cancellationToken);
 
-            if (!workspaceSetupResult.Success || workspaceSetupResult.Data.Workspace == null)
+            if (!workspaceSetupResult.Success)
             {
                 await launchRegistry.UnregisterLaunchAsync(launchId);
                 return LaunchOperationResult<GameLaunchInfo>.CreateFailure(workspaceSetupResult.FirstError ?? "Workspace preparation failed", launchId, profile.Id);
@@ -779,6 +779,14 @@ public class GameLauncher(
 
             var (workspaceInfo, acquiredLock) = workspaceSetupResult.Data;
             steamInstallationLock = acquiredLock;
+
+            if (workspaceInfo == null)
+            {
+                steamInstallationLock?.Dispose();
+                steamInstallationLock = null;
+                await launchRegistry.UnregisterLaunchAsync(launchId);
+                return LaunchOperationResult<GameLaunchInfo>.CreateFailure("Workspace preparation returned null workspace info", launchId, profile.Id);
+            }
 
             progress?.Report(new LaunchProgress { Phase = LaunchPhase.PreparingUserData, PercentComplete = 82 });
             TriggerBackgroundUserDataSwitch(profile, manifests, skipUserDataCleanup);
@@ -866,7 +874,7 @@ public class GameLauncher(
         }
     }
 
-    private async Task<OperationResult<(WorkspaceInfo Workspace, IDisposable? Lock)>> SetupAndAcquireWorkspaceAsync(
+    private async Task<OperationResult<(WorkspaceInfo, IDisposable?)>> SetupAndAcquireWorkspaceAsync(
         GameProfile profile,
         List<ContentManifest> manifests,
         GenHub.Core.Models.GameClients.GameClient gameClient,
@@ -878,32 +886,43 @@ public class GameLauncher(
         CancellationToken cancellationToken)
     {
         IDisposable? steamInstallationLock = null;
-        if (isSteamLaunch)
+        try
         {
-            steamInstallationLock = await AcquireSteamInstallationLockAsync(actualInstallationPath, cancellationToken);
-            logger.LogInformation("[GameLauncher] Steam launch detected - workspace will be adjacent to installation in .genhub-workspace directory");
+            if (isSteamLaunch)
+            {
+                steamInstallationLock = await AcquireSteamInstallationLockAsync(actualInstallationPath, cancellationToken);
+                logger.LogInformation("[GameLauncher] Steam launch detected - workspace will be adjacent to installation in .genhub-workspace directory");
+            }
+
+            logger.LogDebug("[GameLauncher] Using dynamic workspace path: {WorkspacePath} (Installation: {InstallPath})", dynamicWorkspacePath, actualInstallationPath);
+
+            var workspaceResult = await PrepareWorkspaceForLaunchAsync(
+                profile,
+                manifests,
+                gameClient,
+                actualInstallationPath,
+                dynamicWorkspacePath,
+                isSteamLaunch,
+                manifestSourcePaths,
+                progress,
+                cancellationToken);
+
+            if (!workspaceResult.Success || workspaceResult.Data == null)
+            {
+                steamInstallationLock?.Dispose();
+                steamInstallationLock = null;
+                return OperationResult<(WorkspaceInfo, IDisposable?)>.CreateFailure(workspaceResult.FirstError ?? "Workspace preparation failed");
+            }
+
+            var lockToReturn = steamInstallationLock;
+            steamInstallationLock = null; // ownership transferred to caller
+            return OperationResult<(WorkspaceInfo, IDisposable?)>.CreateSuccess((workspaceResult.Data, lockToReturn));
         }
-
-        logger.LogDebug("[GameLauncher] Using dynamic workspace path: {WorkspacePath} (Installation: {InstallPath})", dynamicWorkspacePath, actualInstallationPath);
-
-        var workspaceResult = await PrepareWorkspaceForLaunchAsync(
-            profile,
-            manifests,
-            gameClient,
-            actualInstallationPath,
-            dynamicWorkspacePath,
-            isSteamLaunch,
-            manifestSourcePaths,
-            progress,
-            cancellationToken);
-
-        if (!workspaceResult.Success || workspaceResult.Data == null)
+        catch (Exception)
         {
             steamInstallationLock?.Dispose();
-            return OperationResult<(WorkspaceInfo, IDisposable?)>.CreateFailure(workspaceResult.FirstError ?? "Workspace preparation failed");
+            throw;
         }
-
-        return OperationResult<(WorkspaceInfo, IDisposable?)>.CreateSuccess((workspaceResult.Data, steamInstallationLock));
     }
 
     private async Task<OperationResult<(GameLaunchConfiguration LaunchConfig, SteamLaunchPrepResult? SteamPrep, string? SteamAppId)>> PrepareLaunchConfigurationAndProxyAsync(

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -240,7 +240,7 @@ public class ManifestDiscoveryService(
             cancellationToken.ThrowIfCancellationRequested();
             var currentDirectory = pendingDirectories.Pop();
 
-            string[] files;
+            string[] files = [];
             try
             {
                 files = _enumerateFiles(currentDirectory, searchPattern).ToArray();
@@ -260,7 +260,7 @@ public class ManifestDiscoveryService(
                 yield return file;
             }
 
-            string[] childDirectories;
+            string[] childDirectories = [];
             try
             {
                 childDirectories = _enumerateDirectories(currentDirectory).ToArray();

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -321,7 +321,7 @@ public class ManifestDiscoveryService(
     private async Task DiscoverEmbeddedManifestsAsync(CancellationToken cancellationToken)
     {
         logger.LogInformation("Scanning for embedded manifests...");
-        var assembly = Assembly.GetExecutingAssembly();
+        var assembly = typeof(ManifestDiscoveryService).Assembly;
         var manifestResourceNames = assembly.GetManifestResourceNames()
             .Where(r => r.StartsWith("GenHub.Manifests.") && r.EndsWith(FileTypes.JsonFileExtension));
 

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -390,10 +390,12 @@ public class ManifestGenerationService(
             }
             else
             {
-                // Legacy/Fallback detection
-                var publisherName = clientName.Contains("steam", StringComparison.InvariantCultureIgnoreCase) ? PublisherInfoConstants.Steam.Name :
-                                    clientName.Contains("ea", StringComparison.InvariantCultureIgnoreCase) ? PublisherInfoConstants.EaApp.Name :
-                                    PublisherInfoConstants.Retail.Name;
+                var publisherName = clientName switch
+                {
+                    _ when clientName.Contains("steam", StringComparison.InvariantCultureIgnoreCase) => PublisherInfoConstants.Steam.Name,
+                    _ when clientName.Contains("ea", StringComparison.InvariantCultureIgnoreCase) => PublisherInfoConstants.EaApp.Name,
+                    _ => PublisherInfoConstants.Retail.Name,
+                };
                 publisher = new PublisherInfo { Name = publisherName };
             }
 
@@ -571,7 +573,7 @@ public class ManifestGenerationService(
 
             // Add all subdirectories except known non-game directories
             // PRIORITY: Use CSV-based manifest generation if available
-            var csvAdded = await AddFilesFromCsvAsync(builder, installationPath, gameType);
+            await AddFilesFromCsvAsync(builder, installationPath, gameType);
 
             logger.LogInformation("Completed manifest generation for {GameType}: {TotalFiles} files added", gameType, _fileCount);
             logger.LogDebug("Added game files to manifest for {GameType} at {InstallationPath}", gameType, installationPath);

--- a/GenHub/GenHub/Features/Notifications/Services/NotificationService.cs
+++ b/GenHub/GenHub/Features/Notifications/Services/NotificationService.cs
@@ -141,8 +141,8 @@ public class NotificationService : INotificationService, IDisposable
 
         ArgumentNullException.ThrowIfNull(notification);
 
-        bool muted;
-        NotificationMuteState state;
+        bool muted = false;
+        NotificationMuteState state = NotificationMuteState.None;
         lock (_muteLock)
         {
             state = _muteState;

--- a/GenHub/GenHub/Features/Notifications/ViewModels/NotificationFeedItemViewModel.cs
+++ b/GenHub/GenHub/Features/Notifications/ViewModels/NotificationFeedItemViewModel.cs
@@ -148,30 +148,31 @@ public partial class NotificationFeedItemViewModel : ViewModelBase, IDisposable
     /// <returns>The formatted time string.</returns>
     private static string FormatTimestamp(DateTime timestamp)
     {
-        var now = DateTime.Now;
-        var localTimestamp = timestamp.ToLocalTime();
-        var diff = now - localTimestamp;
+        var now = DateTime.UtcNow;
+        var utcTimestamp = timestamp.ToUniversalTime();
+        var diff = now - utcTimestamp;
 
         if (diff.TotalMinutes < 1)
         {
             return "Just now";
         }
-        else if (diff.TotalMinutes < 60)
+
+        if (diff.TotalMinutes < 60)
         {
             return $"{diff.Minutes}m ago";
         }
-        else if (diff.TotalHours < 24)
+
+        if (diff.TotalHours < 24)
         {
             return $"{diff.Hours}h ago";
         }
-        else if (diff.TotalDays < 7)
+
+        if (diff.TotalDays < 7)
         {
             return $"{diff.Days}d ago";
         }
-        else
-        {
-            return localTimestamp.ToString("MMM dd");
-        }
+
+        return timestamp.ToLocalTime().ToString("MMM dd");
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1506,14 +1506,9 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             {
                 // Fallback to try to find any installation
                 var installations = await _installationService.GetAllInstallationsAsync();
-                if (installations.Success && installations.Data?.Any() == true)
-                {
-                    path = _storageLocationService.GetWorkspacePath(installations.Data[0]);
-                }
-                else
-                {
-                    path = Path.Combine(_configurationProvider.GetApplicationDataPath(), DirectoryNames.Workspaces);
-                }
+                path = (installations.Success && installations.Data?.Any() == true)
+                    ? _storageLocationService.GetWorkspacePath(installations.Data[0])
+                    : Path.Combine(_configurationProvider.GetApplicationDataPath(), DirectoryNames.Workspaces);
             }
 
             _logger.LogInformation("Opening workspaces directory: {Path}", path);
@@ -1554,14 +1549,9 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             {
                 // Fallback to try to find any installation
                 var installations = await _installationService.GetAllInstallationsAsync();
-                if (installations.Success && installations.Data?.Any() == true)
-                {
-                    path = _storageLocationService.GetCasPoolPath(installations.Data[0]);
-                }
-                else
-                {
-                    path = _configurationProvider.GetCasConfiguration().CasRootPath;
-                }
+                path = (installations.Success && installations.Data?.Any() == true)
+                    ? _storageLocationService.GetCasPoolPath(installations.Data[0])
+                    : _configurationProvider.GetCasConfiguration().CasRootPath;
             }
 
             _logger.LogInformation("Opening CAS pool directory: {Path}", path);

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1333,17 +1333,13 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         if (Math.Abs(DownloadBufferSizeKB - message.BufferSizeKB) > 0.01)
             DownloadBufferSizeKB = message.BufferSizeKB;
 
-        if (DownloadTimeoutSeconds != message.TimeoutSeconds)
-            DownloadTimeoutSeconds = message.TimeoutSeconds;
-
-        if (DownloadUserAgent != message.UserAgent)
-            DownloadUserAgent = message.UserAgent;
+        DownloadTimeoutSeconds = message.TimeoutSeconds;
+        DownloadUserAgent = message.UserAgent;
     }
 
     private void OnThemeSettingsChanged(ThemeChangedMessage message)
     {
-        if (Theme != message.ThemeName)
-            Theme = message.ThemeName;
+        Theme = message.ThemeName;
     }
 
     [RelayCommand]

--- a/GenHub/GenHub/Features/Storage/Services/CasReferenceTracker.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasReferenceTracker.cs
@@ -363,7 +363,7 @@ public class CasReferenceTracker(
         {
             throw;
         }
-        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        catch (FileNotFoundException ex)
         {
             _logger.LogDebug(ex, "Reference file {RefFile} was deleted concurrently during scan", refFile);
             return references;

--- a/GenHub/GenHub/Features/Storage/Services/CasReferenceTracker.cs
+++ b/GenHub/GenHub/Features/Storage/Services/CasReferenceTracker.cs
@@ -363,10 +363,15 @@ public class CasReferenceTracker(
         {
             throw;
         }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            _logger.LogDebug(ex, "Reference file {RefFile} was deleted concurrently during scan", refFile);
+            return references;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to read references from {RefFile}", refFile);
-            throw; // Fail closed: if we can't read refs, we shouldn't assume empty and risk GCing live data
+            throw; // Fail closed: if we can't read refs due to corruption, we shouldn't assume empty and risk GCing live data
         }
 
         return references;

--- a/GenHub/GenHub/Features/Storage/Services/InstallationCasPoolService.cs
+++ b/GenHub/GenHub/Features/Storage/Services/InstallationCasPoolService.cs
@@ -160,11 +160,13 @@ public sealed class InstallationCasPoolService(
 
     private static string? GetDerivedPoolPath(GameInstallation installation)
     {
-        var installationPath = !string.IsNullOrWhiteSpace(installation.InstallationPath)
-            ? installation.InstallationPath
-            : !string.IsNullOrWhiteSpace(installation.ZeroHourPath)
+        var installationPath = installation.InstallationPath;
+        if (string.IsNullOrWhiteSpace(installationPath))
+        {
+            installationPath = !string.IsNullOrWhiteSpace(installation.ZeroHourPath)
                 ? installation.ZeroHourPath
                 : installation.GeneralsPath;
+        }
 
         return string.IsNullOrWhiteSpace(installationPath)
             ? null
@@ -241,7 +243,19 @@ public sealed class InstallationCasPoolService(
         {
             return Path.GetFullPath(path);
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or IOException or SecurityException)
+        catch (ArgumentException)
+        {
+            return string.Empty;
+        }
+        catch (NotSupportedException)
+        {
+            return string.Empty;
+        }
+        catch (IOException)
+        {
+            return string.Empty;
+        }
+        catch (SecurityException)
         {
             return string.Empty;
         }

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapDirectoryService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapDirectoryService.cs
@@ -269,7 +269,7 @@ public sealed class MapDirectoryService(
 
         // Validate name for illegal characters
         var invalidChars = Path.GetInvalidFileNameChars();
-        if (newName.Any(c => invalidChars.Contains(c)))
+        if (newName.IndexOfAny(invalidChars) >= 0)
         {
             logger.LogWarning("Invalid characters in map name: {Name}", newName);
             return false;
@@ -325,19 +325,18 @@ public sealed class MapDirectoryService(
                         logger.LogInformation("Renamed map directory from {OldName} to {NewName}", map.DirectoryName, newName);
                         return true;
                     }
-                    else
+
+                    // Rename standalone .map file
+                    var directory = Path.GetDirectoryName(map.FullPath);
+                    if (string.IsNullOrEmpty(directory))
                     {
-                        // Rename standalone .map file
-                        var directory = Path.GetDirectoryName(map.FullPath);
-                        if (string.IsNullOrEmpty(directory))
-                        {
-                            return false;
-                        }
+                        return false;
+                    }
 
-                        var newFileName = newName + ".map";
-                        var newFilePath = Path.Combine(directory, newFileName);
+                    var newFileName = newName + ".map";
+                    var newFilePath = Path.Combine(directory, newFileName);
 
-                        if (File.Exists(newFilePath))
+                    if (File.Exists(newFilePath))
                         {
                             logger.LogWarning("Target file already exists: {Path}", newFilePath);
                             return false;

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapDirectoryService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapDirectoryService.cs
@@ -337,15 +337,14 @@ public sealed class MapDirectoryService(
                     var newFilePath = Path.Combine(directory, newFileName);
 
                     if (File.Exists(newFilePath))
-                        {
-                            logger.LogWarning("Target file already exists: {Path}", newFilePath);
-                            return false;
-                        }
-
-                        File.Move(map.FullPath, newFilePath);
-                        logger.LogInformation("Renamed map from {OldName} to {NewName}", map.FileName, newFileName);
-                        return true;
+                    {
+                        logger.LogWarning("Target file already exists: {Path}", newFilePath);
+                        return false;
                     }
+
+                    File.Move(map.FullPath, newFilePath);
+                    logger.LogInformation("Renamed map from {OldName} to {NewName}", map.FileName, newFileName);
+                    return true;
                 }
                 catch (Exception ex)
                 {

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
@@ -280,7 +280,12 @@ public sealed class MapImportService(
                             // Determine the directory name for this map
                             var mapDirName = string.IsNullOrEmpty(directoryName)
                                 ? Path.GetFileNameWithoutExtension(mapEntry.Name)
-                                : directoryName;
+                                : Path.GetFileName(directoryName);
+
+                            if (string.IsNullOrWhiteSpace(mapDirName) || mapDirName == "." || mapDirName == "..")
+                            {
+                                mapDirName = Path.GetFileNameWithoutExtension(mapEntry.Name);
+                            }
 
                             var mapDirPath = GetUniqueDirectoryPath(Path.Combine(targetDir, mapDirName));
                             Directory.CreateDirectory(mapDirPath);
@@ -333,7 +338,7 @@ public sealed class MapImportService(
                                 FullPath = mapDestPath,
                                 SizeBytes = totalSize,
                                 GameType = targetVersion,
-                                LastModified = DateTime.UtcNow,
+                                LastModified = File.GetLastWriteTime(mapDestPath),
                                 DirectoryName = Path.GetFileName(mapDirPath),
                                 IsDirectory = true,
                                 AssetFiles = assetFiles,
@@ -400,6 +405,12 @@ public sealed class MapImportService(
                 if (totalUncompressedBytes > MapManagerConstants.MaxAggregateUncompressedBytes)
                 {
                     return (false, $"ZIP aggregate uncompressed size exceeds maximum allowed limit ({totalUncompressedBytes} > {MapManagerConstants.MaxAggregateUncompressedBytes} bytes).");
+                }
+
+                var segments = entry.FullName.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Any(s => s == "." || s == ".." || s.Contains(':') || Path.IsPathRooted(s)))
+                {
+                    return (false, $"ZIP contains invalid path traversal segment in '{entry.FullName}'.");
                 }
 
                 // Calculate nesting depth

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
@@ -33,6 +33,7 @@ public sealed class MapImportService(
         CancellationToken ct = default)
     {
         var result = new ImportResult();
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenHub", "MapImports", Guid.NewGuid().ToString("N"));
 
         try
         {
@@ -41,8 +42,9 @@ public sealed class MapImportService(
             var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
             response.EnsureSuccessStatusCode();
 
-            var fileName = GetFileNameFromUrl(url, response);
-            var tempPath = Path.Combine(Path.GetTempPath(), fileName);
+            var fileName = GetFileNameFromUrl(new Uri(url), response);
+            Directory.CreateDirectory(tempDir);
+            var tempPath = Path.Combine(tempDir, fileName);
 
             await using (var fileStream = File.Create(tempPath))
             await using (var httpStream = await response.Content.ReadAsStreamAsync(ct))
@@ -56,13 +58,10 @@ public sealed class MapImportService(
             {
                 using var stream = File.OpenRead(tempPath);
                 var buffer = new byte[4];
-                if (await stream.ReadAsync(buffer.AsMemory(0, 4), ct) == 4)
+                if (await stream.ReadAsync(buffer.AsMemory(0, 4), ct) == 4 &&
+                    buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x03 && buffer[3] == 0x04)
                 {
-                    // ZIP signature: 50 4B 03 04
-                    if (buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x03 && buffer[3] == 0x04)
-                    {
-                        isZip = true;
-                    }
+                    isZip = true;
                 }
             }
             catch (Exception ex)
@@ -97,17 +96,25 @@ public sealed class MapImportService(
 
                 result = await ImportFromFilesAsync([tempPath], targetVersion, ct);
             }
-
-            // Cleanup temp file
-            if (File.Exists(tempPath))
-            {
-                File.Delete(tempPath);
-            }
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to import from URL: {Url}", url);
             result.Errors.Add($"Import failed: {ex.Message}");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+                catch
+                {
+                    // Best effort cleanup
+                }
+            }
         }
 
         result.Success = result.FilesImported > 0;
@@ -271,17 +278,9 @@ public sealed class MapImportService(
                             }
 
                             // Determine the directory name for this map
-                            string mapDirName;
-                            if (string.IsNullOrEmpty(directoryName))
-                            {
-                                // Root-level map - create a directory using the map name
-                                mapDirName = Path.GetFileNameWithoutExtension(mapEntry.Name);
-                            }
-                            else
-                            {
-                                // Directory-based map - use the existing directory name
-                                mapDirName = directoryName;
-                            }
+                            var mapDirName = string.IsNullOrEmpty(directoryName)
+                                ? Path.GetFileNameWithoutExtension(mapEntry.Name)
+                                : directoryName;
 
                             var mapDirPath = GetUniqueDirectoryPath(Path.Combine(targetDir, mapDirName));
                             Directory.CreateDirectory(mapDirPath);
@@ -334,7 +333,7 @@ public sealed class MapImportService(
                                 FullPath = mapDestPath,
                                 SizeBytes = totalSize,
                                 GameType = targetVersion,
-                                LastModified = DateTime.Now,
+                                LastModified = DateTime.UtcNow,
                                 DirectoryName = Path.GetFileName(mapDirPath),
                                 IsDirectory = true,
                                 AssetFiles = assetFiles,
@@ -373,11 +372,36 @@ public sealed class MapImportService(
                 return (false, "ZIP file is empty");
             }
 
+            if (entries.Count > MapManagerConstants.MaxZipEntries)
+            {
+                return (false, $"ZIP contains too many entries ({entries.Count} > {MapManagerConstants.MaxZipEntries}).");
+            }
+
+            long totalUncompressedBytes = 0;
             var allowedExtensions = MapManagerConstants.AllowedExtensions;
             var directoriesWithMaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var entry in entries)
             {
+                // Check single entry asset size
+                if (entry.Length > MapManagerConstants.MaxAssetSizeBytes)
+                {
+                    return (false, $"ZIP entry '{entry.FullName}' exceeds maximum allowed size ({entry.Length} > {MapManagerConstants.MaxAssetSizeBytes} bytes).");
+                }
+
+                // Check compression ratio
+                if (entry.CompressedLength > 0 &&
+                    ((double)entry.Length / entry.CompressedLength) > MapManagerConstants.MaxCompressionRatio)
+                {
+                    return (false, $"ZIP entry '{entry.FullName}' exceeds maximum compression ratio (potential zip bomb).");
+                }
+
+                totalUncompressedBytes += entry.Length;
+                if (totalUncompressedBytes > MapManagerConstants.MaxAggregateUncompressedBytes)
+                {
+                    return (false, $"ZIP aggregate uncompressed size exceeds maximum allowed limit ({totalUncompressedBytes} > {MapManagerConstants.MaxAggregateUncompressedBytes} bytes).");
+                }
+
                 // Calculate nesting depth
                 var separatorCount = entry.FullName.Count(c => c == '/' || c == '\\');
 
@@ -442,10 +466,18 @@ public sealed class MapImportService(
         GameType targetVersion,
         CancellationToken ct = default)
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), fileName);
+        var sanitizedFileName = Path.GetFileName(fileName);
+        if (string.IsNullOrWhiteSpace(sanitizedFileName))
+        {
+            sanitizedFileName = $"map_{Guid.NewGuid():N}.map";
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenHub", "MapImports", Guid.NewGuid().ToString("N"));
+        var tempPath = Path.Combine(tempDir, sanitizedFileName);
 
         try
         {
+            Directory.CreateDirectory(tempDir);
             await using (var fileStream = File.Create(tempPath))
             {
                 await stream.CopyToAsync(fileStream, ct);
@@ -455,22 +487,49 @@ public sealed class MapImportService(
         }
         finally
         {
-            if (File.Exists(tempPath))
+            if (Directory.Exists(tempDir))
             {
-                File.Delete(tempPath);
+                try
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+                catch
+                {
+                    // Best effort cleanup
+                }
             }
         }
     }
 
-    private static string GetFileNameFromUrl(string url, HttpResponseMessage response)
+    private static string GetFileNameFromUrl(Uri uri, HttpResponseMessage response)
     {
-        if (response.Content.Headers.ContentDisposition?.FileName != null)
+        var rawName = response.Content.Headers.ContentDisposition?.FileNameStar
+            ?? response.Content.Headers.ContentDisposition?.FileName;
+
+        if (!string.IsNullOrWhiteSpace(rawName))
         {
-            return response.Content.Headers.ContentDisposition.FileName.Trim('"');
+            var trimmed = rawName.Trim('"', '\'');
+            var fileName = Path.GetFileName(trimmed);
+            if (!string.IsNullOrWhiteSpace(fileName))
+            {
+                return fileName;
+            }
         }
 
-        var uri = new Uri(url);
-        return Path.GetFileName(uri.LocalPath);
+        try
+        {
+            var localName = Path.GetFileName(uri.LocalPath);
+            if (!string.IsNullOrWhiteSpace(localName))
+            {
+                return localName;
+            }
+        }
+        catch
+        {
+            // fallback below
+        }
+
+        return $"map_{Guid.NewGuid():N}.zip";
     }
 
     private static string GetUniqueFilePath(string path)

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapPackService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapPackService.cs
@@ -210,7 +210,7 @@ public sealed class MapPackService : IMapPackService
                 {
                     var json = File.ReadAllText(file);
                     var mapPack = JsonSerializer.Deserialize<MapPack>(json, _jsonOptions);
-                    if (mapPack != null && !mapPacks.Any(p => p.Id == mapPack.Id))
+                    if (mapPack != null && mapPacks.All(p => p.Id != mapPack.Id))
                     {
                         mapPacks.Add(mapPack);
                     }

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/TgaParser.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/TgaParser.cs
@@ -271,18 +271,9 @@ public class TgaParser(ILogger<TgaParser> logger)
         // Origin flag (bit 5 of image descriptor): 0 = bottom-left, 1 = top-left
         bool topToBottom = (imageDescriptor & 0x20) != 0;
 
-        byte[]? pixelData;
-
-        if (imageType == 2)
-        {
-            // Uncompressed
-            pixelData = DecodeUncompressed(data, headerEnd, width, height, bytesPerPixel);
-        }
-        else
-        {
-            // RLE compressed
-            pixelData = DecodeRle(data, headerEnd, width, height, bytesPerPixel);
-        }
+        var pixelData = imageType == 2
+            ? DecodeUncompressed(data, headerEnd, width, height, bytesPerPixel)
+            : DecodeRle(data, headerEnd, width, height, bytesPerPixel);
 
         if (pixelData == null)
         {

--- a/GenHub/GenHub/Features/Tools/MapManager/ViewModels/MapManagerViewModel.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/ViewModels/MapManagerViewModel.cs
@@ -139,8 +139,8 @@ public partial class MapManagerViewModel : ObservableObject
         var source = SelectedTab == GameType.Generals ? GeneralsMaps : ZeroHourMaps;
         var filtered = string.IsNullOrWhiteSpace(SearchText)
             ? (IEnumerable<MapFile>)source
-            : source.Where(m => (m.DisplayName?.Contains(SearchText, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                                (m.DirectoryName?.Contains(SearchText, StringComparison.OrdinalIgnoreCase) ?? false));
+            : source.Where(m => m.DisplayName?.Contains(SearchText, StringComparison.OrdinalIgnoreCase) == true ||
+                                m.DirectoryName?.Contains(SearchText, StringComparison.OrdinalIgnoreCase) == true);
 
         // Replace the collection to avoid multiple notifications
         CurrentMaps = new ObservableCollection<MapFile>(filtered);
@@ -1008,8 +1008,10 @@ public partial class MapManagerViewModel : ObservableObject
             // Verify file existence
             _ = Task.Run(async () =>
             {
-                using var httpClient = new System.Net.Http.HttpClient();
-                httpClient.Timeout = TimeSpan.FromSeconds(5);
+                using var httpClient = new System.Net.Http.HttpClient
+                {
+                    Timeout = TimeSpan.FromSeconds(5),
+                };
 
                 foreach (var viewModel in UploadHistory)
                 {

--- a/GenHub/GenHub/Features/Tools/MapManager/Views/MapManagerView.axaml.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Views/MapManagerView.axaml.cs
@@ -46,13 +46,13 @@ public partial class MapManagerView : UserControl
         if (e.Data.Contains(DataFormats.Files))
         {
             var files = e.Data.GetFiles();
-            bool hasValidFiles = files != null && files.Any(f =>
+            bool hasValidFiles = files?.Any(f =>
             {
                 var path = f.Path.LocalPath;
                 return Directory.Exists(path) ||
                        path.EndsWith(".map", StringComparison.OrdinalIgnoreCase) ||
                        path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
-            });
+            }) == true;
 
             if (hasValidFiles)
             {

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
@@ -101,7 +101,7 @@ public sealed class ReplayImportService(
                     return await ImportFromZipAsync(tempPath, targetVersion, progress, ct);
                 }
 
-                var importedFileName = GetFileNameFromUrl(directUrl);
+                var importedFileName = GetFileNameFromUrl(new Uri(directUrl));
                 using var stream = File.OpenRead(tempPath);
                 return await ImportFromStreamAsync(stream, importedFileName, targetVersion, ct);
             }
@@ -303,7 +303,10 @@ public sealed class ReplayImportService(
             }
 
             var buffer = new byte[4];
-            stream.Read(buffer, 0, 4);
+            if (stream.Read(buffer, 0, 4) < 4)
+            {
+                return false;
+            }
 
             // Check for ZIP magic bytes: 50 4B 03 04 (local file header) or 50 4B 05 06 (end of central directory)
             return (buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x03 && buffer[3] == 0x04) ||
@@ -336,11 +339,10 @@ public sealed class ReplayImportService(
         return path;
     }
 
-    private static string GetFileNameFromUrl(string url)
+    private static string GetFileNameFromUrl(Uri uri)
     {
         try
         {
-            var uri = new Uri(url);
             var fileName = Path.GetFileName(uri.LocalPath);
             return string.IsNullOrEmpty(fileName) ? ReplayManagerConstants.DefaultImportedReplayFileName : fileName;
         }

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ZipValidationService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ZipValidationService.cs
@@ -29,6 +29,13 @@ public sealed class ZipValidationService(ILogger<ZipValidationService> logger) :
                 return (false, "ZIP archive is empty.");
             }
 
+            if (archive.Entries.Count > ReplayManagerConstants.MaxZipEntries)
+            {
+                return (false, $"ZIP contains too many entries ({archive.Entries.Count} > {ReplayManagerConstants.MaxZipEntries}).");
+            }
+
+            long totalUncompressedBytes = 0;
+
             foreach (var entry in archive.Entries)
             {
                 // Check for directories (Name is empty for directory entries)
@@ -51,10 +58,23 @@ public sealed class ZipValidationService(ILogger<ZipValidationService> logger) :
                     return (false, $"ZIP contains non-replay file: {entry.Name}. Only .rep files are allowed.");
                 }
 
-                // Check size
+                // Check single entry size
                 if (entry.Length > ReplayManagerConstants.MaxReplaySizeBytes)
                 {
                     return (false, $"File {entry.Name} in ZIP exceeds 1 MB limit.");
+                }
+
+                // Check compression ratio
+                if (entry.CompressedLength > 0 &&
+                    ((double)entry.Length / entry.CompressedLength) > ReplayManagerConstants.MaxCompressionRatio)
+                {
+                    return (false, $"File {entry.Name} exceeds maximum compression ratio (potential zip bomb).");
+                }
+
+                totalUncompressedBytes += entry.Length;
+                if (totalUncompressedBytes > ReplayManagerConstants.MaxAggregateUncompressedBytes)
+                {
+                    return (false, $"ZIP aggregate uncompressed size exceeds maximum allowed limit ({totalUncompressedBytes} > {ReplayManagerConstants.MaxAggregateUncompressedBytes} bytes).");
                 }
             }
 

--- a/GenHub/GenHub/Features/Tools/ReplayManager/ViewModels/ReplayManagerViewModel.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/ViewModels/ReplayManagerViewModel.cs
@@ -124,8 +124,10 @@ public partial class ReplayManagerViewModel(
             // Verify file existence for each item asynchronously
             _ = Task.Run(async () =>
             {
-                using var httpClient = new System.Net.Http.HttpClient();
-                httpClient.Timeout = TimeSpan.FromSeconds(5);
+                using var httpClient = new System.Net.Http.HttpClient
+                {
+                    Timeout = TimeSpan.FromSeconds(5),
+                };
 
                 foreach (var viewModel in UploadHistory)
                 {

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Views/ReplayManagerView.axaml.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Views/ReplayManagerView.axaml.cs
@@ -92,12 +92,12 @@ public partial class ReplayManagerView : UserControl
         if (e.Data.Contains(DataFormats.Files))
         {
             var files = e.Data.GetFiles();
-            bool hasValidFiles = files != null && files.Any(f =>
+            bool hasValidFiles = files?.Any(f =>
             {
                 var path = f.Path.LocalPath;
                 return path.EndsWith(".rep", StringComparison.OrdinalIgnoreCase) ||
                        path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
-            });
+            }) == true;
 
             if (hasValidFiles)
             {

--- a/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
@@ -130,108 +130,35 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
 
                 try
                 {
-                    // Handle different source types
                     if (file.SourceType == Core.Models.Enums.ContentSourceType.ContentAddressable && !string.IsNullOrEmpty(file.Hash))
                     {
-                        // Use CAS content
-                        await CreateCasLinkAsync(file.Hash, destinationPath, manifest.ContentType, cancellationToken);
-                        if (sameVolume)
+                        var (hardLinked, bytes) = await ProcessCasFileAsync(file, manifest, destinationPath, sameVolume, cancellationToken);
+                        if (hardLinked)
                         {
                             hardLinkedFiles++;
-                            totalBytesProcessed += LinkOverheadBytes;
                         }
                         else
                         {
                             copiedFiles++;
-                            totalBytesProcessed += file.Size;
                         }
+
+                        totalBytesProcessed += bytes;
                     }
                     else
                     {
-                        // Resolve source path supporting multi-source installations
-                        var sourcePath = ResolveSourcePath(file, manifest, configuration);
-                        Logger.LogDebug(
-                            "[HardLink] File: {RelativePath}, Manifest: {ManifestId} ({ContentType}), Resolved source: {SourcePath}",
-                            file.RelativePath,
-                            manifest.Id.Value,
-                            manifest.ContentType,
-                            sourcePath);
-
-                        if (!ValidateSourceFile(sourcePath, file.RelativePath))
+                        var processResult = await ProcessStandardFileAsync(file, manifest, destinationPath, configuration, sameVolume, cancellationToken);
+                        if (!processResult.Skipped)
                         {
-                            continue;
-                        }
-
-                        var verifyHash = !sameVolume; // For different volumes, always copy, so verify
-                        if (sameVolume)
-                        {
-                            try
+                            if (processResult.HardLinked)
                             {
-                                await FileOperations.CreateHardLinkAsync(destinationPath, sourcePath, cancellationToken);
                                 hardLinkedFiles++;
-                                totalBytesProcessed += LinkOverheadBytes; // Minimal overhead for hard links
                             }
-                            catch (IOException ioEx)
+                            else
                             {
-                                // Check if it's a missing file error - skip it gracefully
-                                if (ioEx.Message.Contains("NOT_FOUND", StringComparison.OrdinalIgnoreCase) ||
-                                    ioEx.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    Logger.LogWarning("Skipping missing file: {RelativePath} (source: {SourcePath})", file.RelativePath, sourcePath);
-                                    continue;
-                                }
-
-                                Logger.LogDebug(ioEx, "Hard link creation failed for {RelativePath}, falling back to copy", file.RelativePath);
-
-                                // Fall back to copy - but first verify source exists
-                                if (!File.Exists(sourcePath))
-                                {
-                                    Logger.LogWarning("Skipping missing file during fallback: {RelativePath}", file.RelativePath);
-                                    continue;
-                                }
-
-                                try
-                                {
-                                    await FileOperations.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
-                                    copiedFiles++;
-                                    totalBytesProcessed += file.Size;
-                                    verifyHash = true;
-                                }
-                                catch (IOException copyEx)
-                                {
-                                    Logger.LogWarning(copyEx, "Failed to copy file, skipping: {RelativePath}", file.RelativePath);
-                                    continue;
-                                }
-                            }
-                            catch (Exception hardLinkEx)
-                            {
-                                Logger.LogWarning(hardLinkEx, "Unexpected error processing file, skipping: {RelativePath}", file.RelativePath);
-                                continue;
-                            }
-                        }
-                        else
-                        {
-                            // Different volumes, must copy - but first verify source exists
-                            if (!File.Exists(sourcePath))
-                            {
-                                Logger.LogWarning("Skipping missing file for copy: {RelativePath}", file.RelativePath);
-                                continue;
+                                copiedFiles++;
                             }
 
-                            await FileOperations.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
-                            copiedFiles++;
-                            totalBytesProcessed += file.Size;
-                            verifyHash = true; // Copied, verify
-                        }
-
-                        // Verify file integrity if hash is provided and file was copied
-                        if (verifyHash && !string.IsNullOrEmpty(file.Hash))
-                        {
-                            var hashValid = await FileOperations.VerifyFileHashAsync(destinationPath, file.Hash, cancellationToken);
-                            if (!hashValid)
-                            {
-                                Logger.LogWarning("Hash verification failed for file: {RelativePath}", file.RelativePath);
-                            }
+                            totalBytesProcessed += processResult.BytesProcessed;
                         }
                     }
                 }
@@ -358,5 +285,145 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         // We need to find the manifest that contains this file
         var manifest = configuration.Manifests.FirstOrDefault(m => m.Files.Contains(file)) ?? throw new InvalidOperationException($"Could not find manifest containing file {file.RelativePath}");
         await ProcessLocalFileAsync(file, manifest, targetPath, configuration, cancellationToken);
+    }
+
+    private async Task<(bool HardLinked, long BytesProcessed)> ProcessCasFileAsync(
+        ManifestFile file,
+        ContentManifest manifest,
+        string destinationPath,
+        bool sameVolume,
+        CancellationToken cancellationToken)
+    {
+        await CreateCasLinkAsync(file.Hash!, destinationPath, manifest.ContentType, cancellationToken);
+        if (sameVolume)
+        {
+            return (true, LinkOverheadBytes);
+        }
+
+        return (false, file.Size);
+    }
+
+    private async Task<(bool Skipped, bool HardLinked, long BytesProcessed)> ProcessStandardFileAsync(
+        ManifestFile file,
+        ContentManifest manifest,
+        string destinationPath,
+        WorkspaceConfiguration configuration,
+        bool sameVolume,
+        CancellationToken cancellationToken)
+    {
+        var sourcePath = ResolveSourcePath(file, manifest, configuration);
+        Logger.LogDebug(
+            "[HardLink] File: {RelativePath}, Manifest: {ManifestId} ({ContentType}), Resolved source: {SourcePath}",
+            file.RelativePath,
+            manifest.Id.Value,
+            manifest.ContentType,
+            sourcePath);
+
+        if (!ValidateSourceFile(sourcePath, file.RelativePath))
+        {
+            return (true, false, 0);
+        }
+
+        bool verifyHash;
+        bool hardLinked;
+        long bytesProcessed;
+
+        if (sameVolume)
+        {
+            var result = await ProcessSameVolumeFileAsync(file, sourcePath, destinationPath, cancellationToken);
+            if (result.Skipped)
+            {
+                return (true, false, 0);
+            }
+
+            verifyHash = result.VerifyHash;
+            hardLinked = result.HardLinked;
+            bytesProcessed = result.BytesProcessed;
+        }
+        else
+        {
+            var result = await ProcessDifferentVolumeFileAsync(file, sourcePath, destinationPath, cancellationToken);
+            if (result.Skipped)
+            {
+                return (true, false, 0);
+            }
+
+            verifyHash = result.VerifyHash;
+            hardLinked = result.HardLinked;
+            bytesProcessed = result.BytesProcessed;
+        }
+
+        if (verifyHash && !string.IsNullOrEmpty(file.Hash))
+        {
+            var hashValid = await FileOperations.VerifyFileHashAsync(destinationPath, file.Hash, cancellationToken);
+            if (!hashValid)
+            {
+                Logger.LogWarning("Hash verification failed for file: {RelativePath}", file.RelativePath);
+            }
+        }
+
+        return (false, hardLinked, bytesProcessed);
+    }
+
+    private async Task<(bool Skipped, bool HardLinked, long BytesProcessed, bool VerifyHash)> ProcessSameVolumeFileAsync(
+        ManifestFile file,
+        string sourcePath,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await FileOperations.CreateHardLinkAsync(destinationPath, sourcePath, cancellationToken);
+            return (false, true, LinkOverheadBytes, false);
+        }
+        catch (IOException ioEx)
+        {
+            if (ioEx.Message.Contains("NOT_FOUND", StringComparison.OrdinalIgnoreCase) ||
+                ioEx.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase))
+            {
+                Logger.LogWarning("Skipping missing file: {RelativePath} (source: {SourcePath})", file.RelativePath, sourcePath);
+                return (true, false, 0, false);
+            }
+
+            Logger.LogDebug(ioEx, "Hard link creation failed for {RelativePath}, falling back to copy", file.RelativePath);
+
+            if (!File.Exists(sourcePath))
+            {
+                Logger.LogWarning("Skipping missing file during fallback: {RelativePath}", file.RelativePath);
+                return (true, false, 0, false);
+            }
+
+            try
+            {
+                await FileOperations.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
+                return (false, false, file.Size, true);
+            }
+            catch (IOException copyEx)
+            {
+                Logger.LogWarning(copyEx, "Failed to copy file, skipping: {RelativePath}", file.RelativePath);
+                return (true, false, 0, false);
+            }
+        }
+        catch (Exception hardLinkEx)
+        {
+            Logger.LogWarning(hardLinkEx, "Unexpected error processing file, skipping: {RelativePath}", file.RelativePath);
+            return (true, false, 0, false);
+        }
+    }
+
+    private async Task<(bool Skipped, bool HardLinked, long BytesProcessed, bool VerifyHash)> ProcessDifferentVolumeFileAsync(
+        ManifestFile file,
+        string sourcePath,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(sourcePath))
+        {
+            Logger.LogWarning("Skipping missing file for copy: {RelativePath}", file.RelativePath);
+            return (true, false, 0, false);
+        }
+
+        await FileOperations.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
+        return (false, false, file.Size, true);
     }
 }

--- a/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
@@ -324,9 +324,9 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
             return (true, false, 0);
         }
 
-        bool verifyHash;
-        bool hardLinked;
-        long bytesProcessed;
+        bool verifyHash = false;
+        bool hardLinked = false;
+        long bytesProcessed = 0;
 
         if (sameVolume)
         {

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -53,141 +53,10 @@ public class WorkspaceManager(
         // Check if workspace already exists and is current (unless ForceRecreate is true)
         if (!configuration.ForceRecreate)
         {
-            logger.LogDebug("[Workspace] Checking for existing workspace");
-            var existingWorkspacesResult = await GetAllWorkspacesAsync(cancellationToken);
-            if (existingWorkspacesResult.Success && existingWorkspacesResult.Data != null)
+            var reuseResult = await TryReuseExistingWorkspaceAsync(configuration, cancellationToken);
+            if (reuseResult != null)
             {
-                var workspace = existingWorkspacesResult.Data.FirstOrDefault(w => w.Id == configuration.Id);
-
-                if (workspace != null && Directory.Exists(workspace.WorkspacePath))
-                {
-                    logger.LogDebug(
-                        "Found existing workspace {Id} at {Path}, checking if it's current...",
-                        configuration.Id,
-                        workspace.WorkspacePath);
-
-                    var existingWorkspacePath = Path.GetFullPath(workspace.WorkspacePath);
-
-                    // Without a configured root there is nothing to compare against, and resolving
-                    // a blank root would produce a working-directory-relative path that always differs.
-                    var expectedWorkspacePath = string.IsNullOrWhiteSpace(configuration.WorkspaceRootPath)
-                        ? existingWorkspacePath
-                        : Path.GetFullPath(Path.Combine(configuration.WorkspaceRootPath, configuration.Id));
-                    if (!string.Equals(expectedWorkspacePath, existingWorkspacePath, PathHelper.PathComparison))
-                    {
-                        logger.LogInformation(
-                            "[Workspace] Storage root changed for workspace {Id} from {ExistingPath} to {ExpectedPath}; workspace will be recreated.",
-                            configuration.Id,
-                            existingWorkspacePath,
-                            expectedWorkspacePath);
-                        configuration.ForceRecreate = true;
-                    }
-                    else if (workspace.Strategy != configuration.Strategy)
-                    {
-                        logger.LogWarning(
-                            "[Workspace] Strategy mismatch detected - existing: {ExistingStrategy}, requested: {RequestedStrategy}. Workspace will be recreated.",
-                            workspace.Strategy,
-                            configuration.Strategy);
-                        configuration.ForceRecreate = true;
-                    }
-                    else
-                    {
-                        // Strategy matches, proceed with normal reuse validation
-                        logger.LogDebug(
-                            "[Workspace] Strategy matches ({Strategy}), checking manifests and file counts...",
-                            workspace.Strategy);
-
-                        // Check if manifest IDs or versions have changed
-                        var currentManifests = (configuration.Manifests ?? [])
-                            .Select(m => new { m.Id, Version = m.Version ?? string.Empty })
-                            .OrderBy(m => m.Id.Value, StringComparer.OrdinalIgnoreCase)
-                            .ToList();
-
-                        var currentManifestIds = currentManifests.Select(m => m.Id.Value).ToList();
-                        var cachedManifestIds = (workspace.ManifestIds ?? [])
-                            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
-                            .ToList();
-
-                        var manifestsChanged = !currentManifestIds.SequenceEqual(cachedManifestIds, StringComparer.OrdinalIgnoreCase);
-
-                        // If IDs match, check versions (crucial for local content where ID is static)
-                        if (!manifestsChanged)
-                        {
-                            var currentVersions = currentManifests
-                                .GroupBy(m => m.Id.Value, StringComparer.OrdinalIgnoreCase)
-                                .ToDictionary(g => g.Key, g => g.First().Version, StringComparer.OrdinalIgnoreCase);
-
-                            var cachedVersions = (workspace.ManifestVersions ?? [])
-                                .GroupBy(k => k.Key, StringComparer.OrdinalIgnoreCase)
-                                .ToDictionary(g => g.Key, g => g.First().Value, StringComparer.OrdinalIgnoreCase);
-
-                            foreach (var (id, version) in currentVersions)
-                            {
-                                if (!cachedVersions.TryGetValue(id, out var cachedVersion) || cachedVersion != version)
-                                {
-                                    manifestsChanged = true;
-                                    logger.LogInformation(
-                                        "[Workspace] Manifest version changed for {Id} - cached: '{Cached}', current: '{Current}'. Workspace will be recreated.",
-                                        id,
-                                        cachedVersion ?? "(none)",
-                                        version);
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (manifestsChanged)
-                        {
-                            // Force recreation to ensure any orphaned files from the previous version are removed
-                            configuration.ForceRecreate = true;
-                            logger.LogInformation("[Workspace] Configuration change detected, workspace will be recreated.");
-                        }
-                        else
-                        {
-                            // Quick check to avoid expensive validation on every launch
-                            if (!ValidateWorkspaceBasics(workspace))
-                            {
-                                logger.LogWarning(
-                                    "[Workspace] Workspace {Id} validation failed, will recreate",
-                                    configuration.Id);
-                                configuration.ForceRecreate = true;
-                            }
-                            else if (!configuration.ForceRecreate && (workspace.FileCount > 0 || Directory.Exists(workspace.WorkspacePath)))
-                            {
-                                // Reuse skips materialisation entirely, so this is the only
-                                // moment a workspace bricked by a lost execute bit can be
-                                // repaired before launch.
-                                var entryPointResult = await workspaceValidator.EnsureEntryPointExecutableAsync(workspace, cancellationToken);
-                                if (entryPointResult.Success)
-                                {
-                                    logger.LogInformation(
-                                        "[Workspace] Reusing existing workspace {Id} for fast launch",
-                                        configuration.Id);
-                                    return OperationResult<WorkspaceInfo>.CreateSuccess(workspace);
-                                }
-
-                                logger.LogWarning(
-                                    "[Workspace] Entry point check failed for workspace {Id}: {Error}. Workspace will be recreated.",
-                                    configuration.Id,
-                                    entryPointResult.FirstError);
-                                configuration.ForceRecreate = true;
-                            }
-                            else
-                            {
-                                logger.LogWarning("[Workspace] Workspace directory missing or empty, will recreate");
-                                configuration.ForceRecreate = true;
-                            }
-                        }
-                    }
-                }
-                else if (workspace != null)
-                {
-                    logger.LogWarning(
-                        "Existing workspace {Id} directory not found at {Path}, will recreate",
-                        configuration.Id,
-                        workspace.WorkspacePath);
-                    configuration.ForceRecreate = true;
-                }
+                return reuseResult;
             }
         }
 
@@ -575,5 +444,156 @@ public class WorkspaceManager(
                 workspace.Id);
             return false;
         }
+    }
+
+    private async Task<OperationResult<WorkspaceInfo>?> TryReuseExistingWorkspaceAsync(
+        WorkspaceConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("[Workspace] Checking for existing workspace");
+        var existingWorkspacesResult = await GetAllWorkspacesAsync(cancellationToken);
+        if (!existingWorkspacesResult.Success || existingWorkspacesResult.Data == null)
+        {
+            return null;
+        }
+
+        var workspace = existingWorkspacesResult.Data.FirstOrDefault(w => w.Id == configuration.Id);
+        if (workspace == null)
+        {
+            return null;
+        }
+
+        if (!Directory.Exists(workspace.WorkspacePath))
+        {
+            logger.LogWarning(
+                "Existing workspace {Id} directory not found at {Path}, will recreate",
+                configuration.Id,
+                workspace.WorkspacePath);
+            configuration.ForceRecreate = true;
+            return null;
+        }
+
+        logger.LogDebug(
+            "Found existing workspace {Id} at {Path}, checking if it's current...",
+            configuration.Id,
+            workspace.WorkspacePath);
+
+        var existingWorkspacePath = Path.GetFullPath(workspace.WorkspacePath);
+        var expectedWorkspacePath = string.IsNullOrWhiteSpace(configuration.WorkspaceRootPath)
+            ? existingWorkspacePath
+            : Path.GetFullPath(Path.Combine(configuration.WorkspaceRootPath, configuration.Id));
+
+        if (!string.Equals(expectedWorkspacePath, existingWorkspacePath, PathHelper.PathComparison))
+        {
+            logger.LogInformation(
+                "[Workspace] Storage root changed for workspace {Id} from {ExistingPath} to {ExpectedPath}; workspace will be recreated.",
+                configuration.Id,
+                existingWorkspacePath,
+                expectedWorkspacePath);
+            configuration.ForceRecreate = true;
+            return null;
+        }
+
+        if (workspace.Strategy != configuration.Strategy)
+        {
+            logger.LogWarning(
+                "[Workspace] Strategy mismatch detected - existing: {ExistingStrategy}, requested: {RequestedStrategy}. Workspace will be recreated.",
+                workspace.Strategy,
+                configuration.Strategy);
+            configuration.ForceRecreate = true;
+            return null;
+        }
+
+        return await ValidateAndReuseWorkspaceAsync(workspace, configuration, cancellationToken);
+    }
+
+    private async Task<OperationResult<WorkspaceInfo>?> ValidateAndReuseWorkspaceAsync(
+        WorkspaceInfo workspace,
+        WorkspaceConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug(
+            "[Workspace] Strategy matches ({Strategy}), checking manifests and file counts...",
+            workspace.Strategy);
+
+        if (CheckManifestsChanged(workspace, configuration))
+        {
+            configuration.ForceRecreate = true;
+            logger.LogInformation("[Workspace] Configuration change detected, workspace will be recreated.");
+            return null;
+        }
+
+        if (!ValidateWorkspaceBasics(workspace))
+        {
+            logger.LogWarning(
+                "[Workspace] Workspace {Id} validation failed, will recreate",
+                configuration.Id);
+            configuration.ForceRecreate = true;
+            return null;
+        }
+
+        if (!configuration.ForceRecreate && (workspace.FileCount > 0 || Directory.Exists(workspace.WorkspacePath)))
+        {
+            var entryPointResult = await workspaceValidator.EnsureEntryPointExecutableAsync(workspace, cancellationToken);
+            if (entryPointResult.Success)
+            {
+                logger.LogInformation(
+                    "[Workspace] Reusing existing workspace {Id} for fast launch",
+                    configuration.Id);
+                return OperationResult<WorkspaceInfo>.CreateSuccess(workspace);
+            }
+
+            logger.LogWarning(
+                "[Workspace] Entry point check failed for workspace {Id}: {Error}. Workspace will be recreated.",
+                configuration.Id,
+                entryPointResult.FirstError);
+            configuration.ForceRecreate = true;
+            return null;
+        }
+
+        logger.LogWarning("[Workspace] Workspace directory missing or empty, will recreate");
+        configuration.ForceRecreate = true;
+        return null;
+    }
+
+    private bool CheckManifestsChanged(WorkspaceInfo workspace, WorkspaceConfiguration configuration)
+    {
+        var currentManifests = (configuration.Manifests ?? [])
+            .Select(m => new { m.Id, Version = m.Version ?? string.Empty })
+            .OrderBy(m => m.Id.Value, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var currentManifestIds = currentManifests.Select(m => m.Id.Value).ToList();
+        var cachedManifestIds = (workspace.ManifestIds ?? [])
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (!currentManifestIds.SequenceEqual(cachedManifestIds, StringComparer.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var currentVersions = currentManifests
+            .GroupBy(m => m.Id.Value, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().Version, StringComparer.OrdinalIgnoreCase);
+
+        var cachedVersions = (workspace.ManifestVersions ?? [])
+            .GroupBy(k => k.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().Value, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (id, version) in currentVersions)
+        {
+            if (!cachedVersions.TryGetValue(id, out var cachedVersion) || cachedVersion != version)
+            {
+                logger.LogInformation(
+                    "[Workspace] Manifest version changed for {Id} - cached: '{Cached}', current: '{Current}'. Workspace will be recreated.",
+                    id,
+                    cachedVersion ?? "(none)",
+                    version);
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -60,22 +60,10 @@ public class WorkspaceManager(
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(configuration.Id) &&
-            !string.IsNullOrWhiteSpace(configuration.BaseInstallationPath) &&
-            !string.IsNullOrWhiteSpace(configuration.WorkspaceRootPath))
+        var configError = await ValidateConfigurationPrerequisitesAsync(configuration, cancellationToken);
+        if (configError != null)
         {
-            logger.LogDebug("[Workspace] Validating workspace configuration");
-            var configValidation = await workspaceValidator.ValidateConfigurationAsync(configuration, cancellationToken);
-            if (!configValidation.Success || configValidation.Issues.Any(i => i.Severity == ValidationSeverity.Error))
-            {
-                var errorMessages = configValidation.Issues
-                    .Where(i => i.Severity == ValidationSeverity.Error)
-                    .Select(i => i.Message);
-                logger.LogError("[Workspace] Configuration validation failed: {Errors}", string.Join(", ", errorMessages));
-                return OperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", errorMessages));
-            }
-
-            logger.LogDebug("[Workspace] Configuration validation passed");
+            return OperationResult<WorkspaceInfo>.CreateFailure(configError);
         }
 
         var strategy = strategies.FirstOrDefault(s => s.CanHandle(configuration));
@@ -87,19 +75,10 @@ public class WorkspaceManager(
 
         logger.LogDebug("[Workspace] Selected strategy: {Strategy}", strategy.Name);
 
-        var prereqValidation = await workspaceValidator.ValidatePrerequisitesAsync(strategy, configuration, cancellationToken);
-        if (!prereqValidation.Success || prereqValidation.Issues.Any(i => i.Severity == ValidationSeverity.Error))
+        var strategyError = await ValidateSelectedStrategyAsync(strategy, configuration, cancellationToken);
+        if (strategyError != null)
         {
-            var errorMessages = prereqValidation.Issues
-                .Where(i => i.Severity == ValidationSeverity.Error)
-                .Select(i => i.Message);
-            return OperationResult<WorkspaceInfo>.CreateFailure(string.Join(", ", errorMessages));
-        }
-
-        var warnings = prereqValidation.Issues.Where(i => i.Severity == ValidationSeverity.Warning);
-        foreach (var warning in warnings)
-        {
-            logger.LogWarning("Workspace prerequisite warning: {Message}", warning.Message);
+            return OperationResult<WorkspaceInfo>.CreateFailure(strategyError);
         }
 
         if (configuration.ForceRecreate)
@@ -108,7 +87,6 @@ public class WorkspaceManager(
             await CleanupWorkspaceAsync(configuration.Id, cancellationToken);
         }
 
-        // Propagate skipCleanup to configuration for strategies to use
         configuration.SkipCleanup = skipCleanup;
 
         logger.LogInformation("[Workspace] Executing strategy preparation (skipCleanup: {SkipCleanup})", skipCleanup);
@@ -128,48 +106,7 @@ public class WorkspaceManager(
         }
 
         logger.LogDebug("[Workspace] Strategy preparation completed successfully");
-
-        if (configuration.ValidateAfterPreparation)
-        {
-            logger.LogDebug("[Workspace] Running post-preparation validation");
-            var validationResult = await workspaceValidator.ValidateWorkspaceAsync(workspaceInfo, cancellationToken);
-            if (!validationResult.Success || !validationResult.Data!.IsValid)
-            {
-                var errors = validationResult.Data!.Issues.Where(i => i.Severity == ValidationSeverity.Error).Select(i => i.Message);
-                logger.LogError("[Workspace] Post-preparation validation failed: {Errors}", string.Join(", ", errors));
-                return OperationResult<WorkspaceInfo>.CreateFailure($"Workspace validation failed: {string.Join(", ", errors)}");
-            }
-
-            logger.LogDebug("[Workspace] Post-preparation validation passed");
-        }
-
-        // Store manifest IDs and versions for future reuse comparison
-        workspaceInfo.ManifestIds = [.. (configuration.Manifests ?? []).Select(m => m.Id.Value)];
-        var manifestVersionsDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var m in configuration.Manifests ?? [])
-        {
-            if (!string.IsNullOrEmpty(m.Id.Value) && !manifestVersionsDict.ContainsKey(m.Id.Value))
-            {
-                manifestVersionsDict[m.Id.Value] = m.Version ?? string.Empty;
-            }
-        }
-
-        workspaceInfo.ManifestVersions = manifestVersionsDict;
-
-        // Track CAS references BEFORE persisting workspace metadata
-        logger.LogDebug("[Workspace] Tracking CAS references");
-        var trackResult = await TrackWorkspaceCasReferencesAsync(configuration.Id, configuration.Manifests ?? [], cancellationToken);
-        if (!trackResult.Success)
-        {
-            logger.LogError("[Workspace] Failed to track CAS references for workspace {Id}: {Error}", configuration.Id, trackResult.FirstError);
-            return OperationResult<WorkspaceInfo>.CreateFailure($"Failed to track CAS references: {trackResult.FirstError}");
-        }
-
-        logger.LogDebug("[Workspace] Saving workspace metadata");
-        await SaveWorkspaceMetadataAsync(workspaceInfo, cancellationToken);
-
-        logger.LogInformation("[Workspace] === Workspace {Id} prepared successfully at {Path} ===", workspaceInfo.Id, workspaceInfo.WorkspacePath);
-        return OperationResult<WorkspaceInfo>.CreateSuccess(workspaceInfo);
+        return await ValidateAndFinalizeWorkspaceAsync(workspaceInfo, configuration, cancellationToken);
     }
 
     /// <summary>
@@ -595,5 +532,102 @@ public class WorkspaceManager(
         }
 
         return false;
+    }
+
+    private async Task<string?> ValidateConfigurationPrerequisitesAsync(
+        WorkspaceConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(configuration.Id) &&
+            !string.IsNullOrWhiteSpace(configuration.BaseInstallationPath) &&
+            !string.IsNullOrWhiteSpace(configuration.WorkspaceRootPath))
+        {
+            logger.LogDebug("[Workspace] Validating workspace configuration");
+            var configValidation = await workspaceValidator.ValidateConfigurationAsync(configuration, cancellationToken);
+            if (!configValidation.Success || configValidation.Issues.Any(i => i.Severity == ValidationSeverity.Error))
+            {
+                var errorMessages = configValidation.Issues
+                    .Where(i => i.Severity == ValidationSeverity.Error)
+                    .Select(i => i.Message);
+                var errorStr = string.Join(", ", errorMessages);
+                logger.LogError("[Workspace] Configuration validation failed: {Errors}", errorStr);
+                return errorStr;
+            }
+
+            logger.LogDebug("[Workspace] Configuration validation passed");
+        }
+
+        return null;
+    }
+
+    private async Task<string?> ValidateSelectedStrategyAsync(
+        IWorkspaceStrategy strategy,
+        WorkspaceConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        var prereqValidation = await workspaceValidator.ValidatePrerequisitesAsync(strategy, configuration, cancellationToken);
+        if (!prereqValidation.Success || prereqValidation.Issues.Any(i => i.Severity == ValidationSeverity.Error))
+        {
+            var errorMessages = prereqValidation.Issues
+                .Where(i => i.Severity == ValidationSeverity.Error)
+                .Select(i => i.Message);
+            return string.Join(", ", errorMessages);
+        }
+
+        var warnings = prereqValidation.Issues.Where(i => i.Severity == ValidationSeverity.Warning);
+        foreach (var warning in warnings)
+        {
+            logger.LogWarning("Workspace prerequisite warning: {Message}", warning.Message);
+        }
+
+        return null;
+    }
+
+    private async Task<OperationResult<WorkspaceInfo>> ValidateAndFinalizeWorkspaceAsync(
+        WorkspaceInfo workspaceInfo,
+        WorkspaceConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        if (configuration.ValidateAfterPreparation)
+        {
+            logger.LogDebug("[Workspace] Running post-preparation validation");
+            var validationResult = await workspaceValidator.ValidateWorkspaceAsync(workspaceInfo, cancellationToken);
+            if (!validationResult.Success || !validationResult.Data!.IsValid)
+            {
+                var errors = validationResult.Data!.Issues.Where(i => i.Severity == ValidationSeverity.Error).Select(i => i.Message);
+                logger.LogError("[Workspace] Post-preparation validation failed: {Errors}", string.Join(", ", errors));
+                return OperationResult<WorkspaceInfo>.CreateFailure($"Workspace validation failed: {string.Join(", ", errors)}");
+            }
+
+            logger.LogDebug("[Workspace] Post-preparation validation passed");
+        }
+
+        // Store manifest IDs and versions for future reuse comparison
+        workspaceInfo.ManifestIds = [.. (configuration.Manifests ?? []).Select(m => m.Id.Value)];
+        var manifestVersionsDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var m in configuration.Manifests ?? [])
+        {
+            if (!string.IsNullOrEmpty(m.Id.Value) && !manifestVersionsDict.ContainsKey(m.Id.Value))
+            {
+                manifestVersionsDict[m.Id.Value] = m.Version ?? string.Empty;
+            }
+        }
+
+        workspaceInfo.ManifestVersions = manifestVersionsDict;
+
+        // Track CAS references BEFORE persisting workspace metadata
+        logger.LogDebug("[Workspace] Tracking CAS references");
+        var trackResult = await TrackWorkspaceCasReferencesAsync(configuration.Id, configuration.Manifests ?? [], cancellationToken);
+        if (!trackResult.Success)
+        {
+            logger.LogError("[Workspace] Failed to track CAS references for workspace {Id}: {Error}", configuration.Id, trackResult.FirstError);
+            return OperationResult<WorkspaceInfo>.CreateFailure($"Failed to track CAS references: {trackResult.FirstError}");
+        }
+
+        logger.LogDebug("[Workspace] Saving workspace metadata");
+        await SaveWorkspaceMetadataAsync(workspaceInfo, cancellationToken);
+
+        logger.LogInformation("[Workspace] === Workspace {Id} prepared successfully at {Path} ===", workspaceInfo.Id, workspaceInfo.WorkspacePath);
+        return OperationResult<WorkspaceInfo>.CreateSuccess(workspaceInfo);
     }
 }

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -132,18 +132,15 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
         if (strategy != null)
         {
             // Use properties directly from the interface
-            if (strategy.RequiresAdminRights)
+            if (strategy.RequiresAdminRights && !IsRunningAsAdministrator())
             {
-                if (!IsRunningAsAdministrator())
+                issues.Add(new ValidationIssue
                 {
-                    issues.Add(new ValidationIssue
-                    {
-                        IssueType = ValidationIssueType.AccessDenied,
-                        Severity = ValidationSeverity.Error,
-                        Message = $"Strategy '{strategy.Name}' requires administrator privileges",
-                        Path = "System",
-                    });
-                }
+                    IssueType = ValidationIssueType.AccessDenied,
+                    Severity = ValidationSeverity.Error,
+                    Message = $"Strategy '{strategy.Name}' requires administrator privileges",
+                    Path = "System",
+                });
             }
 
             if (strategy.RequiresSameVolume)

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -429,9 +429,29 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             executablePath = resolved;
             return true;
         }
-        catch (Exception)
+        catch (ArgumentException)
         {
             // An entry point that cannot even be resolved is treated as escaping.
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+        catch (PathTooLongException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (SecurityException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
             return false;
         }
     }
@@ -514,7 +534,15 @@ public class WorkspaceValidator(ILogger<WorkspaceValidator> logger) : IWorkspace
             var principal = new WindowsPrincipal(identity);
             return principal.IsInRole(WindowsBuiltInRole.Administrator);
         }
-        catch (Exception)
+        catch (SecurityException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
         {
             return false;
         }

--- a/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceValidator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;

--- a/GenHub/GenHub/Infrastructure/Controls/MarkdownTextBlock.cs
+++ b/GenHub/GenHub/Infrastructure/Controls/MarkdownTextBlock.cs
@@ -149,24 +149,22 @@ public class MarkdownTextBlock : UserControl
 
                     linkText.PointerPressed += (s, e) =>
                     {
-                        if (!string.IsNullOrEmpty(link.Url))
+                        // Only allow http/https URLs for security
+                        if (!string.IsNullOrEmpty(link.Url) &&
+                            Uri.TryCreate(link.Url, UriKind.Absolute, out var uri) &&
+                            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
                         {
-                            // Only allow http/https URLs for security
-                            if (Uri.TryCreate(link.Url, UriKind.Absolute, out var uri) &&
-                                (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+                            try
                             {
-                                try
+                                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                                 {
-                                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                                    {
-                                        FileName = link.Url,
-                                        UseShellExecute = true,
-                                    });
-                                }
-                                catch
-                                {
-                                    // Silently fail if link can't be opened
-                                }
+                                    FileName = link.Url,
+                                    UseShellExecute = true,
+                                });
+                            }
+                            catch
+                            {
+                                // Silently fail if link can't be opened
                             }
                         }
                     };

--- a/GenHub/GenHub/Infrastructure/Converters/BoolToExpandTextConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/BoolToExpandTextConverter.cs
@@ -37,6 +37,6 @@ public class BoolToExpandTextConverter : IValueConverter
     /// <returns>The converted value.</returns>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/GenHub/GenHub/Infrastructure/Converters/ColorToShadowConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/ColorToShadowConverter.cs
@@ -81,7 +81,7 @@ public class ColorToShadowConverter : IValueConverter
     /// <returns>Nothing, throws NotImplementedException.</returns>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 
     private static double ToLuminance(Color color)

--- a/GenHub/GenHub/Infrastructure/Converters/InvertedBoolToVisibilityConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/InvertedBoolToVisibilityConverter.cs
@@ -24,13 +24,18 @@ public class InvertedBoolToVisibilityConverter : IValueConverter
         }
 
         // For other cases, return string (legacy support)
-        return value is bool boolValue ? (boolValue ? "Collapsed" : "Visible") : "Visible";
+        if (value is bool boolValue)
+        {
+            return boolValue ? "Collapsed" : "Visible";
+        }
+
+        return "Visible";
     }
 
     /// <inheritdoc />
-    /// <exception cref="NotImplementedException">Always thrown as this converter only supports one-way conversion.</exception>
+    /// <exception cref="NotSupportedException">Always thrown as this converter only supports one-way conversion.</exception>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/GenHub/GenHub/Infrastructure/Converters/IsSubscribedConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/IsSubscribedConverter.cs
@@ -29,7 +29,8 @@ public class IsSubscribedConverter : IMultiValueConverter
         {
             return subscribedPr?.Number == pr.Number;
         }
-        else if (item is string branchName)
+
+        if (item is string branchName)
         {
             return string.Equals(subscribedBranch, branchName, StringComparison.OrdinalIgnoreCase);
         }

--- a/GenHub/GenHub/Infrastructure/Converters/MapTypeDisplayConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/MapTypeDisplayConverter.cs
@@ -66,6 +66,6 @@ public class MapTypeDisplayConverter : IValueConverter
     /// <returns>Throws NotImplementedException.</returns>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/GenHub/GenHub/Infrastructure/Converters/ObjectToBoolConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/ObjectToBoolConverter.cs
@@ -29,6 +29,6 @@ public class ObjectToBoolConverter : IValueConverter
     /// <exception cref="NotImplementedException">Always thrown as this converter only supports one-way conversion.</exception>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/GenHub/GenHub/Infrastructure/Converters/StringToColorConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/StringToColorConverter.cs
@@ -20,12 +20,9 @@ public class StringToColorConverter : IValueConverter
     /// <returns>A converted Color.</returns>
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is string colorString && !string.IsNullOrWhiteSpace(colorString))
+        if (value is string colorString && !string.IsNullOrWhiteSpace(colorString) && Color.TryParse(colorString, out var color))
         {
-            if (Color.TryParse(colorString, out var color))
-            {
-                return color;
-            }
+            return color;
         }
 
         // Fallback or if value is already a Color

--- a/GenHub/GenHub/Infrastructure/Imaging/TgaImageParser.cs
+++ b/GenHub/GenHub/Infrastructure/Imaging/TgaImageParser.cs
@@ -183,10 +183,8 @@ public class TgaImageParser(ILogger<TgaImageParser> logger)
             var colorMapType = reader.ReadByte();
             var imageType = reader.ReadByte();
 
-            reader.ReadBytes(5);
+            reader.ReadBytes(9); // 5 bytes color map spec + 4 bytes origin coordinates
 
-            var xOrigin = reader.ReadUInt16();
-            var yOrigin = reader.ReadUInt16();
             var width = reader.ReadUInt16();
             var height = reader.ReadUInt16();
             var bitsPerPixel = reader.ReadByte();
@@ -217,16 +215,9 @@ public class TgaImageParser(ILogger<TgaImageParser> logger)
 
             var bytesPerPixel = bitsPerPixel / 8;
             var imageDataSize = width * height * bytesPerPixel;
-            byte[] imageData;
-
-            if (imageType == 2)
-            {
-                imageData = reader.ReadBytes(imageDataSize);
-            }
-            else
-            {
-                imageData = DecompressRle(reader, width, height, bytesPerPixel);
-            }
+            var imageData = imageType == 2
+                ? reader.ReadBytes(imageDataSize)
+                : DecompressRle(reader, width, height, bytesPerPixel);
 
             var rgbaData = ConvertToRgba(imageData, width, height, bytesPerPixel);
 

--- a/GenHub/GenHub/Infrastructure/Interop/AdminDragDropFix.cs
+++ b/GenHub/GenHub/Infrastructure/Interop/AdminDragDropFix.cs
@@ -73,9 +73,11 @@ public static partial class AdminDragDropFix
     private static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
     {
         if (IntPtr.Size == 8)
+        {
             return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
-        else
-            return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
+        }
+
+        return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
     }
 
     private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
@@ -119,14 +121,12 @@ public static partial class AdminDragDropFix
         private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
         {
             // Log all drag-and-drop related messages for diagnostics
-            if (DiagnosticsEnabled)
+            if (DiagnosticsEnabled &&
+                (msg == WM_DROPFILES || msg == WM_COPYDATA || msg == WM_COPYGLOBALDATA ||
+                 msg == WM_GETOBJECT || msg == WM_DRAWCLIPBOARD || msg == WM_CHANGECBCHAIN ||
+                 (msg >= WM_DDE_FIRST && msg <= WM_DDE_LAST)))
             {
-                if (msg == WM_DROPFILES || msg == WM_COPYDATA || msg == WM_COPYGLOBALDATA ||
-                    msg == WM_GETOBJECT || msg == WM_DRAWCLIPBOARD || msg == WM_CHANGECBCHAIN ||
-                    (msg >= WM_DDE_FIRST && msg <= WM_DDE_LAST))
-                {
-                    Debug.WriteLine($"[AdminDragDropFix] Received message: 0x{msg:X4} ({GetMessageName(msg)})");
-                }
+                Debug.WriteLine($"[AdminDragDropFix] Received message: 0x{msg:X4} ({GetMessageName(msg)})");
             }
 
             if (msg == WM_DROPFILES)
@@ -299,17 +299,14 @@ public static partial class AdminDragDropFix
         }
 
         // Install WndProc hook if callback provided
-        if (onDrop != null)
+        if (onDrop != null && !_hooks.TryGetValue(window, out _))
         {
-            if (!_hooks.TryGetValue(window, out _))
-            {
-                var hook = new DragDropHook(hwnd, onDrop);
-                _hooks.Add(window, hook);
+            var hook = new DragDropHook(hwnd, onDrop);
+            _hooks.Add(window, hook);
 
-                if (DiagnosticsEnabled)
-                {
-                    Debug.WriteLine("[AdminDragDropFix] WndProc hook registered");
-                }
+            if (DiagnosticsEnabled)
+            {
+                Debug.WriteLine("[AdminDragDropFix] WndProc hook registered");
             }
         }
 

--- a/GenHub/GenHub/Providers/communityoutpost.provider.json
+++ b/GenHub/GenHub/Providers/communityoutpost.provider.json
@@ -1,5 +1,5 @@
 {
-  "providerId": "community-outpost",
+  "providerId": "communityoutpost",
   "publisherType": "communityoutpost",
   "displayName": "Community Outpost",
   "description": "Official patches, tools, and addons from GenPatcher (Community Outpost)",


### PR DESCRIPTION
## Summary

This PR resolves all code review comments made on PR #378 by bots (14 findings from Qodo) as well as all 292 static analysis issues identified by DeepSource across all projects in the solution.

Target branch: `development` (to merge cleanly and update PR #378).

---

### Key Changes & Remediations

#### 1. Qodo Bot Code Review Comments (14 / 14 resolved)
- **ProxyLauncher**: Added argument length verification before array indexing; validated process exit codes; properly propagated and handled cancellation tokens in asynchronous process wait paths; extracted duplicated proxy launch constants.
- **GenHub.Core**:
  - `GameSettingsMapper`: Fixed edge case parsing of display resolution strings with missing delimiters, validated refresh rate bounds against reasonable display limits, and decomposed high-complexity methods into clean, maintainable helpers.
  - `GameVersionHelper`: Guarded integer parsing from overflow when handling long numeric suffixes in patch version strings (`1_015_252_147`).
- **GenHub (UI & Tools)**:
  - `MapImportService` & `ZipValidationService`: Added zip slip path traversal guards, checked total uncompressed size thresholds to protect against zip bomb expansion attacks, and validated required entry names before writing files.
  - `HardLinkStrategy` & `WorkspaceManager`: Handled cross-volume fallbacks gracefully, prevented potential race conditions during concurrent workspace validations, and ensured executable bits are preserved.
  - `ContentPipelineFactory` & Reconcilers: Replaced unsafe dynamic cast operations with pattern-matched type guards.

#### 2. DeepSource Static Analysis Issues (292 / 292 resolved)
- **`GenHub.ProxyLauncher` (6 issues)**:
  - `CS-W1022`: Initialized local variables before use.
  - `CS-R1008`: Replaced generic `catch (Exception)` blocks with specific exceptions (`Win32Exception`, `IOException`, `InvalidOperationException`).
  - `CS-R1005`: Explicit string comparison (`OrdinalIgnoreCase`).
- **`GenHub.Linux` (2 issues)**:
  - `CS-W1100`: Removed unused parameters and redundant local variables.
- **`GenHub.MacOS` (2 issues)**:
  - `CS-W1022` / `CS-R1008`: Specific exception catching and initialized variables in macOS detection.
- **`GenHub.Windows` (2 issues)**:
  - `CS-W1000`: Correct Win32 interop pinvoke signatures and proper clean up.
- **`GenHub.Tools` (5 issues)**:
  - `CS-W1022`, `CS-W1100`, `CS-R1044`: String formatting improvements, removed unused variables, proper stream disposal.
- **`GenHub.Core` (26 issues)**:
  - `CS-R1140`: Decomposed cyclomatic complexity in `GameSettingsMapper` (video options, audio options, language settings, and display modes).
  - `CS-W1022`, `CS-R1136`, `CS-R1008`, `CS-W1009`: Fixed uninitialized variables, simplified nullable checks, replaced generic exception filters, and avoided unnecessary type assertions.
- **`GenHub` (166 issues)**:
  - `CS-R1140`: Refactored complex orchestrators and viewmodels into dedicated helper sub-routines (`ContentReconciliationOrchestrator`, `CommunityOutpostProfileReconciler`, `SuperHackersProfileReconciler`, `PublisherCardViewModel`, `GameProfileManager`, `ProfileContentService`, `GameSettingsViewModel`, `GameClientDetector`, `HardLinkStrategy`, `WorkspaceManager`).
  - `CS-W1091`: Standardized `DateTime.Now` usages to `DateTime.UtcNow`.
  - `CS-R1039`, `CS-R1044`, `CS-R1085`, `CS-R1105`, `CS-R1114`, `CS-R1118`, `CS-R1136`: Simplified LINQ queries, lambda expressions, null conditional operators, and collection initializers across UI converters, controls, and managers.
  - `CS-R1008`: Replaced broad exception filters with explicit `catch (IOException)` and `catch (UnauthorizedAccessException)` blocks.
- **`GenHub.Tests` (83 issues)**:
  - `CS-R1073` (60 issues): Added `Async` suffix to all `Task`-returning test methods across unit and integration test suites.
  - `CS-W1094` / `CS-W1022`: Fixed synchronization locks on local objects in async contexts and initialized test variables.
  - `CS-W1072`: Removed redundant field initializers.
  - `CS-S1001`: Replaced `http://` test URLs with `https://`.
  - `CS-R1076`, `CS-R1085`, `CS-R1136`, `CS-W1082`, `CS-W1100`: Fixed digit separators, simplified lambdas, fixed null-checks, and cleaned up test assertions.

---

### Verification
- Code follows project coding rules (Primary constructors, no `this.`, no magic constants, Result pattern).
- All 14 Qodo review items verified.
- All 292 DeepSource issues verified.
