### PR TITLE
fix(launching): only rewrite GeneralsOnline settings for GeneralsOnline profiles

### DIFF
--- a/GenHub/GenHub.Core/Constants/GameSettingsGeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsGeneralsOnlineConstants.cs
@@ -16,6 +16,18 @@ public static class GameSettingsGeneralsOnlineConstants
     public const string TemporarySettingsFileExtension = ".tmp";
 
     /// <summary>
+    /// Number of times the completed settings file is moved over settings.json before the save
+    /// gives up and reports the failure. Anything holding settings.json open releases it within
+    /// milliseconds, so a handful of attempts either succeeds or is looking at a real fault.
+    /// </summary>
+    public const int SettingsReplaceAttemptLimit = 5;
+
+    /// <summary>
+    /// Delay between attempts to move the completed settings file over settings.json.
+    /// </summary>
+    public const int SettingsReplaceRetryDelayMilliseconds = 20;
+
+    /// <summary>
     /// Default chat font size.
     /// </summary>
     public const int DefaultChatFontSize = 12;

--- a/GenHub/GenHub.Core/Constants/GameSettingsGeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsGeneralsOnlineConstants.cs
@@ -11,6 +11,11 @@ public static class GameSettingsGeneralsOnlineConstants
     public const string SettingsFileName = "settings.json";
 
     /// <summary>
+    /// Extension of the file a save is written to before it is moved over settings.json.
+    /// </summary>
+    public const string TemporarySettingsFileExtension = ".tmp";
+
+    /// <summary>
     /// Default chat font size.
     /// </summary>
     public const int DefaultChatFontSize = 12;

--- a/GenHub/GenHub.Core/Constants/GameSettingsGeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsGeneralsOnlineConstants.cs
@@ -24,4 +24,29 @@ public static class GameSettingsGeneralsOnlineConstants
     /// Maximum chat font size.
     /// </summary>
     public const int MaxChatFontSize = 24;
+
+    /// <summary>
+    /// Default for whether ping is shown.
+    /// </summary>
+    public const bool DefaultShowPing = true;
+
+    /// <summary>
+    /// Default for whether player ranks are shown.
+    /// </summary>
+    public const bool DefaultShowPlayerRanks = true;
+
+    /// <summary>
+    /// Default for whether the username is remembered.
+    /// </summary>
+    public const bool DefaultRememberUsername = true;
+
+    /// <summary>
+    /// Default for whether notifications are enabled.
+    /// </summary>
+    public const bool DefaultEnableNotifications = true;
+
+    /// <summary>
+    /// Default for whether sound notifications are enabled.
+    /// </summary>
+    public const bool DefaultEnableSoundNotifications = true;
 }

--- a/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
@@ -46,6 +46,12 @@ public static class GameSettingsTheSuperHackersConstants
     public const int DefaultSystemTimeFontSize = 8;
 
     /// <summary>
+    /// Default volume for money transaction audio events, on the same 0-100 scale the settings
+    /// screen exposes. Zero would mute them, which is a choice rather than a default.
+    /// </summary>
+    public const int DefaultMoneyTransactionVolume = 50;
+
+    /// <summary>
     /// Default for whether player observer mode is enabled.
     /// Matches the engine fallback in OptionPreferences::getPlayerObserverEnabled.
     /// </summary>

--- a/GenHub/GenHub.Core/Extensions/GameProfileExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/GameProfileExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using GenHub.Core.Constants;
 using GenHub.Core.Models.GameProfile;
 
 namespace GenHub.Core.Extensions;
@@ -19,6 +22,32 @@ public static class GameProfileExtensions
                HasCustomTshSettings(profile) ||
                HasCustomGeneralsOnlineSettings(profile) ||
                HasCustomNetworkSettings(profile);
