### PR TITLE
fix(userdata): copy CAS content to user-writable targets and guard destructive data deletion

### DIFF
--- a/GenHub/GenHub.Core/Constants/AppConstants.cs
+++ b/GenHub/GenHub.Core/Constants/AppConstants.cs
@@ -133,6 +133,25 @@ public static class AppConstants
     public const string TokenFileName = ".ghtoken";
 
     /// <summary>
+    /// Title of the confirmation prompt shown before all application data is deleted.
+    /// </summary>
+    public const string DeleteAllDataConfirmationTitle = "Delete All Application Data";
+
+    /// <summary>
+    /// Body of the confirmation prompt shown before all application data is deleted.
+    /// </summary>
+    public const string DeleteAllDataConfirmationMessage =
+        "This permanently deletes every profile, workspace, manifest, CAS object and tracked user data " +
+        "installation. The pristine backups GenHub keeps of your original game data will be discarded " +
+        "as part of this, so anything GenHub replaced cannot be recovered afterwards.\n\n" +
+        "This action is irreversible. Continue?";
+
+    /// <summary>
+    /// Confirm button text for the delete-all-application-data prompt.
+    /// </summary>
+    public const string DeleteAllDataConfirmText = "Delete Everything";
+
+    /// <summary>
     /// Gets assembly metadata by key.
     /// </summary>
     private static string? GetAssemblyMetadata(string key)

--- a/GenHub/GenHub.Core/Constants/UserDataConstants.cs
+++ b/GenHub/GenHub.Core/Constants/UserDataConstants.cs
@@ -1,0 +1,13 @@
+namespace GenHub.Core.Constants;
+
+/// <summary>
+/// Constants for tracked user data installations.
+/// </summary>
+public static class UserDataConstants
+{
+    /// <summary>
+    /// Suffix appended to a deployed file that no longer matches its recorded hash when it is
+    /// moved aside so the pristine backup can be restored over it.
+    /// </summary>
+    public const string UserModifiedSuffix = ".user-modified";
+}

--- a/GenHub/GenHub.Core/Extensions/Enums/ContentInstallTargetExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/Enums/ContentInstallTargetExtensions.cs
@@ -11,15 +11,19 @@ public static class ContentInstallTargetExtensions
     /// Determines whether the target resolves to a directory the user and the game engine
     /// write to directly, which means deployed content must never share storage with the
     /// content-addressable object it originated from.
+    /// <para>
+    /// Only the two targets that are definitively not user data are listed as such: every other
+    /// value, including any added later, is treated as user-writable and therefore copied. That
+    /// matches the resolver, whose own default arm places unmapped targets inside the user data
+    /// root, and it fails towards an extra copy rather than towards a hard link into Documents.
+    /// </para>
     /// </summary>
     /// <param name="installTarget">The install target to inspect.</param>
     /// <returns><c>true</c> when the destination is user-writable; otherwise, <c>false</c>.</returns>
     public static bool IsUserWritableTarget(this ContentInstallTarget installTarget) => installTarget switch
     {
-        ContentInstallTarget.UserDataDirectory => true,
-        ContentInstallTarget.UserMapsDirectory => true,
-        ContentInstallTarget.UserReplaysDirectory => true,
-        ContentInstallTarget.UserScreenshotsDirectory => true,
-        _ => false,
+        ContentInstallTarget.Workspace => false,
+        ContentInstallTarget.System => false,
+        _ => true,
     };
 }

--- a/GenHub/GenHub.Core/Extensions/Enums/ContentInstallTargetExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/Enums/ContentInstallTargetExtensions.cs
@@ -1,0 +1,25 @@
+using GenHub.Core.Models.Enums;
+
+namespace GenHub.Core.Extensions.Enums;
+
+/// <summary>
+/// Provides extension methods for the <see cref="ContentInstallTarget"/> enum.
+/// </summary>
+public static class ContentInstallTargetExtensions
+{
+    /// <summary>
+    /// Determines whether the target resolves to a directory the user and the game engine
+    /// write to directly, which means deployed content must never share storage with the
+    /// content-addressable object it originated from.
+    /// </summary>
+    /// <param name="installTarget">The install target to inspect.</param>
+    /// <returns><c>true</c> when the destination is user-writable; otherwise, <c>false</c>.</returns>
+    public static bool IsUserWritableTarget(this ContentInstallTarget installTarget) => installTarget switch
+    {
+        ContentInstallTarget.UserDataDirectory => true,
+        ContentInstallTarget.UserMapsDirectory => true,
+        ContentInstallTarget.UserReplaysDirectory => true,
+        ContentInstallTarget.UserScreenshotsDirectory => true,
+        _ => false,
+    };
+}

