### PR TITLE
fix(replays): require complete zip signature read

### DIFF
--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
@@ -303,7 +303,7 @@ public sealed class ReplayImportService(
             }
 
             var buffer = new byte[4];
-            stream.Read(buffer, 0, 4);
+            stream.ReadExactly(buffer);
 
             // Check for ZIP magic bytes: 50 4B 03 04 (local file header) or 50 4B 05 06 (end of central directory)
             return (buffer[0] == 0x50 && buffer[1] == 0x4B && buffer[2] == 0x03 && buffer[3] == 0x04) ||


### PR DESCRIPTION
## Summary

Ensure replay ZIP detection reads the complete four-byte signature.

## Changes

- Replace unchecked `Stream.Read` with `Stream.ReadExactly`.
- Prevent partial reads from producing an incorrect ZIP classification.

## Testing

- `dotnet build GenHub/GenHub/GenHub.csproj -c Release` with SDK 8.0.424.

## Risks and rollback

Low risk; this only changes ZIP signature detection.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ZIP signature validation in `ReplayImportService` to require complete 4-byte read
> Replaces `stream.Read(buffer, 0, 4)` with `stream.ReadExactly(buffer)` in the ZIP header check, after confirming the stream length is at least 4 bytes. This prevents partial reads from being silently misclassified as valid or invalid ZIP files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c513ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->