+    }
+
+    /// <summary>
+    /// Checks if a profile runs the GeneralsOnline client.
+    /// </summary>
+    /// <remarks>
+    /// The publisher type is the authoritative marker, but profiles created before it was
+    /// recorded carry it only in the client name or the enabled content ids, so both are
+    /// consulted as fallbacks.
+    /// </remarks>
+    /// <param name="profile">The game profile.</param>
+    /// <returns>True if the profile runs GeneralsOnline, false otherwise.</returns>
+    public static bool IsGeneralsOnlineProfile(this GameProfile profile)
+    {
+        if (string.Equals(profile.GameClient?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (profile.GameClient?.Name?.Contains(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return true;
+        }
+
+        return profile.EnabledContentIds?
+            .Any(id => id.Contains(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase)) == true;
     }
 
     private static bool HasCustomVideoSettings(GameProfile profile)

--- a/GenHub/GenHub.Core/Extensions/GameProfileExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/GameProfileExtensions.cs
@@ -28,17 +28,20 @@ public static class GameProfileExtensions
     /// Checks if a profile runs the GeneralsOnline client.
     /// </summary>
     /// <remarks>
-    /// The publisher type is the authoritative marker, but profiles created before it was
-    /// recorded carry it only in the client name or the enabled content ids, so both are
-    /// consulted as fallbacks.
+    /// A recorded publisher type settles the question either way. The client name and the enabled
+    /// content ids are consulted only when no publisher type was recorded, which is the case for
+    /// profiles created before it existed: a TheSuperHackers profile with GeneralsOnline content
+    /// enabled belongs to TheSuperHackers, and answering otherwise would let it rewrite the
+    /// GeneralsOnline client's global settings.
     /// </remarks>
     /// <param name="profile">The game profile.</param>
     /// <returns>True if the profile runs GeneralsOnline, false otherwise.</returns>
     public static bool IsGeneralsOnlineProfile(this GameProfile profile)
     {
-        if (string.Equals(profile.GameClient?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase))
+        var publisherType = profile.GameClient?.PublisherType;
+        if (!string.IsNullOrWhiteSpace(publisherType))
         {
-            return true;
+            return string.Equals(publisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase);
         }
 
         if (profile.GameClient?.Name?.Contains(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) == true)

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -89,6 +89,11 @@ public static class GameSettingsMapper
     /// Applies settings from a GameProfile to a GeneralsOnlineSettings object.
     /// Used by GameLauncher to prepare settings.json for launch.
     /// </summary>
+    /// <remarks>
+    /// Only the fields the profile declares are written, as <see cref="ApplyToOptions"/> does for
+    /// Options.ini. The caller passes the settings already on disk, and anything the profile leaves
+    /// unset is the GeneralsOnline client's own configuration, which a launch must not overwrite.
+    /// </remarks>
     /// <param name="profile">The GameProfile source.</param>
     /// <param name="settings">The GeneralsOnlineSettings to populate.</param>
     public static void ApplyToGeneralsOnlineSettings(GameProfile profile, GeneralsOnlineSettings settings)
@@ -607,60 +612,60 @@ public static class GameSettingsMapper
 
     private static void ApplyGoGeneralSettings(GameProfile profile, GeneralsOnlineSettings settings)
     {
-        settings.ShowFps = profile.GoShowFps ?? false;
-        settings.ShowPing = profile.GoShowPing ?? true;
-        settings.ShowPlayerRanks = profile.GoShowPlayerRanks ?? true;
-        settings.AutoLogin = profile.GoAutoLogin ?? false;
-        settings.RememberUsername = profile.GoRememberUsername ?? true;
-        settings.EnableNotifications = profile.GoEnableNotifications ?? true;
-        settings.EnableSoundNotifications = profile.GoEnableSoundNotifications ?? true;
-        settings.ChatFontSize = profile.GoChatFontSize ?? 12;
+        if (profile.GoShowFps.HasValue) settings.ShowFps = profile.GoShowFps.Value;
+        if (profile.GoShowPing.HasValue) settings.ShowPing = profile.GoShowPing.Value;
+        if (profile.GoShowPlayerRanks.HasValue) settings.ShowPlayerRanks = profile.GoShowPlayerRanks.Value;
+        if (profile.GoAutoLogin.HasValue) settings.AutoLogin = profile.GoAutoLogin.Value;
+        if (profile.GoRememberUsername.HasValue) settings.RememberUsername = profile.GoRememberUsername.Value;
+        if (profile.GoEnableNotifications.HasValue) settings.EnableNotifications = profile.GoEnableNotifications.Value;
+        if (profile.GoEnableSoundNotifications.HasValue) settings.EnableSoundNotifications = profile.GoEnableSoundNotifications.Value;
+        if (profile.GoChatFontSize.HasValue) settings.ChatFontSize = profile.GoChatFontSize.Value;
     }
 
     private static void ApplyGoCameraAndChatSettings(GameProfile profile, GeneralsOnlineSettings settings)
     {
-        settings.Camera.MaxHeightOnlyWhenLobbyHost = profile.GoCameraMaxHeightOnlyWhenLobbyHost ?? 310.0f;
-        settings.Camera.MinHeight = profile.GoCameraMinHeight ?? 310.0f;
-        settings.Camera.MoveSpeedRatio = profile.GoCameraMoveSpeedRatio ?? 1.5f;
-        settings.Chat.DurationSecondsUntilFadeOut = profile.GoChatDurationSecondsUntilFadeOut ?? 30;
+        if (profile.GoCameraMaxHeightOnlyWhenLobbyHost.HasValue) settings.Camera.MaxHeightOnlyWhenLobbyHost = profile.GoCameraMaxHeightOnlyWhenLobbyHost.Value;
+        if (profile.GoCameraMinHeight.HasValue) settings.Camera.MinHeight = profile.GoCameraMinHeight.Value;
+        if (profile.GoCameraMoveSpeedRatio.HasValue) settings.Camera.MoveSpeedRatio = profile.GoCameraMoveSpeedRatio.Value;
+        if (profile.GoChatDurationSecondsUntilFadeOut.HasValue) settings.Chat.DurationSecondsUntilFadeOut = profile.GoChatDurationSecondsUntilFadeOut.Value;
     }
 
     private static void ApplyGoRenderAndDebugSettings(GameProfile profile, GeneralsOnlineSettings settings)
     {
-        settings.Debug.VerboseLogging = profile.GoDebugVerboseLogging ?? false;
-        settings.Render.FpsLimit = profile.GoRenderFpsLimit ?? 144;
-        settings.Render.LimitFramerate = profile.GoRenderLimitFramerate ?? true;
-        settings.Render.StatsOverlay = profile.GoRenderStatsOverlay ?? true;
+        if (profile.GoDebugVerboseLogging.HasValue) settings.Debug.VerboseLogging = profile.GoDebugVerboseLogging.Value;
+        if (profile.GoRenderFpsLimit.HasValue) settings.Render.FpsLimit = profile.GoRenderFpsLimit.Value;
+        if (profile.GoRenderLimitFramerate.HasValue) settings.Render.LimitFramerate = profile.GoRenderLimitFramerate.Value;
+        if (profile.GoRenderStatsOverlay.HasValue) settings.Render.StatsOverlay = profile.GoRenderStatsOverlay.Value;
     }
 
     private static void ApplyGoSocialSettings(GameProfile profile, GeneralsOnlineSettings settings)
     {
-        settings.Social.NotificationFriendComesOnlineGameplay = profile.GoSocialNotificationFriendComesOnlineGameplay ?? true;
-        settings.Social.NotificationFriendComesOnlineMenus = profile.GoSocialNotificationFriendComesOnlineMenus ?? true;
-        settings.Social.NotificationFriendGoesOfflineGameplay = profile.GoSocialNotificationFriendGoesOfflineGameplay ?? true;
-        settings.Social.NotificationFriendGoesOfflineMenus = profile.GoSocialNotificationFriendGoesOfflineMenus ?? true;
-        settings.Social.NotificationPlayerAcceptsRequestGameplay = profile.GoSocialNotificationPlayerAcceptsRequestGameplay ?? true;
-        settings.Social.NotificationPlayerAcceptsRequestMenus = profile.GoSocialNotificationPlayerAcceptsRequestMenus ?? true;
-        settings.Social.NotificationPlayerSendsRequestGameplay = profile.GoSocialNotificationPlayerSendsRequestGameplay ?? true;
-        settings.Social.NotificationPlayerSendsRequestMenus = profile.GoSocialNotificationPlayerSendsRequestMenus ?? true;
+        if (profile.GoSocialNotificationFriendComesOnlineGameplay.HasValue) settings.Social.NotificationFriendComesOnlineGameplay = profile.GoSocialNotificationFriendComesOnlineGameplay.Value;
+        if (profile.GoSocialNotificationFriendComesOnlineMenus.HasValue) settings.Social.NotificationFriendComesOnlineMenus = profile.GoSocialNotificationFriendComesOnlineMenus.Value;
+        if (profile.GoSocialNotificationFriendGoesOfflineGameplay.HasValue) settings.Social.NotificationFriendGoesOfflineGameplay = profile.GoSocialNotificationFriendGoesOfflineGameplay.Value;
+        if (profile.GoSocialNotificationFriendGoesOfflineMenus.HasValue) settings.Social.NotificationFriendGoesOfflineMenus = profile.GoSocialNotificationFriendGoesOfflineMenus.Value;
+        if (profile.GoSocialNotificationPlayerAcceptsRequestGameplay.HasValue) settings.Social.NotificationPlayerAcceptsRequestGameplay = profile.GoSocialNotificationPlayerAcceptsRequestGameplay.Value;
+        if (profile.GoSocialNotificationPlayerAcceptsRequestMenus.HasValue) settings.Social.NotificationPlayerAcceptsRequestMenus = profile.GoSocialNotificationPlayerAcceptsRequestMenus.Value;
+        if (profile.GoSocialNotificationPlayerSendsRequestGameplay.HasValue) settings.Social.NotificationPlayerSendsRequestGameplay = profile.GoSocialNotificationPlayerSendsRequestGameplay.Value;
+        if (profile.GoSocialNotificationPlayerSendsRequestMenus.HasValue) settings.Social.NotificationPlayerSendsRequestMenus = profile.GoSocialNotificationPlayerSendsRequestMenus.Value;
     }
 
     private static void ApplyGoTshSettings(GameProfile profile, GeneralsOnlineSettings settings)
     {
-        settings.ArchiveReplays = profile.TshArchiveReplays ?? false;
-        settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume ?? 50;
-        settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute ?? false;
-        settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled ?? GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled;
-        settings.SystemTimeFontSize = profile.TshSystemTimeFontSize ?? GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize;
-        settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize ?? GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize;
-        settings.RenderFpsFontSize = profile.TshRenderFpsFontSize ?? GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize;
-        settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment ?? GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment;
-        settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame;
-        settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu;
-        settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame;
-        settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu ?? GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu;
-        settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp;
-        settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp ?? GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
+        if (profile.TshArchiveReplays.HasValue) settings.ArchiveReplays = profile.TshArchiveReplays.Value;
+        if (profile.TshMoneyTransactionVolume.HasValue) settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume.Value;
+        if (profile.TshShowMoneyPerMinute.HasValue) settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute.Value;
+        if (profile.TshPlayerObserverEnabled.HasValue) settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled.Value;
+        if (profile.TshSystemTimeFontSize.HasValue) settings.SystemTimeFontSize = profile.TshSystemTimeFontSize.Value;
+        if (profile.TshNetworkLatencyFontSize.HasValue) settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize.Value;
+        if (profile.TshRenderFpsFontSize.HasValue) settings.RenderFpsFontSize = profile.TshRenderFpsFontSize.Value;
+        if (profile.TshResolutionFontAdjustment.HasValue) settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment.Value;
+        if (profile.TshCursorCaptureEnabledInFullscreenGame.HasValue) settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame.Value;
+        if (profile.TshCursorCaptureEnabledInFullscreenMenu.HasValue) settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu.Value;
+        if (profile.TshCursorCaptureEnabledInWindowedGame.HasValue) settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame.Value;
+        if (profile.TshCursorCaptureEnabledInWindowedMenu.HasValue) settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu.Value;
+        if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value;
+        if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp.Value;
     }
 
     private static void ApplyVideoResolutionAndQualityToOptions(GameProfile profile, IniOptions options, ILogger? logger)

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -98,6 +98,8 @@ public static class GameSettingsMapper
     /// <param name="settings">The GeneralsOnlineSettings to populate.</param>
     public static void ApplyToGeneralsOnlineSettings(GameProfile profile, GeneralsOnlineSettings settings)
     {
+        settings.EnsureNestedSectionsInitialized();
+
         ApplyGoGeneralSettings(profile, settings);
         ApplyGoCameraAndChatSettings(profile, settings);
         ApplyGoRenderAndDebugSettings(profile, settings);

--- a/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
+++ b/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
@@ -55,6 +55,19 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
     [JsonExtensionData]
     public Dictionary<string, JsonElement> AdditionalSettings { get; set; } = [];
 
+    /// <summary>
+    /// Replaces nested sections that a settings.json spelled as an explicit null, which is valid
+    /// JSON and overwrites the initializers, so that merging into this instance cannot throw.
+    /// </summary>
+    public void EnsureNestedSectionsInitialized()
+    {
+        Camera ??= new CameraSettings();
+        Chat ??= new ChatSettings();
+        Debug ??= new DebugSettings();
+        Render ??= new RenderSettings();
+        Social ??= new SocialSettings();
+    }
+
     /// <summary>Nested camera settings.</summary>
     public class CameraSettings
     {

--- a/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
+++ b/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace GenHub.Core.Models.GameSettings;
 
 /// <summary>GeneralsOnline game client settings (inherits TheSuperHackers settings plus GeneralsOnline-specific options).</summary>
@@ -42,6 +46,14 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
     /// <summary>Gets or sets the social notification settings.</summary>
     public SocialSettings Social { get; set; } = new();
 
+    /// <summary>
+    /// Gets or sets the settings.json keys this model does not declare. GenHub rewrites the
+    /// GeneralsOnline client's own settings.json wholesale, so without this the client would
+    /// lose every option GenHub has no property for.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> AdditionalSettings { get; set; } = [];
+
     /// <summary>Nested camera settings.</summary>
     public class CameraSettings
     {
@@ -53,6 +65,10 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
 
         /// <summary>Gets or sets the camera move speed ratio.</summary>
         public float MoveSpeedRatio { get; set; } = 1.5f;
+
+        /// <summary>Gets or sets the camera keys this model does not declare, so they survive a rewrite.</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalSettings { get; set; } = [];
     }
 
     /// <summary>Nested chat settings.</summary>
@@ -60,6 +76,10 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
     {
         /// <summary>Gets or sets the chat duration in seconds until fade out.</summary>
         public int DurationSecondsUntilFadeOut { get; set; } = 30;
+
+        /// <summary>Gets or sets the chat keys this model does not declare, so they survive a rewrite.</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalSettings { get; set; } = [];
     }
 
     /// <summary>Nested debug settings.</summary>
@@ -67,6 +87,10 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
     {
         /// <summary>Gets or sets a value indicating whether debug verbose logging is enabled.</summary>
         public bool VerboseLogging { get; set; }
+
+        /// <summary>Gets or sets the debug keys this model does not declare, so they survive a rewrite.</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalSettings { get; set; } = [];
     }
 
     /// <summary>Nested render settings.</summary>
@@ -80,6 +104,10 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
 
         /// <summary>Gets or sets a value indicating whether to render stats overlay.</summary>
         public bool StatsOverlay { get; set; } = true;
+
+        /// <summary>Gets or sets the render keys this model does not declare, so they survive a rewrite.</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalSettings { get; set; } = [];
     }
 
     /// <summary>Nested social settings.</summary>
@@ -108,5 +136,9 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
 
         /// <summary>Gets or sets a value indicating whether to show notification when player sends request in menus.</summary>
         public bool NotificationPlayerSendsRequestMenus { get; set; } = true;
+
+        /// <summary>Gets or sets the social keys this model does not declare, so they survive a rewrite.</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalSettings { get; set; } = [];
     }
 }

--- a/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
+++ b/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GenHub.Core.Constants;
 
 namespace GenHub.Core.Models.GameSettings;
 
@@ -11,25 +12,25 @@ public class GeneralsOnlineSettings : TheSuperHackersSettings
     public bool ShowFps { get; set; }
 
     /// <summary>Gets or sets a value indicating whether to show ping/latency.</summary>
-    public bool ShowPing { get; set; } = true;
+    public bool ShowPing { get; set; } = GameSettingsGeneralsOnlineConstants.DefaultShowPing;
 
     /// <summary>Gets or sets a value indicating whether to enable auto-login.</summary>
     public bool AutoLogin { get; set; }
 
     /// <summary>Gets or sets a value indicating whether to remember username.</summary>
-    public bool RememberUsername { get; set; } = true;
+    public bool RememberUsername { get; set; } = GameSettingsGeneralsOnlineConstants.DefaultRememberUsername;
 
     /// <summary>Gets or sets a value indicating whether to enable notifications.</summary>
-    public bool EnableNotifications { get; set; } = true;
+    public bool EnableNotifications { get; set; } = GameSettingsGeneralsOnlineConstants.DefaultEnableNotifications;
 
     /// <summary>Gets or sets the chat font size.</summary>
-    public int ChatFontSize { get; set; } = 12;
+    public int ChatFontSize { get; set; } = GameSettingsGeneralsOnlineConstants.DefaultChatFontSize;
 
     /// <summary>Gets or sets a value indicating whether to enable sound notifications.</summary>
-    public bool EnableSoundNotifications { get; set; } = true;
+    public bool EnableSoundNotifications { get; set; } = GameSettingsGeneralsOnlineConstants.DefaultEnableSoundNotifications;
 
     /// <summary>Gets or sets a value indicating whether to show player ranks.</summary>
-    public bool ShowPlayerRanks { get; set; } = true;
+    public bool ShowPlayerRanks { get; set; } = GameSettingsGeneralsOnlineConstants.DefaultShowPlayerRanks;
 
     /// <summary>Gets or sets the camera settings.</summary>
     public CameraSettings Camera { get; set; } = new();

--- a/GenHub/GenHub.Core/Models/GameSettings/TheSuperHackersSettings.cs
+++ b/GenHub/GenHub.Core/Models/GameSettings/TheSuperHackersSettings.cs
@@ -1,3 +1,5 @@
+using GenHub.Core.Constants;
+
 namespace GenHub.Core.Models.GameSettings;
 
 /// <summary>TheSuperHackers game client settings from Options.ini.</summary>
@@ -19,7 +21,7 @@ public class TheSuperHackersSettings
     public bool CursorCaptureEnabledInWindowedMenu { get; set; }
 
     /// <summary>Gets or sets the volume of money transaction audio events (0-100, 0 to mute).</summary>
-    public int MoneyTransactionVolume { get; set; }
+    public int MoneyTransactionVolume { get; set; } = GameSettingsTheSuperHackersConstants.DefaultMoneyTransactionVolume;
 
     /// <summary>Gets or sets the font size for network latency display (0 to disable).</summary>
     public int NetworkLatencyFontSize { get; set; } = 8;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
@@ -1,0 +1,93 @@
+using GenHub.Core.Constants;
+using GenHub.Core.Extensions;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameClients;
+using GenHub.Core.Models.GameProfile;
+
+namespace GenHub.Tests.Core.Extensions;
+
+/// <summary>
+/// Tests for <see cref="GameProfileExtensions"/>.
+/// </summary>
+public class GameProfileExtensionsTests
+{
+    /// <summary>
+    /// Verifies that the publisher type identifies a GeneralsOnline profile regardless of casing.
+    /// </summary>
+    /// <param name="publisherType">The publisher type recorded on the profile's client.</param>
+    [Theory]
+    [InlineData("generalsonline")]
+    [InlineData("GeneralsOnline")]
+    [InlineData("GENERALSONLINE")]
+    public void IsGeneralsOnlineProfile_WithGeneralsOnlinePublisher_ReturnsTrue(string publisherType)
+    {
+        // Arrange
+        var profile = CreateZeroHourProfile(publisherType, "Zero Hour", []);
+
+        // Act & Assert
+        Assert.True(profile.IsGeneralsOnlineProfile());
+    }
+
+    /// <summary>
+    /// Verifies that other Zero Hour publishers are not mistaken for GeneralsOnline, which is what
+    /// kept their launches from overwriting the GeneralsOnline client's settings.json.
+    /// </summary>
+    /// <param name="publisherType">The publisher type recorded on the profile's client.</param>
+    [Theory]
+    [InlineData(PublisherTypeConstants.TheSuperHackers)]
+    [InlineData(CommunityOutpostConstants.PublisherType)]
+    [InlineData("")]
+    public void IsGeneralsOnlineProfile_WithOtherPublisher_ReturnsFalse(string publisherType)
+    {
+        // Arrange
+        var profile = CreateZeroHourProfile(publisherType, "Zero Hour", ["1.0.genhub.mod.test"]);
+
+        // Act & Assert
+        Assert.False(profile.IsGeneralsOnlineProfile());
+    }
+
+    /// <summary>
+    /// Verifies that a profile predating the recorded publisher type is still recognised by its
+    /// client name.
+    /// </summary>
+    [Fact]
+    public void IsGeneralsOnlineProfile_WithGeneralsOnlineClientName_ReturnsTrue()
+    {
+        // Arrange
+        var profile = CreateZeroHourProfile(string.Empty, "GeneralsOnline 30Hz", []);
+
+        // Act & Assert
+        Assert.True(profile.IsGeneralsOnlineProfile());
+    }
+
+    /// <summary>
+    /// Verifies that a profile predating the recorded publisher type is still recognised by its
+    /// enabled content.
+    /// </summary>
+    [Fact]
+    public void IsGeneralsOnlineProfile_WithGeneralsOnlineContent_ReturnsTrue()
+    {
+        // Arrange
+        var profile = CreateZeroHourProfile(string.Empty, "Zero Hour", ["1.9.generalsonline.gameclient.30hz"]);
+
+        // Act & Assert
+        Assert.True(profile.IsGeneralsOnlineProfile());
+    }
+
+    private static GameProfile CreateZeroHourProfile(string publisherType, string clientName, List<string> enabledContentIds)
+    {
+        return new GameProfile
+        {
+            Id = "profile-1",
+            Name = "Test Profile",
+            GameClient = new GameClient
+            {
+                Id = "client-1",
+                Name = clientName,
+                GameType = GameType.ZeroHour,
+                PublisherType = publisherType,
+            },
+            EnabledContentIds = enabledContentIds,
+        };
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
@@ -37,10 +37,32 @@ public class GameProfileExtensionsTests
     [InlineData(PublisherTypeConstants.TheSuperHackers)]
     [InlineData(CommunityOutpostConstants.PublisherType)]
     [InlineData("")]
+    [InlineData("   ")]
     public void IsGeneralsOnlineProfile_WithOtherPublisher_ReturnsFalse(string publisherType)
     {
         // Arrange
         var profile = CreateZeroHourProfile(publisherType, "Zero Hour", ["1.0.genhub.mod.test"]);
+
+        // Act & Assert
+        Assert.False(profile.IsGeneralsOnlineProfile());
+    }
+
+    /// <summary>
+    /// Verifies that a recorded publisher settles the question, so a profile belonging to another
+    /// client is not reclassified by content it happens to enable or by its client name. Answering
+    /// otherwise would let it rewrite the GeneralsOnline client's global settings.
+    /// </summary>
+    /// <param name="publisherType">The publisher type recorded on the profile's client.</param>
+    [Theory]
+    [InlineData(PublisherTypeConstants.TheSuperHackers)]
+    [InlineData(CommunityOutpostConstants.PublisherType)]
+    public void IsGeneralsOnlineProfile_WithOtherPublisherAndGeneralsOnlineHints_ReturnsFalse(string publisherType)
+    {
+        // Arrange
+        var profile = CreateZeroHourProfile(
+            publisherType,
+            "GeneralsOnline Compatible",
+            ["1.9.generalsonline.gameclient.30hz"]);
 
         // Act & Assert
         Assert.False(profile.IsGeneralsOnlineProfile());

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
@@ -103,6 +103,29 @@ public class GameProfileExtensionsTests
         Assert.True(profile.IsGeneralsOnlineProfile());
     }
 
+    /// <summary>
+    /// Verifies that a profile with no client at all, which is the shape the settings editor sees
+    /// while a profile is being created, falls back to its enabled content.
+    /// </summary>
+    /// <param name="contentId">The content the profile enables.</param>
+    /// <param name="expected">Whether that content makes it a GeneralsOnline profile.</param>
+    [Theory]
+    [InlineData("1.9.generalsonline.gameclient.30hz", true)]
+    [InlineData("1.0.genhub.mod.test", false)]
+    public void IsGeneralsOnlineProfile_WithoutGameClient_FallsBackToContent(string contentId, bool expected)
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            Id = "profile-1",
+            Name = "Test Profile",
+            EnabledContentIds = [contentId],
+        };
+
+        // Act & Assert
+        Assert.Equal(expected, profile.IsGeneralsOnlineProfile());
+    }
+
     private static GameProfile CreateZeroHourProfile(string? publisherType, string clientName, List<string> enabledContentIds)
     {
         return new GameProfile

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/GameProfileExtensionsTests.cs
@@ -36,9 +36,10 @@ public class GameProfileExtensionsTests
     [Theory]
     [InlineData(PublisherTypeConstants.TheSuperHackers)]
     [InlineData(CommunityOutpostConstants.PublisherType)]
+    [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void IsGeneralsOnlineProfile_WithOtherPublisher_ReturnsFalse(string publisherType)
+    public void IsGeneralsOnlineProfile_WithOtherPublisher_ReturnsFalse(string? publisherType)
     {
         // Arrange
         var profile = CreateZeroHourProfile(publisherType, "Zero Hour", ["1.0.genhub.mod.test"]);
@@ -70,13 +71,16 @@ public class GameProfileExtensionsTests
 
     /// <summary>
     /// Verifies that a profile predating the recorded publisher type is still recognised by its
-    /// client name.
+    /// client name. Such a profile records no publisher at all, so null is its real shape.
     /// </summary>
-    [Fact]
-    public void IsGeneralsOnlineProfile_WithGeneralsOnlineClientName_ReturnsTrue()
+    /// <param name="publisherType">The publisher type recorded on the profile's client.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsGeneralsOnlineProfile_WithGeneralsOnlineClientName_ReturnsTrue(string? publisherType)
     {
         // Arrange
-        var profile = CreateZeroHourProfile(string.Empty, "GeneralsOnline 30Hz", []);
+        var profile = CreateZeroHourProfile(publisherType, "GeneralsOnline 30Hz", []);
 
         // Act & Assert
         Assert.True(profile.IsGeneralsOnlineProfile());
@@ -84,19 +88,22 @@ public class GameProfileExtensionsTests
 
     /// <summary>
     /// Verifies that a profile predating the recorded publisher type is still recognised by its
-    /// enabled content.
+    /// enabled content. Such a profile records no publisher at all, so null is its real shape.
     /// </summary>
-    [Fact]
-    public void IsGeneralsOnlineProfile_WithGeneralsOnlineContent_ReturnsTrue()
+    /// <param name="publisherType">The publisher type recorded on the profile's client.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsGeneralsOnlineProfile_WithGeneralsOnlineContent_ReturnsTrue(string? publisherType)
     {
         // Arrange
-        var profile = CreateZeroHourProfile(string.Empty, "Zero Hour", ["1.9.generalsonline.gameclient.30hz"]);
+        var profile = CreateZeroHourProfile(publisherType, "Zero Hour", ["1.9.generalsonline.gameclient.30hz"]);
 
         // Act & Assert
         Assert.True(profile.IsGeneralsOnlineProfile());
     }
 
-    private static GameProfile CreateZeroHourProfile(string publisherType, string clientName, List<string> enabledContentIds)
+    private static GameProfile CreateZeroHourProfile(string? publisherType, string clientName, List<string> enabledContentIds)
     {
         return new GameProfile
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -430,16 +430,15 @@ public class GameSettingsViewModelTests
     }
 
     /// <summary>
-    /// Should read settings.json before rewriting it, even when the view model was initialized
-    /// from a profile and so never loaded it.
+    /// Should read settings.json before rewriting it, including when the first read failed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SaveSettings_Should_ReadGeneralsOnlineSettings_WhenNeverLoadedAsync()
+    public async Task SaveSettings_Should_ReadGeneralsOnlineSettings_BeforeRewritingAsync()
     {
         // Arrange
         var profile = CreateGeneralsOnlineProfile();
-        profile.GoShowFps = true; // custom settings, so initialization does not read settings.json
+        profile.GoShowFps = true;
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
         _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
@@ -450,7 +449,89 @@ public class GameSettingsViewModelTests
         await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
 
         // Assert
-        _gameSettingsServiceMock.Verify(x => x.LoadGeneralsOnlineSettingsAsync(), Times.Once);
+        _gameSettingsServiceMock.Verify(x => x.LoadGeneralsOnlineSettingsAsync(), Times.AtLeastOnce);
+    }
+
+    /// <summary>
+    /// Should keep the values a user configured inside the GeneralsOnline client when saving a
+    /// profile that declares only some GeneralsOnline options.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_NotOverwriteClientValues_TheProfileDoesNotDeclareAsync()
+    {
+        // Arrange - the client's values are all the opposite of the view model's defaults
+        var existing = new GeneralsOnlineSettings
+        {
+            ShowPing = false,
+            ShowPlayerRanks = false,
+            RememberUsername = false,
+            EnableNotifications = false,
+            EnableSoundNotifications = false,
+            ChatFontSize = 24,
+        };
+
+        var profile = CreateGeneralsOnlineProfile();
+        profile.GoShowFps = true;
+
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(existing));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.NotNull(saved);
+        Assert.True(saved.ShowFps);
+        Assert.False(saved.ShowPing);
+        Assert.False(saved.ShowPlayerRanks);
+        Assert.False(saved.RememberUsername);
+        Assert.False(saved.EnableNotifications);
+        Assert.False(saved.EnableSoundNotifications);
+        Assert.Equal(24, saved.ChatFontSize);
+    }
+
+    /// <summary>
+    /// Should not turn the client's enabled toggles off when nothing has read them, which is what
+    /// a view model default of false would do to a model that defaults them to true.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_NotFlipEnabledTogglesOffAsync()
+    {
+        // Arrange - nothing supplies GeneralsOnline settings, so the defaults decide
+        var profile = CreateGeneralsOnlineProfile();
+        profile.GoShowFps = true;
+
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.NotNull(saved);
+        var expected = new GeneralsOnlineSettings();
+        Assert.Equal(expected.ShowPing, saved.ShowPing);
+        Assert.Equal(expected.ShowPlayerRanks, saved.ShowPlayerRanks);
+        Assert.Equal(expected.RememberUsername, saved.RememberUsername);
+        Assert.Equal(expected.EnableNotifications, saved.EnableNotifications);
+        Assert.Equal(expected.EnableSoundNotifications, saved.EnableSoundNotifications);
+        Assert.Equal(expected.ChatFontSize, saved.ChatFontSize);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -590,7 +590,112 @@ public class GameSettingsViewModelTests
         _gameSettingsServiceMock.Verify(
             x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()),
             Times.Never);
+        Assert.Contains("Options.ini saved", _viewModel.StatusMessage);
+        Assert.Contains("GeneralsOnline settings not written", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
+    /// Should never report that nothing was saved once Options.ini has been written, because the
+    /// Options.ini write happens before the settings.json rewrite is gated and a user told the save
+    /// failed outright would redo work that is already on disk.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_NotReportTotalFailure_WhenOnlyTheGeneralsOnlineWriteIsSkippedAsync()
+    {
+        // Arrange - seeding fails, so the save may not rewrite settings.json
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.DoesNotContain("Failed to save settings", _viewModel.StatusMessage);
+        Assert.Contains("Options.ini saved", _viewModel.StatusMessage);
+        Assert.Contains("never read", _viewModel.StatusMessage);
+        Assert.True(_viewModel.OptionsFileExists);
+    }
+
+    /// <summary>
+    /// Should report Options.ini as written when the settings.json rewrite itself is refused, which
+    /// is the same split outcome as a refused read reached through a later step.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_ReportOptionsIniSaved_WhenTheGeneralsOnlineWriteFailsAsync()
+    {
+        // Arrange
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("settings.json is read-only"));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.DoesNotContain("Failed to save settings", _viewModel.StatusMessage);
+        Assert.Contains("Options.ini saved", _viewModel.StatusMessage);
+        Assert.Contains("settings.json is read-only", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
+    /// Should report settings.json as written when it is the Options.ini write that fails, because
+    /// the rewrite is attempted regardless of how the Options.ini write went.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_ReportGeneralsOnlineSaved_WhenTheOptionsIniWriteFailsAsync()
+    {
+        // Arrange
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("Options.ini is read-only"));
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.DoesNotContain("Failed to save settings", _viewModel.StatusMessage);
+        Assert.Contains("GeneralsOnline settings saved", _viewModel.StatusMessage);
+        Assert.Contains("Options.ini is read-only", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
+    /// Should still report a plain failure when neither file was written, so the split reporting
+    /// does not soften an outcome where nothing landed.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_ReportTotalFailure_WhenNeitherFileIsWrittenAsync()
+    {
+        // Arrange
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("Options.ini is read-only"));
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("settings.json is read-only"));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
         Assert.Contains("Failed to save settings", _viewModel.StatusMessage);
+        Assert.Contains("Options.ini is read-only", _viewModel.StatusMessage);
+        Assert.Contains("settings.json is read-only", _viewModel.StatusMessage);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -443,7 +443,9 @@ public class GameSettingsViewModelTests
         var profile = CreateGeneralsOnlineProfile();
         profile.GoShowFps = true;
 
-        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+        // The file was readable when the editor opened and is not when the save reads it again
+        _gameSettingsServiceMock.SetupSequence(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()))
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"));
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
@@ -494,7 +496,8 @@ public class GameSettingsViewModelTests
     }
 
     /// <summary>
-    /// Should read settings.json before rewriting it, including when the first read failed.
+    /// Should read settings.json again immediately before rewriting it, rather than reusing what
+    /// initialization read.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
@@ -503,6 +506,8 @@ public class GameSettingsViewModelTests
         // Arrange
         var profile = CreateGeneralsOnlineProfile();
         profile.GoShowFps = true;
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
         _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
@@ -512,8 +517,114 @@ public class GameSettingsViewModelTests
         await _viewModel.InitializeForProfileAsync("go-profile", profile);
         await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
 
+        // Assert - once to seed the view model, once more as the baseline for the rewrite
+        _gameSettingsServiceMock.Verify(x => x.LoadGeneralsOnlineSettingsAsync(), Times.Exactly(2));
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.Is<GeneralsOnlineSettings>(s => s.ShowFps)),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Should build every save on what settings.json holds at that moment, so that changes the
+    /// GeneralsOnline client made while this editor was open are not reverted by the rewrite.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_RewriteWhatSettingsJsonHoldsNow_NotWhatItHeldAtInitializationAsync()
+    {
+        // Arrange
+        var atInitialization = new GeneralsOnlineSettings();
+        atInitialization.AdditionalSettings["auth_token"] = JsonSerializer.Deserialize<JsonElement>("\"old-token\"");
+
+        var writtenByTheClientSince = new GeneralsOnlineSettings { ChatFontSize = 24 };
+        writtenByTheClientSince.AdditionalSettings["auth_token"] = JsonSerializer.Deserialize<JsonElement>("\"new-token\"");
+
+        _gameSettingsServiceMock.SetupSequence(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(atInitialization))
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(writtenByTheClientSince));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var profile = CreateGeneralsOnlineProfile();
+        profile.GoShowFps = true;
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
         // Assert
-        _gameSettingsServiceMock.Verify(x => x.LoadGeneralsOnlineSettingsAsync(), Times.AtLeastOnce);
+        Assert.NotNull(saved);
+        Assert.True(saved.AdditionalSettings.ContainsKey("auth_token"), "client-owned key was dropped");
+        Assert.Equal("new-token", saved.AdditionalSettings["auth_token"].GetString());
+    }
+
+    /// <summary>
+    /// Should leave settings.json alone when the view model was never seeded from it, because the
+    /// view model has no unset state and would otherwise write its own defaults over every option
+    /// the user configured inside the GeneralsOnline client.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_NotRewriteGeneralsOnlineSettings_WhenSeedingFailedAsync()
+    {
+        // Arrange - the read fails while the view model is seeded, then recovers before the save
+        _gameSettingsServiceMock.SetupSequence(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"))
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var profile = CreateGeneralsOnlineProfile();
+        profile.GoShowFps = true;
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()),
+            Times.Never);
+        Assert.Contains("Failed to save settings", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
+    /// Should not carry one profile's settings.json read into the next profile, because saving the
+    /// second profile would then rewrite the file from a reading taken for the first.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task InitializeForProfileAsync_Should_NotReuseThePreviousProfilesSettingsAsync()
+    {
+        // Arrange
+        _gameSettingsServiceMock.SetupSequence(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()))
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"))
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var first = CreateGeneralsOnlineProfile();
+        first.GoShowFps = true;
+
+        var second = CreateGeneralsOnlineProfile();
+        second.Id = "go-profile-2";
+        second.GoShowFps = false;
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", first);
+        await _viewModel.InitializeForProfileAsync("go-profile-2", second);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()),
+            Times.Never);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using GenHub.Core.Constants;
 using GenHub.Core.Extensions;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Models.Enums;
@@ -407,11 +408,11 @@ public class GameSettingsViewModelTests
         var existing = new GeneralsOnlineSettings();
         existing.AdditionalSettings["auth_token"] = JsonSerializer.Deserialize<JsonElement>("\"preserve-me\"");
 
-        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.Generals))
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.ZeroHour))
             .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(new IniOptions()));
         _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(existing));