--- a/GenHub/GenHub.Core/Interfaces/Workspace/IFileOperationsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Workspace/IFileOperationsService.cs
@@ -59,6 +59,20 @@ public interface IFileOperationsService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Compares a file against an expected hash, distinguishing a genuine mismatch from a failure to
+    /// compute the hash at all. Callers that act destructively on a mismatch must use this rather
+    /// than <see cref="VerifyFileHashAsync"/>, which collapses both outcomes into <c>false</c>.
+    /// </summary>
+    /// <param name="filePath">The file path.</param>
+    /// <param name="expectedHash">The expected hash value.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The verification outcome.</returns>
+    Task<FileHashVerification> CheckFileHashAsync(
+        string filePath,
+        string expectedHash,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Applies a patch to a target file. The patch format is determined by the implementation.
     /// </summary>
     /// <param name="targetPath">The file to be patched.</param>

--- a/GenHub/GenHub.Core/Interfaces/Workspace/IFileOperationsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Workspace/IFileOperationsService.cs
@@ -62,6 +62,8 @@ public interface IFileOperationsService
     /// Compares a file against an expected hash, distinguishing a genuine mismatch from a failure to
     /// compute the hash at all. Callers that act destructively on a mismatch must use this rather
     /// than <see cref="VerifyFileHashAsync"/>, which collapses both outcomes into <c>false</c>.
+    /// A file that does not exist yields <see cref="FileHashVerification.Failed"/>: no hash was
+    /// computed, so its absence is not evidence that its content ever differed.
     /// </summary>
     /// <param name="filePath">The file path.</param>
     /// <param name="expectedHash">The expected hash value.</param>

--- a/GenHub/GenHub.Core/Models/Enums/FileHashVerification.cs
+++ b/GenHub/GenHub.Core/Models/Enums/FileHashVerification.cs
@@ -1,0 +1,23 @@
+namespace GenHub.Core.Models.Enums;
+
+/// <summary>
+/// Outcome of comparing a file's content against an expected hash.
+/// </summary>
+public enum FileHashVerification
+{
+    /// <summary>
+    /// The hash could not be computed, so nothing is known about the file's content.
+    /// Callers must not treat this as evidence that the file changed.
+    /// </summary>
+    Failed = 0,
+
+    /// <summary>
+    /// The hash was computed and matches the expected value.
+    /// </summary>
+    Match = 1,
+
+    /// <summary>
+    /// The hash was computed and differs from the expected value.
+    /// </summary>
+    Mismatch = 2,
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/Enums/ContentInstallTargetExtensionsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/Enums/ContentInstallTargetExtensionsTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using GenHub.Core.Extensions.Enums;
+using GenHub.Core.Models.Enums;
+using Xunit;
+
+namespace GenHub.Tests.Core.Extensions.Enums;
+
+/// <summary>
+/// Tests for <see cref="ContentInstallTargetExtensions"/>.
+/// </summary>
+public class ContentInstallTargetExtensionsTests
+{
+    /// <summary>
+    /// The four user directories must be copied out of CAS rather than hard-linked, because the game
+    /// engine writes into them in place and would otherwise rewrite the canonical CAS object.
+    /// </summary>
+    /// <param name="installTarget">The user-writable target under test.</param>
+    [Theory]
+    [InlineData(ContentInstallTarget.UserDataDirectory)]
+    [InlineData(ContentInstallTarget.UserMapsDirectory)]
+    [InlineData(ContentInstallTarget.UserReplaysDirectory)]
+    [InlineData(ContentInstallTarget.UserScreenshotsDirectory)]
+    public void IsUserWritableTarget_ForUserDirectories_ReturnsTrue(ContentInstallTarget installTarget)
+    {
+        Assert.True(installTarget.IsUserWritableTarget());
+    }
+
+    /// <summary>
+    /// Workspace and system installs are managed by GenHub rather than written to by the user, so
+    /// they remain eligible for hard links to CAS.
+    /// </summary>
+    /// <param name="installTarget">The GenHub-managed target under test.</param>
+    [Theory]
+    [InlineData(ContentInstallTarget.Workspace)]
+    [InlineData(ContentInstallTarget.System)]
+    public void IsUserWritableTarget_ForGenHubManagedTargets_ReturnsFalse(ContentInstallTarget installTarget)
+    {
+        Assert.False(installTarget.IsUserWritableTarget());
+    }
+
+    /// <summary>
+    /// An install target this method has never been taught about must fail towards copying. The path
+    /// resolver sends unmapped targets into the user data root, so answering "not user-writable"
+    /// would hard-link a CAS object straight into the user's Documents folder.
+    /// </summary>
+    [Fact]
+    public void IsUserWritableTarget_ForAnUnmappedTarget_FailsTowardsCopying()
+    {
+        var unmapped = Enum.GetValues<ContentInstallTarget>().Cast<int>().Max() + 1;
+
+        Assert.True(((ContentInstallTarget)unmapped).IsUserWritableTarget());
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/MainViewModelTests.cs
@@ -253,6 +253,7 @@ public class MainViewModelTests
         var mockInstallationService = new Mock<IGameInstallationService>();
         var mockStorageLocationService = new Mock<IStorageLocationService>();
         var mockUserDataTracker = new Mock<IUserDataTracker>();
+        var mockDialogService = new Mock<IDialogService>();
         var mockGitHubTokenStorage = new Mock<IGitHubTokenStorage>();
 
         var settingsVm = new SettingsViewModel(
@@ -268,6 +269,7 @@ public class MainViewModelTests
             mockInstallationService.Object,
             mockStorageLocationService.Object,
             mockUserDataTracker.Object,
+            mockDialogService.Object,
             mockGitHubTokenStorage.Object);
         return (settingsVm, mockUserSettings);
     }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -439,6 +439,7 @@ public class SettingsViewModelTests
     public async Task DeleteAllDataCommand_WhenConfirmationDeclined_DeletesNothingAsync()
     {
         // Arrange
+        SetupDeletableData();
         _mockDialogService
             .Setup(x => x.ShowConfirmationAsync(
                 It.IsAny<string>(),
@@ -460,6 +461,41 @@ public class SettingsViewModelTests
     }
 
     /// <summary>
+    /// Verifies that a confirmation prompt that fails to open — no main window, or an Avalonia
+    /// failure — is reported to the user instead of escaping the command unlogged, and that it still
+    /// deletes nothing.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DeleteAllDataCommand_WhenConfirmationThrows_ReportsErrorAndDeletesNothingAsync()
+    {
+        // Arrange
+        SetupDeletableData();
+        _mockDialogService
+            .Setup(x => x.ShowConfirmationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>()))
+            .ThrowsAsync(new InvalidOperationException("no main window"));
+
+        var viewModel = CreateViewModel();
+
+        // Act
+        await viewModel.DeleteAllDataCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockNotificationService.Verify(
+            x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        _mockUserDataTracker.Verify(x => x.DeleteAllUserDataAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mockProfileManager.Verify(x => x.DeleteProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockWorkspaceManager.Verify(x => x.CleanupWorkspaceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockManifestPool.Verify(x => x.RemoveManifestAsync(It.IsAny<ManifestId>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
     /// Verifies that accepting the confirmation prompt performs the deletion.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
@@ -467,6 +503,7 @@ public class SettingsViewModelTests
     public async Task DeleteAllDataCommand_WhenConfirmationAccepted_DeletesAllDataAsync()
     {
         // Arrange
+        SetupDeletableData();
         _mockDialogService
             .Setup(x => x.ShowConfirmationAsync(
                 It.IsAny<string>(),
@@ -522,6 +559,19 @@ public class SettingsViewModelTests
         Assert.Contains("irreversible", capturedMessage!, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("backups", capturedMessage!, StringComparison.OrdinalIgnoreCase);
         Assert.Null(capturedSessionKey);
+    }
+
+    private void SetupDeletableData()
+    {
+        _mockProfileManager
+            .Setup(x => x.GetAllProfilesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<IReadOnlyList<GameProfile>>.CreateSuccess([new GameProfile { Id = "profile-to-delete" }]));
+        _mockWorkspaceManager
+            .Setup(x => x.GetAllWorkspacesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<WorkspaceInfo>>.CreateSuccess([new WorkspaceInfo { Id = "workspace-to-delete" }]));
+        _mockManifestPool
+            .Setup(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([new ContentManifest { Name = "manifest-to-delete" }]));
     }
 
     private SettingsViewModel CreateViewModel() => new(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -63,6 +63,9 @@ public class SettingsViewModelTests
         _defaultSettings = new UserSettings();
 
         _mockConfigService.Setup(x => x.Get()).Returns(_defaultSettings);
+        _mockUserDataTracker
+            .Setup(x => x.DeleteAllUserDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -458,6 +458,9 @@ public class SettingsViewModelTests
         _mockUserDataTracker.Verify(x => x.DeleteAllUserDataAsync(It.IsAny<CancellationToken>()), Times.Never);
         _mockCasService.Verify(x => x.RunGarbageCollectionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
         _mockInstallationService.Verify(x => x.InvalidateCache(), Times.Never);
+        _mockProfileManager.Verify(x => x.DeleteProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockWorkspaceManager.Verify(x => x.CleanupWorkspaceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockManifestPool.Verify(x => x.RemoveManifestAsync(It.IsAny<ManifestId>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     /// <summary>
@@ -522,6 +525,9 @@ public class SettingsViewModelTests
         _mockUserDataTracker.Verify(x => x.DeleteAllUserDataAsync(It.IsAny<CancellationToken>()), Times.Once);
         _mockCasService.Verify(x => x.RunGarbageCollectionAsync(true, It.IsAny<CancellationToken>()), Times.Once);
         _mockInstallationService.Verify(x => x.InvalidateCache(), Times.Once);
+        _mockProfileManager.Verify(x => x.DeleteProfileAsync("profile-to-delete", It.IsAny<CancellationToken>()), Times.Once);
+        _mockWorkspaceManager.Verify(x => x.CleanupWorkspaceAsync("workspace-to-delete", It.IsAny<CancellationToken>()), Times.Once);
+        _mockManifestPool.Verify(x => x.RemoveManifestAsync(It.IsAny<ManifestId>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -39,6 +39,7 @@ public class SettingsViewModelTests
     private readonly Mock<IGameInstallationService> _mockInstallationService;
     private readonly Mock<IStorageLocationService> _mockStorageLocationService;
     private readonly Mock<IUserDataTracker> _mockUserDataTracker;
+    private readonly Mock<IDialogService> _mockDialogService;
     private readonly UserSettings _defaultSettings;
 
     /// <summary>
@@ -58,6 +59,7 @@ public class SettingsViewModelTests
         _mockInstallationService = new Mock<IGameInstallationService>();
         _mockStorageLocationService = new Mock<IStorageLocationService>();
         _mockUserDataTracker = new Mock<IUserDataTracker>();
+        _mockDialogService = new Mock<IDialogService>();
         _defaultSettings = new UserSettings();
 
         _mockConfigService.Setup(x => x.Get()).Returns(_defaultSettings);
@@ -93,7 +95,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Assert
         Assert.Equal("Light", viewModel.Theme);
@@ -122,7 +125,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object)
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object)
         {
             Theme = "Light",
             MaxConcurrentDownloads = 5,
@@ -156,7 +160,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object)
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object)
         {
             Theme = "Light",
             MaxConcurrentDownloads = 10,
@@ -192,7 +197,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object)
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object)
         {
             // Act & Assert - Test lower bound
             MaxConcurrentDownloads = 0,
@@ -227,7 +233,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Act
         var themes = SettingsViewModel.AvailableThemes.ToList();
@@ -257,7 +264,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Act
         var strategies = SettingsViewModel.AvailableWorkspaceStrategies.ToList();
@@ -289,7 +297,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Act
         await Task.Run(() => viewModel.SaveSettingsCommand.Execute(null));
@@ -327,7 +336,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Assert - Should not throw and use defaults
         Assert.Equal("Dark", viewModel.Theme);
@@ -367,7 +377,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Act
         await viewModel.DeleteCasStorageCommand.ExecuteAsync(null);
@@ -410,7 +421,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Act
         await viewModel.UninstallGenHubCommand.ExecuteAsync(null);
@@ -418,4 +430,112 @@ public class SettingsViewModelTests
         // Assert
         _mockUpdateManager.Verify(x => x.Uninstall(), Times.Once);
     }
+
+    /// <summary>
+    /// Verifies that declining the confirmation prompt leaves every piece of application data alone.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DeleteAllDataCommand_WhenConfirmationDeclined_DeletesNothingAsync()
+    {
+        // Arrange
+        _mockDialogService
+            .Setup(x => x.ShowConfirmationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync(false);
+
+        var viewModel = CreateViewModel();
+
+        // Act
+        await viewModel.DeleteAllDataCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockUserDataTracker.Verify(x => x.DeleteAllUserDataAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mockCasService.Verify(x => x.RunGarbageCollectionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockInstallationService.Verify(x => x.InvalidateCache(), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that accepting the confirmation prompt performs the deletion.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DeleteAllDataCommand_WhenConfirmationAccepted_DeletesAllDataAsync()
+    {
+        // Arrange
+        _mockDialogService
+            .Setup(x => x.ShowConfirmationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync(true);
+
+        var viewModel = CreateViewModel();
+
+        // Act
+        await viewModel.DeleteAllDataCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockUserDataTracker.Verify(x => x.DeleteAllUserDataAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockCasService.Verify(x => x.RunGarbageCollectionAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        _mockInstallationService.Verify(x => x.InvalidateCache(), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that the confirmation prompt states the action is irreversible and that game data
+    /// backups are discarded, and that it cannot be suppressed by a "do not ask again" preference.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DeleteAllDataCommand_WarnsThatBackupsAreDiscardedAndCannotBeSuppressedAsync()
+    {
+        // Arrange
+        string? capturedMessage = null;
+        string? capturedSessionKey = null;
+        _mockDialogService
+            .Setup(x => x.ShowConfirmationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>()))
+            .Callback<string, string, string, string, string?>((title, message, confirmText, cancelText, sessionKey) =>
+            {
+                capturedMessage = message;
+                capturedSessionKey = sessionKey;
+            })
+            .ReturnsAsync(false);
+
+        var viewModel = CreateViewModel();
+
+        // Act
+        await viewModel.DeleteAllDataCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal(AppConstants.DeleteAllDataConfirmationMessage, capturedMessage);
+        Assert.Contains("irreversible", capturedMessage!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("backups", capturedMessage!, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(capturedSessionKey);
+    }
+
+    private SettingsViewModel CreateViewModel() => new(
+        _mockConfigService.Object,
+        _mockLogger.Object,
+        _mockCasService.Object,
+        _mockProfileManager.Object,
+        _mockWorkspaceManager.Object,
+        _mockManifestPool.Object,
+        _mockUpdateManager.Object,
+        _mockNotificationService.Object,
+        _mockConfigurationProvider.Object,
+        _mockInstallationService.Object,
+        _mockStorageLocationService.Object,
+        _mockUserDataTracker.Object,
+        _mockDialogService.Object);
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -534,6 +534,45 @@ public class SettingsViewModelTests
     }
 
     /// <summary>
+    /// Verifies that a user data deletion that had to keep some data is not followed by a success
+    /// message claiming that data was deleted.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DeleteAllDataCommand_WhenUserDataPartiallyDeleted_DoesNotClaimSuccessAsync()
+    {
+        // Arrange
+        SetupDeletableData();
+        _mockDialogService
+            .Setup(x => x.ShowConfirmationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync(true);
+        _mockUserDataTracker
+            .Setup(x => x.DeleteAllUserDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateFailure("Your originals were kept at 'backups'."));
+
+        var viewModel = CreateViewModel();
+
+        // Act
+        await viewModel.DeleteAllDataCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockNotificationService.Verify(
+            x => x.ShowError("User Data Partially Deleted", It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        _mockNotificationService.Verify(
+            x => x.ShowSuccess("Data Deleted", It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+        _mockNotificationService.Verify(
+            x => x.ShowWarning("Data Partially Deleted", It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    /// <summary>
     /// Verifies that the confirmation prompt states the action is irreversible and that game data
     /// backups are discarded, and that it cannot be suppressed by a "do not ask again" preference.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -342,9 +342,13 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
         var deleteResult = await _trackerService.DeleteAllUserDataAsync(CancellationToken.None);
 
         // Assert
-        Assert.True(deleteResult.Success);
-
         var backupsPath = Path.Combine(_appDataDir, "UserData", "backups");
+
+        // The caller must be told, and told where: "all user data deleted successfully" is a lie
+        // while the user's pristine originals are still sitting in the backups folder.
+        Assert.False(deleteResult.Success);
+        Assert.Contains(backupsPath, deleteResult.FirstError);
+
         Assert.True(Directory.Exists(backupsPath));
         Assert.NotEmpty(Directory.GetFiles(backupsPath, "*", SearchOption.AllDirectories));
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -103,6 +103,13 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FileHashVerification.Match);
+
         _trackerService = new UserDataTrackerService(
             _configProviderMock.Object,
             _fileOperationsMock.Object,
@@ -194,8 +201,8 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
 
         File.WriteAllText(deployedPath, modifiedContent);
         _fileOperationsMock
-            .Setup(f => f.VerifyFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FileHashVerification.Mismatch);
 
         // Act
         var uninstallResult = await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
@@ -207,6 +214,49 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
         var preservedPath = deployedPath + UserDataConstants.UserModifiedSuffix;
         Assert.True(File.Exists(preservedPath));
         Assert.Equal(modifiedContent, File.ReadAllText(preservedPath));
+    }
+
+    /// <summary>
+    /// A deployed file whose hash could not be computed at all — an IO error, or the running game
+    /// briefly holding it open — is not evidence that the user changed it. Moving it aside and
+    /// restoring over it would churn a pristine file and log a preserved edit that never happened,
+    /// so the file and its backup are both left alone.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task UninstallUserDataAsync_WhenVerificationFails_LeavesDeployedFileUntouchedAsync()
+    {
+        // Arrange
+        const string originalUserContent = "the-user-original-file";
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, originalUserContent);
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        var backupPath = installResult.Data!.InstalledFiles[0].BackupPath;
+        Assert.NotNull(backupPath);
+
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FileHashVerification.Failed);
+
+        // Act
+        await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
+
+        // Assert
+        Assert.False(File.Exists(deployedPath + UserDataConstants.UserModifiedSuffix));
+        Assert.Equal(CasContent, File.ReadAllText(deployedPath));
+        Assert.True(File.Exists(backupPath));
+        Assert.Equal(originalUserContent, File.ReadAllText(backupPath!));
     }
 
     /// <summary>
@@ -233,8 +283,8 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
         Assert.True(installResult.Success);
 
         _fileOperationsMock
-            .Setup(f => f.VerifyFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new IOException("hash verification unavailable"));
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FileHashVerification.Failed);
 
         // Act
         var deleteResult = await _trackerService.DeleteAllUserDataAsync(CancellationToken.None);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -396,6 +396,44 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
     }
 
     /// <summary>
+    /// An index key whose manifest is already gone has nothing left to restore, so it must not put
+    /// delete-all into the retention path forever: "Delete All Application Data" would then never be
+    /// able to finish on an installation with one stale entry.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllUserDataAsync_WithStaleIndexEntry_StillClearsEverythingAsync()
+    {
+        // Arrange
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, "the-user-original-file");
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        var userDataPath = Path.Combine(_appDataDir, "UserData");
+        foreach (var manifestFile in Directory.GetFiles(Path.Combine(userDataPath, "manifests"), "*", SearchOption.AllDirectories))
+        {
+            File.Delete(manifestFile);
+        }
+
+        // Act
+        var deleteResult = await _trackerService.DeleteAllUserDataAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(deleteResult.Success);
+        Assert.Empty(Directory.GetFiles(userDataPath, "*", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
     /// Verifies that a clean delete-all still restores the originals and clears the backups, so the
     /// retention path does not become the permanent behaviour.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -250,13 +250,65 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
             .ReturnsAsync(FileHashVerification.Failed);
 
         // Act
-        await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
+        var uninstallResult = await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
 
         // Assert
+        Assert.False(uninstallResult.Success);
         Assert.False(File.Exists(deployedPath + UserDataConstants.UserModifiedSuffix));
         Assert.Equal(CasContent, File.ReadAllText(deployedPath));
         Assert.True(File.Exists(backupPath));
         Assert.Equal(originalUserContent, File.ReadAllText(backupPath!));
+    }
+
+    /// <summary>
+    /// Pins the dangerous window an uninstall opens: the deployed file has already been moved aside
+    /// and the restore of the pristine original then fails, leaving the original path empty. The
+    /// uninstall must report that failure and keep its tracking data, because the manifest is the
+    /// only record tying a machine-named backup to the path it belongs at.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task UninstallUserDataAsync_WhenRestoreFailsAfterMoveAside_ReportsFailureAndKeepsTrackingDataAsync()
+    {
+        // Arrange
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, "the-user-original-file");
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        var backupPath = installResult.Data!.InstalledFiles[0].BackupPath!;
+
+        // The backup disappears in the window between the move-aside and the restore.
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                File.Delete(backupPath);
+                return FileHashVerification.Mismatch;
+            });
+
+        // Act
+        var uninstallResult = await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
+
+        // Assert
+        Assert.False(uninstallResult.Success);
+        Assert.False(File.Exists(deployedPath));
+
+        var preservedPath = deployedPath + UserDataConstants.UserModifiedSuffix;
+        Assert.True(File.Exists(preservedPath));
+        Assert.Equal(CasContent, File.ReadAllText(preservedPath));
+
+        var manifestsPath = Path.Combine(_appDataDir, "UserData", "manifests");
+        Assert.NotEmpty(Directory.GetFiles(manifestsPath, "*", SearchOption.AllDirectories));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -317,7 +317,7 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
                 ? CreateHardLinkWindows(linkPath, existingPath, IntPtr.Zero)
                 : LinkUnix(existingPath, linkPath) == 0;
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or EntryPointNotFoundException or DllNotFoundException)
         {
             return false;
         }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -451,6 +451,69 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
     }
 
     /// <summary>
+    /// The restore is what protects the user's data; deleting the consumed backup afterwards is
+    /// housekeeping. A delete that fails must not report the restore as failed, because the retry
+    /// would read the restored original as a modification and duplicate it.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task UninstallUserDataAsync_WhenConsumedBackupCannotBeDeleted_StillReportsSuccessAsync()
+    {
+        // Arrange
+        const string originalUserContent = "the-user-original-file";
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, originalUserContent);
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        var backupPath = installResult.Data!.InstalledFiles[0].BackupPath!;
+        var backupDir = Path.GetDirectoryName(backupPath)!;
+
+        // Deleting the backup has to fail while reading it still works: an open handle does that on
+        // Windows, and a directory the process may not write to does it everywhere else.
+        FileStream? openBackupHandle = null;
+        UnixFileMode? originalDirectoryMode = null;
+        if (OperatingSystem.IsWindows())
+        {
+            openBackupHandle = new FileStream(backupPath, System.IO.FileMode.Open, FileAccess.Read, FileShare.Read);
+        }
+        else
+        {
+            originalDirectoryMode = File.GetUnixFileMode(backupDir);
+            File.SetUnixFileMode(backupDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        }
+
+        try
+        {
+            // Act
+            var uninstallResult = await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
+
+            // Assert
+            Assert.True(uninstallResult.Success);
+            Assert.True(File.Exists(backupPath));
+            Assert.Equal(originalUserContent, File.ReadAllText(deployedPath));
+            Assert.False(File.Exists(deployedPath + UserDataConstants.UserModifiedSuffix));
+        }
+        finally
+        {
+            openBackupHandle?.Dispose();
+            if (!OperatingSystem.IsWindows() && originalDirectoryMode.HasValue)
+            {
+                File.SetUnixFileMode(backupDir, originalDirectoryMode.Value);
+            }
+        }
+    }
+
+    /// <summary>
     /// A cancelled delete-all must abort before any tracking metadata is destroyed. Swallowing the
     /// cancellation and carrying on wipes the manifests and the index while the backups they describe
     /// are still on disk, leaving the user's originals unrecoverable by anything but hand.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -528,14 +528,27 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
         // Windows, and a directory the process may not write to does it everywhere else.
         FileStream? openBackupHandle = null;
         UnixFileMode? originalDirectoryMode = null;
+        string? probePath = null;
         if (OperatingSystem.IsWindows())
         {
             openBackupHandle = new FileStream(backupPath, System.IO.FileMode.Open, FileAccess.Read, FileShare.Read);
         }
         else
         {
+            probePath = Path.Combine(backupDir, "delete-permission-probe");
+            File.WriteAllText(probePath, string.Empty);
+
             originalDirectoryMode = File.GetUnixFileMode(backupDir);
             File.SetUnixFileMode(backupDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            if (DeleteSucceeds(probePath))
+            {
+                // The mode is advisory for this process: root, and anything else holding
+                // CAP_DAC_OVERRIDE, deletes regardless. There is no failing delete left to set up,
+                // so the scenario cannot be reached here rather than the product being wrong.
+                File.SetUnixFileMode(backupDir, originalDirectoryMode.Value);
+                return;
+            }
         }
 
         try
@@ -555,6 +568,11 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
             if (!OperatingSystem.IsWindows() && originalDirectoryMode.HasValue)
             {
                 File.SetUnixFileMode(backupDir, originalDirectoryMode.Value);
+            }
+
+            if (probePath is not null)
+            {
+                File.Delete(probePath);
             }
         }
     }
@@ -765,6 +783,27 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
                 : LinkUnix(existingPath, linkPath) == 0;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or EntryPointNotFoundException or DllNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reports whether a delete inside a directory whose mode was just tightened still goes through.
+    /// A process holding CAP_DAC_OVERRIDE - root in a dev container or a privileged CI image - is
+    /// not bound by the mode, so a test that assumed the delete would fail would instead report the
+    /// product as broken.
+    /// </summary>
+    /// <param name="path">The probe file the tightened directory is meant to protect.</param>
+    /// <returns><c>true</c> when the delete succeeded despite the directory mode.</returns>
+    private static bool DeleteSucceeds(string path)
+    {
+        try
+        {
+            File.Delete(path);
+            return !File.Exists(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return false;
         }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -353,6 +353,49 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
     }
 
     /// <summary>
+    /// A cancelled delete-all must abort before any tracking metadata is destroyed. Swallowing the
+    /// cancellation and carrying on wipes the manifests and the index while the backups they describe
+    /// are still on disk, leaving the user's originals unrecoverable by anything but hand.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllUserDataAsync_WhenCancelledMidCleanup_KeepsTrackingMetadataAsync()
+    {
+        // Arrange
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, "the-user-original-file");
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        using var cts = new CancellationTokenSource();
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, string, CancellationToken>((_, _, token) =>
+            {
+                cts.Cancel();
+                token.ThrowIfCancellationRequested();
+                return Task.FromResult(FileHashVerification.Match);
+            });
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _trackerService.DeleteAllUserDataAsync(cts.Token));
+
+        // Assert
+        Assert.True(File.Exists(Path.Combine(_appDataDir, "UserData", "index.json")));
+        Assert.NotEmpty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData", "manifests"), "*", SearchOption.AllDirectories));
+        Assert.NotEmpty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData", "backups"), "*", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
     /// Verifies that a clean delete-all still restores the originals and clears the backups, so the
     /// retention path does not become the permanent behaviour.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -353,6 +353,56 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
     }
 
     /// <summary>
+    /// Deactivation puts the user's original back at its own path, which consumes the backup. Keeping
+    /// the backup file and its recorded path would make the following uninstall read that restored
+    /// original as a user modification, move the byte-identical file aside and restore a duplicate.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeactivateThenUninstall_DoesNotDuplicateTheRestoredOriginalAsync()
+    {
+        // Arrange
+        const string originalUserContent = "the-user-original-file";
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, originalUserContent);
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        var backupPath = installResult.Data!.InstalledFiles[0].BackupPath;
+        Assert.NotNull(backupPath);
+
+        // Only the deployed CAS content matches the recorded hash; the user's own file does not.
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string path, string hash, CancellationToken _) =>
+                File.Exists(path) && File.ReadAllText(path) == CasContent
+                    ? FileHashVerification.Match
+                    : FileHashVerification.Mismatch);
+
+        // Act
+        var deactivateResult = await _trackerService.DeactivateProfileUserDataAsync(TestProfileId, CancellationToken.None);
+        Assert.True(deactivateResult.Success);
+        Assert.Equal(originalUserContent, File.ReadAllText(deployedPath));
+        Assert.False(File.Exists(backupPath));
+
+        var uninstallResult = await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
+
+        // Assert
+        Assert.True(uninstallResult.Success);
+        Assert.Equal(originalUserContent, File.ReadAllText(deployedPath));
+        Assert.False(File.Exists(deployedPath + UserDataConstants.UserModifiedSuffix));
+    }
+
+    /// <summary>
     /// A cancelled delete-all must abort before any tracking metadata is destroyed. Swallowing the
     /// cancellation and carrying on wipes the manifests and the index while the backups they describe
     /// are still on disk, leaving the user's originals unrecoverable by anything but hand.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -312,6 +312,50 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
     }
 
     /// <summary>
+    /// Profile cleanup runs the same uninstall, so it must not report success while an original the
+    /// user never asked to lose is still sitting in the backups tree. Every caller above it reads
+    /// this result and nothing else.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CleanupProfileAsync_WhenRestoreFails_ReportsTheUnfinishedUninstallAsync()
+    {
+        // Arrange
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, "the-user-original-file");
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        var backupPath = installResult.Data!.InstalledFiles[0].BackupPath!;
+
+        // The backup disappears in the window between the move-aside and the restore.
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                File.Delete(backupPath);
+                return FileHashVerification.Mismatch;
+            });
+
+        // Act
+        var cleanupResult = await _trackerService.CleanupProfileAsync(TestProfileId, CancellationToken.None);
+
+        // Assert
+        Assert.False(cleanupResult.Success);
+        Assert.Contains(Path.Combine(_appDataDir, "UserData", "backups"), cleanupResult.FirstError);
+        Assert.NotEmpty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData", "manifests"), "*", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
     /// Verifies that a restore failure keeps the backups directory intact, so the user's pristine
     /// originals are still recoverable by hand after a delete-all.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -494,6 +494,61 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
     }
 
     /// <summary>
+    /// Cancellation that lands on the manifest read itself must abort the delete-all too. Treating
+    /// the cancelled read as an unreadable manifest turns an abort into a retention decision and
+    /// carries on into the step that removes the tracking data.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllUserDataAsync_WhenCancelledLoadingManifest_KeepsTrackingMetadataAsync()
+    {
+        // Arrange
+        const string secondHash = "hash-splash-safety-second";
+        const string secondRelativePath = "GeneralsOnlineGameData/loading.bmp";
+        File.WriteAllText(Path.Combine(_casDir, secondHash), CasContent);
+
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, "the-user-original-file");
+
+        Assert.True((await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None)).Success);
+
+        Assert.True((await _trackerService.InstallUserDataAsync(
+            TestManifestId + ".loading",
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(secondRelativePath, secondHash),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None)).Success);
+
+        // Cancel while the first installation is being cleaned up, so the cancellation is first
+        // observed by the read of the second installation's manifest.
+        using var cts = new CancellationTokenSource();
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                cts.Cancel();
+                return FileHashVerification.Match;
+            });
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _trackerService.DeleteAllUserDataAsync(cts.Token));
+
+        // Assert
+        Assert.True(File.Exists(Path.Combine(_appDataDir, "UserData", "index.json")));
+        Assert.NotEmpty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData", "manifests"), "*", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
     /// An index key whose manifest is already gone has nothing left to restore, so it must not put
     /// delete-all into the retention path forever: "Delete All Application Data" would then never be
     /// able to finish on an installation with one stale entry.
@@ -574,12 +629,14 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
     [LibraryImport("libc", EntryPoint = "link", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
     private static partial int LinkUnix(string existingPath, string newPath);
 
-    private static List<ManifestFile> BuildFiles() =>
+    private static List<ManifestFile> BuildFiles() => BuildFiles(TestRelativePath, TestHash);
+
+    private static List<ManifestFile> BuildFiles(string relativePath, string hash) =>
     [
         new()
         {
-            RelativePath = TestRelativePath,
-            Hash = TestHash,
+            RelativePath = relativePath,
+            Hash = hash,
             Size = CasContent.Length,
             InstallTarget = ContentInstallTarget.UserDataDirectory,
         },

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -396,8 +396,54 @@ public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
         Assert.True(Directory.Exists(backupsPath));
         Assert.NotEmpty(Directory.GetFiles(backupsPath, "*", SearchOption.AllDirectories));
 
-        Assert.False(File.Exists(Path.Combine(_appDataDir, "UserData", "index.json")));
-        Assert.Empty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData", "manifests"), "*", SearchOption.AllDirectories));
+        // The manifests and the index are the only map from a machine-named backup file back to the
+        // path it belongs at, so retaining the backups while deleting them would strand them.
+        Assert.True(File.Exists(Path.Combine(_appDataDir, "UserData", "index.json")));
+        Assert.NotEmpty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData", "manifests"), "*", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
+    /// A delete-all that retains backups keeps its tracking data, so retrying it once the restores
+    /// can succeed must still finish the job rather than leave the tracking directory behind forever.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllUserDataAsync_RetriedAfterRetention_ClearsEverythingAsync()
+    {
+        // Arrange
+        const string originalUserContent = "the-user-original-file";
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, originalUserContent);
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FileHashVerification.Failed);
+
+        var firstAttempt = await _trackerService.DeleteAllUserDataAsync(CancellationToken.None);
+        Assert.False(firstAttempt.Success);
+
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FileHashVerification.Match);
+
+        // Act
+        var retry = await _trackerService.DeleteAllUserDataAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(retry.Success);
+        Assert.Equal(originalUserContent, File.ReadAllText(deployedPath));
+        Assert.Empty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData"), "*", SearchOption.AllDirectories));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceSafetyTests.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.GameSettings;
+using GenHub.Core.Interfaces.Workspace;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Features.UserData.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.UserData;
+
+/// <summary>
+/// Tests covering the data-safety guarantees of <see cref="UserDataTrackerService"/>: deployed user
+/// data must be independent of the CAS object it came from, and a pristine backup must survive a
+/// deployed file the user has since modified.
+/// </summary>
+public sealed partial class UserDataTrackerServiceSafetyTests : IDisposable
+{
+    private const string TestManifestId = "1.1015255.generalsonline.patch.gamedata";
+    private const string TestProfileId = "profile-zh-safety";
+    private const string TestVersion = "101525_QFE5";
+    private const string TestManifestName = "GameData Patch";
+    private const string TestRelativePath = "GeneralsOnlineGameData/splash.bmp";
+    private const string TestHash = "hash-splash-safety";
+    private const string CasContent = "pristine-cas-content";
+
+    private readonly string _tempDir;
+    private readonly string _appDataDir;
+    private readonly string _casDir;
+    private readonly string _zeroHourDataDir;
+    private readonly Mock<IConfigurationProviderService> _configProviderMock;
+    private readonly Mock<IFileOperationsService> _fileOperationsMock;
+    private readonly Mock<ILogger<UserDataTrackerService>> _loggerMock;
+    private readonly Mock<IGamePathProvider> _pathProviderMock;
+    private readonly UserDataTrackerService _trackerService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserDataTrackerServiceSafetyTests"/> class.
+    /// </summary>
+    public UserDataTrackerServiceSafetyTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "GenHub_UserDataSafetyTests_" + Guid.NewGuid().ToString("N"));
+        _appDataDir = Path.Combine(_tempDir, "AppData");
+        _casDir = Path.Combine(_tempDir, "Cas");
+        _zeroHourDataDir = Path.Combine(_tempDir, GameSettingsConstants.FolderNames.ZeroHour);
+
+        Directory.CreateDirectory(_appDataDir);
+        Directory.CreateDirectory(_casDir);
+        Directory.CreateDirectory(_zeroHourDataDir);
+        File.WriteAllText(Path.Combine(_casDir, TestHash), CasContent);
+
+        _configProviderMock = new Mock<IConfigurationProviderService>();
+        _configProviderMock.Setup(c => c.GetApplicationDataPath()).Returns(_appDataDir);
+
+        _loggerMock = new Mock<ILogger<UserDataTrackerService>>();
+
+        _pathProviderMock = new Mock<IGamePathProvider>();
+        _pathProviderMock.Setup(p => p.GetOptionsDirectory(GameType.ZeroHour)).Returns(_zeroHourDataDir);
+
+        _fileOperationsMock = new Mock<IFileOperationsService>();
+
+        // Faithful CAS behaviour: a hard link really shares storage with the object, a copy does not.
+        _fileOperationsMock
+            .Setup(f => f.LinkFromCasAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<ContentType?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, string, bool, ContentType?, CancellationToken>((hash, targetPath, useHardLink, contentType, token) =>
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                return Task.FromResult(TryCreateHardLink(Path.Combine(_casDir, hash), targetPath));
+            });
+
+        _fileOperationsMock
+            .Setup(f => f.CopyFromCasAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ContentType?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, string, ContentType?, CancellationToken>((hash, targetPath, contentType, token) =>
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                File.Copy(Path.Combine(_casDir, hash), targetPath, overwrite: true);
+                return Task.FromResult(true);
+            });
+
+        _fileOperationsMock
+            .Setup(f => f.VerifyFileHashAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _trackerService = new UserDataTrackerService(
+            _configProviderMock.Object,
+            _fileOperationsMock.Object,
+            _loggerMock.Object,
+            _pathProviderMock.Object);
+    }
+
+    /// <summary>
+    /// Cleans up test resources.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore test cleanup errors
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a file installed into the user's game data directory is an independent copy, so
+    /// writing to it — as the game engine and GenHub's own settings writer both do — cannot reach the
+    /// CAS object that every profile referencing the hash shares.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task InstallUserDataAsync_UserWritableTarget_DeploysIndependentCopyAsync()
+    {
+        // Arrange
+        var casObjectPath = Path.Combine(_casDir, TestHash);
+
+        // Act
+        var result = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Assert.True(File.Exists(deployedPath));
+        Assert.Equal(CasContent, File.ReadAllText(deployedPath));
+
+        // The game writes into this directory in place; that must not reach the CAS object.
+        File.WriteAllText(deployedPath, "engine-rewrote-this-file-with-different-content");
+
+        Assert.Equal(CasContent, File.ReadAllText(casObjectPath));
+        Assert.False(result.Data!.InstalledFiles[0].IsHardLink);
+
+        _fileOperationsMock.Verify(
+            f => f.LinkFromCasAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<ContentType?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that a deployed file the user has modified is moved aside rather than left in place,
+    /// so the pristine backup is still restored over the original path instead of being discarded.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task UninstallUserDataAsync_HashMismatch_PreservesModifiedFileAndRestoresBackupAsync()
+    {
+        // Arrange
+        const string originalUserContent = "the-user-original-file";
+        const string modifiedContent = "the-user-edited-this";
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, originalUserContent);
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        File.WriteAllText(deployedPath, modifiedContent);
+        _fileOperationsMock
+            .Setup(f => f.VerifyFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var uninstallResult = await _trackerService.UninstallUserDataAsync(TestManifestId, TestProfileId, CancellationToken.None);
+
+        // Assert
+        Assert.True(uninstallResult.Success);
+        Assert.Equal(originalUserContent, File.ReadAllText(deployedPath));
+
+        var preservedPath = deployedPath + UserDataConstants.UserModifiedSuffix;
+        Assert.True(File.Exists(preservedPath));
+        Assert.Equal(modifiedContent, File.ReadAllText(preservedPath));
+    }
+
+    /// <summary>
+    /// Verifies that a restore failure keeps the backups directory intact, so the user's pristine
+    /// originals are still recoverable by hand after a delete-all.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllUserDataAsync_WhenRestoreFails_RetainsBackupsAsync()
+    {
+        // Arrange
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, "the-user-original-file");
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        _fileOperationsMock
+            .Setup(f => f.VerifyFileHashAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("hash verification unavailable"));
+
+        // Act
+        var deleteResult = await _trackerService.DeleteAllUserDataAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(deleteResult.Success);
+
+        var backupsPath = Path.Combine(_appDataDir, "UserData", "backups");
+        Assert.True(Directory.Exists(backupsPath));
+        Assert.NotEmpty(Directory.GetFiles(backupsPath, "*", SearchOption.AllDirectories));
+
+        Assert.False(File.Exists(Path.Combine(_appDataDir, "UserData", "index.json")));
+        Assert.Empty(Directory.GetFiles(Path.Combine(_appDataDir, "UserData", "manifests"), "*", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
+    /// Verifies that a clean delete-all still restores the originals and clears the backups, so the
+    /// retention path does not become the permanent behaviour.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteAllUserDataAsync_WhenRestoresSucceed_ClearsBackupsAsync()
+    {
+        // Arrange
+        const string originalUserContent = "the-user-original-file";
+        var deployedPath = Path.Combine(_zeroHourDataDir, "GeneralsOnlineGameData", "splash.bmp");
+        Directory.CreateDirectory(Path.GetDirectoryName(deployedPath)!);
+        File.WriteAllText(deployedPath, originalUserContent);
+
+        var installResult = await _trackerService.InstallUserDataAsync(
+            TestManifestId,
+            TestProfileId,
+            GameType.ZeroHour,
+            BuildFiles(),
+            TestVersion,
+            TestManifestName,
+            CancellationToken.None);
+        Assert.True(installResult.Success);
+
+        // Act
+        var deleteResult = await _trackerService.DeleteAllUserDataAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(deleteResult.Success);
+        Assert.Equal(originalUserContent, File.ReadAllText(deployedPath));
+
+        var backupsPath = Path.Combine(_appDataDir, "UserData", "backups");
+        Assert.True(Directory.Exists(backupsPath));
+        Assert.Empty(Directory.GetFiles(backupsPath, "*", SearchOption.AllDirectories));
+    }
+
+    [LibraryImport("kernel32.dll", EntryPoint = "CreateHardLinkW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CreateHardLinkWindows(string lpFileName, string lpExistingFileName, IntPtr lpSecurityAttributes);
+
+    [LibraryImport("libc", EntryPoint = "link", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int LinkUnix(string existingPath, string newPath);
+
+    private static List<ManifestFile> BuildFiles() =>
+    [
+        new()
+        {
+            RelativePath = TestRelativePath,
+            Hash = TestHash,
+            Size = CasContent.Length,
+            InstallTarget = ContentInstallTarget.UserDataDirectory,
+        },
+    ];
+
+    private static bool TryCreateHardLink(string existingPath, string linkPath)
+    {
+        try
+        {
+            if (File.Exists(linkPath))
+            {
+                File.Delete(linkPath);
+            }
+
+            return OperatingSystem.IsWindows()
+                ? CreateHardLinkWindows(linkPath, existingPath, IntPtr.Zero)
+                : LinkUnix(existingPath, linkPath) == 0;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceTests.cs
@@ -109,6 +109,13 @@ public sealed class UserDataTrackerServiceTests : IDisposable
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
+        _fileOperationsMock
+            .Setup(f => f.CheckFileHashAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FileHashVerification.Match);
+
         _trackerService = new UserDataTrackerService(
             _configProviderMock.Object,
             _fileOperationsMock.Object,

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/UserData/UserDataTrackerServiceTests.cs
@@ -83,6 +83,25 @@ public sealed class UserDataTrackerServiceTests : IDisposable
             })
             .ReturnsAsync(true);
 
+        // Default mock for CAS copying: user-writable destinations are always copied, never linked
+        _fileOperationsMock
+            .Setup(f => f.CopyFromCasAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ContentType?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, ContentType?, CancellationToken>((hash, targetPath, contentType, token) =>
+            {
+                var dir = Path.GetDirectoryName(targetPath);
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                File.WriteAllText(targetPath, "cas-content-" + hash);
+            })
+            .ReturnsAsync(true);
+
         _fileOperationsMock
             .Setup(f => f.VerifyFileHashAsync(
                 It.IsAny<string>(),

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -88,35 +88,57 @@ public class FileOperationsServiceTests : IDisposable
     }
 
     /// <summary>
-    /// A path reached through a symbolic link names the same file as the link's target, so the
-    /// same-file guard must follow the link rather than compare the two spellings of the path.
+    /// A destination that is a leftover link to the source is exactly what callers copy to get rid
+    /// of: skipping the copy because the link resolves to the source leaves the workspace file
+    /// pointing at the shared CAS object, so later writes reach the object every profile shares.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CopyFileAsync_DestinationIsSymlinkToSource_LeavesFileIntactAsync()
+    public async Task CopyFileAsync_DestinationIsSymlinkToSource_ReplacesLinkWithIndependentCopyAsync()
     {
         var file = Path.Combine(_tempDir, "real.txt");
         var link = Path.Combine(_tempDir, "link.txt");
-        await File.WriteAllTextAsync(file, "irreplaceable content");
+        await File.WriteAllTextAsync(file, "shared content");
 
-        try
+        if (!TryCreateSymbolicLink(link, file))
         {
-            File.CreateSymbolicLink(link, file);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
-        {
-            // Creating symlinks needs a privilege this machine does not grant; nothing to assert.
             return;
         }
 
         await _service.CopyFileAsync(file, link);
 
-        Assert.True(File.Exists(file));
-        Assert.Equal("irreplaceable content", await File.ReadAllTextAsync(file));
+        Assert.Null(File.ResolveLinkTarget(link, returnFinalTarget: true));
+        Assert.Equal("shared content", await File.ReadAllTextAsync(link));
 
-        // The guard must have skipped the copy outright; unlinking the destination would have left
-        // an independent duplicate where the link used to be.
-        Assert.NotNull(File.ResolveLinkTarget(link, returnFinalTarget: true));
+        await File.WriteAllTextAsync(link, "workspace content");
+
+        Assert.Equal("shared content", await File.ReadAllTextAsync(file));
+        Assert.Equal("workspace content", await File.ReadAllTextAsync(link));
+    }
+
+    /// <summary>
+    /// When the source is the link and the destination is the real file it points at, the
+    /// destination is already the independent copy the caller wants. Unlinking it would destroy the
+    /// only copy of the content, so the copy must be skipped.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CopyFileAsync_SourceIsSymlinkToDestination_LeavesFileIntactAsync()
+    {
+        var file = Path.Combine(_tempDir, "target.txt");
+        var link = Path.Combine(_tempDir, "pointer.txt");
+        await File.WriteAllTextAsync(file, "irreplaceable content");
+
+        if (!TryCreateSymbolicLink(link, file))
+        {
+            return;
+        }
+
+        await _service.CopyFileAsync(link, file);
+
+        Assert.True(File.Exists(file));
+        Assert.Null(File.ResolveLinkTarget(file, returnFinalTarget: true));
+        Assert.Equal("irreplaceable content", await File.ReadAllTextAsync(file));
     }
 
     /// <summary>
@@ -431,5 +453,25 @@ public class FileOperationsServiceTests : IDisposable
     public void Dispose()
     {
         FileOperationsService.DeleteDirectoryIfExists(_tempDir);
+    }
+
+    /// <summary>
+    /// Creates a symbolic link, reporting failure rather than throwing when the platform withholds
+    /// the privilege it needs.
+    /// </summary>
+    /// <param name="linkPath">The link to create.</param>
+    /// <param name="targetPath">The file the link points at.</param>
+    /// <returns>True when the link was created.</returns>
+    private static bool TryCreateSymbolicLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            File.CreateSymbolicLink(linkPath, targetPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return false;
+        }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -88,6 +88,38 @@ public class FileOperationsServiceTests : IDisposable
     }
 
     /// <summary>
+    /// A path reached through a symbolic link names the same file as the link's target, so the
+    /// same-file guard must follow the link rather than compare the two spellings of the path.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CopyFileAsync_DestinationIsSymlinkToSource_LeavesFileIntactAsync()
+    {
+        var file = Path.Combine(_tempDir, "real.txt");
+        var link = Path.Combine(_tempDir, "link.txt");
+        await File.WriteAllTextAsync(file, "irreplaceable content");
+
+        try
+        {
+            File.CreateSymbolicLink(link, file);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            // Creating symlinks needs a privilege this machine does not grant; nothing to assert.
+            return;
+        }
+
+        await _service.CopyFileAsync(file, link);
+
+        Assert.True(File.Exists(file));
+        Assert.Equal("irreplaceable content", await File.ReadAllTextAsync(file));
+
+        // The guard must have skipped the copy outright; unlinking the destination would have left
+        // an independent duplicate where the link used to be.
+        Assert.NotNull(File.ResolveLinkTarget(link, returnFinalTarget: true));
+    }
+
+    /// <summary>
     /// Tests that CreateSymlinkAsync creates a symbolic link or falls back to copy on unsupported platforms.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -1,6 +1,7 @@
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Results;
 using GenHub.Features.Workspace;
 using Microsoft.Extensions.Logging;
@@ -317,6 +318,22 @@ public class FileOperationsServiceTests : IDisposable
         _downloadService.Verify(
             x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// A file that is not there yields no hash at all, so it must be reported as a failed check
+    /// rather than as a confirmed difference that a destructive caller could act on.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckFileHashAsync_MissingFile_ReportsFailedAsync()
+    {
+        var missing = Path.Combine(_tempDir, "not-here.txt");
+
+        var result = await _service.CheckFileHashAsync(missing, "any-hash");
+
+        Assert.Equal(FileHashVerification.Failed, result);
+        Assert.False(await _service.VerifyFileHashAsync(missing, "any-hash"));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/FileOperationsServiceTests.cs
@@ -50,6 +50,43 @@ public class FileOperationsServiceTests : IDisposable
     }
 
     /// <summary>
+    /// A copy that cannot even open its source must not have destroyed the file already sitting at
+    /// the destination: the destination is unlinked to break hard links, and doing that before the
+    /// source is known to be readable turns a failed copy into data loss.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CopyFileAsync_MissingSource_LeavesExistingDestinationIntactAsync()
+    {
+        var src = Path.Combine(_tempDir, "missing-source.txt");
+        var dst = Path.Combine(_tempDir, "existing-destination.txt");
+
+        await File.WriteAllTextAsync(dst, "the file the user already had");
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() => _service.CopyFileAsync(src, dst));
+
+        Assert.True(File.Exists(dst));
+        Assert.Equal("the file the user already had", await File.ReadAllTextAsync(dst));
+    }
+
+    /// <summary>
+    /// Copying a file onto itself must leave it alone rather than unlinking it and then failing to
+    /// read the source it has just deleted.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CopyFileAsync_SameSourceAndDestination_LeavesFileIntactAsync()
+    {
+        var file = Path.Combine(_tempDir, "self.txt");
+        await File.WriteAllTextAsync(file, "irreplaceable content");
+
+        await _service.CopyFileAsync(file, Path.Combine(_tempDir, ".", "self.txt"));
+
+        Assert.True(File.Exists(file));
+        Assert.Equal("irreplaceable content", await File.ReadAllTextAsync(file));
+    }
+
+    /// <summary>
     /// Tests that CreateSymlinkAsync creates a symbolic link or falls back to copy on unsupported platforms.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/TestFileOperationsService.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/TestFileOperationsService.cs
@@ -81,6 +81,10 @@ public partial class TestFileOperationsService(
         => _innerService.VerifyFileHashAsync(filePath, expectedHash, cancellationToken);
 
     /// <inheritdoc/>
+    public Task<FileHashVerification> CheckFileHashAsync(string filePath, string expectedHash, CancellationToken cancellationToken = default)
+        => _innerService.CheckFileHashAsync(filePath, expectedHash, cancellationToken);
+
+    /// <inheritdoc/>
     public Task ApplyPatchAsync(string targetPath, string patchPath, CancellationToken cancellationToken = default)
         => _innerService.ApplyPatchAsync(targetPath, patchPath, cancellationToken);
 

--- a/GenHub/GenHub.Windows/Features/Workspace/WindowsFileOperationsService.cs
+++ b/GenHub/GenHub.Windows/Features/Workspace/WindowsFileOperationsService.cs
@@ -34,6 +34,10 @@ public partial class WindowsFileOperationsService(
         => baseService.VerifyFileHashAsync(filePath, expectedHash, cancellationToken);
 
     /// <inheritdoc/>
+    public Task<FileHashVerification> CheckFileHashAsync(string filePath, string expectedHash, CancellationToken cancellationToken = default)
+        => baseService.CheckFileHashAsync(filePath, expectedHash, cancellationToken);
+
+    /// <inheritdoc/>
     public Task DownloadFileAsync(Uri url, string destinationPath, IProgress<DownloadProgress>? progress = null, CancellationToken cancellationToken = default)
         => baseService.DownloadFileAsync(url, destinationPath, progress, cancellationToken);
 

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1099,16 +1099,29 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             await DeleteWorkspaces();
             await DeleteManifests();
             await DeleteCasStorage();
-            await DeleteUserData();
+            var userDataDeleted = await DeleteUserDataInternalAsync();
 
             // Invalidate installation cache to force re-generation of manifests on next scan
             _installationService.InvalidateCache();
 
             await UpdateDangerZoneDataAsync();
-            _notificationService.ShowSuccess(
-                "Data Deleted",
-                $"Profiles, workspaces, manifests, and user data were deleted. {CasDefaults.GarbageCollectionDisabledMessage}",
-                5000);
+
+            // A success toast on top of the partial-failure toast the user data deletion just raised
+            // would tell the user their data is gone while their originals are still on disk.
+            if (userDataDeleted)
+            {
+                _notificationService.ShowSuccess(
+                    "Data Deleted",
+                    $"Profiles, workspaces, manifests, and user data were deleted. {CasDefaults.GarbageCollectionDisabledMessage}",
+                    5000);
+            }
+            else
+            {
+                _notificationService.ShowWarning(
+                    "Data Partially Deleted",
+                    $"Profiles, workspaces, and manifests were deleted, but some user data was kept. {CasDefaults.GarbageCollectionDisabledMessage}",
+                    5000);
+            }
         }
         catch (Exception ex)
         {
@@ -1332,6 +1345,16 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task DeleteUserData()
     {
+        await DeleteUserDataInternalAsync();
+    }
+
+    /// <summary>
+    /// Deletes the tracked user data and reports whether everything was actually removed, so a
+    /// caller that follows it with a summary message cannot contradict the partial-failure it raised.
+    /// </summary>
+    /// <returns><c>true</c> when all tracked user data was deleted; otherwise, <c>false</c>.</returns>
+    private async Task<bool> DeleteUserDataInternalAsync()
+    {
         try
         {
             _logger.LogWarning("Deleting all user data");
@@ -1350,11 +1373,13 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             }
 
             await UpdateDangerZoneDataAsync();
+            return result.Success;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to delete user data");
             _notificationService.ShowError("Deletion Failed", $"Failed to delete user data: {ex.Message}", 5000);
+            return false;
         }
     }
 

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1080,33 +1080,41 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task DeleteAllData()
     {
-        _logger.LogWarning("Deleting ALL application data requested");
-
-        var confirmed = await _dialogService.ShowConfirmationAsync(
-            AppConstants.DeleteAllDataConfirmationTitle,
-            AppConstants.DeleteAllDataConfirmationMessage,
-            confirmText: AppConstants.DeleteAllDataConfirmText);
-
-        if (!confirmed)
+        try
         {
-            _logger.LogInformation("Deleting ALL application data was cancelled at the confirmation prompt");
-            return;
+            _logger.LogWarning("Deleting ALL application data requested");
+
+            var confirmed = await _dialogService.ShowConfirmationAsync(
+                AppConstants.DeleteAllDataConfirmationTitle,
+                AppConstants.DeleteAllDataConfirmationMessage,
+                confirmText: AppConstants.DeleteAllDataConfirmText);
+
+            if (!confirmed)
+            {
+                _logger.LogInformation("Deleting ALL application data was cancelled at the confirmation prompt");
+                return;
+            }
+
+            await DeleteProfiles();
+            await DeleteWorkspaces();
+            await DeleteManifests();
+            await DeleteCasStorage();
+            await DeleteUserData();
+
+            // Invalidate installation cache to force re-generation of manifests on next scan
+            _installationService.InvalidateCache();
+
+            await UpdateDangerZoneDataAsync();
+            _notificationService.ShowSuccess(
+                "Data Deleted",
+                $"Profiles, workspaces, manifests, and user data were deleted. {CasDefaults.GarbageCollectionDisabledMessage}",
+                5000);
         }
-
-        await DeleteProfiles();
-        await DeleteWorkspaces();
-        await DeleteManifests();
-        await DeleteCasStorage();
-        await DeleteUserData();
-
-        // Invalidate installation cache to force re-generation of manifests on next scan
-        _installationService.InvalidateCache();
-
-        await UpdateDangerZoneDataAsync();
-        _notificationService.ShowSuccess(
-            "Data Deleted",
-            $"Profiles, workspaces, manifests, and user data were deleted. {CasDefaults.GarbageCollectionDisabledMessage}",
-            5000);
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete all application data");
+            _notificationService.ShowError("Deletion Failed", $"Failed to delete all application data: {ex.Message}", 5000);
+        }
     }
 
     [RelayCommand]

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -68,6 +68,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private readonly IGameInstallationService _installationService;
     private readonly IStorageLocationService _storageLocationService;
     private readonly IUserDataTracker _userDataTracker;
+    private readonly IDialogService _dialogService;
 
     private bool _isViewVisible;
     private bool _disposed;
@@ -216,6 +217,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     /// <param name="installationService">Game installation service.</param>
     /// <param name="storageLocationService">Storage location service.</param>
     /// <param name="userDataTracker">User data tracker service.</param>
+    /// <param name="dialogService">Dialog service used to confirm destructive actions.</param>
     /// <param name="gitHubTokenStorage">GitHub token storage.</param>
     public SettingsViewModel(
         IUserSettingsService userSettingsService,
@@ -230,6 +232,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         IGameInstallationService installationService,
         IStorageLocationService storageLocationService,
         IUserDataTracker userDataTracker,
+        IDialogService dialogService,
         IGitHubTokenStorage? gitHubTokenStorage = null)
     {
         _userSettingsService = userSettingsService ?? throw new ArgumentNullException(nameof(userSettingsService));
@@ -244,6 +247,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _installationService = installationService ?? throw new ArgumentNullException(nameof(installationService));
         _storageLocationService = storageLocationService ?? throw new ArgumentNullException(nameof(storageLocationService));
         _userDataTracker = userDataTracker ?? throw new ArgumentNullException(nameof(userDataTracker));
+        _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
         _gitHubTokenStorage = gitHubTokenStorage;
 
         LoadSettings();
@@ -1077,6 +1081,17 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private async Task DeleteAllData()
     {
         _logger.LogWarning("Deleting ALL application data requested");
+
+        var confirmed = await _dialogService.ShowConfirmationAsync(
+            AppConstants.DeleteAllDataConfirmationTitle,
+            AppConstants.DeleteAllDataConfirmationMessage,
+            confirmText: AppConstants.DeleteAllDataConfirmText);
+
+        if (!confirmed)
+        {
+            _logger.LogInformation("Deleting ALL application data was cancelled at the confirmation prompt");
+            return;
+        }
 
         await DeleteProfiles();
         await DeleteWorkspaces();

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1335,8 +1335,19 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         try
         {
             _logger.LogWarning("Deleting all user data");
-            await _userDataTracker.DeleteAllUserDataAsync();
-            _notificationService.ShowSuccess("User Data Deleted", "All user data deleted successfully.", 3000);
+            var result = await _userDataTracker.DeleteAllUserDataAsync();
+            if (result.Success)
+            {
+                _notificationService.ShowSuccess("User Data Deleted", "All user data deleted successfully.", 3000);
+            }
+            else
+            {
+                _logger.LogWarning("User data deletion kept some data: {Error}", result.FirstError);
+                _notificationService.ShowError(
+                    "User Data Partially Deleted",
+                    result.FirstError ?? "Some tracked user data could not be deleted.",
+                    5000);
+            }
 
             await UpdateDangerZoneDataAsync();
         }

--- a/GenHub/GenHub/Features/UserData/Services/ProfileContentLinkerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/ProfileContentLinkerService.cs
@@ -77,8 +77,18 @@ public class ProfileContentLinkerService(
                             "[ProfileContentLinker] User data verification failed for {ManifestId}, reinstalling",
                             manifest.Id.Value);
 
-                        // Reinstall
-                        await userDataTracker.UninstallUserDataAsync(manifest.Id.Value, profileId, cancellationToken);
+                        // Reinstall, but never on top of an uninstall that could not put the user's
+                        // originals back: redeploying would bury the unfinished restore.
+                        var uninstallResult = await userDataTracker.UninstallUserDataAsync(manifest.Id.Value, profileId, cancellationToken);
+                        if (!uninstallResult.Success)
+                        {
+                            logger.LogError(
+                                "[ProfileContentLinker] Cannot reinstall {ManifestId}: the previous installation could not be fully removed: {Error}",
+                                manifest.Id.Value,
+                                uninstallResult.FirstError);
+                            return OperationResult<bool>.CreateFailure(uninstallResult.Errors);
+                        }
+
                         await InstallManifestUserDataAsync(manifest, profileId, targetGame, cancellationToken);
                     }
                     else if (!existingResult.Data.IsActive)
@@ -256,10 +266,19 @@ public class ProfileContentLinkerService(
 
             // Find manifests to remove (in current but not in new)
             var toRemove = currentManifestIds.Except(newManifestIds).ToList();
+            var uninstallErrors = new List<string>();
             foreach (var manifestId in toRemove)
             {
                 logger.LogInformation("[ProfileContentLinker] Removing deselected content: {ManifestId}", manifestId);
-                await userDataTracker.UninstallUserDataAsync(manifestId, profileId, cancellationToken);
+                var uninstallResult = await userDataTracker.UninstallUserDataAsync(manifestId, profileId, cancellationToken);
+                if (!uninstallResult.Success)
+                {
+                    logger.LogError(
+                        "[ProfileContentLinker] Failed to remove deselected content {ManifestId}: {Error}",
+                        manifestId,
+                        uninstallResult.FirstError);
+                    uninstallErrors.AddRange(uninstallResult.Errors);
+                }
             }
 
             // Find manifests to add (in new but not in current)
@@ -292,7 +311,9 @@ public class ProfileContentLinkerService(
                 toRemove.Count,
                 toAdd.Count);
 
-            return OperationResult<bool>.CreateSuccess(true);
+            return uninstallErrors.Count > 0
+                ? OperationResult<bool>.CreateFailure(uninstallErrors)
+                : OperationResult<bool>.CreateSuccess(true);
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -198,7 +198,17 @@ public class UserDataTrackerService(
 
             var manifest = manifestResult.Data;
 
-            _ = await CleanupInstalledFilesAsync(manifest, cancellationToken);
+            // Keep the manifest and index entry when a pristine original could not be put back: they
+            // are the only record of which backup belongs to which path, so discarding them would
+            // strand the user's originals under machine-generated names with nothing referencing them.
+            if (!await CleanupInstalledFilesAsync(manifest, cancellationToken))
+            {
+                logger.LogError(
+                    "[UserData] Uninstall of {ManifestId} left one or more pristine backups unrestored; keeping its tracking data so the originals stay recoverable",
+                    manifestId);
+                return OperationResult<bool>.CreateFailure(
+                    $"Uninstalled files for '{manifestId}' but could not restore every original. Your originals are still under '{_backupsPath}' and GenHub kept tracking them so the uninstall can be retried.");
+            }
 
             // Remove the manifest file
             await DeleteUserDataManifestAsync(manifestId, profileId, cancellationToken);
@@ -1241,6 +1251,7 @@ public class UserDataTrackerService(
             cancellationToken.ThrowIfCancellationRequested();
 
             var hasBackup = !string.IsNullOrEmpty(file.BackupPath) && File.Exists(file.BackupPath);
+            var backupRestored = false;
 
             try
             {
@@ -1292,6 +1303,7 @@ public class UserDataTrackerService(
                     // to another drive or to OneDrive, and File.Move cannot cross a volume boundary.
                     RestoreBackupCopy(file.BackupPath!, file.AbsolutePath);
                     File.Delete(file.BackupPath!);
+                    backupRestored = true;
                     logger.LogInformation("[UserData] Restored backup: {Backup} -> {Path}", file.BackupPath, file.AbsolutePath);
                 }
             }
@@ -1304,11 +1316,11 @@ public class UserDataTrackerService(
                 logger.LogWarning(ex, "[UserData] Failed to uninstall file: {Path}", file.AbsolutePath);
             }
 
-            if (hasBackup && File.Exists(file.BackupPath!))
+            if (hasBackup && !backupRestored)
             {
                 allBackupsRestored = false;
                 logger.LogWarning(
-                    "[UserData] Backup for {Path} was not restored and is still held at {BackupPath}",
+                    "[UserData] Backup for {Path} was not restored; the recorded backup is {BackupPath}",
                     file.AbsolutePath,
                     file.BackupPath);
             }

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -473,6 +473,10 @@ public class UserDataTrackerService(
 
             return OperationResult<IReadOnlyList<UserDataManifest>>.CreateSuccess(manifests);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "[UserData] Failed to get game user data for {Game}", targetGame);
@@ -491,6 +495,11 @@ public class UserDataTrackerService(
             var key = $"{manifestId}_{profileId}";
             var manifest = await LoadUserDataManifestByKeyAsync(key, cancellationToken);
             return OperationResult<UserDataManifest?>.CreateSuccess(manifest);
+        }
+        catch (OperationCanceledException)
+        {
+            // A cancelled read must not reach the uninstall path as "no manifest, nothing to do".
+            throw;
         }
         catch (Exception ex)
         {
@@ -1525,8 +1534,10 @@ public class UserDataTrackerService(
             var json = await File.ReadAllTextAsync(filePath, cancellationToken);
             return JsonSerializer.Deserialize<UserDataManifest>(json);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            // Cancellation must escape: a caller that reads a null manifest as "unreadable, its
+            // backups can no longer be put back" would turn an abort into a retention decision.
             logger.LogWarning(ex, "[UserData] Failed to load manifest from {Path}", filePath);
             return null;
         }

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -584,13 +584,34 @@ public class UserDataTrackerService(
                 return OperationResult<bool>.CreateSuccess(true);
             }
 
+            var uninstallErrors = new List<string>();
             foreach (var manifest in manifestsResult.Data)
             {
-                await UninstallUserDataAsync(manifest.ManifestId, profileId, cancellationToken);
+                var uninstallResult = await UninstallUserDataAsync(manifest.ManifestId, profileId, cancellationToken);
+                if (!uninstallResult.Success)
+                {
+                    uninstallErrors.AddRange(uninstallResult.Errors);
+                }
+            }
+
+            // A discarded uninstall failure is a silent data-safety failure: the user's pristine
+            // originals are still under the backups tree and nothing above would ever say so.
+            if (uninstallErrors.Count > 0)
+            {
+                logger.LogError(
+                    "[UserData] Cleanup of profile {ProfileId} left {Count} uninstall(s) unfinished; their originals are still tracked under {BackupsPath}",
+                    profileId,
+                    uninstallErrors.Count,
+                    _backupsPath);
+                return OperationResult<bool>.CreateFailure(uninstallErrors);
             }
 
             logger.LogInformation("[UserData] Cleaned up {Count} manifests for profile {ProfileId}", manifestsResult.Data.Count, profileId);
             return OperationResult<bool>.CreateSuccess(true);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -370,7 +370,7 @@ public class UserDataTrackerService(
                             }
 
                             var restoredFrom = file.BackupPath;
-                            RestoreAndConsumeBackup(file);
+                            RestoreAndConsumeBackup(file, logger);
                             logger.LogInformation("[UserData] Restored backup during deactivation: {Backup} -> {Path}", restoredFrom, file.AbsolutePath);
                         }
                         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -866,27 +866,55 @@ public class UserDataTrackerService(
     /// identical duplicate in its place.
     /// </summary>
     /// <param name="file">The entry whose backup should be restored and then cleared.</param>
-    private static void RestoreAndConsumeBackup(UserDataFileEntry file)
+    /// <param name="logger">The logger used to record a backup file that could not be deleted.</param>
+    private static void RestoreAndConsumeBackup(UserDataFileEntry file, ILogger logger)
     {
-        RestoreBackupCopy(file.BackupPath!, file.AbsolutePath);
-        File.Delete(file.BackupPath!);
+        var backupPath = file.BackupPath!;
+        RestoreBackupCopy(backupPath, file.AbsolutePath);
         file.BackupPath = null;
         file.WasOverwritten = false;
+
+        DeleteConsumedBackup(backupPath, logger);
     }
 
-    private static void RestoreBackupQuietly(string? backupPath, string targetPath, bool wasOverwritten, ILogger? logger = null)
+    /// <summary>
+    /// Deletes a backup whose content has already been put back at the path it belongs to. The
+    /// restore is what protects the user's data, so a delete that fails - an antivirus scanner or an
+    /// indexer holding the file open for a moment - must not turn the restore into a failure: the
+    /// retry would read the restored original as a modification and duplicate it.
+    /// </summary>
+    /// <param name="backupPath">The backup file to remove.</param>
+    /// <param name="logger">The logger used to record a backup file that could not be deleted.</param>
+    private static void DeleteConsumedBackup(string backupPath, ILogger logger)
+    {
+        try
+        {
+            File.Delete(backupPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(
+                ex,
+                "[UserData] Restored backup {BackupPath} but could not delete it; it is now a stray copy and can be removed by hand",
+                backupPath);
+        }
+    }
+
+    private static void RestoreBackupQuietly(string? backupPath, string targetPath, bool wasOverwritten, ILogger logger)
     {
         if (wasOverwritten && !string.IsNullOrEmpty(backupPath) && File.Exists(backupPath))
         {
             try
             {
                 RestoreBackupCopy(backupPath, targetPath);
-                File.Delete(backupPath);
             }
             catch (Exception ex)
             {
-                logger?.LogWarning(ex, "[UserData] Failed to restore safety backup from {BackupPath} to {TargetPath}", backupPath, targetPath);
+                logger.LogWarning(ex, "[UserData] Failed to restore safety backup from {BackupPath} to {TargetPath}", backupPath, targetPath);
+                return;
             }
+
+            DeleteConsumedBackup(backupPath, logger);
         }
     }
 
@@ -1284,7 +1312,7 @@ public class UserDataTrackerService(
                         Directory.CreateDirectory(targetDir);
                     }
 
-                    RestoreAndConsumeBackup(file);
+                    RestoreAndConsumeBackup(file, logger);
                 }
                 else
                 {
@@ -1403,9 +1431,10 @@ public class UserDataTrackerService(
                     // tree while the deployed path is under Documents, which is routinely redirected
                     // to another drive or to OneDrive, and File.Move cannot cross a volume boundary.
                     RestoreBackupCopy(file.BackupPath!, file.AbsolutePath);
-                    File.Delete(file.BackupPath!);
                     backupRestored = true;
                     logger.LogInformation("[UserData] Restored backup: {Backup} -> {Path}", file.BackupPath, file.AbsolutePath);
+
+                    DeleteConsumedBackup(file.BackupPath!, logger);
                 }
             }
             catch (OperationCanceledException)

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -723,10 +723,7 @@ public class UserDataTrackerService(
                     }
                 }
 
-                // 2. Clear the in-memory index
-                _cachedIndex = new UserDataIndex();
-
-                // 3. Nuke the directories to be sure
+                // 2. Nuke the directories to be sure
                 if (Directory.Exists(_userDataTrackingPath))
                 {
                     // Sanity check: ensure we're not deleting a system root or unrelated directory
@@ -740,29 +737,26 @@ public class UserDataTrackerService(
                     {
                         logger.LogInformation("[UserData] Deleting UserData directory: {Path}", _userDataTrackingPath);
                         Directory.Delete(_userDataTrackingPath, true);
+                        _cachedIndex = new UserDataIndex();
                     }
                     else
                     {
+                        // Keep the manifests and the index alongside the retained backups: they are
+                        // the only map from a machine-named backup file back to the path it belongs
+                        // at, and a later delete-all clears whatever is left once the restores work.
                         logger.LogWarning(
-                            "[UserData] One or more pristine game data backups could not be restored, so they were NOT deleted. Your originals remain at {BackupsPath}; restore them by hand or delete that folder once you no longer need them.",
+                            "[UserData] One or more pristine game data backups could not be restored, so they were NOT deleted. Your originals remain at {BackupsPath} and GenHub kept tracking them; retry the deletion or restore them by hand.",
                             _backupsPath);
-
-                        if (Directory.Exists(_manifestsPath))
-                        {
-                            Directory.Delete(_manifestsPath, true);
-                        }
-
-                        FileOperationsService.DeleteFileIfExists(_indexPath);
                     }
                 }
 
-                // 4. Re-create empty directories
+                // 3. Re-create empty directories
                 EnsureDirectoriesExist();
 
                 if (!allBackupsRestored)
                 {
                     return OperationResult<bool>.CreateFailure(
-                        $"Removed GenHub's tracked user data, but one or more pristine game data backups could not be restored. Your originals were kept at '{_backupsPath}'.");
+                        $"Removed what could be removed, but one or more pristine game data backups could not be restored. Your originals were kept at '{_backupsPath}' along with the tracking data that records where each one belongs, so the deletion can be retried.");
                 }
 
                 return OperationResult<bool>.CreateSuccess(true);

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -1287,7 +1287,11 @@ public class UserDataTrackerService(
                         Directory.CreateDirectory(targetDir);
                     }
 
-                    File.Move(file.BackupPath!, file.AbsolutePath, overwrite: true);
+                    // Delete-then-copy rather than File.Move: backups live under the application data
+                    // tree while the deployed path is under Documents, which is routinely redirected
+                    // to another drive or to OneDrive, and File.Move cannot cross a volume boundary.
+                    RestoreBackupCopy(file.BackupPath!, file.AbsolutePath);
+                    File.Delete(file.BackupPath!);
                     logger.LogInformation("[UserData] Restored backup: {Backup} -> {Path}", file.BackupPath, file.AbsolutePath);
                 }
             }

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -364,8 +364,9 @@ public class UserDataTrackerService(
                                 Directory.CreateDirectory(targetDir);
                             }
 
-                            RestoreBackupCopy(file.BackupPath, file.AbsolutePath);
-                            logger.LogInformation("[UserData] Restored backup during deactivation: {Backup} -> {Path}", file.BackupPath, file.AbsolutePath);
+                            var restoredFrom = file.BackupPath;
+                            RestoreAndConsumeBackup(file);
+                            logger.LogInformation("[UserData] Restored backup during deactivation: {Backup} -> {Path}", restoredFrom, file.AbsolutePath);
                         }
                         catch (Exception ex) when (ex is not OperationCanceledException)
                         {
@@ -817,6 +818,21 @@ public class UserDataTrackerService(
         File.Copy(backupPath, targetPath, overwrite: true);
     }
 
+    /// <summary>
+    /// Restores a backup over the deployed path and consumes it. The protected content is back where
+    /// it belongs, so leaving the backup file and its recorded path behind would make the next
+    /// uninstall read the restored original as a user modification, move it aside and put an
+    /// identical duplicate in its place.
+    /// </summary>
+    /// <param name="file">The entry whose backup should be restored and then cleared.</param>
+    private static void RestoreAndConsumeBackup(UserDataFileEntry file)
+    {
+        RestoreBackupCopy(file.BackupPath!, file.AbsolutePath);
+        File.Delete(file.BackupPath!);
+        file.BackupPath = null;
+        file.WasOverwritten = false;
+    }
+
     private static void RestoreBackupQuietly(string? backupPath, string targetPath, bool wasOverwritten, ILogger? logger = null)
     {
         if (wasOverwritten && !string.IsNullOrEmpty(backupPath) && File.Exists(backupPath))
@@ -1227,7 +1243,7 @@ public class UserDataTrackerService(
                         Directory.CreateDirectory(targetDir);
                     }
 
-                    RestoreBackupCopy(file.BackupPath, file.AbsolutePath);
+                    RestoreAndConsumeBackup(file);
                 }
                 else
                 {

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -1223,8 +1223,10 @@ public class UserDataTrackerService(
 
     /// <summary>
     /// Removes the deployed files for a manifest and restores the pristine originals GenHub backed up.
-    /// A deployed file whose hash no longer matches is moved aside instead of being discarded, so the
-    /// user's edit survives and the backup can still be restored over the original path.
+    /// A deployed file confirmed to differ from its recorded hash is moved aside instead of being
+    /// discarded, so the user's edit survives and the backup can still be restored over the original
+    /// path. A file whose hash could not be computed is left alone: an unreadable or briefly locked
+    /// file is not evidence that the user changed it.
     /// </summary>
     /// <param name="manifest">The manifest whose installed files should be removed.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
@@ -1246,25 +1248,34 @@ public class UserDataTrackerService(
 
                 if (File.Exists(file.AbsolutePath))
                 {
-                    if (await fileOperations.VerifyFileHashAsync(file.AbsolutePath, file.SourceHash, cancellationToken))
+                    switch (await fileOperations.CheckFileHashAsync(file.AbsolutePath, file.SourceHash, cancellationToken))
                     {
-                        File.Delete(file.AbsolutePath);
-                        logger.LogDebug("[UserData] Deleted file: {Path}", file.AbsolutePath);
+                        case FileHashVerification.Match:
+                            File.Delete(file.AbsolutePath);
+                            logger.LogDebug("[UserData] Deleted file: {Path}", file.AbsolutePath);
 
-                        CleanupEmptyDirectories(Path.GetDirectoryName(file.AbsolutePath), userDataBasePath);
-                    }
-                    else if (hasBackup)
-                    {
-                        var preservedPath = MoveModifiedFileAside(file.AbsolutePath);
-                        logger.LogWarning(
-                            "[UserData] File hash mismatch for {Path}; your modified copy was preserved at {PreservedPath} so the original could be restored",
-                            file.AbsolutePath,
-                            preservedPath);
-                    }
-                    else
-                    {
-                        restoreNeeded = false;
-                        logger.LogWarning("[UserData] File hash mismatch and no backup to restore, leaving in place: {Path}", file.AbsolutePath);
+                            CleanupEmptyDirectories(Path.GetDirectoryName(file.AbsolutePath), userDataBasePath);
+                            break;
+
+                        case FileHashVerification.Mismatch when hasBackup:
+                            var preservedPath = MoveModifiedFileAside(file.AbsolutePath);
+                            logger.LogWarning(
+                                "[UserData] File hash mismatch for {Path}; your modified copy was preserved at {PreservedPath} so the original could be restored",
+                                file.AbsolutePath,
+                                preservedPath);
+                            break;
+
+                        case FileHashVerification.Mismatch:
+                            restoreNeeded = false;
+                            logger.LogWarning("[UserData] File hash mismatch and no backup to restore, leaving in place: {Path}", file.AbsolutePath);
+                            break;
+
+                        default:
+                            restoreNeeded = false;
+                            logger.LogWarning(
+                                "[UserData] Could not verify {Path} against its recorded hash, so it is left untouched along with any backup; the deployed file may still be pristine",
+                                file.AbsolutePath);
+                            break;
                     }
                 }
 

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -650,8 +650,20 @@ public class UserDataTrackerService(
                                 var manifest = await LoadUserDataManifestByKeyAsync(key, cancellationToken);
                                 if (manifest == null)
                                 {
-                                    logger.LogWarning("[UserData] No manifest found for installation key {Key}; its backups cannot be restored", key);
-                                    allBackupsRestored = false;
+                                    // A key whose manifest file is simply gone is a stale index entry
+                                    // with nothing left to restore, and must not block the cleanup
+                                    // forever. Only a manifest that exists but cannot be read leaves
+                                    // backups we can no longer put back.
+                                    if (File.Exists(GetManifestFilePath(key)))
+                                    {
+                                        logger.LogError("[UserData] Manifest for installation key {Key} could not be read; its backups cannot be restored", key);
+                                        allBackupsRestored = false;
+                                    }
+                                    else
+                                    {
+                                        logger.LogWarning("[UserData] Index entry {Key} has no manifest; nothing to restore for it", key);
+                                    }
+
                                     continue;
                                 }
 

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -724,6 +724,12 @@ public class UserDataTrackerService(
                 // 4. Re-create empty directories
                 EnsureDirectoriesExist();
 
+                if (!allBackupsRestored)
+                {
+                    return OperationResult<bool>.CreateFailure(
+                        $"Removed GenHub's tracked user data, but one or more pristine game data backups could not be restored. Your originals were kept at '{_backupsPath}'.");
+                }
+
                 return OperationResult<bool>.CreateSuccess(true);
             }
             finally

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Extensions.Enums;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Interfaces.UserData;
@@ -22,7 +23,8 @@ namespace GenHub.Features.UserData.Services;
 /// <summary>
 /// Service for tracking and managing user data files (maps, replays, etc.)
 /// that are installed to the user's Documents folder.
-/// Uses hard links to CAS content when possible for efficient disk usage.
+/// Content bound for a user-writable destination is always copied out of CAS so that later writes
+/// by the game or by GenHub cannot reach the canonical CAS object.
 /// </summary>
 public class UserDataTrackerService(
     IConfigurationProviderService configProvider,
@@ -122,7 +124,7 @@ public class UserDataTrackerService(
                 var installResult = await InstallSingleUserDataFileAsync(file, targetPath, targetGame, userDataManifest.InstallationKey, priorEntry, cancellationToken);
                 if (!installResult.Success || installResult.Data == null)
                 {
-                    await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
+                    _ = await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
                     return OperationResult<UserDataManifest>.CreateFailure(installResult.FirstError ?? $"Failed to install '{targetPath}'.");
                 }
 
@@ -143,13 +145,13 @@ public class UserDataTrackerService(
             }
             catch (OperationCanceledException)
             {
-                await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
+                _ = await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
                 throw;
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "[UserData] Failed to persist manifest or update index for {ManifestId}; cleaning up installed files", manifestId);
-                await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
+                _ = await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
                 throw;
             }
 
@@ -196,7 +198,7 @@ public class UserDataTrackerService(
 
             var manifest = manifestResult.Data;
 
-            await CleanupInstalledFilesAsync(manifest, cancellationToken);
+            _ = await CleanupInstalledFilesAsync(manifest, cancellationToken);
 
             // Remove the manifest file
             await DeleteUserDataManifestAsync(manifestId, profileId, cancellationToken);
@@ -352,7 +354,7 @@ public class UserDataTrackerService(
                                 Directory.CreateDirectory(targetDir);
                             }
 
-                            File.Copy(file.BackupPath, file.AbsolutePath, overwrite: true);
+                            RestoreBackupCopy(file.BackupPath, file.AbsolutePath);
                             logger.LogInformation("[UserData] Restored backup during deactivation: {Backup} -> {Path}", file.BackupPath, file.AbsolutePath);
                         }
                         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -623,6 +625,7 @@ public class UserDataTrackerService(
                 var index = await LoadIndexUnlockedAsync(cancellationToken);
 
                 // Uninstall all installations (this handles backup restoration and file deletion)
+                var allBackupsRestored = true;
                 foreach (var profileId in index.ProfileInstallations.Keys.ToList())
                 {
                     // Get keys for this profile
@@ -633,17 +636,24 @@ public class UserDataTrackerService(
                             try
                             {
                                 // We are already holding the lock, so we can't call UninstallUserDataAsync which tries to acquire it.
-                                // Instead, we directly clean up the files. We don't need to update the index or delete the manifest file
-                                // because we are about to delete the entire UserData directory.
+                                // Instead, we directly clean up the files.
                                 var manifest = await LoadUserDataManifestByKeyAsync(key, cancellationToken);
-                                if (manifest != null)
+                                if (manifest == null)
                                 {
-                                    await CleanupInstalledFilesAsync(manifest, cancellationToken);
+                                    logger.LogWarning("[UserData] No manifest found for installation key {Key}; its backups cannot be restored", key);
+                                    allBackupsRestored = false;
+                                    continue;
+                                }
+
+                                if (!await CleanupInstalledFilesAsync(manifest, cancellationToken))
+                                {
+                                    allBackupsRestored = false;
                                 }
                             }
                             catch (Exception ex)
                             {
                                 logger.LogError(ex, "[UserData] Failed to cleanup user data for installation key {Key}", key);
+                                allBackupsRestored = false;
                             }
                         }
                     }
@@ -662,8 +672,24 @@ public class UserDataTrackerService(
                         return OperationResult<bool>.CreateFailure("UserData tracking path does not appear to be application-specific");
                     }
 
-                    logger.LogInformation("[UserData] Deleting UserData directory: {Path}", _userDataTrackingPath);
-                    Directory.Delete(_userDataTrackingPath, true);
+                    if (allBackupsRestored)
+                    {
+                        logger.LogInformation("[UserData] Deleting UserData directory: {Path}", _userDataTrackingPath);
+                        Directory.Delete(_userDataTrackingPath, true);
+                    }
+                    else
+                    {
+                        logger.LogWarning(
+                            "[UserData] One or more pristine game data backups could not be restored, so they were NOT deleted. Your originals remain at {BackupsPath}; restore them by hand or delete that folder once you no longer need them.",
+                            _backupsPath);
+
+                        if (Directory.Exists(_manifestsPath))
+                        {
+                            Directory.Delete(_manifestsPath, true);
+                        }
+
+                        FileOperationsService.DeleteFileIfExists(_indexPath);
+                    }
                 }
 
                 // 4. Re-create empty directories
@@ -726,13 +752,46 @@ public class UserDataTrackerService(
         return path;
     }
 
+    /// <summary>
+    /// Moves a deployed file that no longer matches its recorded hash to a clearly named sibling so
+    /// the user's edit is never discarded when the pristine backup is restored over the original path.
+    /// </summary>
+    /// <param name="filePath">The deployed file to move aside.</param>
+    /// <returns>The path the modified file was moved to.</returns>
+    private static string MoveModifiedFileAside(string filePath)
+    {
+        var preservedPath = filePath + UserDataConstants.UserModifiedSuffix;
+        var attempt = 1;
+        while (File.Exists(preservedPath) || Directory.Exists(preservedPath))
+        {
+            preservedPath = $"{filePath}{UserDataConstants.UserModifiedSuffix}.{attempt}";
+            attempt++;
+        }
+
+        File.Move(filePath, preservedPath);
+        return preservedPath;
+    }
+
+    /// <summary>
+    /// Copies a backup back over a deployed path, unlinking the destination first. An older install
+    /// may have left a hard link to a CAS object there, and copying onto it in place would write the
+    /// backup's content into the canonical object rather than replacing the deployed file.
+    /// </summary>
+    /// <param name="backupPath">The backup to restore from.</param>
+    /// <param name="targetPath">The path to restore to.</param>
+    private static void RestoreBackupCopy(string backupPath, string targetPath)
+    {
+        FileOperationsService.DeleteFileIfExists(targetPath);
+        File.Copy(backupPath, targetPath, overwrite: true);
+    }
+
     private static void RestoreBackupQuietly(string? backupPath, string targetPath, bool wasOverwritten, ILogger? logger = null)
     {
         if (wasOverwritten && !string.IsNullOrEmpty(backupPath) && File.Exists(backupPath))
         {
             try
             {
-                File.Copy(backupPath, targetPath, overwrite: true);
+                RestoreBackupCopy(backupPath, targetPath);
                 File.Delete(backupPath);
             }
             catch (Exception ex)
@@ -931,24 +990,16 @@ public class UserDataTrackerService(
         var fileMaterialized = false;
         try
         {
-            var linkResult = await fileOperations.LinkFromCasAsync(
+            var (materialized, isHardLink) = await MaterializeFromCasAsync(
                 file.CasHash,
                 file.AbsolutePath,
-                useHardLink: true,
-                contentType: null,
-                cancellationToken: cancellationToken);
+                file.InstallTarget,
+                cancellationToken);
 
-            if (linkResult)
+            fileMaterialized = materialized;
+            if (materialized)
             {
-                fileMaterialized = true;
-            }
-            else
-            {
-                var copyResult = await fileOperations.CopyFromCasAsync(file.CasHash, file.AbsolutePath, contentType: null, cancellationToken: cancellationToken);
-                if (copyResult)
-                {
-                    fileMaterialized = true;
-                }
+                file.IsHardLink = isHardLink;
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -1030,7 +1081,7 @@ public class UserDataTrackerService(
             return OperationResult<UserDataFileEntry>.CreateFailure($"File '{file.RelativePath}' has no hash. Installation aborted.");
         }
 
-        var (materialized, isHardLink) = await MaterializeFileFromCasAsync(file.Hash, targetPath, backupPath, wasOverwritten, cancellationToken);
+        var (materialized, isHardLink) = await MaterializeFileFromCasAsync(file.Hash, targetPath, file.InstallTarget, backupPath, wasOverwritten, cancellationToken);
         if (!materialized)
         {
             logger.LogError("[UserData] Failed to install file {Path}; aborting installation", targetPath);
@@ -1056,31 +1107,14 @@ public class UserDataTrackerService(
     private async Task<(bool Materialized, bool IsHardLink)> MaterializeFileFromCasAsync(
         string hash,
         string targetPath,
+        ContentInstallTarget installTarget,
         string? backupPath,
         bool wasOverwritten,
         CancellationToken cancellationToken)
     {
         try
         {
-            var linkResult = await fileOperations.LinkFromCasAsync(
-                hash,
-                targetPath,
-                useHardLink: true,
-                contentType: null,
-                cancellationToken: cancellationToken);
-
-            if (linkResult)
-            {
-                logger.LogDebug("[UserData] Created hard link for {Path}", targetPath);
-                return (true, true);
-            }
-
-            var copyResult = await fileOperations.CopyFromCasAsync(hash, targetPath, contentType: null, cancellationToken: cancellationToken);
-            if (copyResult)
-            {
-                logger.LogDebug("[UserData] Copied file for {Path} (hard link failed)", targetPath);
-                return (true, false);
-            }
+            return await MaterializeFromCasAsync(hash, targetPath, installTarget, cancellationToken);
         }
         catch (OperationCanceledException)
         {
@@ -1090,6 +1124,58 @@ public class UserDataTrackerService(
         catch (Exception ex)
         {
             logger.LogError(ex, "[UserData] Exception while materializing file {Path} from CAS", targetPath);
+        }
+
+        return (false, false);
+    }
+
+    /// <summary>
+    /// Materializes CAS content at the destination. User-writable destinations always receive an
+    /// independent copy: a hard link would share the underlying storage with the CAS object, so any
+    /// in-place write by the game or by GenHub would rewrite the canonical object and break the
+    /// hash-to-content invariant for every profile referencing it.
+    /// </summary>
+    /// <param name="hash">The CAS hash of the content to materialize.</param>
+    /// <param name="targetPath">The destination file path.</param>
+    /// <param name="installTarget">The install target the destination was resolved from.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>Whether the file was materialized and whether it is a hard link.</returns>
+    private async Task<(bool Materialized, bool IsHardLink)> MaterializeFromCasAsync(
+        string hash,
+        string targetPath,
+        ContentInstallTarget installTarget,
+        CancellationToken cancellationToken)
+    {
+        if (installTarget.IsUserWritableTarget())
+        {
+            var userCopyResult = await fileOperations.CopyFromCasAsync(hash, targetPath, contentType: null, cancellationToken: cancellationToken);
+            if (userCopyResult)
+            {
+                logger.LogDebug("[UserData] Copied file for {Path} (user-writable destination)", targetPath);
+                return (true, false);
+            }
+
+            return (false, false);
+        }
+
+        var linkResult = await fileOperations.LinkFromCasAsync(
+            hash,
+            targetPath,
+            useHardLink: true,
+            contentType: null,
+            cancellationToken: cancellationToken);
+
+        if (linkResult)
+        {
+            logger.LogDebug("[UserData] Created hard link for {Path}", targetPath);
+            return (true, true);
+        }
+
+        var copyResult = await fileOperations.CopyFromCasAsync(hash, targetPath, contentType: null, cancellationToken: cancellationToken);
+        if (copyResult)
+        {
+            logger.LogDebug("[UserData] Copied file for {Path} (hard link failed)", targetPath);
+            return (true, false);
         }
 
         return (false, false);
@@ -1109,7 +1195,7 @@ public class UserDataTrackerService(
                         Directory.CreateDirectory(targetDir);
                     }
 
-                    File.Copy(file.BackupPath, file.AbsolutePath, overwrite: true);
+                    RestoreBackupCopy(file.BackupPath, file.AbsolutePath);
                 }
                 else
                 {
@@ -1135,34 +1221,54 @@ public class UserDataTrackerService(
 
     private string GetUserDataBasePath(GameType gameType) => pathProvider.GetOptionsDirectory(gameType);
 
-    private async Task CleanupInstalledFilesAsync(UserDataManifest manifest, CancellationToken cancellationToken)
+    /// <summary>
+    /// Removes the deployed files for a manifest and restores the pristine originals GenHub backed up.
+    /// A deployed file whose hash no longer matches is moved aside instead of being discarded, so the
+    /// user's edit survives and the backup can still be restored over the original path.
+    /// </summary>
+    /// <param name="manifest">The manifest whose installed files should be removed.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns><c>true</c> when every backup for the manifest was restored; otherwise, <c>false</c>.</returns>
+    private async Task<bool> CleanupInstalledFilesAsync(UserDataManifest manifest, CancellationToken cancellationToken)
     {
         var userDataBasePath = GetUserDataBasePath(manifest.TargetGame);
+        var allBackupsRestored = true;
+
         foreach (var file in manifest.InstalledFiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            var hasBackup = !string.IsNullOrEmpty(file.BackupPath) && File.Exists(file.BackupPath);
+
             try
             {
+                var restoreNeeded = hasBackup;
+
                 if (File.Exists(file.AbsolutePath))
                 {
-                    // Verify we should delete this file (hash matches)
                     if (await fileOperations.VerifyFileHashAsync(file.AbsolutePath, file.SourceHash, cancellationToken))
                     {
                         File.Delete(file.AbsolutePath);
                         logger.LogDebug("[UserData] Deleted file: {Path}", file.AbsolutePath);
 
-                        // Clean up empty directories up to the base user data path
                         CleanupEmptyDirectories(Path.GetDirectoryName(file.AbsolutePath), userDataBasePath);
+                    }
+                    else if (hasBackup)
+                    {
+                        var preservedPath = MoveModifiedFileAside(file.AbsolutePath);
+                        logger.LogWarning(
+                            "[UserData] File hash mismatch for {Path}; your modified copy was preserved at {PreservedPath} so the original could be restored",
+                            file.AbsolutePath,
+                            preservedPath);
                     }
                     else
                     {
-                        logger.LogWarning("[UserData] File hash mismatch, user may have modified: {Path}", file.AbsolutePath);
+                        restoreNeeded = false;
+                        logger.LogWarning("[UserData] File hash mismatch and no backup to restore, leaving in place: {Path}", file.AbsolutePath);
                     }
                 }
 
-                // Restore backup if exists and target file was removed or absent
-                if (!File.Exists(file.AbsolutePath) && !string.IsNullOrEmpty(file.BackupPath) && File.Exists(file.BackupPath))
+                if (restoreNeeded)
                 {
                     var targetDir = Path.GetDirectoryName(file.AbsolutePath);
                     if (!string.IsNullOrEmpty(targetDir))
@@ -1170,15 +1276,30 @@ public class UserDataTrackerService(
                         Directory.CreateDirectory(targetDir);
                     }
 
-                    File.Move(file.BackupPath, file.AbsolutePath, overwrite: true);
+                    File.Move(file.BackupPath!, file.AbsolutePath, overwrite: true);
                     logger.LogInformation("[UserData] Restored backup: {Backup} -> {Path}", file.BackupPath, file.AbsolutePath);
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "[UserData] Failed to uninstall file: {Path}", file.AbsolutePath);
             }
+
+            if (hasBackup && File.Exists(file.BackupPath!))
+            {
+                allBackupsRestored = false;
+                logger.LogWarning(
+                    "[UserData] Backup for {Path} was not restored and is still held at {BackupPath}",
+                    file.AbsolutePath,
+                    file.BackupPath);
+            }
         }
+
+        return allBackupsRestored;
     }
 
     private void EnsureDirectoriesExist()

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -660,6 +660,12 @@ public class UserDataTrackerService(
                                     allBackupsRestored = false;
                                 }
                             }
+                            catch (OperationCanceledException)
+                            {
+                                // Abort before step 3 removes the manifests and the index: those are
+                                // the only map from a backup file back to the path it belongs at.
+                                throw;
+                            }
                             catch (Exception ex)
                             {
                                 logger.LogError(ex, "[UserData] Failed to cleanup user data for installation key {Key}", key);
@@ -711,6 +717,10 @@ public class UserDataTrackerService(
             {
                 IndexLock.Release();
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -124,8 +124,13 @@ public class UserDataTrackerService(
                 var installResult = await InstallSingleUserDataFileAsync(file, targetPath, targetGame, userDataManifest.InstallationKey, priorEntry, cancellationToken);
                 if (!installResult.Success || installResult.Data == null)
                 {
-                    _ = await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
-                    return OperationResult<UserDataManifest>.CreateFailure(installResult.FirstError ?? $"Failed to install '{targetPath}'.");
+                    var error = installResult.FirstError ?? $"Failed to install '{targetPath}'.";
+                    if (!await CleanupFailedInstallAsync(userDataManifest, manifestId))
+                    {
+                        error += $" Some of your original files could not be put back and were kept at '{_backupsPath}'.";
+                    }
+
+                    return OperationResult<UserDataManifest>.CreateFailure(error);
                 }
 
                 var entry = installResult.Data;
@@ -145,13 +150,13 @@ public class UserDataTrackerService(
             }
             catch (OperationCanceledException)
             {
-                _ = await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
+                _ = await CleanupFailedInstallAsync(userDataManifest, manifestId);
                 throw;
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "[UserData] Failed to persist manifest or update index for {ManifestId}; cleaning up installed files", manifestId);
-                _ = await CleanupInstalledFilesAsync(userDataManifest, CancellationToken.None);
+                _ = await CleanupFailedInstallAsync(userDataManifest, manifestId);
                 throw;
             }
 
@@ -1274,6 +1279,28 @@ public class UserDataTrackerService(
     }
 
     private string GetUserDataBasePath(GameType gameType) => pathProvider.GetOptionsDirectory(gameType);
+
+    /// <summary>
+    /// Rolls a failed installation back. The manifest has not been persisted at this point, so a
+    /// backup that cannot be put back is referenced by nothing at all; say so loudly rather than
+    /// leaving the user to identify a machine-named file in the backups tree.
+    /// </summary>
+    /// <param name="manifest">The partially installed manifest to roll back.</param>
+    /// <param name="manifestId">The manifest identifier, for logging.</param>
+    /// <returns><c>true</c> when every backup was restored; otherwise, <c>false</c>.</returns>
+    private async Task<bool> CleanupFailedInstallAsync(UserDataManifest manifest, string manifestId)
+    {
+        if (await CleanupInstalledFilesAsync(manifest, CancellationToken.None))
+        {
+            return true;
+        }
+
+        logger.LogError(
+            "[UserData] Rolling back the failed install of {ManifestId} left one or more originals unrestored; they are kept at {BackupsPath} but no manifest records where they belong",
+            manifestId,
+            _backupsPath);
+        return false;
+    }
 
     /// <summary>
     /// Removes the deployed files for a manifest and restores the pristine originals GenHub backed up.

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -446,7 +446,10 @@ public class FileOperationsService(
         {
             if (!File.Exists(filePath))
             {
-                return FileHashVerification.Mismatch;
+                // No hash was computed, so nothing is known about the content that used to be here.
+                // Reporting a mismatch would invite a caller to act on a change it never observed.
+                logger.LogDebug("Hash verification for {File}: file does not exist", filePath);
+                return FileHashVerification.Failed;
             }
 
             var actualHash = await downloadService.ComputeFileHashAsync(

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -152,11 +152,27 @@ public class FileOperationsService(
         const int MaxRetries = 3;
         const int InitialDelayMs = 50;
 
+        if (IsSamePath(sourcePath, destinationPath))
+        {
+            logger.LogDebug("Skipped copy because source and destination are the same path: {Source}", sourcePath);
+            return;
+        }
+
         for (int attempt = 0; attempt <= MaxRetries; attempt++)
         {
             try
             {
                 EnsureDirectoryExists(destinationPath);
+
+                // Open the source before touching the destination: a missing or unreadable source
+                // must fail without having destroyed a valid file already sitting at the destination.
+                await using var source = new FileStream(
+                    sourcePath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    BufferSize,
+                    useAsync: true);
 
                 // Always unlink an existing destination rather than truncating it. A symlink left by
                 // the Symlink strategy, or a hard link to a CAS object, would otherwise receive the
@@ -166,13 +182,6 @@ public class FileOperationsService(
                     logger.LogDebug("Removed existing destination at {Destination} before copying", destinationPath);
                 }
 
-                await using var source = new FileStream(
-                    sourcePath,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read,
-                    BufferSize,
-                    useAsync: true);
                 await using var destination = new FileStream(
                     destinationPath,
                     FileMode.Create,
@@ -651,6 +660,28 @@ public class FileOperationsService(
         {
             logger.LogError(ex, "Exception opening CAS content stream for hash {Hash}", hash);
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether two paths name the same file, so a copy never unlinks its own source.
+    /// </summary>
+    /// <param name="path1">First path to compare.</param>
+    /// <param name="path2">Second path to compare.</param>
+    /// <returns>True if both paths resolve to the same location.</returns>
+    private static bool IsSamePath(string path1, string path2)
+    {
+        try
+        {
+            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            return string.Equals(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(path1)),
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(path2)),
+                comparison);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
         }
     }
 

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -158,16 +158,12 @@ public class FileOperationsService(
             {
                 EnsureDirectoryExists(destinationPath);
 
-                // If destination exists and is a symlink/reparse point, delete it first
-                // This prevents issues when switching from Symlink strategy to FullCopy strategy
-                if (File.Exists(destinationPath))
+                // Always unlink an existing destination rather than truncating it. A symlink left by
+                // the Symlink strategy, or a hard link to a CAS object, would otherwise receive the
+                // write through to its target instead of yielding an independent copy here.
+                if (DeleteFileIfExists(destinationPath))
                 {
-                    var destInfo = new FileInfo(destinationPath);
-                    if (destInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
-                    {
-                        logger.LogDebug("Removing existing symlink at {Destination} before copying", destinationPath);
-                        destInfo.Delete();
-                    }
+                    logger.LogDebug("Removed existing destination at {Destination} before copying", destinationPath);
                 }
 
                 await using var source = new FileStream(

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -689,23 +689,64 @@ public class FileOperationsService(
 
     /// <summary>
     /// Determines whether two paths name the same file, so a copy never unlinks its own source.
+    /// Symbolic links and junctions are followed to their final target, so a path reached through a
+    /// link still compares equal to the file it points at. Hard links and Windows 8.3 short names
+    /// have no resolvable target and are not detected here; opening the source before unlinking the
+    /// destination is what makes those cases fail safely rather than destructively.
     /// </summary>
     /// <param name="path1">First path to compare.</param>
     /// <param name="path2">Second path to compare.</param>
     /// <returns>True if both paths resolve to the same location.</returns>
     private static bool IsSamePath(string path1, string path2)
     {
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var resolved1 = ResolveFinalPath(path1);
+        var resolved2 = ResolveFinalPath(path2);
+
+        return resolved1 != null &&
+               resolved2 != null &&
+               string.Equals(resolved1, resolved2, comparison);
+    }
+
+    /// <summary>
+    /// Normalizes a path and follows any symbolic link or junction to its final target.
+    /// </summary>
+    /// <param name="path">The path to resolve.</param>
+    /// <returns>The resolved path, or <c>null</c> when the path cannot be normalized.</returns>
+    private static string? ResolveFinalPath(string path)
+    {
+        string fullPath;
         try
         {
-            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-            return string.Equals(
-                Path.TrimEndingDirectorySeparator(Path.GetFullPath(path1)),
-                Path.TrimEndingDirectorySeparator(Path.GetFullPath(path2)),
-                comparison);
+            fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        catch (ArgumentException)
         {
-            return false;
+            return null;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+        catch (PathTooLongException)
+        {
+            return null;
+        }
+
+        try
+        {
+            var target = File.ResolveLinkTarget(fullPath, returnFinalTarget: true);
+            return target == null
+                ? fullPath
+                : Path.TrimEndingDirectorySeparator(target.FullName);
+        }
+        catch (IOException)
+        {
+            return fullPath;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return fullPath;
         }
     }
 

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -152,9 +152,9 @@ public class FileOperationsService(
         const int MaxRetries = 3;
         const int InitialDelayMs = 50;
 
-        if (IsSamePath(sourcePath, destinationPath))
+        if (WouldCopyOntoItself(sourcePath, destinationPath))
         {
-            logger.LogDebug("Skipped copy because source and destination are the same path: {Source}", sourcePath);
+            logger.LogDebug("Skipped copy because source and destination are the same file: {Source}", sourcePath);
             return;
         }
 
@@ -688,37 +688,59 @@ public class FileOperationsService(
     }
 
     /// <summary>
-    /// Determines whether two paths name the same file, so a copy never unlinks its own source.
-    /// Symbolic links and junctions are followed to their final target, so a path reached through a
-    /// link still compares equal to the file it points at. Hard links and Windows 8.3 short names
-    /// have no resolvable target and are not detected here; opening the source before unlinking the
-    /// destination is what makes those cases fail safely rather than destructively.
+    /// Determines whether a copy would do nothing but unlink the file it is reading, in which case
+    /// there is nothing to copy and the file must be left alone.
+    /// <para>
+    /// A destination that is itself a symbolic link never qualifies, even when it resolves to the
+    /// source. Callers copy precisely to replace such a link with an independent file, and unlinking
+    /// a link leaves the file it points at untouched. Only a destination that is a real file naming
+    /// the same file as the source qualifies - the identical path, or the file a source link points
+    /// at - because unlinking that would destroy the only copy.
+    /// </para>
+    /// <para>
+    /// Hard links and Windows 8.3 short names have no resolvable target and are not detected here;
+    /// opening the source before unlinking the destination is what makes those cases fail safely
+    /// rather than destructively.
+    /// </para>
     /// </summary>
-    /// <param name="path1">First path to compare.</param>
-    /// <param name="path2">Second path to compare.</param>
-    /// <returns>True if both paths resolve to the same location.</returns>
-    private static bool IsSamePath(string path1, string path2)
+    /// <param name="sourcePath">The file being read.</param>
+    /// <param name="destinationPath">The path being written.</param>
+    /// <returns>True when the copy must be skipped.</returns>
+    private static bool WouldCopyOntoItself(string sourcePath, string destinationPath)
     {
-        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        var resolved1 = ResolveFinalPath(path1);
-        var resolved2 = ResolveFinalPath(path2);
+        var source = TryGetFullPath(sourcePath);
+        var destination = TryGetFullPath(destinationPath);
 
-        return resolved1 != null &&
-               resolved2 != null &&
-               string.Equals(resolved1, resolved2, comparison);
+        if (source is null || destination is null)
+        {
+            return false;
+        }
+
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        if (string.Equals(source, destination, comparison))
+        {
+            return true;
+        }
+
+        if (TryResolveLinkTarget(destination) is not null)
+        {
+            return false;
+        }
+
+        return string.Equals(TryResolveLinkTarget(source) ?? source, destination, comparison);
     }
 
     /// <summary>
-    /// Normalizes a path and follows any symbolic link or junction to its final target.
+    /// Normalizes a path without consulting the file system.
     /// </summary>
-    /// <param name="path">The path to resolve.</param>
-    /// <returns>The resolved path, or <c>null</c> when the path cannot be normalized.</returns>
-    private static string? ResolveFinalPath(string path)
+    /// <param name="path">The path to normalize.</param>
+    /// <returns>The normalized path, or <c>null</c> when the path cannot be normalized.</returns>
+    private static string? TryGetFullPath(string path)
     {
-        string fullPath;
         try
         {
-            fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+            return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
         }
         catch (ArgumentException)
         {
@@ -732,21 +754,27 @@ public class FileOperationsService(
         {
             return null;
         }
+    }
 
+    /// <summary>
+    /// Follows a symbolic link or junction to its final target.
+    /// </summary>
+    /// <param name="fullPath">The normalized path to inspect.</param>
+    /// <returns>The final target, or <c>null</c> when the path is not a link or cannot be read.</returns>
+    private static string? TryResolveLinkTarget(string fullPath)
+    {
         try
         {
             var target = File.ResolveLinkTarget(fullPath, returnFinalTarget: true);
-            return target == null
-                ? fullPath
-                : Path.TrimEndingDirectorySeparator(target.FullName);
+            return target is null ? null : Path.TrimEndingDirectorySeparator(target.FullName);
         }
         catch (IOException)
         {
-            return fullPath;
+            return null;
         }
         catch (UnauthorizedAccessException)
         {
-            return fullPath;
+            return null;
         }
     }
 

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -427,15 +427,32 @@ public class FileOperationsService(
     {
         try
         {
+            return await CheckFileHashAsync(filePath, expectedHash, cancellationToken) == FileHashVerification.Match;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to verify hash for {File}", filePath);
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<FileHashVerification> CheckFileHashAsync(
+        string filePath,
+        string expectedHash,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
             if (!File.Exists(filePath))
             {
-                return false;
+                return FileHashVerification.Mismatch;
             }
 
             var actualHash = await downloadService.ComputeFileHashAsync(
                 filePath,
                 cancellationToken);
-            var result = string.Equals(
+            var matches = string.Equals(
                 actualHash,
                 expectedHash,
                 StringComparison.OrdinalIgnoreCase);
@@ -443,13 +460,17 @@ public class FileOperationsService(
             logger.LogDebug(
                 "Hash verification for {File}: {Result}",
                 filePath,
-                result);
-            return result;
+                matches);
+            return matches ? FileHashVerification.Match : FileHashVerification.Mismatch;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to verify hash for {File}", filePath);
-            return false;
+            logger.LogError(ex, "Failed to compute hash for {File}", filePath);
+            return FileHashVerification.Failed;
         }
     }
 

--- a/GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs
@@ -47,6 +47,10 @@ public class UnixFileOperationsService(
         => baseService.VerifyFileHashAsync(filePath, expectedHash, cancellationToken);
 
     /// <inheritdoc/>
+    public Task<FileHashVerification> CheckFileHashAsync(string filePath, string expectedHash, CancellationToken cancellationToken = default)
+        => baseService.CheckFileHashAsync(filePath, expectedHash, cancellationToken);
+
+    /// <inheritdoc/>
     public Task DownloadFileAsync(Uri url, string destinationPath, IProgress<DownloadProgress>? progress = null, CancellationToken cancellationToken = default)
         => baseService.DownloadFileAsync(url, destinationPath, progress, cancellationToken);
 

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/SharedViewModelModule.cs
@@ -57,6 +57,7 @@ public static class SharedViewModelModule
             sp.GetRequiredService<IGameInstallationService>(),
             sp.GetRequiredService<IStorageLocationService>(),
             sp.GetRequiredService<IUserDataTracker>(),
+            sp.GetRequiredService<IDialogService>(),
             sp.GetService<IGitHubTokenStorage>()));
         services.AddSingleton<GameProfileSettingsViewModel>();
 

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -61,6 +61,9 @@ Application-wide constants for GenHub.
 | `DefaultTheme`            | `Theme.Dark`        | Default UI theme                                 |
 | `DefaultThemeName`        | `"Dark"`            | Default theme name as string                     |
 | `TokenFileName`           | `".ghtoken"`        | Default GitHub token file name                   |
+| `DeleteAllDataConfirmationTitle`   | `"Delete All Application Data"` | Title of the confirmation prompt shown before all application data is deleted |
+| `DeleteAllDataConfirmationMessage` | string              | Body of that prompt, warning that the deletion is irreversible and that pristine game data backups are discarded |
+| `DeleteAllDataConfirmText`         | `"Delete Everything"` | Confirm button text for the delete-all-application-data prompt |
 
 ---
 
@@ -1309,6 +1312,7 @@ Constants for content pipeline component identifiers used in dependency injectio
 - **StorageConstants**: Storage and CAS operation constants
 - **TimeIntervals**: Time spans and intervals
 - **UiConstants**: User interface sizing and behavior
+- **UserDataConstants**: Tracked user data installation constants
 - **ValidationLimits**: Input validation boundaries
 
 ### Best Practices
@@ -1511,6 +1515,17 @@ Constants specifically for the Map Manager feature.
 | `ToolId`                       | `"map-manager"`                            | Unique identifier for Map Manager                                                     |
 | `ToolName`                     | `"Map Manager"`                            | Display name for Map Manager                                                          |
 | `ToolDescription`              | `"Manage, import, and share custom maps. Create MapPacks for easy profile switching."` | Description of the tool |
+
+---
+
+## UserDataConstants Class
+
+Constants for tracked user data installations — content GenHub deploys into the user's game data
+folder under `Documents`.
+
+| Constant             | Value              | Description                                                                                                       |
+| -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `UserModifiedSuffix` | `".user-modified"` | Suffix appended to a deployed file that no longer matches its recorded hash when it is moved aside so the pristine backup can be restored over it |
 
 ---
 


### PR DESCRIPTION
## Problem

Three defects around user data, the first of which silently corrupts content-addressable storage.

**1. Mutable user data was hard-linked directly to CAS objects.** `UserDataTrackerService` materialized content with `useHardLink: true` into the user's real game data directory (`Documents\Command and Conquer Generals Zero Hour Data`) — the directory the game engine and GenHub both write to. A hard link shares the inode, and `GameSettingsService` writes there with `File.WriteAllLinesAsync`, which truncates in place. Any such write therefore rewrote the canonical CAS object, breaking the hash-to-content invariant for **every profile** referencing that hash, with no detection and no user-visible symptom until hashes started failing. GeneralsOnline routes its data patch (community balance and core INI files) through exactly this path.

**2. "Delete All Application Data" had no confirmation.** The button was bound straight to the command — one click, irreversible, and it discards the pristine game data backups.

**3. A hash mismatch silently forfeited the user's backup.** In `CleanupInstalledFilesAsync`, if the deployed file failed hash verification (i.e. the user or game had modified it) the file was left in place and only logged; the restore was then guarded by `!File.Exists(...)`, which was consequently false, so the backup was never restored — and `DeleteAllUserDataAsync` then deleted the backups directory. The modified file stayed and the pristine original was gone forever. Defect 1 is what makes those files get modified in the first place, so the two compound.

## Changes

- **Copy, never link, for user-writable destinations.** New `ContentInstallTargetExtensions.IsUserWritableTarget()` covers `UserDataDirectory`, `UserMapsDirectory`, `UserReplaysDirectory` and `UserScreenshotsDirectory`; both materialization paths funnel through a single helper that calls `CopyFromCasAsync` for those targets and never reaches `LinkFromCasAsync`. The decision is gated on the install target, not hardcoded.
- **Fixed the same defect class in the restore paths.** `RestoreBackupQuietly`, `RollbackActivatedFiles` and the deactivation restore used `File.Copy(..., overwrite: true)`, which truncates in place — on an existing hard-linked deployment that would write backup content *into* the CAS object on the first uninstall after upgrading. They now unlink the destination first. `FileOperationsService.CopyFileAsync` had the same hazard and now unlinks via `DeleteFileIfExists` rather than only handling reparse points.
- **Confirmation before deletion**, reusing the existing `IDialogService.ShowConfirmationAsync` pattern already used by profile deletion. The prompt states the action is irreversible and that backups are discarded, and deliberately has no `sessionKey` so it cannot be suppressed. The gate lives in the command, not the view, so it is unit-testable.
- **Hash mismatch now preserves both files.** An explicit restore-needed flag replaces the `!File.Exists(...)` guard; the modified file is moved aside to `<name>.user-modified` (collision-suffixed) and the backup is restored. `DeleteAllUserDataAsync` tracks failed restores and missing manifests, and on failure keeps the backups directory, deleting only the manifests and index, with a warning naming the retained path.

## Tests

1638 -> 1645, all passing.

The independent-copy test uses a real CAS directory and a link mock that creates a genuine hard link, so the copy-vs-link distinction is real rather than simulated. Verified it bites: flipping `IsUserWritableTarget` back to `false` for `UserDataDirectory` fails the assertion with the CAS object reading back `engine-rewrote-this-file...` instead of `pristine-cas-content`.

- user-writable target deploys an independent copy
- hash mismatch preserves the modified file and restores the backup
- delete-all retains backups when a restore failed, clears them when all succeeded
- delete-all deletes nothing when confirmation is declined, proceeds when accepted, and warns that backups are discarded

## Notes

An earlier revision of this branch also marked CAS objects read-only as defense in depth. That was removed deliberately: on NTFS a hard link shares one attribute record, and `HardLinkStrategy` links CAS objects straight into workspaces, so it would have made every workspace file read-only and changed workspace deletion behavior on Windows — untestable from this machine, and the guarantee decayed on the first workspace delete anyway. The copy-not-link change closes the reported corruption vector on its own. Worth revisiting separately with Windows coverage.