### PR TITLE
ci: pin .NET 8 SDK

### DIFF
--- a/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/GitHubTopicsDiscoverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDiscoverers/GitHubTopicsDiscoverer.cs
@@ -415,7 +415,7 @@ public partial class GitHubTopicsDiscoverer(
         }
 
         // Fallback: extract meaningful suffix
-        var parts = nameWithoutExt.Split(['_', '-', '.'], StringSplitOptions.RemoveEmptyEntries);
+        var parts = nameWithoutExt.Split(new[] { '_', '-', '.' }, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length > 1)
         {
             // Return last meaningful part (often the variant)

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.424",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Summary

Pin builds to .NET SDK 8.0.424 instead of implicitly using the highest installed SDK.

## Changes

- Add `global.json` constrained to .NET 8.
- Make the `Split` separator array explicit for compiler compatibility.

## Testing

- `dotnet build GenHub/GenHub/GenHub.csproj -c Release` with SDK 8.0.424.

## Risks and rollback

Contributors need a compatible .NET 8 SDK. Reverting `global.json` restores the previous SDK selection.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin .NET SDK to version 8.0.424 via `global.json`
> Adds [global.json](https://github.com/community-outpost/GenHub/pull/380/files#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bf) to lock builds to .NET SDK 8.0.424 with `rollForward=latestFeature` and prerelease SDKs disallowed. Also updates a `String.Split` call in [GitHubTopicsDiscoverer.cs](https://github.com/community-outpost/GenHub/pull/380/files#diff-4f56608234dee0dfbf5751391bda9c270554f9ddbe9ca044425a9f1af9ba8ca4) to use an explicit `char[]` instead of a target-typed collection expression for compatibility with the pinned SDK.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 427dacf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->