-        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.Generals, It.IsAny<IniOptions>()))
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         GeneralsOnlineSettings? saved = null;
@@ -420,7 +421,7 @@ public class GameSettingsViewModelTests
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
-        await _viewModel.LoadSettingsCommand.ExecuteAsync(null);
+        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
         await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
 
         // Assert
@@ -437,16 +438,55 @@ public class GameSettingsViewModelTests
     public async Task SaveSettings_Should_ReadGeneralsOnlineSettings_WhenNeverLoadedAsync()
     {
         // Arrange
-        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.Generals, It.IsAny<IniOptions>()))
+        var profile = CreateGeneralsOnlineProfile();
+        profile.GoShowFps = true; // custom settings, so initialization does not read settings.json
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
         _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
         await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
 
         // Assert
         _gameSettingsServiceMock.Verify(x => x.LoadGeneralsOnlineSettingsAsync(), Times.Once);
+    }
+
+    /// <summary>
+    /// Should leave the GeneralsOnline client's global settings.json alone when the profile being
+    /// edited runs some other client.
+    /// </summary>
+    /// <param name="publisherType">The publisher the profile's client belongs to.</param>
+    /// <param name="gameType">The game the profile targets.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Theory]
+    [InlineData(PublisherTypeConstants.TheSuperHackers, GameType.ZeroHour)]
+    [InlineData(CommunityOutpostConstants.PublisherType, GameType.ZeroHour)]
+    [InlineData(PublisherTypeConstants.TheSuperHackers, GameType.Generals)]
+    public async Task SaveSettings_Should_NotWriteGeneralsOnlineSettings_ForOtherPublishersAsync(string publisherType, GameType gameType)
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            Id = "other-profile",
+            Name = "Other Profile",
+            GameClient = new GameClient { GameType = gameType, PublisherType = publisherType },
+            VideoResolutionWidth = 1920,
+        };
+
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(gameType, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("other-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()),
+            Times.Never);
+        Assert.Contains("saved successfully", _viewModel.StatusMessage);
     }
 
     /// <summary>
@@ -471,5 +511,19 @@ public class GameSettingsViewModelTests
 
         // Assert
         Assert.Equal("1920x1080", _viewModel.SelectedResolutionPreset);
+    }
+
+    private static GameProfile CreateGeneralsOnlineProfile()
+    {
+        return new GameProfile
+        {
+            Id = "go-profile",
+            Name = "GeneralsOnline Profile",
+            GameClient = new GameClient
+            {
+                GameType = GameType.ZeroHour,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+            },
+        };
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -430,6 +430,35 @@ public class GameSettingsViewModelTests
     }
 
     /// <summary>
+    /// Should leave settings.json alone when it could not be read, because a missing file reads as
+    /// defaults and reports success: a failed read means the client's own file exists and is
+    /// unreadable, and rewriting it from defaults would discard everything the client owns.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_NotRewriteGeneralsOnlineSettings_WhenTheyCannotBeReadAsync()
+    {
+        // Arrange
+        var profile = CreateGeneralsOnlineProfile();
+        profile.GoShowFps = true;
+
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()),
+            Times.Never);
+        Assert.Contains("settings.json is locked", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
     /// Should read settings.json before rewriting it, including when the first read failed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
@@ -507,10 +536,12 @@ public class GameSettingsViewModelTests
     [Fact]
     public async Task SaveSettings_Should_NotFlipEnabledTogglesOffAsync()
     {
-        // Arrange - nothing supplies GeneralsOnline settings, so the defaults decide
+        // Arrange - settings.json does not exist yet, which reads as defaults, so the defaults decide
         var profile = CreateGeneralsOnlineProfile();
         profile.GoShowFps = true;
 
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -459,6 +459,40 @@ public class GameSettingsViewModelTests
     }
 
     /// <summary>
+    /// Should save a settings.json that spells a nested section as an explicit null, which is
+    /// valid JSON and leaves the section null once deserialized.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_HandleNullGeneralsOnlineSectionsAsync()
+    {
+        // Arrange
+        var existing = new GeneralsOnlineSettings { Camera = null!, Chat = null!, Debug = null!, Render = null!, Social = null! };
+
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(existing));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var profile = CreateGeneralsOnlineProfile();
+        profile.GoCameraMinHeight = 200.0f;
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.NotNull(saved);
+        Assert.Equal(200.0f, saved.Camera.MinHeight);
+        Assert.Contains("saved successfully", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
     /// Should read settings.json before rewriting it, including when the first read failed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GenHub.Core.Extensions;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Models.Enums;
@@ -393,6 +394,59 @@ public class GameSettingsViewModelTests
 
         // Assert
         Assert.Contains("Failed to save settings", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
+    /// Should keep settings.json keys the view model does not model when saving over them.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_PreserveUnknownGeneralsOnlineKeysAsync()
+    {
+        // Arrange
+        var existing = new GeneralsOnlineSettings();
+        existing.AdditionalSettings["auth_token"] = JsonSerializer.Deserialize<JsonElement>("\"preserve-me\"");
+
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.Generals))
+            .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(new IniOptions()));
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(existing));
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.Generals, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.LoadSettingsCommand.ExecuteAsync(null);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.NotNull(saved);
+        Assert.Equal("preserve-me", saved.AdditionalSettings["auth_token"].GetString());
+    }
+
+    /// <summary>
+    /// Should read settings.json before rewriting it, even when the view model was initialized
+    /// from a profile and so never loaded it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_ReadGeneralsOnlineSettings_WhenNeverLoadedAsync()
+    {
+        // Arrange
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.Generals, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        _gameSettingsServiceMock.Verify(x => x.LoadGeneralsOnlineSettingsAsync(), Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -426,6 +426,7 @@ public class GameSettingsViewModelTests
 
         // Assert
         Assert.NotNull(saved);
+        Assert.True(saved.AdditionalSettings.ContainsKey("auth_token"), "client-owned key was dropped");
         Assert.Equal("preserve-me", saved.AdditionalSettings["auth_token"].GetString());
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
@@ -1,9 +1,11 @@
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameSettings;
 using GenHub.Features.GameSettings;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Moq.Protected;
 
 namespace GenHub.Tests.Core.Features.GameSettings;
 
@@ -384,5 +386,85 @@ Resolution=1024 768
         Assert.Contains("[CUSTOM_SECTION]", savedContent);
         Assert.Contains("CustomKey=CustomValue", savedContent);
         Assert.Contains("AnotherKey=AnotherValue", savedContent);
+    }
+
+    /// <summary>
+    /// Should replace settings.json by moving a completed file over it, leaving nothing behind,
+    /// because a half-written settings.json costs the GeneralsOnline client every key it owns.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveGeneralsOnlineSettingsAsync_Should_ReplaceTheFileWithoutTruncatingItAsync()
+    {
+        // Arrange
+        var directory = Directory.CreateTempSubdirectory().FullName;
+        var settingsPath = Path.Combine(directory, GameSettingsGeneralsOnlineConstants.SettingsFileName);
+        await File.WriteAllTextAsync(settingsPath, "{ \"chat_font_size\": 8 }");
+        var service = CreateServiceWritingGeneralsOnlineSettingsTo(settingsPath);
+
+        try
+        {
+            // Act
+            var result = await service.SaveGeneralsOnlineSettingsAsync(new GeneralsOnlineSettings { ChatFontSize = 24 });
+
+            // Assert
+            Assert.True(result.Success, result.FirstError);
+            var reloaded = await service.LoadGeneralsOnlineSettingsAsync();
+            Assert.True(reloaded.Success, reloaded.FirstError);
+            Assert.Equal(24, reloaded.Data!.ChatFontSize);
+            Assert.Empty(Directory.GetFiles(directory, $"*{GameSettingsGeneralsOnlineConstants.TemporarySettingsFileExtension}"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Should survive concurrent saves, which two GeneralsOnline launches produce because the
+    /// launch lock is per profile while settings.json is a single global file.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveGeneralsOnlineSettingsAsync_Should_LeaveReadableSettings_WhenSavesOverlapAsync()
+    {
+        // Arrange
+        var directory = Directory.CreateTempSubdirectory().FullName;
+        var settingsPath = Path.Combine(directory, GameSettingsGeneralsOnlineConstants.SettingsFileName);
+        var service = CreateServiceWritingGeneralsOnlineSettingsTo(settingsPath);
+
+        try
+        {
+            // Act
+            var fontSizes = Enumerable.Range(
+                GameSettingsGeneralsOnlineConstants.MinChatFontSize,
+                GameSettingsGeneralsOnlineConstants.MaxChatFontSize - GameSettingsGeneralsOnlineConstants.MinChatFontSize);
+            var results = await Task.WhenAll(
+                fontSizes.Select(fontSize => service.SaveGeneralsOnlineSettingsAsync(new GeneralsOnlineSettings { ChatFontSize = fontSize })));
+
+            // Assert
+            Assert.All(results, result => Assert.True(result.Success, result.FirstError));
+            var reloaded = await service.LoadGeneralsOnlineSettingsAsync();
+            Assert.True(reloaded.Success, reloaded.FirstError);
+            Assert.InRange(
+                reloaded.Data!.ChatFontSize,
+                GameSettingsGeneralsOnlineConstants.MinChatFontSize,
+                GameSettingsGeneralsOnlineConstants.MaxChatFontSize);
+            Assert.Empty(Directory.GetFiles(directory, $"*{GameSettingsGeneralsOnlineConstants.TemporarySettingsFileExtension}"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private GameSettingsService CreateServiceWritingGeneralsOnlineSettingsTo(string settingsPath)
+    {
+        var mockService = new Mock<GameSettingsService>(MockBehavior.Loose, _loggerMock.Object, _pathProviderMock.Object)
+        {
+            CallBase = true,
+        };
+        mockService.Protected().Setup<string>("GetGeneralsOnlineSettingsPath").Returns(settingsPath);
+        return mockService.Object;
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
@@ -421,12 +421,14 @@ Resolution=1024 768
     }
 
     /// <summary>
-    /// Should survive concurrent saves, which two GeneralsOnline launches produce because the
-    /// launch lock is per profile while settings.json is a single global file.
+    /// Should report success for every one of a set of concurrent saves, which two GeneralsOnline
+    /// launches produce because the launch lock is per profile while settings.json is a single
+    /// global file. Which save wins is not defined, but none of them may be turned away: a launch
+    /// that reports a settings failure has lost the settings the user chose for that profile.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SaveGeneralsOnlineSettingsAsync_Should_LeaveReadableSettings_WhenSavesOverlapAsync()
+    public async Task SaveGeneralsOnlineSettingsAsync_Should_SucceedForEverySave_WhenSavesOverlapAsync()
     {
         // Arrange
         var directory = Directory.CreateTempSubdirectory().FullName;
@@ -450,6 +452,80 @@ Resolution=1024 768
                 reloaded.Data!.ChatFontSize,
                 GameSettingsGeneralsOnlineConstants.MinChatFontSize,
                 GameSettingsGeneralsOnlineConstants.MaxChatFontSize);
+            Assert.Empty(Directory.GetFiles(directory, $"*{GameSettingsGeneralsOnlineConstants.TemporarySettingsFileExtension}"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Should keep both concurrent saves and concurrent loads working against the one global
+    /// settings.json. A load that overlaps the replacement of the file it is reading is the
+    /// other half of the same race, because the GameLauncher reads settings.json before every
+    /// save it makes.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GeneralsOnlineSettings_Should_SucceedForEveryCall_WhenLoadsAndSavesOverlapAsync()
+    {
+        // Arrange
+        var directory = Directory.CreateTempSubdirectory().FullName;
+        var settingsPath = Path.Combine(directory, GameSettingsGeneralsOnlineConstants.SettingsFileName);
+        var service = CreateServiceWritingGeneralsOnlineSettingsTo(settingsPath);
+        await service.SaveGeneralsOnlineSettingsAsync(new GeneralsOnlineSettings { ChatFontSize = GameSettingsGeneralsOnlineConstants.DefaultChatFontSize });
+
+        try
+        {
+            // Act
+            var fontSizes = Enumerable.Range(
+                GameSettingsGeneralsOnlineConstants.MinChatFontSize,
+                GameSettingsGeneralsOnlineConstants.MaxChatFontSize - GameSettingsGeneralsOnlineConstants.MinChatFontSize)
+                .ToList();
+            var saves = Task.WhenAll(fontSizes.Select(fontSize => service.SaveGeneralsOnlineSettingsAsync(new GeneralsOnlineSettings { ChatFontSize = fontSize })));
+            var loads = Task.WhenAll(fontSizes.Select(_ => service.LoadGeneralsOnlineSettingsAsync()));
+            var saveResults = await saves;
+            var loadResults = await loads;
+
+            // Assert
+            Assert.All(saveResults, result => Assert.True(result.Success, result.FirstError));
+            Assert.All(loadResults, result => Assert.True(result.Success, result.FirstError));
+            Assert.All(
+                loadResults,
+                result => Assert.InRange(
+                    result.Data!.ChatFontSize,
+                    GameSettingsGeneralsOnlineConstants.MinChatFontSize,
+                    GameSettingsGeneralsOnlineConstants.MaxChatFontSize));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Should report the failure once a replacement that cannot succeed has used up its
+    /// attempts, rather than retrying a real fault forever or claiming a save that never
+    /// happened, and should leave no temporary file behind when it does.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveGeneralsOnlineSettingsAsync_Should_ReportFailure_WhenTheReplacementNeverSucceedsAsync()
+    {
+        // Arrange
+        var directory = Directory.CreateTempSubdirectory().FullName;
+        var settingsPath = Path.Combine(directory, GameSettingsGeneralsOnlineConstants.SettingsFileName);
+        Directory.CreateDirectory(settingsPath);
+        var service = CreateServiceWritingGeneralsOnlineSettingsTo(settingsPath);
+
+        try
+        {
+            // Act
+            var result = await service.SaveGeneralsOnlineSettingsAsync(new GeneralsOnlineSettings());
+
+            // Assert
+            Assert.False(result.Success);
             Assert.Empty(Directory.GetFiles(directory, $"*{GameSettingsGeneralsOnlineConstants.TemporarySettingsFileExtension}"));
         }
         finally

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Text.Json;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameProfiles;
@@ -90,6 +92,10 @@ public class GameLauncherTests : IDisposable
         _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(It.IsAny<GameType>()))
             .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(new IniOptions()));
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(It.IsAny<GameType>(), It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Setup storage location service mock
@@ -897,6 +903,94 @@ public class GameLauncherTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that a Zero Hour profile running some other client leaves the GeneralsOnline
+    /// client's settings.json alone.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_WithNonGeneralsOnlineZeroHourProfile_ShouldNotWriteGeneralsOnlineSettingsAsync()
+    {
+        // Arrange
+        var profile = CreateZeroHourProfile(PublisherTypeConstants.TheSuperHackers, "TheSuperHackers Zero Hour");
+        ArrangeSuccessfulLaunch(profile);
+
+        // Act
+        var result = await _gameLauncher.LaunchProfileAsync(profile.Id);
+
+        // Assert
+        Assert.True(result.Success, result.FirstError);
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that a GeneralsOnline profile does write its client settings.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_WithGeneralsOnlineProfile_ShouldWriteGeneralsOnlineSettingsAsync()
+    {
+        // Arrange
+        var profile = CreateZeroHourProfile(PublisherTypeConstants.GeneralsOnline, "GeneralsOnline");
+        profile.GoShowFps = true;
+        ArrangeSuccessfulLaunch(profile);
+
+        // Act
+        var result = await _gameLauncher.LaunchProfileAsync(profile.Id);
+
+        // Assert
+        Assert.True(result.Success);
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.Is<GeneralsOnlineSettings>(s => s.ShowFps)),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that the values a user configured inside the GeneralsOnline client survive a launch
+    /// of a profile that says nothing about them.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_WithGeneralsOnlineProfile_ShouldPreserveSettingsTheProfileDoesNotSpecifyAsync()
+    {
+        // Arrange - every seeded value is the opposite of the GenHub default
+        var existing = new GeneralsOnlineSettings
+        {
+            ShowPing = false,
+            ChatFontSize = 24,
+            RememberUsername = false,
+        };
+        existing.Render.FpsLimit = 60;
+        existing.AdditionalSettings["auth_token"] = JsonSerializer.Deserialize<JsonElement>("\"preserve-me\"");
+
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(existing));
+
+        var profile = CreateZeroHourProfile(PublisherTypeConstants.GeneralsOnline, "GeneralsOnline");
+        profile.GoShowFps = true;
+        ArrangeSuccessfulLaunch(profile);
+
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        var result = await _gameLauncher.LaunchProfileAsync(profile.Id);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(saved);
+        Assert.True(saved.ShowFps);
+        Assert.False(saved.ShowPing);
+        Assert.Equal(24, saved.ChatFontSize);
+        Assert.False(saved.RememberUsername);
+        Assert.Equal(60, saved.Render.FpsLimit);
+        Assert.Equal("preserve-me", saved.AdditionalSettings["auth_token"].GetString());
+    }
+
+    /// <summary>
     /// Removes the temporary retail root.
     /// </summary>
     public void Dispose()
@@ -925,6 +1019,31 @@ public class GameLauncherTests : IDisposable
             Name = "Test Profile",
             GameInstallationId = "install-1",
             GameClient = new GameClient { Id = "version-1", ExecutablePath = @"C:\Games\generals.exe", GameType = GameType.Generals },
+            EnabledContentIds = ["1.0.genhub.mod.test"],
+        };
+    }
+
+    /// <summary>
+    /// Creates a Zero Hour <see cref="GameProfile"/> attributed to a specific publisher.
+    /// </summary>
+    /// <param name="publisherType">The publisher the profile's client belongs to.</param>
+    /// <param name="clientName">The client name, which is also consulted when identifying the publisher.</param>
+    /// <returns>A valid Zero Hour <see cref="GameProfile"/>.</returns>
+    private static GameProfile CreateZeroHourProfile(string publisherType, string clientName)
+    {
+        return new GameProfile
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Test Profile",
+            GameInstallationId = "install-1",
+            GameClient = new GameClient
+            {
+                Id = "version-1",
+                Name = clientName,
+                ExecutablePath = @"C:\Games\generals.exe",
+                GameType = GameType.ZeroHour,
+                PublisherType = publisherType,
+            },
             EnabledContentIds = ["1.0.genhub.mod.test"],
         };
     }
@@ -963,5 +1082,39 @@ public class GameLauncherTests : IDisposable
             throw new InvalidOperationException("Failed to start junction creation process.");
         process.WaitForExit();
         Assert.Equal(0, process.ExitCode);
+    }
+
+    /// <summary>
+    /// Wires the mocks a launch needs to reach the settings-writing step and succeed.
+    /// </summary>
+    /// <param name="profile">The profile being launched.</param>
+    private void ArrangeSuccessfulLaunch(GameProfile profile)
+    {
+        var manifest = new ContentManifest { Id = "1.0.genhub.mod.test", Name = "Test Content" };
+        var workspaceInfo = new WorkspaceInfo { Id = profile.Id, WorkspacePath = @"C:\workspace" };
+        var processInfo = new GameProcessInfo { ProcessId = 123, ProcessName = "generals.exe" };
+
+        // Zero Hour launches resolve their own installation path, so both roots are declared.
+        var installation = new GameInstallation(_retailRoot, GameInstallationType.Steam);
+        installation.SetPaths(_retailRoot, _retailRoot);
+        _gameInstallationServiceMock.Setup(x => x.GetInstallationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GameInstallation>.CreateSuccess(installation));
+
+        _profileManagerMock.Setup(x => x.GetProfileAsync(profile.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(profile));
+
+        _manifestPoolMock.Setup(x => x.GetManifestAsync(It.IsAny<ManifestId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest?>.CreateSuccess(manifest));
+
+        _dependencyResolverMock.Setup(x => x.ResolveDependenciesWithManifestsAsync(
+                It.Is<IEnumerable<string>>(ids => ids.SequenceEqual(TestContentIds)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DependencyResolutionResult.CreateSuccess(TestContentIds, [manifest], []));
+
+        _workspaceManagerMock.Setup(x => x.PrepareWorkspaceAsync(It.IsAny<WorkspaceConfiguration>(), It.IsAny<IProgress<WorkspacePreparationProgress>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<WorkspaceInfo>.CreateSuccess(workspaceInfo));
+
+        _processManagerMock.Setup(x => x.StartProcessAsync(It.IsAny<GameLaunchConfiguration>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GameProcessInfo>.CreateSuccess(processInfo));
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -904,14 +904,15 @@ public class GameLauncherTests : IDisposable
 
     /// <summary>
     /// Tests that a Zero Hour profile running some other client leaves the GeneralsOnline
-    /// client's settings.json alone.
+    /// client's settings.json alone, even when its name would match the heuristic that
+    /// identifies profiles with no recorded publisher.
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
     public async Task LaunchProfileAsync_WithNonGeneralsOnlineZeroHourProfile_ShouldNotWriteGeneralsOnlineSettingsAsync()
     {
         // Arrange
-        var profile = CreateZeroHourProfile(PublisherTypeConstants.TheSuperHackers, "TheSuperHackers Zero Hour");
+        var profile = CreateZeroHourProfile(PublisherTypeConstants.TheSuperHackers, "GeneralsOnline-compatible TheSuperHackers");
         ArrangeSuccessfulLaunch(profile);
 
         // Act

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -948,6 +948,33 @@ public class GameLauncherTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that settings.json is left alone when it could not be read. A missing file reads as
+    /// defaults and reports success, so a failed read means the client's own file exists and is
+    /// unreadable, and rewriting it from defaults would discard everything the client owns.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_WithUnreadableGeneralsOnlineSettings_ShouldNotRewriteThemAsync()
+    {
+        // Arrange
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"));
+
+        var profile = CreateZeroHourProfile(PublisherTypeConstants.GeneralsOnline, "GeneralsOnline");
+        profile.GoShowFps = true;
+        ArrangeSuccessfulLaunch(profile);
+
+        // Act
+        var result = await _gameLauncher.LaunchProfileAsync(profile.Id);
+
+        // Assert
+        Assert.True(result.Success, result.FirstError);
+        _gameSettingsServiceMock.Verify(
+            x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Tests that the values a user configured inside the GeneralsOnline client survive a launch
     /// of a profile that says nothing about them.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -941,7 +941,7 @@ public class GameLauncherTests : IDisposable
         var result = await _gameLauncher.LaunchProfileAsync(profile.Id);
 
         // Assert
-        Assert.True(result.Success);
+        Assert.True(result.Success, result.FirstError);
         _gameSettingsServiceMock.Verify(
             x => x.SaveGeneralsOnlineSettingsAsync(It.Is<GeneralsOnlineSettings>(s => s.ShowFps)),
             Times.Once);
@@ -1040,13 +1040,14 @@ public class GameLauncherTests : IDisposable
         var result = await _gameLauncher.LaunchProfileAsync(profile.Id);
 
         // Assert
-        Assert.True(result.Success);
+        Assert.True(result.Success, result.FirstError);
         Assert.NotNull(saved);
         Assert.True(saved.ShowFps);
         Assert.False(saved.ShowPing);
         Assert.Equal(24, saved.ChatFontSize);
         Assert.False(saved.RememberUsername);
         Assert.Equal(60, saved.Render.FpsLimit);
+        Assert.True(saved.AdditionalSettings.ContainsKey("auth_token"), "client-owned key was dropped");
         Assert.Equal("preserve-me", saved.AdditionalSettings["auth_token"].GetString());
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Launching/GameLauncherTests.cs
@@ -975,6 +975,38 @@ public class GameLauncherTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that a settings.json spelling a nested section as an explicit null, which is valid
+    /// JSON, does not break the merge the launch performs.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    public async Task LaunchProfileAsync_WithNullGeneralsOnlineSection_ShouldStillWriteSettingsAsync()
+    {
+        // Arrange
+        var existing = new GeneralsOnlineSettings { Camera = null! };
+
+        _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
+            .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(existing));
+
+        var profile = CreateZeroHourProfile(PublisherTypeConstants.GeneralsOnline, "GeneralsOnline");
+        profile.GoCameraMinHeight = 200.0f;
+        ArrangeSuccessfulLaunch(profile);
+
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        var result = await _gameLauncher.LaunchProfileAsync(profile.Id);
+
+        // Assert
+        Assert.True(result.Success, result.FirstError);
+        Assert.NotNull(saved);
+        Assert.Equal(200.0f, saved.Camera.MinHeight);
+    }
+
+    /// <summary>
     /// Tests that the values a user configured inside the GeneralsOnline client survive a launch
     /// of a profile that says nothing about them.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -61,56 +61,62 @@ public class GameSettingsMapperTests
     }
 
     /// <summary>
-    /// Verifies that a profile with no TheSuperHackers font sizes set falls back to the declared defaults.
+    /// Verifies that font sizes the profile leaves unset keep the values already in settings.json,
+    /// which is where the values a user configured inside the client itself live.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_UsesDeclaredDefaults()
+    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_PreservesExistingValues()
     {
-        // Arrange - seed with values the mapper must overwrite, so a missing assignment fails
+        // Arrange - seed with values no GenHub default would produce
         var profile = new GameProfile();
         var settings = new GeneralsOnlineSettings
         {
             SystemTimeFontSize = 99,
-            NetworkLatencyFontSize = 99,
-            RenderFpsFontSize = 99,
-            ResolutionFontAdjustment = 99,
+            NetworkLatencyFontSize = 98,
+            RenderFpsFontSize = 97,
+            ResolutionFontAdjustment = 96,
         };
 
         // Act
         GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
 
         // Assert
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultSystemTimeFontSize, settings.SystemTimeFontSize);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultNetworkLatencyFontSize, settings.NetworkLatencyFontSize);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultRenderFpsFontSize, settings.RenderFpsFontSize);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultResolutionFontAdjustment, settings.ResolutionFontAdjustment);
+        Assert.Equal(99, settings.SystemTimeFontSize);
+        Assert.Equal(98, settings.NetworkLatencyFontSize);
+        Assert.Equal(97, settings.RenderFpsFontSize);
+        Assert.Equal(96, settings.ResolutionFontAdjustment);
     }
 
     /// <summary>
-    /// Verifies that the fallback defaults match the values declared on the settings model itself.
+    /// Verifies that GeneralsOnline options the profile leaves unset keep the values already in
+    /// settings.json rather than being reset to GenHub's defaults.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_MatchesModelDefaults()
+    public void ApplyToGeneralsOnlineSettings_UnsetGeneralsOnlineOptions_PreservesExistingValues()
     {
-        // Arrange - seed with values the mapper must overwrite, so a missing assignment fails
-        var profile = new GameProfile();
-        var expected = new GeneralsOnlineSettings();
+        // Arrange - the profile declares one option; everything else is the client's own
+        var profile = new GameProfile { GoShowFps = true };
         var settings = new GeneralsOnlineSettings
         {
-            SystemTimeFontSize = 99,
-            NetworkLatencyFontSize = 99,
-            RenderFpsFontSize = 99,
-            ResolutionFontAdjustment = 99,
+            ShowPing = false,
+            RememberUsername = false,
+            ChatFontSize = 24,
         };
+        settings.Camera.MinHeight = 42.0f;
+        settings.Render.FpsLimit = 60;
+        settings.Social.NotificationFriendComesOnlineMenus = false;
 
         // Act
         GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
 
         // Assert
-        Assert.Equal(expected.SystemTimeFontSize, settings.SystemTimeFontSize);
-        Assert.Equal(expected.NetworkLatencyFontSize, settings.NetworkLatencyFontSize);
-        Assert.Equal(expected.RenderFpsFontSize, settings.RenderFpsFontSize);
-        Assert.Equal(expected.ResolutionFontAdjustment, settings.ResolutionFontAdjustment);
+        Assert.True(settings.ShowFps);
+        Assert.False(settings.ShowPing);
+        Assert.False(settings.RememberUsername);
+        Assert.Equal(24, settings.ChatFontSize);
+        Assert.Equal(42.0f, settings.Camera.MinHeight);
+        Assert.Equal(60, settings.Render.FpsLimit);
+        Assert.False(settings.Social.NotificationFriendComesOnlineMenus);
     }
 
     /// <summary>
@@ -140,13 +146,13 @@ public class GameSettingsMapperTests
     }
 
     /// <summary>
-    /// Verifies that a profile with no cursor capture, edge scroll or observer toggles set
-    /// falls back to the declared defaults.
+    /// Verifies that cursor capture, edge scroll and observer toggles the profile leaves unset
+    /// keep the values already in settings.json.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_UnsetToggles_UsesDeclaredDefaults()
+    public void ApplyToGeneralsOnlineSettings_UnsetToggles_PreservesExistingValues()
     {
-        // Arrange - seed each toggle inverted, so a missing assignment fails
+        // Arrange - seed each toggle inverted relative to its GenHub default
         var profile = new GameProfile();
         var settings = new GeneralsOnlineSettings
         {
@@ -163,46 +169,13 @@ public class GameSettingsMapperTests
         GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
 
         // Assert
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultPlayerObserverEnabled, settings.PlayerObserverEnabled);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenGame, settings.CursorCaptureEnabledInFullscreenGame);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInFullscreenMenu, settings.CursorCaptureEnabledInFullscreenMenu);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedGame, settings.CursorCaptureEnabledInWindowedGame);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultCursorCaptureEnabledInWindowedMenu, settings.CursorCaptureEnabledInWindowedMenu);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInFullscreenApp, settings.ScreenEdgeScrollEnabledInFullscreenApp);
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp, settings.ScreenEdgeScrollEnabledInWindowedApp);
-    }
-
-    /// <summary>
-    /// Verifies that the toggle fallbacks match the values declared on the settings model itself.
-    /// </summary>
-    [Fact]
-    public void ApplyToGeneralsOnlineSettings_UnsetToggles_MatchesModelDefaults()
-    {
-        // Arrange - seed each toggle inverted, so a missing assignment fails
-        var profile = new GameProfile();
-        var expected = new GeneralsOnlineSettings();
-        var settings = new GeneralsOnlineSettings
-        {
-            PlayerObserverEnabled = false,
-            CursorCaptureEnabledInFullscreenGame = false,
-            CursorCaptureEnabledInFullscreenMenu = false,
-            CursorCaptureEnabledInWindowedGame = false,
-            CursorCaptureEnabledInWindowedMenu = true,
-            ScreenEdgeScrollEnabledInFullscreenApp = false,
-            ScreenEdgeScrollEnabledInWindowedApp = true,
-        };
-
-        // Act
-        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
-
-        // Assert
-        Assert.Equal(expected.PlayerObserverEnabled, settings.PlayerObserverEnabled);
-        Assert.Equal(expected.CursorCaptureEnabledInFullscreenGame, settings.CursorCaptureEnabledInFullscreenGame);
-        Assert.Equal(expected.CursorCaptureEnabledInFullscreenMenu, settings.CursorCaptureEnabledInFullscreenMenu);
-        Assert.Equal(expected.CursorCaptureEnabledInWindowedGame, settings.CursorCaptureEnabledInWindowedGame);
-        Assert.Equal(expected.CursorCaptureEnabledInWindowedMenu, settings.CursorCaptureEnabledInWindowedMenu);
-        Assert.Equal(expected.ScreenEdgeScrollEnabledInFullscreenApp, settings.ScreenEdgeScrollEnabledInFullscreenApp);
-        Assert.Equal(expected.ScreenEdgeScrollEnabledInWindowedApp, settings.ScreenEdgeScrollEnabledInWindowedApp);
+        Assert.False(settings.PlayerObserverEnabled);
+        Assert.False(settings.CursorCaptureEnabledInFullscreenGame);
+        Assert.False(settings.CursorCaptureEnabledInFullscreenMenu);
+        Assert.False(settings.CursorCaptureEnabledInWindowedGame);
+        Assert.True(settings.CursorCaptureEnabledInWindowedMenu);
+        Assert.False(settings.ScreenEdgeScrollEnabledInFullscreenApp);
+        Assert.True(settings.ScreenEdgeScrollEnabledInWindowedApp);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -146,6 +146,25 @@ public class GameSettingsMapperTests
     }
 
     /// <summary>
+    /// Verifies that a fresh settings.json keeps money transaction audio audible, so that the
+    /// model default and the settings screen agree on what an unconfigured profile writes.
+    /// </summary>
+    [Fact]
+    public void ApplyToGeneralsOnlineSettings_UnsetMoneyTransactionVolume_StaysAudible()
+    {
+        // Arrange
+        var profile = new GameProfile();
+        var settings = new GeneralsOnlineSettings();
+
+        // Act
+        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+
+        // Assert
+        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultMoneyTransactionVolume, settings.MoneyTransactionVolume);
+        Assert.NotEqual(0, settings.MoneyTransactionVolume);
+    }
+
+    /// <summary>
     /// Verifies that cursor capture, edge scroll and observer toggles the profile leaves unset
     /// keep the values already in settings.json.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameSettings/GeneralsOnlineSettingsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameSettings/GeneralsOnlineSettingsTests.cs
@@ -120,6 +120,9 @@ public class GeneralsOnlineSettingsTests
         Assert.NotNull(reloaded);
         Assert.False(reloaded.ShowPing);
         Assert.Equal(100.0f, reloaded.Camera.MinHeight);
+        Assert.True(reloaded.AdditionalSettings.ContainsKey("auth_token"), "client-owned key was dropped");
+        Assert.True(reloaded.AdditionalSettings.ContainsKey("unmodelled_toggle"), "client-owned key was dropped");
+        Assert.True(reloaded.Camera.AdditionalSettings.ContainsKey("unmodelled_zoom_step"), "client-owned nested key was dropped");
         Assert.Equal("secret", reloaded.AdditionalSettings["auth_token"].GetString());
         Assert.False(reloaded.AdditionalSettings["unmodelled_toggle"].GetBoolean());
         Assert.Equal(7, reloaded.Camera.AdditionalSettings["unmodelled_zoom_step"].GetInt32());

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameSettings/GeneralsOnlineSettingsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameSettings/GeneralsOnlineSettingsTests.cs
@@ -124,4 +124,28 @@ public class GeneralsOnlineSettingsTests
         Assert.False(reloaded.AdditionalSettings["unmodelled_toggle"].GetBoolean());
         Assert.Equal(7, reloaded.Camera.AdditionalSettings["unmodelled_zoom_step"].GetInt32());
     }
+
+    /// <summary>
+    /// Verifies that a section spelled as an explicit null, which is valid JSON and overwrites the
+    /// property initializer, is restored so that merging into the loaded settings cannot throw.
+    /// </summary>
+    [Fact]
+    public void EnsureNestedSectionsInitialized_Should_ReplaceSectionsDeserializedAsNull()
+    {
+        // Arrange
+        var json = @"{ ""camera"": null, ""chat"": null, ""debug"": null, ""render"": null, ""social"": null }";
+        var settings = JsonSerializer.Deserialize<GeneralsOnlineSettings>(json, _options);
+        Assert.NotNull(settings);
+        Assert.Null(settings.Camera);
+
+        // Act
+        settings.EnsureNestedSectionsInitialized();
+
+        // Assert
+        Assert.NotNull(settings.Camera);
+        Assert.NotNull(settings.Chat);
+        Assert.NotNull(settings.Debug);
+        Assert.NotNull(settings.Render);
+        Assert.NotNull(settings.Social);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameSettings/GeneralsOnlineSettingsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameSettings/GeneralsOnlineSettingsTests.cs
@@ -89,4 +89,39 @@ public class GeneralsOnlineSettingsTests
         Assert.Contains("\"fps_limit\": 144", json);
         Assert.Contains("\"verbose_logging\": true", json);
     }
+
+    /// <summary>
+    /// Verifies that settings.json keys this model does not declare survive a load-modify-save
+    /// round trip, because saving replaces the GeneralsOnline client's file wholesale.
+    /// </summary>
+    [Fact]
+    public void RoundTrip_Should_PreserveUnknownKeys()
+    {
+        // Arrange
+        var json = @"
+{
+ ""show_ping"": true,
+ ""auth_token"": ""secret"",
+ ""unmodelled_toggle"": false,
+ ""camera"": {
+  ""min_height"": 100.0,
+  ""unmodelled_zoom_step"": 7
+ }
+}";
+
+        // Act
+        var settings = JsonSerializer.Deserialize<GeneralsOnlineSettings>(json, _options);
+        Assert.NotNull(settings);
+        settings.ShowPing = false;
+        var rewritten = JsonSerializer.Serialize(settings, _options);
+        var reloaded = JsonSerializer.Deserialize<GeneralsOnlineSettings>(rewritten, _options);
+
+        // Assert
+        Assert.NotNull(reloaded);
+        Assert.False(reloaded.ShowPing);
+        Assert.Equal(100.0f, reloaded.Camera.MinHeight);
+        Assert.Equal("secret", reloaded.AdditionalSettings["auth_token"].GetString());
+        Assert.False(reloaded.AdditionalSettings["unmodelled_toggle"].GetBoolean());
+        Assert.Equal(7, reloaded.Camera.AdditionalSettings["unmodelled_zoom_step"].GetInt32());
+    }
 }

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -816,7 +816,7 @@ public class ProfileLauncherFacade(
         }
         else
         {
-            if (IsGeneralsOnlineProfile(profile))
+            if (profile.IsGeneralsOnlineProfile())
             {
                 publisherType = PublisherTypeConstants.GeneralsOnline;
                 reconciler = reconcilerRegistry.GetReconciler(publisherType);
@@ -1167,36 +1167,6 @@ public class ProfileLauncherFacade(
         }
 
         return parts.Count > 0 ? $"({string.Join(" and ", parts)})" : string.Empty;
-    }
-
-    /// <summary>
-    /// Checks if a profile uses a GeneralsOnline game client.
-    /// </summary>
-    /// <param name="profile">The profile to check.</param>
-    /// <returns>True if the profile uses GeneralsOnline, false otherwise.</returns>
-    private bool IsGeneralsOnlineProfile(GameProfile profile)
-    {
-        // Check PublisherType first
-        if (profile.GameClient?.PublisherType?.Equals(
-            PublisherTypeConstants.GeneralsOnline,
-            StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return true;
-        }
-
-        // Check if Name contains "GeneralsOnline" (for legacy or incomplete profiles)
-        if (profile.GameClient?.Name?.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return true;
-        }
-
-        // Final fallback: Check enabled content for GeneralsOnline manifests
-        if (profile.EnabledContentIds?.Any(id => id.Contains("generalsonline", StringComparison.OrdinalIgnoreCase)) == true)
-        {
-            return true;
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -1256,6 +1256,8 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyGeneralsOnlineSettings(GeneralsOnlineSettings settings)
     {
+        settings.EnsureNestedSectionsInitialized();
+
         GoShowFps = settings.ShowFps;
         GoShowPing = settings.ShowPing;
         GoShowPlayerRanks = settings.ShowPlayerRanks;
@@ -1299,6 +1301,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         // GeneralsOnline client's settings.json and the loaded instance is the only thing
         // holding the keys this model does not declare.
         var settings = _currentGeneralsOnlineSettings ?? new GeneralsOnlineSettings();
+        settings.EnsureNestedSectionsInitialized();
 
         settings.ShowFps = GoShowFps;
         settings.ShowPing = GoShowPing;

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -324,25 +324,25 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _goShowFps;
 
     [ObservableProperty]
-    private bool _goShowPing;
+    private bool _goShowPing = GameSettingsGeneralsOnlineConstants.DefaultShowPing;
 
     [ObservableProperty]
-    private bool _goShowPlayerRanks;
+    private bool _goShowPlayerRanks = GameSettingsGeneralsOnlineConstants.DefaultShowPlayerRanks;
 
     [ObservableProperty]
     private bool _goAutoLogin;
 
     [ObservableProperty]
-    private bool _goRememberUsername;
+    private bool _goRememberUsername = GameSettingsGeneralsOnlineConstants.DefaultRememberUsername;
 
     [ObservableProperty]
-    private bool _goEnableNotifications;
+    private bool _goEnableNotifications = GameSettingsGeneralsOnlineConstants.DefaultEnableNotifications;
 
     [ObservableProperty]
-    private bool _goEnableSoundNotifications;
+    private bool _goEnableSoundNotifications = GameSettingsGeneralsOnlineConstants.DefaultEnableSoundNotifications;
 
     [ObservableProperty]
-    private int _goChatFontSize = 12;
+    private int _goChatFontSize = GameSettingsGeneralsOnlineConstants.DefaultChatFontSize;
 
     // Camera settings
     [ObservableProperty]
@@ -459,6 +459,10 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             // If profile has settings, load them
             if (profile?.HasCustomSettings() == true)
             {
+                // Seeded from settings.json first so that the options the profile does not declare
+                // show, and are saved back as, what the user configured inside the GeneralsOnline
+                // client rather than this view model's defaults.
+                await LoadGeneralsOnlineSettingsFromClientAsync();
                 LoadSettingsFromProfile(profile);
             }
             else
@@ -710,6 +714,35 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         finally
         {
             IsLoading = false;
+        }
+    }
+
+    /// <summary>
+    /// Reads the GeneralsOnline client's own settings.json into this view model.
+    /// </summary>
+    /// <remarks>
+    /// The view model's GeneralsOnline properties have no unset state, so every one of them is
+    /// written back on save. Seeding them from the client's file is what keeps that from replacing
+    /// options the profile says nothing about with defaults.
+    /// </remarks>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private async Task LoadGeneralsOnlineSettingsFromClientAsync()
+    {
+        if (_gameSettingsService == null || !_currentProfileIsGeneralsOnline)
+        {
+            return;
+        }
+
+        var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+        if (goResult?.Success == true && goResult.Data != null)
+        {
+            _currentGeneralsOnlineSettings = goResult.Data;
+            ApplyGeneralsOnlineSettings(goResult.Data);
+        }
+        else
+        {
+            var goErrors = goResult?.Errors ?? ["LoadGeneralsOnlineSettings result was null"];
+            _logger.LogWarning("Failed to load GeneralsOnline settings: {Errors}", string.Join(", ", goErrors));
         }
     }
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -425,6 +425,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         {
             _currentProfileId = profileId;
             _currentProfileIsGeneralsOnline = profile?.IsGeneralsOnlineProfile() == true;
+            _generalsOnlineSettingsSeeded = false;
 
             // Auto-select game type from profile
             if (profile != null)
@@ -637,7 +638,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     }
 
     private IniOptions? _currentOptions;
-    private GeneralsOnlineSettings? _currentGeneralsOnlineSettings;
+    private bool _generalsOnlineSettingsSeeded;
     private bool _currentProfileIsGeneralsOnline;
     private string? _currentProfileId;
     private int _initializationDepth;
@@ -696,12 +697,13 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
             if (goResult?.Success == true && goResult.Data != null)
             {
-                _currentGeneralsOnlineSettings = goResult.Data;
                 ApplyGeneralsOnlineSettings(goResult.Data);
+                _generalsOnlineSettingsSeeded = true;
                 _logger.LogInformation("Loaded GeneralsOnline settings");
             }
             else
             {
+                _generalsOnlineSettingsSeeded = false;
                 var goErrors = goResult?.Errors ?? ["LoadGeneralsOnlineSettings result was null"];
                 _logger.LogWarning("Failed to load GeneralsOnline settings: {Errors}", string.Join(", ", goErrors));
             }
@@ -723,7 +725,8 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     /// <remarks>
     /// The view model's GeneralsOnline properties have no unset state, so every one of them is
     /// written back on save. Seeding them from the client's file is what keeps that from replacing
-    /// options the profile says nothing about with defaults.
+    /// options the profile says nothing about with defaults. A read that fails leaves the view
+    /// model unseeded, which is what stops the save from writing over the client's own values.
     /// </remarks>
     /// <returns>A task representing the asynchronous operation.</returns>
     private async Task LoadGeneralsOnlineSettingsFromClientAsync()
@@ -736,11 +739,12 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
         if (goResult?.Success == true && goResult.Data != null)
         {
-            _currentGeneralsOnlineSettings = goResult.Data;
             ApplyGeneralsOnlineSettings(goResult.Data);
+            _generalsOnlineSettingsSeeded = true;
         }
         else
         {
+            _generalsOnlineSettingsSeeded = false;
             var goErrors = goResult?.Errors ?? ["LoadGeneralsOnlineSettings result was null"];
             _logger.LogWarning("Failed to load GeneralsOnline settings: {Errors}", string.Join(", ", goErrors));
         }
@@ -912,26 +916,26 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
             var writeGeneralsOnlineSettings = ShouldWriteGeneralsOnlineSettings();
             OperationResult<bool>? goResult = null;
-            GeneralsOnlineSettings? goSettings = null;
             string? goLoadError = null;
 
             if (writeGeneralsOnlineSettings)
             {
-                goLoadError = await ReadGeneralsOnlineSettingsForRewriteAsync();
-                if (goLoadError == null)
+                var goLoadResult = await ReadGeneralsOnlineSettingsForRewriteAsync();
+                if (goLoadResult.Success && goLoadResult.Data != null)
                 {
-                    goSettings = CreateGeneralsOnlineSettings();
+                    var goSettings = goLoadResult.Data;
+                    MergeViewModelIntoGeneralsOnlineSettings(goSettings);
                     goResult = await _gameSettingsService.SaveGeneralsOnlineSettingsAsync(goSettings);
+                }
+                else
+                {
+                    goLoadError = goLoadResult.FirstError;
                 }
             }
 
             if (result?.Success == true && (!writeGeneralsOnlineSettings || goResult?.Success == true))
             {
                 _currentOptions = options;
-                if (goSettings != null)
-                {
-                    _currentGeneralsOnlineSettings = goSettings;
-                }
 
                 OptionsFileExists = true;
                 StatusMessage = $"{SelectedGameType} settings saved successfully";
@@ -965,28 +969,37 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     /// Reads the GeneralsOnline client's settings.json so the save can be applied on top of it.
     /// </summary>
     /// <remarks>
-    /// A profile-initialized view model may never have read the file, and a missing file reads as
-    /// defaults and reports success. A failure therefore means the client's own file exists and
-    /// could not be read, and rewriting it from defaults would discard every key the client owns.
+    /// The file is read again for every save rather than kept as a snapshot: it is the
+    /// GeneralsOnline client's own global file, so anything it or another GenHub window wrote
+    /// since this editor opened would otherwise be reverted by the rewrite. Reading it is also
+    /// the only way to fail loudly, because a missing file reads as defaults and reports success:
+    /// a failure therefore means the client's file exists and could not be read, and rewriting it
+    /// from defaults would discard every key the client owns.
+    /// <para>
+    /// The read alone is not enough. This view model has no unset state, so it writes all 24
+    /// GeneralsOnline fields; unless they were seeded from a successful read, writing them would
+    /// replace what the user configured inside the client with this view model's defaults.
+    /// </para>
     /// </remarks>
-    /// <returns>Null once the settings are in hand, otherwise the error that must abort the rewrite.</returns>
-    private async Task<string?> ReadGeneralsOnlineSettingsForRewriteAsync()
+    /// <returns>The settings this save must be applied on top of, or the error that aborts the rewrite.</returns>
+    private async Task<OperationResult<GeneralsOnlineSettings>> ReadGeneralsOnlineSettingsForRewriteAsync()
     {
-        if (_currentGeneralsOnlineSettings != null || _gameSettingsService == null)
+        if (!_generalsOnlineSettingsSeeded)
         {
-            return null;
+            const string error = "GeneralsOnline settings.json was never read, so its values cannot be rewritten";
+            _logger.LogWarning("Not writing GeneralsOnline settings: {Error}", error);
+            return OperationResult<GeneralsOnlineSettings>.CreateFailure(error);
         }
 
-        var goLoadResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+        var goLoadResult = await _gameSettingsService!.LoadGeneralsOnlineSettingsAsync();
         if (goLoadResult?.Success == true && goLoadResult.Data != null)
         {
-            _currentGeneralsOnlineSettings = goLoadResult.Data;
-            return null;
+            return goLoadResult;
         }
 
-        var error = goLoadResult?.FirstError ?? "LoadGeneralsOnlineSettings result was null";
-        _logger.LogWarning("Not writing GeneralsOnline settings because settings.json could not be read: {Error}", error);
-        return error;
+        var loadError = goLoadResult?.FirstError ?? "LoadGeneralsOnlineSettings result was null";
+        _logger.LogWarning("Not writing GeneralsOnline settings because settings.json could not be read: {Error}", loadError);
+        return OperationResult<GeneralsOnlineSettings>.CreateFailure(loadError);
     }
 
     /// <summary>
@@ -1295,12 +1308,13 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         return SelectedGameType == GameType.ZeroHour && _currentProfileIsGeneralsOnline;
     }
 
-    private GeneralsOnlineSettings CreateGeneralsOnlineSettings()
+    /// <summary>
+    /// Writes this view model's GeneralsOnline values into settings just read from the client's
+    /// settings.json, which is what carries the keys this model does not declare through a save.
+    /// </summary>
+    /// <param name="settings">The settings read from settings.json, mutated in place.</param>
+    private void MergeViewModelIntoGeneralsOnlineSettings(GeneralsOnlineSettings settings)
     {
-        // Built on top of what was loaded, because saving is a wholesale rewrite of the
-        // GeneralsOnline client's settings.json and the loaded instance is the only thing
-        // holding the keys this model does not declare.
-        var settings = _currentGeneralsOnlineSettings ?? new GeneralsOnlineSettings();
         settings.EnsureNestedSectionsInitialized();
 
         settings.ShowFps = GoShowFps;
@@ -1327,7 +1341,5 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         settings.Social.NotificationPlayerAcceptsRequestMenus = GoSocialNotificationPlayerAcceptsRequestMenus;
         settings.Social.NotificationPlayerSendsRequestGameplay = GoSocialNotificationPlayerSendsRequestGameplay;
         settings.Social.NotificationPlayerSendsRequestMenus = GoSocialNotificationPlayerSendsRequestMenus;
-
-        return settings;
     }
 }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -895,8 +896,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     }
 
     /// <summary>
-    /// Saves the current settings to options.ini.
+    /// Saves the current settings to Options.ini and, for a GeneralsOnline profile, to the client's
+    /// settings.json.
     /// </summary>
+    /// <remarks>
+    /// The two files are separate writes with no transaction between them, so either one can land
+    /// while the other does not: the settings.json rewrite can be refused after Options.ini is
+    /// written, and Options.ini can fail after settings.json has been rewritten. Reordering the
+    /// writes only moves which half is exposed, so the status message names the halves separately
+    /// instead of reporting a total failure over a file that was written.
+    /// </remarks>
     [RelayCommand]
     private async Task SaveSettings()
     {
@@ -933,25 +942,47 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                 }
             }
 
-            if (result?.Success == true && (!writeGeneralsOnlineSettings || goResult?.Success == true))
+            var optionsSaved = result?.Success == true;
+            var generalsOnlineWritten = goResult?.Success == true;
+            var generalsOnlineBlocked = writeGeneralsOnlineSettings && !generalsOnlineWritten;
+
+            if (optionsSaved)
             {
                 _currentOptions = options;
-
                 OptionsFileExists = true;
+            }
+
+            var optionsErrors = new List<string>();
+            if (result == null) optionsErrors.Add("SaveOptions result was null");
+            if (result?.Success == false) optionsErrors.AddRange(result.Errors);
+
+            var generalsOnlineErrors = new List<string>();
+            if (goLoadError != null) generalsOnlineErrors.Add(goLoadError);
+            if (goResult?.Success == false) generalsOnlineErrors.AddRange(goResult.Errors);
+            if (generalsOnlineBlocked && goLoadError == null && goResult == null) generalsOnlineErrors.Add("SaveGeneralsOnlineSettings result was null");
+
+            if (optionsSaved && !generalsOnlineBlocked)
+            {
                 StatusMessage = $"{SelectedGameType} settings saved successfully";
                 _logger.LogInformation("Saved settings for {GameType}", SelectedGameType);
             }
+            else if (optionsSaved)
+            {
+                var goErrors = string.Join(", ", generalsOnlineErrors);
+                StatusMessage = $"Options.ini saved; GeneralsOnline settings not written: {goErrors}";
+                _logger.LogWarning("Saved Options.ini for {GameType} but did not write GeneralsOnline settings: {Errors}", SelectedGameType, goErrors);
+            }
+            else if (generalsOnlineWritten)
+            {
+                var iniErrors = string.Join(", ", optionsErrors);
+                StatusMessage = $"GeneralsOnline settings saved; Options.ini not saved: {iniErrors}";
+                _logger.LogWarning("Wrote GeneralsOnline settings but failed to save Options.ini for {GameType}: {Errors}", SelectedGameType, iniErrors);
+            }
             else
             {
-                var errors = new List<string>();
-                if (result?.Success == false) errors.AddRange(result.Errors);
-                if (goResult?.Success == false) errors.AddRange(goResult.Errors);
-                if (result == null) errors.Add("SaveOptions result was null");
-                if (goLoadError != null) errors.Add(goLoadError);
-                if (writeGeneralsOnlineSettings && goLoadError == null && goResult == null) errors.Add("SaveGeneralsOnlineSettings result was null");
-
-                StatusMessage = $"Failed to save settings: {string.Join(", ", errors)}";
-                _logger.LogWarning("Failed to save settings: {Errors}", string.Join(", ", errors));
+                var errors = string.Join(", ", optionsErrors.Concat(generalsOnlineErrors));
+                StatusMessage = $"Failed to save settings: {errors}";
+                _logger.LogWarning("Failed to save settings: {Errors}", errors);
             }
         }
         catch (Exception ex)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -11,6 +11,7 @@ using GenHub.Core.Extensions;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameSettings;
+using GenHub.Core.Models.Results;
 using Microsoft.Extensions.Logging;
 
 namespace GenHub.Features.GameProfiles.ViewModels;
@@ -423,6 +424,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         try
         {
             _currentProfileId = profileId;
+            _currentProfileIsGeneralsOnline = profile?.IsGeneralsOnlineProfile() == true;
 
             // Auto-select game type from profile
             if (profile != null)
@@ -632,6 +634,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private IniOptions? _currentOptions;
     private GeneralsOnlineSettings? _currentGeneralsOnlineSettings;
+    private bool _currentProfileIsGeneralsOnline;
     private string? _currentProfileId;
     private int _initializationDepth;
     private bool _isLoadingFromOptions;
@@ -874,24 +877,35 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             var options = CreateOptionsFromViewModel();
             var result = await _gameSettingsService.SaveOptionsAsync(SelectedGameType, options);
 
-            // Save GeneralsOnline settings. A profile-initialized view model never reads
-            // settings.json, so it is read here before being rewritten.
-            if (_currentGeneralsOnlineSettings == null)
+            var writeGeneralsOnlineSettings = ShouldWriteGeneralsOnlineSettings();
+            OperationResult<bool>? goResult = null;
+            GeneralsOnlineSettings? goSettings = null;
+
+            if (writeGeneralsOnlineSettings)
             {
-                var goLoadResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
-                if (goLoadResult?.Success == true && goLoadResult.Data != null)
+                // A profile-initialized view model may never have read settings.json, so it is
+                // read here before being rewritten.
+                if (_currentGeneralsOnlineSettings == null)
                 {
-                    _currentGeneralsOnlineSettings = goLoadResult.Data;
+                    var goLoadResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+                    if (goLoadResult?.Success == true && goLoadResult.Data != null)
+                    {
+                        _currentGeneralsOnlineSettings = goLoadResult.Data;
+                    }
                 }
+
+                goSettings = CreateGeneralsOnlineSettings();
+                goResult = await _gameSettingsService.SaveGeneralsOnlineSettingsAsync(goSettings);
             }
 
-            var goSettings = CreateGeneralsOnlineSettings();
-            var goResult = await _gameSettingsService.SaveGeneralsOnlineSettingsAsync(goSettings);
-
-            if (result?.Success == true && goResult?.Success == true)
+            if (result?.Success == true && (!writeGeneralsOnlineSettings || goResult?.Success == true))
             {
                 _currentOptions = options;
-                _currentGeneralsOnlineSettings = goSettings;
+                if (goSettings != null)
+                {
+                    _currentGeneralsOnlineSettings = goSettings;
+                }
+
                 OptionsFileExists = true;
                 StatusMessage = $"{SelectedGameType} settings saved successfully";
                 _logger.LogInformation("Saved settings for {GameType}", SelectedGameType);
@@ -902,7 +916,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                 if (result?.Success == false) errors.AddRange(result.Errors);
                 if (goResult?.Success == false) errors.AddRange(goResult.Errors);
                 if (result == null) errors.Add("SaveOptions result was null");
-                if (goResult == null) errors.Add("SaveGeneralsOnlineSettings result was null");
+                if (writeGeneralsOnlineSettings && goResult == null) errors.Add("SaveGeneralsOnlineSettings result was null");
 
                 StatusMessage = $"Failed to save settings: {string.Join(", ", errors)}";
                 _logger.LogWarning("Failed to save settings: {Errors}", string.Join(", ", errors));
@@ -1210,6 +1224,17 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         GoSocialNotificationPlayerAcceptsRequestMenus = settings.Social.NotificationPlayerAcceptsRequestMenus;
         GoSocialNotificationPlayerSendsRequestGameplay = settings.Social.NotificationPlayerSendsRequestGameplay;
         GoSocialNotificationPlayerSendsRequestMenus = settings.Social.NotificationPlayerSendsRequestMenus;
+    }
+
+    /// <summary>
+    /// Decides whether this save may rewrite settings.json, which is a single global file owned by
+    /// the GeneralsOnline client rather than a per-profile one. Saving a retail, TheSuperHackers or
+    /// CommunityOutpost profile must leave it untouched.
+    /// </summary>
+    /// <returns>True when the profile being edited runs the GeneralsOnline client.</returns>
+    private bool ShouldWriteGeneralsOnlineSettings()
+    {
+        return SelectedGameType == GameType.ZeroHour && _currentProfileIsGeneralsOnline;
     }
 
     private GeneralsOnlineSettings CreateGeneralsOnlineSettings()

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -913,22 +913,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             var writeGeneralsOnlineSettings = ShouldWriteGeneralsOnlineSettings();
             OperationResult<bool>? goResult = null;
             GeneralsOnlineSettings? goSettings = null;
+            string? goLoadError = null;
 
             if (writeGeneralsOnlineSettings)
             {
-                // A profile-initialized view model may never have read settings.json, so it is
-                // read here before being rewritten.
-                if (_currentGeneralsOnlineSettings == null)
+                goLoadError = await ReadGeneralsOnlineSettingsForRewriteAsync();
+                if (goLoadError == null)
                 {
-                    var goLoadResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
-                    if (goLoadResult?.Success == true && goLoadResult.Data != null)
-                    {
-                        _currentGeneralsOnlineSettings = goLoadResult.Data;
-                    }
+                    goSettings = CreateGeneralsOnlineSettings();
+                    goResult = await _gameSettingsService.SaveGeneralsOnlineSettingsAsync(goSettings);
                 }
-
-                goSettings = CreateGeneralsOnlineSettings();
-                goResult = await _gameSettingsService.SaveGeneralsOnlineSettingsAsync(goSettings);
             }
 
             if (result?.Success == true && (!writeGeneralsOnlineSettings || goResult?.Success == true))
@@ -949,7 +943,8 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                 if (result?.Success == false) errors.AddRange(result.Errors);
                 if (goResult?.Success == false) errors.AddRange(goResult.Errors);
                 if (result == null) errors.Add("SaveOptions result was null");
-                if (writeGeneralsOnlineSettings && goResult == null) errors.Add("SaveGeneralsOnlineSettings result was null");
+                if (goLoadError != null) errors.Add(goLoadError);
+                if (writeGeneralsOnlineSettings && goLoadError == null && goResult == null) errors.Add("SaveGeneralsOnlineSettings result was null");
 
                 StatusMessage = $"Failed to save settings: {string.Join(", ", errors)}";
                 _logger.LogWarning("Failed to save settings: {Errors}", string.Join(", ", errors));
@@ -964,6 +959,34 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         {
             IsLoading = false;
         }
+    }
+
+    /// <summary>
+    /// Reads the GeneralsOnline client's settings.json so the save can be applied on top of it.
+    /// </summary>
+    /// <remarks>
+    /// A profile-initialized view model may never have read the file, and a missing file reads as
+    /// defaults and reports success. A failure therefore means the client's own file exists and
+    /// could not be read, and rewriting it from defaults would discard every key the client owns.
+    /// </remarks>
+    /// <returns>Null once the settings are in hand, otherwise the error that must abort the rewrite.</returns>
+    private async Task<string?> ReadGeneralsOnlineSettingsForRewriteAsync()
+    {
+        if (_currentGeneralsOnlineSettings != null || _gameSettingsService == null)
+        {
+            return null;
+        }
+
+        var goLoadResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+        if (goLoadResult?.Success == true && goLoadResult.Data != null)
+        {
+            _currentGeneralsOnlineSettings = goLoadResult.Data;
+            return null;
+        }
+
+        var error = goLoadResult?.FirstError ?? "LoadGeneralsOnlineSettings result was null";
+        _logger.LogWarning("Not writing GeneralsOnline settings because settings.json could not be read: {Error}", error);
+        return error;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -631,6 +631,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     }
 
     private IniOptions? _currentOptions;
+    private GeneralsOnlineSettings? _currentGeneralsOnlineSettings;
     private string? _currentProfileId;
     private int _initializationDepth;
     private bool _isLoadingFromOptions;
@@ -688,6 +689,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
             if (goResult?.Success == true && goResult.Data != null)
             {
+                _currentGeneralsOnlineSettings = goResult.Data;
                 ApplyGeneralsOnlineSettings(goResult.Data);
                 _logger.LogInformation("Loaded GeneralsOnline settings");
             }
@@ -872,13 +874,24 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             var options = CreateOptionsFromViewModel();
             var result = await _gameSettingsService.SaveOptionsAsync(SelectedGameType, options);
 
-            // Save GeneralsOnline settings
+            // Save GeneralsOnline settings. A profile-initialized view model never reads
+            // settings.json, so it is read here before being rewritten.
+            if (_currentGeneralsOnlineSettings == null)
+            {
+                var goLoadResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+                if (goLoadResult?.Success == true && goLoadResult.Data != null)
+                {
+                    _currentGeneralsOnlineSettings = goLoadResult.Data;
+                }
+            }
+
             var goSettings = CreateGeneralsOnlineSettings();
             var goResult = await _gameSettingsService.SaveGeneralsOnlineSettingsAsync(goSettings);
 
             if (result?.Success == true && goResult?.Success == true)
             {
                 _currentOptions = options;
+                _currentGeneralsOnlineSettings = goSettings;
                 OptionsFileExists = true;
                 StatusMessage = $"{SelectedGameType} settings saved successfully";
                 _logger.LogInformation("Saved settings for {GameType}", SelectedGameType);
@@ -1201,18 +1214,19 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private GeneralsOnlineSettings CreateGeneralsOnlineSettings()
     {
-        var settings = new GeneralsOnlineSettings
-        {
-            ShowFps = GoShowFps,
-            ShowPing = GoShowPing,
-            ShowPlayerRanks = GoShowPlayerRanks,
-            AutoLogin = GoAutoLogin,
-            RememberUsername = GoRememberUsername,
-            EnableNotifications = GoEnableNotifications,
-            EnableSoundNotifications = GoEnableSoundNotifications,
-            ChatFontSize = GoChatFontSize,
-        };
+        // Built on top of what was loaded, because saving is a wholesale rewrite of the
+        // GeneralsOnline client's settings.json and the loaded instance is the only thing
+        // holding the keys this model does not declare.
+        var settings = _currentGeneralsOnlineSettings ?? new GeneralsOnlineSettings();
 
+        settings.ShowFps = GoShowFps;
+        settings.ShowPing = GoShowPing;
+        settings.ShowPlayerRanks = GoShowPlayerRanks;
+        settings.AutoLogin = GoAutoLogin;
+        settings.RememberUsername = GoRememberUsername;
+        settings.EnableNotifications = GoEnableNotifications;
+        settings.EnableSoundNotifications = GoEnableSoundNotifications;
+        settings.ChatFontSize = GoChatFontSize;
         settings.Camera.MaxHeightOnlyWhenLobbyHost = GoCameraMaxHeightOnlyWhenLobbyHost;
         settings.Camera.MinHeight = GoCameraMinHeight;
         settings.Camera.MoveSpeedRatio = GoCameraMoveSpeedRatio;

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -317,7 +317,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _tshScreenEdgeScrollEnabledInWindowedApp = GameSettingsTheSuperHackersConstants.DefaultScreenEdgeScrollEnabledInWindowedApp;
 
     [ObservableProperty]
-    private int _tshMoneyTransactionVolume = 50;
+    private int _tshMoneyTransactionVolume = GameSettingsTheSuperHackersConstants.DefaultMoneyTransactionVolume;
 
     // ===== GeneralsOnline Client Settings =====
     [ObservableProperty]

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -33,6 +33,17 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     /// </summary>
     private static readonly SemaphoreSlim _optionsIniWriteSemaphore = new(1, 1);
 
+    /// <summary>
+    /// Static semaphore to serialize settings.json reads and writes across all game launches.
+    /// The launch lock is per profile, so two GeneralsOnline profiles launching at once both
+    /// reach this one global file. On Windows that is not a race one writer simply wins: two
+    /// overlapping replacements of the same destination, or a replacement overlapping a read,
+    /// fail outright with an access denial, and the launch loses the settings it meant to save.
+    /// The lock is released between a load and the save that follows it, so which launch writes
+    /// last is still whichever finishes last.
+    /// </summary>
+    private static readonly SemaphoreSlim _generalsOnlineSettingsSemaphore = new(1, 1);
+
     private readonly ILogger<GameSettingsService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     // Required, not optional. This previously defaulted to WindowsGamePathProvider when
@@ -209,6 +220,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     {
         using var scope = _logger.BeginScope(new Dictionary<string, object> { ["Section"] = "GeneralsOnline" });
 
+        await _generalsOnlineSettingsSemaphore.WaitAsync();
         try
         {
             var settingsPath = GetGeneralsOnlineSettingsPath();
@@ -239,6 +251,10 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             _logger.LogError(ex, "Failed to load GeneralsOnline settings");
             return OperationResult<GeneralsOnlineSettings>.CreateFailure($"Failed to load GeneralsOnline settings: {ex.Message}");
         }
+        finally
+        {
+            _generalsOnlineSettingsSemaphore.Release();
+        }
     }
 
     /// <inheritdoc/>
@@ -247,6 +263,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         using var scope = _logger.BeginScope(new Dictionary<string, object> { ["Section"] = "GeneralsOnline" });
 
         string? temporaryPath = null;
+        await _generalsOnlineSettingsSemaphore.WaitAsync();
         try
         {
             var settingsPath = GetGeneralsOnlineSettingsPath();
@@ -266,7 +283,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             // the same path, would leave the client with a settings.json it cannot read.
             temporaryPath = $"{settingsPath}.{Guid.NewGuid():N}{GameSettingsGeneralsOnlineConstants.TemporarySettingsFileExtension}";
             await File.WriteAllTextAsync(temporaryPath, json, Encoding.UTF8);
-            File.Move(temporaryPath, settingsPath, overwrite: true);
+            await ReplaceSettingsFileAsync(temporaryPath, settingsPath);
             temporaryPath = null;
 
             _logger.LogInformation("Saved GeneralsOnline settings to {SettingsPath}", settingsPath);
@@ -280,6 +297,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         finally
         {
             DiscardTemporarySettingsFile(temporaryPath);
+            _generalsOnlineSettingsSemaphore.Release();
         }
     }
 
@@ -306,9 +324,10 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         {
             File.Delete(temporaryPath);
         }
-        catch (IOException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            // Best effort; a leftover temporary file is not worth failing the save over.
+            // Best effort; a leftover temporary file is not worth failing the save over, and
+            // this runs in a finally block where throwing would hide the error being reported.
         }
     }
 
@@ -784,5 +803,44 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
         // Remove any other control characters or non-printable chars if needed
         return key.Trim();
+    }
+
+    /// <summary>
+    /// Moves a completed settings file over settings.json, retrying the move a bounded number
+    /// of times before letting the failure reach the caller.
+    /// </summary>
+    /// <remarks>
+    /// The semaphore keeps GenHub's own saves off each other, but settings.json belongs to the
+    /// GeneralsOnline client, and a running client, a virus scanner or the search indexer can
+    /// hold it open. Windows refuses a replacement of a file another handle has open instead of
+    /// waiting for it, and reports that as an access denial rather than as contention. Every
+    /// such holder lets go within milliseconds, so a few attempts separated by a short delay
+    /// tell an overlap apart from a file GenHub genuinely may not write.
+    /// </remarks>
+    /// <param name="temporaryPath">The completed file to move.</param>
+    /// <param name="settingsPath">The settings.json path to replace.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private async Task ReplaceSettingsFileAsync(string temporaryPath, string settingsPath)
+    {
+        for (var attempt = 1; attempt < GameSettingsGeneralsOnlineConstants.SettingsReplaceAttemptLimit; attempt++)
+        {
+            try
+            {
+                File.Move(temporaryPath, settingsPath, overwrite: true);
+                return;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogDebug(
+                    ex,
+                    "Attempt {Attempt} of {AttemptLimit} to replace {SettingsPath} was refused, retrying",
+                    attempt,
+                    GameSettingsGeneralsOnlineConstants.SettingsReplaceAttemptLimit,
+                    settingsPath);
+                await Task.Delay(GameSettingsGeneralsOnlineConstants.SettingsReplaceRetryDelayMilliseconds);
+            }
+        }
+
+        File.Move(temporaryPath, settingsPath, overwrite: true);
     }
 }

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -229,6 +229,8 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 return OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings());
             }
 
+            settings.EnsureNestedSectionsInitialized();
+
             _logger.LogInformation("Loaded GeneralsOnline settings from {SettingsPath}", settingsPath);
             return OperationResult<GeneralsOnlineSettings>.CreateSuccess(settings);
         }

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -246,6 +246,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     {
         using var scope = _logger.BeginScope(new Dictionary<string, object> { ["Section"] = "GeneralsOnline" });
 
+        string? temporaryPath = null;
         try
         {
             var settingsPath = GetGeneralsOnlineSettingsPath();
@@ -258,7 +259,15 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             }
 
             var json = JsonSerializer.Serialize(settings, _jsonSerializerOptions);
-            await File.WriteAllTextAsync(settingsPath, json, Encoding.UTF8);
+
+            // Written beside settings.json under a name of its own and then moved over it. This
+            // file belongs to the GeneralsOnline client and holds keys GenHub cannot reconstruct,
+            // so a truncating write that is interrupted, or that overlaps a second launch writing
+            // the same path, would leave the client with a settings.json it cannot read.
+            temporaryPath = $"{settingsPath}.{Guid.NewGuid():N}{GameSettingsGeneralsOnlineConstants.TemporarySettingsFileExtension}";
+            await File.WriteAllTextAsync(temporaryPath, json, Encoding.UTF8);
+            File.Move(temporaryPath, settingsPath, overwrite: true);
+            temporaryPath = null;
 
             _logger.LogInformation("Saved GeneralsOnline settings to {SettingsPath}", settingsPath);
             return OperationResult<bool>.CreateSuccess(true);
@@ -267,6 +276,39 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         {
             _logger.LogError(ex, "Failed to save GeneralsOnline settings");
             return OperationResult<bool>.CreateFailure($"Failed to save GeneralsOnline settings: {ex.Message}");
+        }
+        finally
+        {
+            DiscardTemporarySettingsFile(temporaryPath);
+        }
+    }
+
+    /// <summary>
+    /// Gets the path of the GeneralsOnline client's global settings.json.
+    /// </summary>
+    /// <returns>The full path to settings.json.</returns>
+    protected virtual string GetGeneralsOnlineSettingsPath()
+    {
+        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        var zeroHourDataPath = Path.Combine(documentsPath, GameSettingsConstants.FolderNames.ZeroHour);
+        var generalsOnlineDataPath = Path.Combine(zeroHourDataPath, GameSettingsConstants.FolderNames.GeneralsOnlineData);
+        return Path.Combine(generalsOnlineDataPath, GameSettingsGeneralsOnlineConstants.SettingsFileName);
+    }
+
+    private static void DiscardTemporarySettingsFile(string? temporaryPath)
+    {
+        if (temporaryPath == null || !File.Exists(temporaryPath))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(temporaryPath);
+        }
+        catch (IOException)
+        {
+            // Best effort; a leftover temporary file is not worth failing the save over.
         }
     }
 
@@ -728,14 +770,6 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             ["ShowMoneyPerMinute"] = BoolToString(settings.ShowMoneyPerMinute),
             ["SystemTimeFontSize"] = settings.SystemTimeFontSize.ToString(),
         };
-    }
-
-    private static string GetGeneralsOnlineSettingsPath()
-    {
-        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        var zeroHourDataPath = Path.Combine(documentsPath, GameSettingsConstants.FolderNames.ZeroHour);
-        var generalsOnlineDataPath = Path.Combine(zeroHourDataPath, GameSettingsConstants.FolderNames.GeneralsOnlineData);
-        return Path.Combine(generalsOnlineDataPath, GameSettingsGeneralsOnlineConstants.SettingsFileName);
     }
 
     private static string SanitizeKey(string key)

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -1627,9 +1627,18 @@ public class GameLauncher(
             // Loaded first so the settings the client owns and the profile says nothing about
             // survive the rewrite; the mapper then overwrites only what the profile declares.
             var loadResult = await gameSettingsService.LoadGeneralsOnlineSettingsAsync();
-            var settings = loadResult.Success && loadResult.Data != null
-                ? loadResult.Data
-                : new GeneralsOnlineSettings();
+            if (loadResult?.Success != true || loadResult.Data == null)
+            {
+                // A missing settings.json loads as defaults and reports success, so a failure here
+                // means the client's own file exists and could not be read. Rewriting it from
+                // defaults would discard every key the client owns.
+                logger.LogWarning(
+                    "[GameLauncher] Not writing GeneralsOnline settings because settings.json could not be read: {Error}",
+                    loadResult?.FirstError ?? "LoadGeneralsOnlineSettings result was null");
+                return;
+            }
+
+            var settings = loadResult.Data;
 
             GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
 

--- a/GenHub/GenHub/Features/Launching/GameLauncher.cs
+++ b/GenHub/GenHub/Features/Launching/GameLauncher.cs
@@ -1606,11 +1606,16 @@ public class GameLauncher(
     /// <summary>
     /// Applies GeneralsOnline-specific settings to the settings.json file.
     /// </summary>
+    /// <remarks>
+    /// settings.json is a single global file owned by the GeneralsOnline client, not a
+    /// per-profile one. Only a GeneralsOnline profile may rewrite it: a retail, TheSuperHackers
+    /// or CommunityOutpost Zero Hour profile has nothing to say about that client's settings,
+    /// and writing anyway replaced whatever the user had configured inside the client itself.
+    /// </remarks>
     /// <param name="profile">The game profile containing the settings.</param>
     private async Task ApplyGeneralsOnlineSettingsAsync(GameProfile profile)
     {
-        // Only apply if it's Zero Hour (as GO settings only apply there currently)
-        if (profile.GameClient?.GameType != GameType.ZeroHour)
+        if (profile.GameClient?.GameType != GameType.ZeroHour || !profile.IsGeneralsOnlineProfile())
         {
             return;
         }
@@ -1619,10 +1624,13 @@ public class GameLauncher(
         {
             logger.LogInformation("[GameLauncher] Applying GeneralsOnline settings to settings.json for profile {ProfileId}", profile.Id);
 
-            // Clean Launch Strategy: Create fresh settings object to ensure isolation and prevent pollution
-            var settings = new GeneralsOnlineSettings();
+            // Loaded first so the settings the client owns and the profile says nothing about
+            // survive the rewrite; the mapper then overwrites only what the profile declares.
+            var loadResult = await gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+            var settings = loadResult.Success && loadResult.Data != null
+                ? loadResult.Data
+                : new GeneralsOnlineSettings();
 
-            // Map GO settings from profile using the centralized mapper
             GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
 
             var saveResult = await gameSettingsService.SaveGeneralsOnlineSettingsAsync(settings);

--- a/docs/dev/game-settings-architecture.md
+++ b/docs/dev/game-settings-architecture.md
@@ -65,16 +65,19 @@ These settings are:
 
 **Fix**: Implemented in `GameSettingsViewModel.CreateOptionsFromViewModel()` - now preserves existing `AdditionalProperties` and `AdditionalSections`.
 
-### Settings Not Applying from Profile
+### GeneralsOnline Client Settings Reset After Launching
 
-**Symptom**: Profile settings don't apply when launching the game.
+**Symptom**: Options configured inside the GeneralsOnline client (including ones GenHub has no UI for) revert after launching a profile through GenHub.
 
-**Cause**: The `ApplyToGeneralsOnlineSettings()` mapper was using `if (HasValue)` checks, skipping null values and leaving constructor defaults.
+**Cause**: `ApplyToGeneralsOnlineSettings()` coalesced every field with `?? default`, so a launch wrote GenHub's defaults over each option the profile said nothing about, and the write started from a fresh `GeneralsOnlineSettings` instance, which dropped every key the model does not declare.
 
-**Fix**: Changed to use null-coalescing operators with explicit defaults:
+**Fix**: `settings.json` is loaded first and merged into, and only the fields the profile actually declares are written:
 ```csharp
-settings.ShowFps = profile.GoShowFps ?? false;  // Always sets a value
+if (profile.GoShowFps.HasValue) settings.ShowFps = profile.GoShowFps.Value;  // Merges into what was loaded
 ```
+Anything the profile leaves unset stays as the client wrote it, and unmodelled keys survive through `[JsonExtensionData]`. The load must succeed before the file is rewritten: a missing file loads as defaults and reports success, so a failed load means the client's file exists and is unreadable, and both `GameLauncher` and `GameSettingsViewModel` skip the write in that case.
+
+Note that this applies to `settings.json` only. `ApplyToOptions()` still coalesces, because `Options.ini` keys GenHub does not model are preserved through `AdditionalProperties` and `AdditionalSections` instead.
 
 ## Overview
 
@@ -198,9 +201,9 @@ Tracing a setting change (e.g., "Show FPS") from User to Disk:
     - `GameSettingsService` writes `Options.ini`. *Note: It manually adds the `[TheSuperHackers]` header.*
 
     **Path B: To settings.json (GeneralsOnline)**
-    - Calls `ApplyGeneralsOnlineSettingsAsync`.
-    - Instantiates new `GeneralsOnlineSettings`.
-    - Manually maps properties: `settings.ShowFps = profile.GoShowFps.Value;`
+    - Calls `ApplyGeneralsOnlineSettingsAsync`, which runs only for GeneralsOnline profiles: `settings.json` is a single global file owned by that client, so a retail, TheSuperHackers or CommunityOutpost profile must leave it alone.
+    - Loads the existing `settings.json` into a `GeneralsOnlineSettings`, and skips the write if it could not be read.
+    - Merges the declared properties into it: `if (profile.GoShowFps.HasValue) settings.ShowFps = profile.GoShowFps.Value;`
     - `GameSettingsService` writes `settings.json` using `System.Text.Json`.
 
 ### Inheritance Detail

--- a/docs/dev/game-settings-architecture.md
+++ b/docs/dev/game-settings-architecture.md
@@ -72,12 +72,16 @@ These settings are:
 **Cause**: `ApplyToGeneralsOnlineSettings()` coalesced every field with `?? default`, so a launch wrote GenHub's defaults over each option the profile said nothing about, and the write started from a fresh `GeneralsOnlineSettings` instance, which dropped every key the model does not declare.
 
 **Fix**: `settings.json` is loaded first and merged into, and only the fields the profile actually declares are written:
+
 ```csharp
 if (profile.GoShowFps.HasValue) settings.ShowFps = profile.GoShowFps.Value;  // Merges into what was loaded
 ```
+
 Anything the profile leaves unset stays as the client wrote it, and unmodelled keys survive through `[JsonExtensionData]`. The load must succeed before the file is rewritten: a missing file loads as defaults and reports success, so a failed load means the client's file exists and is unreadable, and both `GameLauncher` and `GameSettingsViewModel` skip the write in that case.
 
-Note that this applies to `settings.json` only. `ApplyToOptions()` still coalesces, because `Options.ini` keys GenHub does not model are preserved through `AdditionalProperties` and `AdditionalSections` instead.
+`ApplyToOptions()` writes `Options.ini` the same way, only conditionally, and the keys GenHub does not model are preserved there through `AdditionalProperties` and `AdditionalSections` rather than `[JsonExtensionData]`.
+
+`GameSettingsViewModel` reads `settings.json` again immediately before each save rather than keeping the copy it read when the editor opened, so a save cannot revert what the client (or another GenHub window) wrote in between. Its GeneralsOnline properties have no unset state, so all of them are written on save; if the read that seeds them fails, the view model skips the rewrite entirely rather than writing its own defaults over the client's values. The save itself is written to a file beside `settings.json` and moved over it, so an interrupted or overlapping write cannot leave a half-written file behind.
 
 ## Overview
 


### PR DESCRIPTION
## Problem

`ApplyGeneralsOnlineSettingsAsync` was gated only on `GameType == ZeroHour`, so launching **any** Zero Hour profile — retail, TheSuperHackers, CommunityOutpost — rewrote the GeneralsOnline client's `settings.json`.

That file is a single global file owned by the GeneralsOnline client, not a per-profile file. The launcher also built a **fresh** `GeneralsOnlineSettings` and saved it wholesale (`SaveGeneralsOnlineSettingsAsync` does a plain serialize + write, no read-modify-write), and the mapper coalesced every unset profile field to a hardcoded default. Net effect: every Zero Hour launch reset whatever the user had configured inside the GeneralsOnline client.

The settings screen had the same defect on its own path, and two ways to write wrong values, both fixed here.

## Changes

**Gating**
- Gate on the profile actually being a GeneralsOnline profile. Rather than inlining a `PublisherType` comparison, this promotes the existing `IsGeneralsOnlineProfile` predicate out of `ProfileLauncherFacade` into `GameProfileExtensions` and reuses it — it is a three-tier check (publisher type, then client name, then enabled content) whose fallbacks exist for legacy/incomplete profiles, so a bare `PublisherType` check would have silently stopped applying settings for those.
- **The publisher type is now authoritative.** The fallbacks previously applied even when `PublisherType` explicitly named a *different* publisher, so a TheSuperHackers or CommunityOutpost profile that merely had GeneralsOnline content enabled was classified as GeneralsOnline — recreating the same cross-client data loss. The name/content heuristics now apply only when the publisher type is absent. The `ProfileLauncherFacade` call site is unaffected: it only reaches the predicate inside the `else` of a blank-publisher check.
- **`GameSettingsViewModel.SaveSettings` is gated too.** It previously loaded and rewrote the global `settings.json` on every save regardless of game type or publisher — the same bug on the settings-screen path.

**Preserving what the user configured**
- Load existing settings and merge, falling back to a new instance only on failure, mirroring the Options.ini path in the same file.
- The five `ApplyGo*` mapper methods now use per-field `HasValue` guards, matching the idiom `ApplyTshToOptions` already uses, so a merge is not immediately flattened.
- `[JsonExtensionData]` on `GeneralsOnlineSettings` **and its five nested classes**, so client-owned keys survive the round-trip (root-only would still have dropped keys inside those objects).
- `GameSettingsViewModel` captures and mutates the loaded settings rather than building a new object, and reads `settings.json` first when initialised from a profile and never loaded.
- **View model defaults no longer fabricate values.** `_goShowPing`, `_goShowPlayerRanks`, `_goRememberUsername`, `_goEnableNotifications` and `_goEnableSoundNotifications` defaulted to `false` while the model defaults them to `true`, so an unconditional save could flip a user's real toggles off. Both the model and the view model now reference shared constants so they cannot drift, and `InitializeForProfileAsync` seeds the view model from the client's own `settings.json` before overlaying the profile's declared values. That matters in both directions — aligning defaults alone stops `true` becoming `false`, but only the seeding stops a deliberate `false` becoming `true`.
- **`MoneyTransactionVolume` default made explicit.** Removing the mapper's coalesce would have silently changed the effective default for a fresh `settings.json` from 50 to the model's 0. The evidence points to 50 being intended (the old mapper, the view model field, and a 0–100 slider where 0 means muted), so 50 is now declared on the model via a constant and shared, rather than living as a literal in one code path.

Nullable-ing the view model's 25 bound bool/int properties to get true `HasValue` semantics was considered and rejected for a release fix: it is a large change to the binding surface and would not actually disambiguate "unticked" from "never touched". Seeding from the client's real settings achieves the same guarantee without that risk.

## Tests

1638 -> 1660, all passing (including the real-engine launch tests). Every guard was verified to bite by reverting it and confirming exactly the intended tests fail.

- non-GeneralsOnline Zero Hour profile writes no GeneralsOnline settings; a GeneralsOnline profile does
- an explicit non-GeneralsOnline publisher is **not** reclassified by a GeneralsOnline client name or enabled content
- saving from the settings screen for TheSuperHackers/CommunityOutpost (Zero Hour and Generals) leaves `settings.json` untouched
- values the profile does not specify survive a launch and a save; enabled toggles cannot be flipped off
- unknown root and nested JSON keys survive a load/modify/save round-trip
- unset money transaction volume stays audible

## Notes

`TheSuperHackersSettings` has the same shape of gap but not the same fix — it round-trips through the `[TheSuperHackers]` section of Options.ini rather than JSON, and both writers assign a freshly built dictionary over that section, so unmodelled keys there are dropped. That needs a dictionary merge and is left out of scope.

Rebased onto `development` after #285, which refactored `ProfileLauncherFacade`; the predicate call site was re-applied against the new structure.