### PR TITLE
fix(config): preserve profiles, settings and workspace metadata across the v0.0.3 upgrade

### DIFF
--- a/GenHub/GenHub.Core/Constants/DirectoryNames.cs
+++ b/GenHub/GenHub.Core/Constants/DirectoryNames.cs
@@ -51,6 +51,11 @@ public static class DirectoryNames
     public const string Profiles = "Profiles";
 
     /// <summary>
+    /// Directory holding manifests authored by the user, alongside <see cref="FileTypes.ManifestsDirectory"/>.
+    /// </summary>
+    public const string CustomManifests = "CustomManifests";
+
+    /// <summary>
     /// Directory that releases up to v0.0.3 nested the manifests, tracked user data and workspace
     /// metadata under. Current releases keep those entries directly in the data root.
     /// </summary>

--- a/GenHub/GenHub.Core/Constants/DirectoryNames.cs
+++ b/GenHub/GenHub.Core/Constants/DirectoryNames.cs
@@ -51,9 +51,33 @@ public static class DirectoryNames
     public const string Profiles = "Profiles";
 
     /// <summary>
+    /// Directory that releases up to v0.0.3 nested the manifests, tracked user data and workspace
+    /// metadata under. Current releases keep those entries directly in the data root.
+    /// </summary>
+    public const string LegacyContent = "Content";
+
+    /// <summary>
     /// Directory for storing tracked user data.
     /// </summary>
     public const string UserData = "UserData";
+
+    /// <summary>
+    /// Directory holding the manifests of tracked user data, nested inside <see cref="UserData"/>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately lower-case and separate from <see cref="FileTypes.ManifestsDirectory"/>: this is
+    /// the exact name written to disk, and matching case matters on case-sensitive filesystems.
+    /// </remarks>
+    public const string UserDataManifests = "manifests";
+
+    /// <summary>
+    /// Directory holding backups of replaced user data files, nested inside <see cref="UserData"/>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately lower-case and separate from <see cref="Backups"/>: this is the exact name
+    /// written to disk, and matching case matters on case-sensitive filesystems.
+    /// </remarks>
+    public const string UserDataBackups = "backups";
 
     /// <summary>
     /// Directory for storing workspaces.

--- a/GenHub/GenHub.Core/Constants/DirectoryNames.cs
+++ b/GenHub/GenHub.Core/Constants/DirectoryNames.cs
@@ -51,6 +51,11 @@ public static class DirectoryNames
     public const string Profiles = "Profiles";
 
     /// <summary>
+    /// Directory for storing tracked user data.
+    /// </summary>
+    public const string UserData = "UserData";
+
+    /// <summary>
     /// Directory for storing workspaces.
     /// </summary>
     public const string Workspaces = "Workspaces";

--- a/GenHub/GenHub.Core/Constants/FileTypes.cs
+++ b/GenHub/GenHub.Core/Constants/FileTypes.cs
@@ -36,6 +36,11 @@ public static class FileTypes
     public const string SettingsFileName = "settings.json";
 
     /// <summary>
+    /// File name holding the persisted workspace metadata.
+    /// </summary>
+    public const string WorkspaceMetadataFileName = "workspaces.json";
+
+    /// <summary>
     /// File extension for replay files.
     /// </summary>
     public const string ReplayFileExtension = ".rep";

--- a/GenHub/GenHub.Core/Constants/FileTypes.cs
+++ b/GenHub/GenHub.Core/Constants/FileTypes.cs
@@ -36,9 +36,20 @@ public static class FileTypes
     public const string SettingsFileName = "settings.json";
 
     /// <summary>
+    /// Settings file name written by releases up to v0.0.3, which combined the data root with the
+    /// JSON extension instead of the settings file name.
+    /// </summary>
+    public const string LegacySettingsFileName = ".json";
+
+    /// <summary>
     /// File name holding the persisted workspace metadata.
     /// </summary>
     public const string WorkspaceMetadataFileName = "workspaces.json";
+
+    /// <summary>
+    /// File name of the index tracking installed user data.
+    /// </summary>
+    public const string UserDataIndexFileName = "index.json";
 
     /// <summary>
     /// File extension for replay files.

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Security;
 
 namespace GenHub.Core.Helpers;
 
@@ -25,6 +26,28 @@ public static class PathHelper
         OperatingSystem.IsWindows()
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
+
+    /// <summary>
+    /// Determines whether two paths point at the same filesystem location, normalizing both and
+    /// comparing them with the platform-appropriate case sensitivity.
+    /// </summary>
+    /// <param name="first">The first path.</param>
+    /// <param name="second">The second path.</param>
+    /// <returns><see langword="true"/> when both paths resolve to the same location.</returns>
+    public static bool AreSamePath(string first, string second)
+    {
+        try
+        {
+            return string.Equals(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(first)),
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(second)),
+                PathComparison);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+        {
+            return string.Equals(first, second, PathComparison);
+        }
+    }
 
     /// <summary>
     /// Gets the parent directory of a path, with fallback to the path itself if at drive root.

--- a/GenHub/GenHub.Core/Interfaces/Common/IAppConfiguration.cs
+++ b/GenHub/GenHub.Core/Interfaces/Common/IAppConfiguration.cs
@@ -12,6 +12,10 @@ public interface IAppConfiguration
     /// <returns>The root application data path.</returns>
     string GetConfiguredDataPath();
 
+    /// <summary>Gets the root application data path used by releases up to v0.0.3, which stored data under the roaming profile.</summary>
+    /// <returns>The legacy root application data path.</returns>
+    string GetLegacyConfiguredDataPath();
+
     /// <summary>Gets the default workspace path for GenHub.</summary>
     /// <returns>The default workspace path.</returns>
     string GetDefaultWorkspacePath();

--- a/GenHub/GenHub.Core/Models/Enums/WorkspaceStrategy.cs
+++ b/GenHub/GenHub.Core/Models/Enums/WorkspaceStrategy.cs
@@ -6,27 +6,31 @@ namespace GenHub.Core.Models.Enums;
 /// <summary>
 /// Workspace preparation strategy preference.
 /// </summary>
+/// <remarks>
+/// The numeric values are part of the on-disk format for workspace metadata written by
+/// releases up to v0.0.3 and must not be reordered.
+/// </remarks>
 [JsonConverter(typeof(JsonWorkspaceStrategyConverter))]
 public enum WorkspaceStrategy
 {
     /// <summary>
-    /// Hard link strategy - creates hard links where possible, copies otherwise. Space-efficient, requires same volume.
-    /// Default strategy for new profiles.
-    /// </summary>
-    HardLink = 0,
-
-    /// <summary>
     /// Symlink only strategy - creates symbolic links to all files. Minimal disk usage, requires admin rights.
     /// </summary>
-    SymlinkOnly = 1,
+    SymlinkOnly = 0,
 
     /// <summary>
     /// Full copy strategy - copies all files to workspace. Maximum compatibility and isolation, highest disk usage.
     /// </summary>
-    FullCopy = 2,
+    FullCopy = 1,
 
     /// <summary>
     /// Hybrid copy/symlink strategy - copies essential files, symlinks others. Balanced disk usage and compatibility.
     /// </summary>
-    HybridCopySymlink = 3,
+    HybridCopySymlink = 2,
+
+    /// <summary>
+    /// Hard link strategy - creates hard links where possible, copies otherwise. Space-efficient, requires same volume.
+    /// Default strategy for new profiles.
+    /// </summary>
+    HardLink = 3,
 }

--- a/GenHub/GenHub.Core/Models/Enums/WorkspaceStrategy.cs
+++ b/GenHub/GenHub.Core/Models/Enums/WorkspaceStrategy.cs
@@ -7,8 +7,17 @@ namespace GenHub.Core.Models.Enums;
 /// Workspace preparation strategy preference.
 /// </summary>
 /// <remarks>
-/// The numeric values are part of the on-disk format for workspace metadata written by
-/// releases up to v0.0.3 and must not be reordered.
+/// <para>
+/// The numeric values are part of the on-disk format. Releases up to v0.0.3 serialized workspace
+/// metadata without an enum converter, so <c>workspaces.json</c> holds raw ordinals in this order;
+/// they must not be reordered. Profile files are unaffected: v0.0.3 wrote the member name.
+/// </para>
+/// <para>
+/// Builds of the default branch made after v0.0.3 and before this ordering was restored wrote
+/// ordinals under a reordered enum, so numbers they persisted are now read as a different member
+/// (<c>0</c> meant HardLink there and means SymlinkOnly here). No release is affected, but such an
+/// install should have its <c>workspaces.json</c> and profile strategies checked after upgrading.
+/// </para>
 /// </remarks>
 [JsonConverter(typeof(JsonWorkspaceStrategyConverter))]
 public enum WorkspaceStrategy

--- a/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
+++ b/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
@@ -7,8 +7,8 @@ using GenHub.Core.Models.Enums;
 namespace GenHub.Core.Serialization;
 
 /// <summary>
-/// Custom JSON converter for WorkspaceStrategy that supports both string and integer formats.
-/// Provides backward compatibility for integer-based strategy values.
+/// Custom JSON converter for WorkspaceStrategy that writes the member name and reads both string
+/// and integer formats, so metadata written by releases up to v0.0.3 still deserializes.
 /// </summary>
 public class JsonWorkspaceStrategyConverter : JsonConverter<WorkspaceStrategy>
 {
@@ -53,6 +53,6 @@ public class JsonWorkspaceStrategyConverter : JsonConverter<WorkspaceStrategy>
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, WorkspaceStrategy value, JsonSerializerOptions options)
     {
-        writer.WriteNumberValue((int)value);
+        writer.WriteStringValue(value.ToString());
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
@@ -914,12 +914,12 @@ public class ConfigurationProviderServiceTests
         {
             SeedLegacyRoot(legacyRoot);
 
-            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot);
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
 
             Assert.Equal("profile", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json")));
             Assert.Equal("manifest", File.ReadAllText(Path.Combine(newRoot, FileTypes.ManifestsDirectory, "content.manifest.json")));
-            Assert.Equal("index", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.UserData, "index.json")));
-            Assert.Equal("backup", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.UserData, "backups", "save.bak")));
+            Assert.Equal("index", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.UserData, FileTypes.UserDataIndexFileName)));
+            Assert.Equal("backup", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.UserData, DirectoryNames.UserDataBackups, "save.bak")));
             Assert.Equal("settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
             Assert.Equal("workspaces", File.ReadAllText(Path.Combine(newRoot, FileTypes.WorkspaceMetadataFileName)));
 
@@ -944,8 +944,8 @@ public class ConfigurationProviderServiceTests
             SeedLegacyRoot(legacyRoot);
             var provider = CreateProvider();
 
-            provider.MigrateLegacyDataRoot(legacyRoot, newRoot);
-            provider.MigrateLegacyDataRoot(legacyRoot, newRoot);
+            provider.MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
+            provider.MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
 
             Assert.Equal("profile", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json")));
             Assert.Equal("settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
@@ -971,7 +971,7 @@ public class ConfigurationProviderServiceTests
             File.WriteAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json"), "current-profile");
             File.WriteAllText(Path.Combine(newRoot, FileTypes.SettingsFileName), "current-settings");
 
-            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot);
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
 
             Assert.Equal("current-profile", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json")));
             Assert.Equal("current-settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
@@ -994,7 +994,7 @@ public class ConfigurationProviderServiceTests
         Directory.Delete(newRoot);
         try
         {
-            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot);
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
 
             Assert.False(Directory.Exists(newRoot));
         }
@@ -1015,10 +1015,164 @@ public class ConfigurationProviderServiceTests
         {
             SeedLegacyRoot(legacyRoot);
 
-            CreateProvider().MigrateLegacyDataRoot(legacyRoot, Path.Combine(legacyRoot, "."));
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, Path.Combine(legacyRoot, "."), Path.Combine(legacyRoot, "."));
 
             Assert.Equal("profile", File.ReadAllText(Path.Combine(legacyRoot, DirectoryNames.Profiles, "profile.json")));
             Assert.Equal("settings", File.ReadAllText(Path.Combine(legacyRoot, FileTypes.SettingsFileName)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the migration leaves nothing behind in the legacy root, so a regression from a
+    /// move to a copy is caught rather than passing every positive assertion.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithLegacyData_RemovesTheLegacySources()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            SeedLegacyRoot(legacyRoot);
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
+
+            Assert.False(File.Exists(Path.Combine(legacyRoot, FileTypes.SettingsFileName)));
+            Assert.False(File.Exists(Path.Combine(legacyRoot, FileTypes.WorkspaceMetadataFileName)));
+            Assert.False(Directory.Exists(Path.Combine(legacyRoot, DirectoryNames.Profiles)));
+            Assert.False(Directory.Exists(Path.Combine(legacyRoot, FileTypes.ManifestsDirectory)));
+            Assert.False(Directory.Exists(Path.Combine(legacyRoot, DirectoryNames.UserData)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the steady state after a successful migration: a legacy root that still holds the CAS
+    /// pool, but none of the migrated entries, is left completely alone.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithoutLegacyEntries_LeavesBothRootsAlone()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        Directory.Delete(newRoot);
+        try
+        {
+            WriteFile(Path.Combine(legacyRoot, DirectoryNames.CasPool, "objects", "blob.bin"), "cas");
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
+
+            Assert.False(Directory.Exists(newRoot));
+            Assert.True(File.Exists(Path.Combine(legacyRoot, DirectoryNames.CasPool, "objects", "blob.bin")));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the sub-layout releases up to v0.0.3 wrote, which nested the manifests, tracked
+    /// user data and workspace metadata under a Content directory, is flattened into the data root.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithContentSubLayout_FlattensIntoDataRoot()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            var legacyContent = Path.Combine(legacyRoot, DirectoryNames.LegacyContent);
+            WriteFile(Path.Combine(legacyRoot, DirectoryNames.Profiles, "profile.json"), "profile");
+            WriteFile(Path.Combine(legacyContent, FileTypes.ManifestsDirectory, "content.manifest.json"), "manifest");
+            WriteFile(Path.Combine(legacyContent, DirectoryNames.UserData, FileTypes.UserDataIndexFileName), "index");
+            WriteFile(Path.Combine(legacyContent, FileTypes.WorkspaceMetadataFileName), "workspaces");
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
+
+            Assert.Equal("profile", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json")));
+            Assert.Equal("manifest", File.ReadAllText(Path.Combine(newRoot, FileTypes.ManifestsDirectory, "content.manifest.json")));
+            Assert.Equal("index", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.UserData, FileTypes.UserDataIndexFileName)));
+            Assert.Equal("workspaces", File.ReadAllText(Path.Combine(newRoot, FileTypes.WorkspaceMetadataFileName)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the settings file releases up to v0.0.3 wrote, which was named after the JSON
+    /// extension rather than the settings file name, is migrated under the current name.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithLegacySettingsFileName_MigratesUnderCurrentName()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            WriteFile(Path.Combine(legacyRoot, FileTypes.LegacySettingsFileName), "settings");
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
+
+            Assert.Equal("settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
+            Assert.False(File.Exists(Path.Combine(legacyRoot, FileTypes.LegacySettingsFileName)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a settings file already under the current name wins over the v0.0.3 one.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithBothSettingsFileNames_PrefersTheCurrentName()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            WriteFile(Path.Combine(legacyRoot, FileTypes.SettingsFileName), "current");
+            WriteFile(Path.Combine(legacyRoot, FileTypes.LegacySettingsFileName), "older");
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot, newRoot);
+
+            Assert.Equal("current", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the data consumers read through the application data path lands in the override
+    /// root while the settings file, which is resolved from the configured root, lands there instead.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithSeparateDataAndSettingsRoots_SplitsTheDestinations()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        var overrideRoot = Path.Combine(Path.GetDirectoryName(newRoot)!, "relocated");
+        try
+        {
+            SeedLegacyRoot(legacyRoot);
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, overrideRoot, newRoot);
+
+            Assert.Equal("profile", File.ReadAllText(Path.Combine(overrideRoot, DirectoryNames.Profiles, "profile.json")));
+            Assert.Equal("manifest", File.ReadAllText(Path.Combine(overrideRoot, FileTypes.ManifestsDirectory, "content.manifest.json")));
+            Assert.Equal("index", File.ReadAllText(Path.Combine(overrideRoot, DirectoryNames.UserData, FileTypes.UserDataIndexFileName)));
+            Assert.Equal("workspaces", File.ReadAllText(Path.Combine(overrideRoot, FileTypes.WorkspaceMetadataFileName)));
+
+            Assert.Equal("settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
+            Assert.False(File.Exists(Path.Combine(overrideRoot, FileTypes.SettingsFileName)));
+            Assert.False(Directory.Exists(Path.Combine(newRoot, DirectoryNames.Profiles)));
         }
         finally
         {
@@ -1048,8 +1202,8 @@ public class ConfigurationProviderServiceTests
     {
         WriteFile(Path.Combine(legacyRoot, DirectoryNames.Profiles, "profile.json"), "profile");
         WriteFile(Path.Combine(legacyRoot, FileTypes.ManifestsDirectory, "content.manifest.json"), "manifest");
-        WriteFile(Path.Combine(legacyRoot, DirectoryNames.UserData, "index.json"), "index");
-        WriteFile(Path.Combine(legacyRoot, DirectoryNames.UserData, "backups", "save.bak"), "backup");
+        WriteFile(Path.Combine(legacyRoot, DirectoryNames.UserData, FileTypes.UserDataIndexFileName), "index");
+        WriteFile(Path.Combine(legacyRoot, DirectoryNames.UserData, DirectoryNames.UserDataBackups, "save.bak"), "backup");
         WriteFile(Path.Combine(legacyRoot, FileTypes.SettingsFileName), "settings");
         WriteFile(Path.Combine(legacyRoot, FileTypes.WorkspaceMetadataFileName), "workspaces");
         WriteFile(Path.Combine(legacyRoot, DirectoryNames.CasPool, "objects", "blob.bin"), "cas");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
@@ -794,8 +794,33 @@ public class ConfigurationProviderServiceTests
 
         // Assert
         Assert.Contains(Path.Combine(appDataPath, FileTypes.ManifestsDirectory), result);
-        Assert.Contains(Path.Combine(appDataPath, "CustomManifests"), result);
+        Assert.Contains(Path.Combine(appDataPath, DirectoryNames.CustomManifests), result);
         Assert.True(result.Count >= 3);
+    }
+
+    /// <summary>
+    /// Verifies that the default content directories follow an explicitly set application data path,
+    /// so local discovery scans the same root the manifests are read from and written to.
+    /// </summary>
+    [Fact]
+    public void GetContentDirectories_WithExplicitApplicationDataPath_ReturnsOverride()
+    {
+        // Arrange
+        var userPath = Path.Combine(Path.GetTempPath(), "genhub-user-data-root");
+        var userSettings = new UserSettings { ApplicationDataPath = userPath, ContentDirectories = [] };
+        userSettings.MarkAsExplicitlySet(nameof(UserSettings.ApplicationDataPath));
+        _mockUserSettings.Setup(x => x.Get()).Returns(userSettings);
+        _mockAppConfig.Setup(x => x.GetConfiguredDataPath()).Returns("/app/data/path");
+
+        var provider = CreateProvider();
+
+        // Act
+        var result = provider.GetContentDirectories();
+
+        // Assert
+        Assert.Contains(Path.Combine(userPath, FileTypes.ManifestsDirectory), result);
+        Assert.Contains(Path.Combine(userPath, DirectoryNames.CustomManifests), result);
+        Assert.Equal(provider.GetManifestsPath(), result[0]);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
@@ -841,6 +841,244 @@ public class ConfigurationProviderServiceTests
     }
 
     /// <summary>
+    /// Verifies that GetProfilesPath honors an explicitly set application data path.
+    /// </summary>
+    [Fact]
+    public void GetProfilesPath_WithExplicitApplicationDataPath_ReturnsOverride()
+    {
+        // Arrange
+        var userPath = Path.Combine(Path.GetTempPath(), "genhub-user-data-root");
+        var userSettings = new UserSettings { ApplicationDataPath = userPath };
+        userSettings.MarkAsExplicitlySet(nameof(UserSettings.ApplicationDataPath));
+        _mockUserSettings.Setup(x => x.Get()).Returns(userSettings);
+        _mockAppConfig.Setup(x => x.GetConfiguredDataPath()).Returns("/app/data/path");
+
+        var provider = CreateProvider();
+
+        // Act
+        var result = provider.GetProfilesPath();
+
+        // Assert
+        Assert.Equal(Path.Combine(userPath, DirectoryNames.Profiles), result);
+    }
+
+    /// <summary>
+    /// Verifies that GetManifestsPath honors an explicitly set application data path.
+    /// </summary>
+    [Fact]
+    public void GetManifestsPath_WithExplicitApplicationDataPath_ReturnsOverride()
+    {
+        // Arrange
+        var userPath = Path.Combine(Path.GetTempPath(), "genhub-user-data-root");
+        var userSettings = new UserSettings { ApplicationDataPath = userPath };
+        userSettings.MarkAsExplicitlySet(nameof(UserSettings.ApplicationDataPath));
+        _mockUserSettings.Setup(x => x.Get()).Returns(userSettings);
+        _mockAppConfig.Setup(x => x.GetConfiguredDataPath()).Returns("/app/data/path");
+
+        var provider = CreateProvider();
+
+        // Act
+        var result = provider.GetManifestsPath();
+
+        // Assert
+        Assert.Equal(Path.Combine(userPath, FileTypes.ManifestsDirectory), result);
+    }
+
+    /// <summary>
+    /// Verifies that the profiles and manifests paths fall back to the configured data path when no
+    /// application data path override is set.
+    /// </summary>
+    [Fact]
+    public void GetProfilesAndManifestsPath_WithoutOverride_ReturnConfiguredDataPath()
+    {
+        // Arrange
+        var appDataPath = "/app/data/path";
+        _mockAppConfig.Setup(x => x.GetConfiguredDataPath()).Returns(appDataPath);
+
+        var provider = CreateProvider();
+
+        // Act & Assert
+        Assert.Equal(Path.Combine(appDataPath, DirectoryNames.Profiles), provider.GetProfilesPath());
+        Assert.Equal(Path.Combine(appDataPath, FileTypes.ManifestsDirectory), provider.GetManifestsPath());
+    }
+
+    /// <summary>
+    /// Verifies that the legacy roaming data root is migrated into the current root while the CAS
+    /// pool, which still defaults to the legacy location, is left in place.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithLegacyData_MovesTrackedEntriesAndLeavesCasPool()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            SeedLegacyRoot(legacyRoot);
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot);
+
+            Assert.Equal("profile", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json")));
+            Assert.Equal("manifest", File.ReadAllText(Path.Combine(newRoot, FileTypes.ManifestsDirectory, "content.manifest.json")));
+            Assert.Equal("index", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.UserData, "index.json")));
+            Assert.Equal("backup", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.UserData, "backups", "save.bak")));
+            Assert.Equal("settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
+            Assert.Equal("workspaces", File.ReadAllText(Path.Combine(newRoot, FileTypes.WorkspaceMetadataFileName)));
+
+            Assert.True(File.Exists(Path.Combine(legacyRoot, DirectoryNames.CasPool, "objects", "blob.bin")));
+            Assert.False(Directory.Exists(Path.Combine(newRoot, DirectoryNames.CasPool)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that running the legacy root migration a second time leaves the migrated data alone.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_RunTwice_IsIdempotent()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            SeedLegacyRoot(legacyRoot);
+            var provider = CreateProvider();
+
+            provider.MigrateLegacyDataRoot(legacyRoot, newRoot);
+            provider.MigrateLegacyDataRoot(legacyRoot, newRoot);
+
+            Assert.Equal("profile", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json")));
+            Assert.Equal("settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
+            Assert.True(File.Exists(Path.Combine(legacyRoot, DirectoryNames.CasPool, "objects", "blob.bin")));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that data already present in the current root wins over the legacy copy.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithExistingData_DoesNotOverwriteNewRoot()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            SeedLegacyRoot(legacyRoot);
+            Directory.CreateDirectory(Path.Combine(newRoot, DirectoryNames.Profiles));
+            File.WriteAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json"), "current-profile");
+            File.WriteAllText(Path.Combine(newRoot, FileTypes.SettingsFileName), "current-settings");
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot);
+
+            Assert.Equal("current-profile", File.ReadAllText(Path.Combine(newRoot, DirectoryNames.Profiles, "profile.json")));
+            Assert.Equal("current-settings", File.ReadAllText(Path.Combine(newRoot, FileTypes.SettingsFileName)));
+            Assert.Equal("workspaces", File.ReadAllText(Path.Combine(newRoot, FileTypes.WorkspaceMetadataFileName)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a missing legacy root does not create the current root.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithoutLegacyRoot_DoesNothing()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        Directory.Delete(legacyRoot);
+        Directory.Delete(newRoot);
+        try
+        {
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, newRoot);
+
+            Assert.False(Directory.Exists(newRoot));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the migration is skipped when both roots resolve to the same directory.
+    /// </summary>
+    [Fact]
+    public void MigrateLegacyDataRoot_WithIdenticalRoots_DoesNothing()
+    {
+        var (legacyRoot, newRoot) = CreateMigrationRoots();
+        try
+        {
+            SeedLegacyRoot(legacyRoot);
+
+            CreateProvider().MigrateLegacyDataRoot(legacyRoot, Path.Combine(legacyRoot, "."));
+
+            Assert.Equal("profile", File.ReadAllText(Path.Combine(legacyRoot, DirectoryNames.Profiles, "profile.json")));
+            Assert.Equal("settings", File.ReadAllText(Path.Combine(legacyRoot, FileTypes.SettingsFileName)));
+        }
+        finally
+        {
+            DeleteDirectories(legacyRoot, newRoot);
+        }
+    }
+
+    /// <summary>
+    /// Creates a fresh legacy and current data root pair under the temp directory.
+    /// </summary>
+    /// <returns>The legacy and current root paths.</returns>
+    private static (string LegacyRoot, string NewRoot) CreateMigrationRoots()
+    {
+        var testRoot = Path.Combine(Path.GetTempPath(), $"genhub-migration-{Guid.NewGuid():N}");
+        var legacyRoot = Path.Combine(testRoot, "roaming");
+        var newRoot = Path.Combine(testRoot, "local");
+        Directory.CreateDirectory(legacyRoot);
+        Directory.CreateDirectory(newRoot);
+        return (legacyRoot, newRoot);
+    }
+
+    /// <summary>
+    /// Populates a legacy data root with the entries an alpha-3 install would contain.
+    /// </summary>
+    /// <param name="legacyRoot">The legacy data root to populate.</param>
+    private static void SeedLegacyRoot(string legacyRoot)
+    {
+        WriteFile(Path.Combine(legacyRoot, DirectoryNames.Profiles, "profile.json"), "profile");
+        WriteFile(Path.Combine(legacyRoot, FileTypes.ManifestsDirectory, "content.manifest.json"), "manifest");
+        WriteFile(Path.Combine(legacyRoot, DirectoryNames.UserData, "index.json"), "index");
+        WriteFile(Path.Combine(legacyRoot, DirectoryNames.UserData, "backups", "save.bak"), "backup");
+        WriteFile(Path.Combine(legacyRoot, FileTypes.SettingsFileName), "settings");
+        WriteFile(Path.Combine(legacyRoot, FileTypes.WorkspaceMetadataFileName), "workspaces");
+        WriteFile(Path.Combine(legacyRoot, DirectoryNames.CasPool, "objects", "blob.bin"), "cas");
+    }
+
+    private static void WriteFile(string path, string content)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    private static void DeleteDirectories(params string[] paths)
+    {
+        foreach (var path in paths.Select(Path.GetDirectoryName).Where(path => !string.IsNullOrEmpty(path)).Distinct())
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path!, true);
+                }
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    /// <summary>
     /// Creates a ConfigurationProviderService instance for testing.
     /// </summary>
     /// <returns>A new ConfigurationProviderService instance.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
@@ -1,0 +1,214 @@
+using GenHub.Common.Services;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Enums;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GenHub.Tests.Core.Common.Services;
+
+/// <summary>
+/// Covers the first launch after upgrading from a release that kept its data under the roaming
+/// profile.
+/// <para>
+/// <see cref="UserSettingsService"/> loads in its own constructor and resolves the settings path
+/// straight from <see cref="IAppConfiguration"/>, so it runs before
+/// <see cref="ConfigurationProviderService"/> has had any chance to migrate the legacy root. Left
+/// alone it would start from defaults, and the first save of the session would then write those
+/// defaults over the freshly migrated settings file, permanently destroying the user's settings.
+/// </para>
+/// </summary>
+public class LegacyRootUpgradeTests : IDisposable
+{
+    private readonly string _testRoot;
+    private readonly string _legacyRoot;
+    private readonly string _newRoot;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LegacyRootUpgradeTests"/> class.
+    /// </summary>
+    public LegacyRootUpgradeTests()
+    {
+        _testRoot = Path.Combine(Path.GetTempPath(), $"genhub-upgrade-{Guid.NewGuid():N}");
+        _legacyRoot = Path.Combine(_testRoot, "roaming");
+        _newRoot = Path.Combine(_testRoot, "local");
+        Directory.CreateDirectory(_legacyRoot);
+        Directory.CreateDirectory(_newRoot);
+    }
+
+    /// <summary>
+    /// Removes the temporary roots created for the test.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Verifies that the settings a user had before the upgrade are in effect on the first launch,
+    /// without waiting for a restart.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithLegacySettings_LoadsLegacyValues()
+    {
+        WriteLegacySettings("""
+        {
+          "theme": "Light",
+          "maxConcurrentDownloads": 7,
+          "defaultWorkspaceStrategy": "SymlinkOnly"
+        }
+        """);
+
+        var settings = CreateSettingsService().Get();
+
+        Assert.Equal("Light", settings.Theme);
+        Assert.Equal(7, settings.MaxConcurrentDownloads);
+        Assert.Equal(WorkspaceStrategy.SymlinkOnly, settings.DefaultWorkspaceStrategy);
+    }
+
+    /// <summary>
+    /// Verifies the exact sequence that destroyed user settings: a first-launch load, the legacy
+    /// root migration moving the settings file into the new root, and then a save during that same
+    /// session. The saved file must still carry the user's values, not defaults.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task FirstLaunch_ThenMigrationThenSave_PreservesLegacyValuesAsync()
+    {
+        WriteLegacySettings("""
+        {
+          "theme": "Light",
+          "maxConcurrentDownloads": 7
+        }
+        """);
+
+        var appConfig = CreateAppConfig();
+        var settingsService = CreateSettingsService(appConfig);
+        var provider = new ConfigurationProviderService(
+            appConfig,
+            settingsService,
+            Mock.Of<ILogger<ConfigurationProviderService>>());
+
+        // Triggers the legacy root migration, which moves settings.json into the new root.
+        provider.GetApplicationDataPath();
+        Assert.True(File.Exists(Path.Combine(_newRoot, FileTypes.SettingsFileName)));
+
+        settingsService.Update(settings => settings.WindowWidth = 1440.0);
+        await settingsService.SaveAsync();
+
+        var persisted = CreateSettingsService(appConfig).Get();
+        Assert.Equal("Light", persisted.Theme);
+        Assert.Equal(7, persisted.MaxConcurrentDownloads);
+        Assert.Equal(1440.0, persisted.WindowWidth);
+    }
+
+    /// <summary>
+    /// Verifies that an application data path override carried over from the legacy settings is
+    /// honored on the first launch rather than after a restart.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithLegacyApplicationDataPathOverride_HonorsOverride()
+    {
+        var overridePath = Path.Combine(_testRoot, "relocated");
+        Directory.CreateDirectory(overridePath);
+        var escapedOverridePath = overridePath.Replace("\\", "\\\\");
+        WriteLegacySettings($$"""
+        {
+          "applicationDataPath": "{{escapedOverridePath}}"
+        }
+        """);
+
+        var appConfig = CreateAppConfig();
+        var provider = new ConfigurationProviderService(
+            appConfig,
+            CreateSettingsService(appConfig),
+            Mock.Of<ILogger<ConfigurationProviderService>>());
+
+        Assert.Equal(overridePath, provider.GetApplicationDataPath());
+        Assert.Equal(Path.Combine(overridePath, DirectoryNames.Profiles), provider.GetProfilesPath());
+        Assert.Equal(Path.Combine(overridePath, FileTypes.ManifestsDirectory), provider.GetManifestsPath());
+    }
+
+    /// <summary>
+    /// Verifies that a settings file already present in the current root wins over the legacy copy.
+    /// </summary>
+    [Fact]
+    public void SecondLaunch_WithSettingsInNewRoot_IgnoresLegacyFile()
+    {
+        WriteLegacySettings("""
+        { "theme": "Light" }
+        """);
+        var currentSettingsJson = """
+        { "theme": "Dark" }
+        """;
+        File.WriteAllText(Path.Combine(_newRoot, FileTypes.SettingsFileName), currentSettingsJson);
+
+        var settings = CreateSettingsService().Get();
+
+        Assert.Equal("Dark", settings.Theme);
+    }
+
+    /// <summary>
+    /// Verifies that a fresh install, which has no legacy root at all, is unaffected.
+    /// </summary>
+    [Fact]
+    public void FreshInstall_WithoutLegacyRoot_UsesDefaults()
+    {
+        Directory.Delete(_legacyRoot);
+
+        var service = CreateSettingsService();
+        var settings = service.Get();
+
+        Assert.Equal(AppConstants.DefaultThemeName, settings.Theme);
+        Assert.False(settings.IsExplicitlySet(nameof(UserSettings.ApplicationDataPath)));
+        Assert.False(File.Exists(Path.Combine(_newRoot, FileTypes.SettingsFileName)));
+    }
+
+    /// <summary>
+    /// Verifies that a failure while looking for the pre-upgrade settings cannot stop startup.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WhenLegacyLookupThrows_FallsBackToDefaults()
+    {
+        var appConfig = CreateAppConfigMock();
+        appConfig.Setup(config => config.GetLegacyConfiguredDataPath()).Throws(new UnauthorizedAccessException("denied"));
+
+        var service = new UserSettingsService(Mock.Of<ILogger<UserSettingsService>>(), appConfig.Object);
+
+        Assert.Equal(AppConstants.DefaultThemeName, service.Get().Theme);
+    }
+
+    private static Mock<IAppConfiguration> CreateBaseAppConfigMock()
+    {
+        var appConfig = new Mock<IAppConfiguration>();
+        appConfig.Setup(config => config.GetMinConcurrentDownloads()).Returns(1);
+        appConfig.Setup(config => config.GetMaxConcurrentDownloads()).Returns(8);
+        appConfig.Setup(config => config.GetMinDownloadTimeoutSeconds()).Returns(30);
+        appConfig.Setup(config => config.GetMaxDownloadTimeoutSeconds()).Returns(600);
+        appConfig.Setup(config => config.GetMinDownloadBufferSizeBytes()).Returns(4096);
+        appConfig.Setup(config => config.GetMaxDownloadBufferSizeBytes()).Returns(1048576);
+        return appConfig;
+    }
+
+    private Mock<IAppConfiguration> CreateAppConfigMock()
+    {
+        var appConfig = CreateBaseAppConfigMock();
+        appConfig.Setup(config => config.GetConfiguredDataPath()).Returns(_newRoot);
+        appConfig.Setup(config => config.GetLegacyConfiguredDataPath()).Returns(_legacyRoot);
+        return appConfig;
+    }
+
+    private IAppConfiguration CreateAppConfig() => CreateAppConfigMock().Object;
+
+    private UserSettingsService CreateSettingsService(IAppConfiguration? appConfig = null) =>
+        new(Mock.Of<ILogger<UserSettingsService>>(), appConfig ?? CreateAppConfig());
+
+    private void WriteLegacySettings(string json) =>
+        File.WriteAllText(Path.Combine(_legacyRoot, FileTypes.SettingsFileName), json);
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
@@ -136,6 +136,101 @@ public class LegacyRootUpgradeTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that the migration puts the profiles where <see cref="ConfigurationProviderService.GetProfilesPath"/>
+    /// resolves them when an application data path override is in effect, rather than in the
+    /// configured root the app would never look at.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithOverride_MigratesDataIntoTheRootTheAppReadsFrom()
+    {
+        var overridePath = Path.Combine(_testRoot, "relocated");
+        WriteLegacySettings($$"""
+        {
+          "applicationDataPath": "{{overridePath.Replace("\\", "\\\\")}}"
+        }
+        """);
+        SeedLegacyDataDirectories();
+
+        var appConfig = CreateAppConfig();
+        var provider = new ConfigurationProviderService(
+            appConfig,
+            CreateSettingsService(appConfig),
+            Mock.Of<ILogger<ConfigurationProviderService>>());
+
+        Assert.Equal("profile", File.ReadAllText(Path.Combine(provider.GetProfilesPath(), "profile.json")));
+        Assert.Equal("manifest", File.ReadAllText(Path.Combine(provider.GetManifestsPath(), "content.manifest.json")));
+        Assert.Equal("workspaces", File.ReadAllText(Path.Combine(provider.GetApplicationDataPath(), FileTypes.WorkspaceMetadataFileName)));
+
+        Assert.False(Directory.Exists(Path.Combine(_newRoot, DirectoryNames.Profiles)));
+        Assert.True(File.Exists(Path.Combine(_newRoot, FileTypes.SettingsFileName)));
+    }
+
+    /// <summary>
+    /// Verifies that the settings file releases up to v0.0.3 wrote, which was named after the JSON
+    /// extension rather than the settings file name, is still picked up on the first launch.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithV003SettingsFileName_LoadsLegacyValues()
+    {
+        var legacyJson = """
+        { "theme": "Light", "maxConcurrentDownloads": 7 }
+        """;
+        File.WriteAllText(Path.Combine(_legacyRoot, FileTypes.LegacySettingsFileName), legacyJson);
+
+        var settings = CreateSettingsService().Get();
+
+        Assert.Equal("Light", settings.Theme);
+        Assert.Equal(7, settings.MaxConcurrentDownloads);
+    }
+
+    /// <summary>
+    /// Verifies that a normalization failure, which used to reset the settings to defaults while the
+    /// settings path still pointed at the user's file, keeps the loaded values instead.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task FirstLaunch_WhenNormalizationThrows_KeepsLoadedValuesAsync()
+    {
+        WriteLegacySettings("""
+        { "theme": "Light", "maxConcurrentDownloads": 7 }
+        """);
+
+        var appConfig = CreateAppConfigMock();
+        appConfig.Setup(config => config.GetMinConcurrentDownloads()).Returns(8);
+        appConfig.Setup(config => config.GetMaxConcurrentDownloads()).Returns(1);
+
+        var service = new UserSettingsService(Mock.Of<ILogger<UserSettingsService>>(), appConfig.Object);
+        Assert.Equal("Light", service.Get().Theme);
+
+        await service.SaveAsync();
+
+        Assert.Equal("Light", CreateSettingsService().Get().Theme);
+    }
+
+    /// <summary>
+    /// Verifies that a failed initialization can never persist defaults over a settings file that was
+    /// never read successfully.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task Save_AfterFailedInitialization_RefusesToOverwriteExistingSettingsAsync()
+    {
+        var settingsPath = Path.Combine(_newRoot, FileTypes.SettingsFileName);
+        var existingJson = """
+        { "theme": "Light" }
+        """;
+        File.WriteAllText(settingsPath, existingJson);
+
+        var appConfig = CreateBaseAppConfigMock();
+        appConfig.Setup(config => config.GetConfiguredDataPath()).Throws(new UnauthorizedAccessException("denied"));
+
+        var service = new UserSettingsService(Mock.Of<ILogger<UserSettingsService>>(), appConfig.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveAsync());
+        Assert.Contains("Light", File.ReadAllText(settingsPath));
+    }
+
+    /// <summary>
     /// Verifies that a settings file already present in the current root wins over the legacy copy.
     /// </summary>
     [Fact]
@@ -211,4 +306,17 @@ public class LegacyRootUpgradeTests : IDisposable
 
     private void WriteLegacySettings(string json) =>
         File.WriteAllText(Path.Combine(_legacyRoot, FileTypes.SettingsFileName), json);
+
+    private void SeedLegacyDataDirectories()
+    {
+        WriteLegacyFile(Path.Combine(_legacyRoot, DirectoryNames.Profiles, "profile.json"), "profile");
+        WriteLegacyFile(Path.Combine(_legacyRoot, FileTypes.ManifestsDirectory, "content.manifest.json"), "manifest");
+        WriteLegacyFile(Path.Combine(_legacyRoot, FileTypes.WorkspaceMetadataFileName), "workspaces");
+    }
+
+    private void WriteLegacyFile(string path, string content)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
@@ -231,6 +231,86 @@ public class LegacyRootUpgradeTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that a settings file the loader could not parse blocks the save that would replace
+    /// it with defaults. The failure is swallowed inside the load, so nothing reaches the outer
+    /// catch and the file looks like a clean load unless the load reports what it produced.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task Save_WithCorruptSettingsFile_RefusesToOverwriteAsync()
+    {
+        var settingsPath = Path.Combine(_newRoot, FileTypes.SettingsFileName);
+        var corruptJson = "{ invalid json }";
+        File.WriteAllText(settingsPath, corruptJson);
+
+        var service = CreateSettingsService();
+        Assert.Equal(AppConstants.DefaultThemeName, service.Get().Theme);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveAsync());
+        Assert.Equal(corruptJson, File.ReadAllText(settingsPath));
+    }
+
+    /// <summary>
+    /// Verifies that a corrupt pre-upgrade settings file blocks saving as well, rather than starting
+    /// the session from defaults and writing them into the current root as if the upgrade had found
+    /// nothing to carry over.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task Save_WithCorruptLegacySettingsFile_RefusesToOverwriteAsync()
+    {
+        var corruptJson = "{ invalid json }";
+        WriteLegacySettings(corruptJson);
+
+        var service = CreateSettingsService();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveAsync());
+        Assert.Equal(corruptJson, File.ReadAllText(Path.Combine(_legacyRoot, FileTypes.SettingsFileName)));
+        Assert.False(File.Exists(Path.Combine(_newRoot, FileTypes.SettingsFileName)));
+    }
+
+    /// <summary>
+    /// Verifies that a settings file which could not be opened, the case of a file locked by another
+    /// process or denied by permissions, blocks saving and therefore survives the session.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task Save_WithUnreadableSettingsFile_RefusesToOverwriteAsync()
+    {
+        var settingsPath = Path.Combine(_newRoot, FileTypes.SettingsFileName);
+        var existingJson = """
+        { "theme": "Light" }
+        """;
+        File.WriteAllText(settingsPath, existingJson);
+
+        UserSettingsService service;
+        using (File.Open(settingsPath, System.IO.FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            service = CreateSettingsService();
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveAsync());
+        Assert.Equal(existingJson, File.ReadAllText(settingsPath));
+    }
+
+    /// <summary>
+    /// Verifies that the absence of any settings file is still a legitimate first run, so blocking
+    /// saves after a failed load cannot leave a fresh install unable to persist anything.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task Save_OnFirstRunWithoutAnySettingsFile_PersistsTheSettingsAsync()
+    {
+        Directory.Delete(_legacyRoot);
+
+        var service = CreateSettingsService();
+        service.Update(settings => settings.Theme = "Light");
+        await service.SaveAsync();
+
+        Assert.Contains("Light", File.ReadAllText(Path.Combine(_newRoot, FileTypes.SettingsFileName)));
+    }
+
+    /// <summary>
     /// Verifies that a settings file already present in the current root wins over the legacy copy.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/UserSettingsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/UserSettingsServiceTests.cs
@@ -233,10 +233,7 @@ public class UserSettingsServiceTests : IDisposable
         var nestedPath = Path.Combine(_tempDirectory, "nested", "path");
         var settingsPath = Path.Combine(nestedPath, FileTypes.JsonFileExtension);
         var service = CreateService();
-        var settingsPathField = typeof(UserSettingsService)
-            .GetField("_settingsFilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        Assert.NotNull(settingsPathField);
-        settingsPathField.SetValue(service, settingsPath);
+        service.AdoptSettingsFile(settingsPath);
         await service.SaveAsync();
         Assert.True(Directory.Exists(nestedPath));
         Assert.True(File.Exists(settingsPath));
@@ -264,10 +261,7 @@ public class UserSettingsServiceTests : IDisposable
         var settingsPath = Path.Combine(deepPath, FileTypes.JsonFileExtension);
 
         var service = CreateService();
-        var settingsPathField = typeof(UserSettingsService)
-            .GetField("_settingsFilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        Assert.NotNull(settingsPathField);
-        settingsPathField.SetValue(service, settingsPath);
+        service.AdoptSettingsFile(settingsPath);
 
         // Act
         await service.SaveAsync();
@@ -385,6 +379,177 @@ public class UserSettingsServiceTests : IDisposable
         Assert.Equal(15, currentSettings.PeriodicUpdateCheckIntervalMinutes);
     }
 
+    /// <summary>
+    /// Verifies that pointing the settings file at a file that already holds settings refuses the
+    /// save instead of replacing that file with values read from a different one, and that the
+    /// edits being saved survive the refusal.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Update_WhenRepointedAtExistingSettingsFile_RefusesToOverwriteItAsync()
+    {
+        var currentPath = Path.Combine(_tempDirectory, FileTypes.SettingsFileName);
+        var otherPath = Path.Combine(_tempDirectory, "backup.json");
+        var otherJson = """{ "theme": "Light", "maxConcurrentDownloads": 7 }""";
+        File.WriteAllText(currentPath, """{ "theme": "Dark" }""");
+        File.WriteAllText(otherPath, otherJson);
+
+        var service = new TestableUserSettingsService(_mockLogger.Object, CreateAppConfigMock(), currentPath);
+        service.Update(settings =>
+        {
+            settings.WorkspacePath = "/edited";
+            settings.SettingsFilePath = otherPath;
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveAsync());
+
+        Assert.Equal(otherJson, File.ReadAllText(otherPath));
+        Assert.Equal("/edited", service.Get().WorkspacePath);
+    }
+
+    /// <summary>
+    /// Verifies that the same re-point through the combined update-and-save entry point reports
+    /// failure rather than overwriting the file it was pointed at.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryUpdateAndSaveAsync_WhenRepointedAtExistingSettingsFile_FailsWithoutOverwritingItAsync()
+    {
+        var currentPath = Path.Combine(_tempDirectory, FileTypes.SettingsFileName);
+        var otherPath = Path.Combine(_tempDirectory, "backup.json");
+        var otherJson = """{ "theme": "Light", "maxConcurrentDownloads": 7 }""";
+        File.WriteAllText(currentPath, """{ "theme": "Dark" }""");
+        File.WriteAllText(otherPath, otherJson);
+
+        var service = new TestableUserSettingsService(_mockLogger.Object, CreateAppConfigMock(), currentPath);
+        var saved = await service.TryUpdateAndSaveAsync(settings =>
+        {
+            settings.SettingsFilePath = otherPath;
+            return true;
+        });
+
+        Assert.False(saved);
+        Assert.Equal(otherJson, File.ReadAllText(otherPath));
+    }
+
+    /// <summary>
+    /// Verifies that relocating the settings to a path that holds nothing is still honoured, since
+    /// there is nothing there for the save to destroy.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Update_WhenRepointedAtUnusedPath_SavesTheEditsThereAsync()
+    {
+        var currentPath = Path.Combine(_tempDirectory, FileTypes.SettingsFileName);
+        var newPath = Path.Combine(_tempDirectory, "moved", FileTypes.SettingsFileName);
+        File.WriteAllText(currentPath, """{ "theme": "Dark" }""");
+
+        var service = new TestableUserSettingsService(_mockLogger.Object, CreateAppConfigMock(), currentPath);
+        service.Update(settings =>
+        {
+            settings.Theme = "Light";
+            settings.SettingsFilePath = newPath;
+        });
+
+        await service.SaveAsync();
+
+        Assert.Contains("Light", File.ReadAllText(newPath));
+    }
+
+    /// <summary>
+    /// Verifies that a refused re-point is recoverable by pointing back at the file the settings
+    /// were read from, so the refusal cannot strand the session.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Update_AfterRefusedRepoint_SavesAgainOncePointedBackAsync()
+    {
+        var currentPath = Path.Combine(_tempDirectory, FileTypes.SettingsFileName);
+        var otherPath = Path.Combine(_tempDirectory, "backup.json");
+        var otherJson = """{ "theme": "Light" }""";
+        File.WriteAllText(currentPath, """{ "theme": "Dark" }""");
+        File.WriteAllText(otherPath, otherJson);
+
+        var service = new TestableUserSettingsService(_mockLogger.Object, CreateAppConfigMock(), currentPath);
+        service.Update(settings =>
+        {
+            settings.WorkspacePath = "/edited";
+            settings.SettingsFilePath = otherPath;
+        });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveAsync());
+
+        service.Update(settings => settings.SettingsFilePath = currentPath);
+        await service.SaveAsync();
+
+        Assert.Contains("/edited", File.ReadAllText(currentPath));
+        Assert.Equal(otherJson, File.ReadAllText(otherPath));
+    }
+
+    /// <summary>
+    /// Verifies that a refused re-point is also recoverable by clearing the path it was refused
+    /// for, so the refusal lasts exactly as long as the file it protects.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Update_AfterRefusedRepoint_SavesOnceTheConflictingFileIsGoneAsync()
+    {
+        var currentPath = Path.Combine(_tempDirectory, FileTypes.SettingsFileName);
+        var otherPath = Path.Combine(_tempDirectory, "backup.json");
+        File.WriteAllText(currentPath, """{ "theme": "Dark" }""");
+        File.WriteAllText(otherPath, """{ "theme": "Light" }""");
+
+        var service = new TestableUserSettingsService(_mockLogger.Object, CreateAppConfigMock(), currentPath);
+        service.Update(settings =>
+        {
+            settings.WorkspacePath = "/edited";
+            settings.SettingsFilePath = otherPath;
+        });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveAsync());
+
+        File.Delete(otherPath);
+        service.Update(settings => settings.SettingsFilePath = otherPath);
+        await service.SaveAsync();
+
+        Assert.Contains("/edited", File.ReadAllText(otherPath));
+    }
+
+    /// <summary>
+    /// Verifies that the ordinary save, where the settings name the very file they were read from,
+    /// is unaffected by the re-point check.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Update_WhenTheSettingsNameTheFileTheyCameFrom_SavesAsync()
+    {
+        var currentPath = Path.Combine(_tempDirectory, FileTypes.SettingsFileName);
+        File.WriteAllText(
+            currentPath,
+            $$"""{ "theme": "Dark", "settingsFilePath": {{JsonSerializer.Serialize(currentPath)}} }""");
+
+        var service = new TestableUserSettingsService(_mockLogger.Object, CreateAppConfigMock(), currentPath);
+        service.Update(settings => settings.Theme = "Light");
+
+        await service.SaveAsync();
+
+        Assert.Contains("Light", File.ReadAllText(currentPath));
+    }
+
+    /// <summary>
+    /// Verifies that a first run, which has no settings file at all, still persists its settings.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task SaveAsync_OnFirstRunWithoutAnExistingFile_PersistsTheSettingsAsync()
+    {
+        var settingsPath = Path.Combine(_tempDirectory, FileTypes.SettingsFileName);
+        var service = CreateServiceWithPath(settingsPath);
+
+        service.Update(settings => settings.Theme = "Light");
+        await service.SaveAsync();
+
+        Assert.Contains("Light", File.ReadAllText(settingsPath));
+    }
+
     private static IAppConfiguration CreateAppConfigMock()
     {
         var appConfig = new Mock<IAppConfiguration>();
@@ -448,5 +613,7 @@ public class UserSettingsServiceTests : IDisposable
             // We then set the path, which will load from the file if it exists.
             SetSettingsFilePath(settingsFilePath);
         }
+
+        public void AdoptSettingsFile(string settingsFilePath) => SetSettingsFilePath(settingsFilePath);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
@@ -34,6 +34,7 @@ public class ApplicationDataPathConventionTests
     {
         // The implementation of the convention itself has to start somewhere.
         ["ConfigurationProviderService.cs"] = "Defines the canonical path.",
+        ["AppConfiguration.cs"] = "Resolves the legacy roaming root the upgrade migration reads from.",
         ["UserSettingsService.cs"] = "Loads the settings file that stores the override; cannot depend on it.",
 
         // Displays the built-in default next to the user's override in the UI.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameProfileDeserializationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameProfileDeserializationTests.cs
@@ -8,9 +8,8 @@ namespace GenHub.Tests.Core.Models;
 
 /// <summary>
 /// Tests to verify that GameProfile correctly applies default values during deserialization.
-/// This addresses the bug where WorkspaceStrategy was defaulting to SymlinkOnly (enum default 0)
-/// WorkspaceStrategyJsonConverter correctly handles the null/missing property, allowing
-/// services to apply the global default fallback.
+/// The numeric values exercised here are the ordinals written by releases up to v0.0.3, so they
+/// also guard the upgrade path for profiles persisted before the strategy was written as a string.
 /// </summary>
 public class GameProfileDeserializationTests
 {
@@ -43,12 +42,12 @@ public class GameProfileDeserializationTests
     [Fact]
     public void Deserialize_ProfileWithSymlinkOnly_ShouldPreserveSymlinkOnly()
     {
-        // Arrange - JSON with explicit SymlinkOnly (1)
+        // Arrange - JSON with explicit SymlinkOnly (0)
         var json = """
         {
             "Id": "test_profile",
             "Name": "Test Profile",
-            "WorkspaceStrategy": 1
+            "WorkspaceStrategy": 0
         }
         """;
 
@@ -58,7 +57,6 @@ public class GameProfileDeserializationTests
         // Assert
         Assert.NotNull(profile);
 
-        // Should NOT be overridden to HardLink anymore
         Assert.Equal(WorkspaceStrategy.SymlinkOnly, profile.WorkspaceStrategy);
     }
 
@@ -68,12 +66,12 @@ public class GameProfileDeserializationTests
     [Fact]
     public void Deserialize_ProfileWithExplicitHardLink_ShouldPreserveHardLink()
     {
-        // Arrange - JSON with explicit HardLink (0)
+        // Arrange - JSON with explicit HardLink (3)
         var json = """
         {
             "Id": "test_profile",
             "Name": "Test Profile",
-            "WorkspaceStrategy": 0
+            "WorkspaceStrategy": 3
         }
         """;
 
@@ -91,12 +89,12 @@ public class GameProfileDeserializationTests
     [Fact]
     public void Deserialize_ProfileWithCopyStrategy_ShouldPreserveCopy()
     {
-        // Arrange - JSON with explicit Copy strategy (2)
+        // Arrange - JSON with explicit Copy strategy (1)
         var json = """
         {
             "Id": "test_profile",
             "Name": "Test Profile",
-            "WorkspaceStrategy": 2
+            "WorkspaceStrategy": 1
         }
         """;
 
@@ -226,5 +224,40 @@ public class GameProfileDeserializationTests
         // Assert
         Assert.NotNull(profile);
         Assert.Equal(WorkspaceStrategy.HardLink, profile.WorkspaceStrategy);
+    }
+
+    /// <summary>
+    /// Verifies that a profile persisted by releases up to v0.0.3, which wrote the strategy as a
+    /// name using the repository serializer options, still resolves to the same strategy.
+    /// </summary>
+    /// <param name="strategyName">The strategy name persisted in the profile file.</param>
+    /// <param name="expected">The strategy the profile must resolve to.</param>
+    [Theory]
+    [InlineData("SymlinkOnly", WorkspaceStrategy.SymlinkOnly)]
+    [InlineData("FullCopy", WorkspaceStrategy.FullCopy)]
+    [InlineData("HybridCopySymlink", WorkspaceStrategy.HybridCopySymlink)]
+    [InlineData("HardLink", WorkspaceStrategy.HardLink)]
+    public void Deserialize_LegacyProfileFile_ShouldPreserveStrategy(string strategyName, WorkspaceStrategy expected)
+    {
+        // Arrange - profile file as written by GameProfileRepository before the move to a string enum
+        var json = $$"""
+        {
+            "id": "test_profile",
+            "name": "Test Profile",
+            "workspaceStrategy": "{{strategyName}}"
+        }
+        """;
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+        };
+
+        // Act
+        var profile = JsonSerializer.Deserialize<GameProfileModel>(json, options);
+
+        // Assert
+        Assert.NotNull(profile);
+        Assert.Equal(expected, profile.WorkspaceStrategy);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameProfileDeserializationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameProfileDeserializationTests.cs
@@ -8,8 +8,11 @@ namespace GenHub.Tests.Core.Models;
 
 /// <summary>
 /// Tests to verify that GameProfile correctly applies default values during deserialization.
-/// The numeric values exercised here are the ordinals written by releases up to v0.0.3, so they
-/// also guard the upgrade path for profiles persisted before the strategy was written as a string.
+/// The numeric values exercised here are not the profile format of any release: v0.0.3 serialized
+/// profiles with a string enum converter, so it wrote member names. Numbers only reach a profile
+/// file from v0.0.2 and older, or from a build of the default branch made while the enum was
+/// reordered. Pinning the mapping is a deliberate decision, because the ordinals below are the ones
+/// v0.0.3 wrote into workspaces.json and the two formats have to agree.
 /// </summary>
 public class GameProfileDeserializationTests
 {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Workspace/WorkspaceMetadataDeserializationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/Workspace/WorkspaceMetadataDeserializationTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Workspace;
+using Xunit;
+
+namespace GenHub.Tests.Core.Models.Workspace;
+
+/// <summary>
+/// Tests that workspace metadata written by releases up to v0.0.3 still resolves to the strategy it
+/// was persisted with. A mismatch between the persisted strategy and the profile strategy makes
+/// WorkspaceManager discard and rebuild the workspace.
+/// </summary>
+public class WorkspaceMetadataDeserializationTests
+{
+    private static readonly JsonSerializerOptions MetadataOptions = new() { WriteIndented = true };
+
+    /// <summary>
+    /// Verifies that the raw ordinals stored in workspaces.json map back to their original strategies.
+    /// </summary>
+    [Fact]
+    public void Deserialize_LegacyWorkspacesFile_MapsOrdinalsToOriginalStrategies()
+    {
+        var json = """
+        [
+          {
+            "Id": "symlink-workspace",
+            "WorkspacePath": "/data/workspaces/symlink-workspace",
+            "GameClientId": "generals-zh",
+            "Strategy": 0,
+            "IsPrepared": true
+          },
+          {
+            "Id": "fullcopy-workspace",
+            "WorkspacePath": "/data/workspaces/fullcopy-workspace",
+            "GameClientId": "generals-zh",
+            "Strategy": 1,
+            "IsPrepared": true
+          },
+          {
+            "Id": "hybrid-workspace",
+            "WorkspacePath": "/data/workspaces/hybrid-workspace",
+            "GameClientId": "generals-zh",
+            "Strategy": 2,
+            "IsPrepared": true
+          },
+          {
+            "Id": "hardlink-workspace",
+            "WorkspacePath": "/data/workspaces/hardlink-workspace",
+            "GameClientId": "generals-zh",
+            "Strategy": 3,
+            "IsPrepared": true
+          }
+        ]
+        """;
+
+        var workspaces = JsonSerializer.Deserialize<List<WorkspaceInfo>>(json, MetadataOptions);
+
+        Assert.NotNull(workspaces);
+        Assert.Equal(
+            new[]
+            {
+                WorkspaceStrategy.SymlinkOnly,
+                WorkspaceStrategy.FullCopy,
+                WorkspaceStrategy.HybridCopySymlink,
+                WorkspaceStrategy.HardLink,
+            },
+            workspaces.Select(workspace => workspace.Strategy));
+    }
+
+    /// <summary>
+    /// Verifies that a legacy workspace and the profile that owns it agree on the strategy, which is
+    /// the comparison that decides whether an existing workspace can be reused.
+    /// </summary>
+    /// <param name="workspaceOrdinal">The ordinal persisted in workspaces.json.</param>
+    /// <param name="profileStrategyName">The strategy name persisted in the profile.</param>
+    [Theory]
+    [InlineData(0, "SymlinkOnly")]
+    [InlineData(1, "FullCopy")]
+    [InlineData(2, "HybridCopySymlink")]
+    [InlineData(3, "HardLink")]
+    public void Deserialize_LegacyWorkspaceAndProfile_AgreeOnStrategy(int workspaceOrdinal, string profileStrategyName)
+    {
+        var workspaceJson = $$"""
+        { "Id": "workspace", "Strategy": {{workspaceOrdinal}} }
+        """;
+        var profileJson = $"\"{profileStrategyName}\"";
+
+        var workspace = JsonSerializer.Deserialize<WorkspaceInfo>(workspaceJson, MetadataOptions);
+        var profileStrategy = JsonSerializer.Deserialize<WorkspaceStrategy>(profileJson);
+
+        Assert.NotNull(workspace);
+        Assert.Equal(profileStrategy, workspace.Strategy);
+    }
+
+    /// <summary>
+    /// Verifies that newly written workspace metadata stores the strategy name, so a future
+    /// reordering of the enum cannot corrupt it.
+    /// </summary>
+    [Fact]
+    public void Serialize_WorkspaceMetadata_WritesStrategyName()
+    {
+        var workspaces = new List<WorkspaceInfo>
+        {
+            new() { Id = "workspace", Strategy = WorkspaceStrategy.HardLink },
+        };
+
+        var json = JsonSerializer.Serialize(workspaces, MetadataOptions);
+
+        Assert.Contains("\"Strategy\": \"HardLink\"", json);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Serialization/JsonWorkspaceStrategyConverterTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Serialization/JsonWorkspaceStrategyConverterTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using GenHub.Core.Models.Enums;
+using Xunit;
+
+namespace GenHub.Tests.Core.Serialization;
+
+/// <summary>
+/// Tests for <see cref="GenHub.Core.Serialization.JsonWorkspaceStrategyConverter"/>.
+/// </summary>
+public class JsonWorkspaceStrategyConverterTests
+{
+    /// <summary>
+    /// Verifies that the strategy is written as its member name rather than its ordinal.
+    /// </summary>
+    /// <param name="strategy">The strategy to serialize.</param>
+    /// <param name="expectedJson">The expected JSON payload.</param>
+    [Theory]
+    [InlineData(WorkspaceStrategy.SymlinkOnly, "\"SymlinkOnly\"")]
+    [InlineData(WorkspaceStrategy.FullCopy, "\"FullCopy\"")]
+    [InlineData(WorkspaceStrategy.HybridCopySymlink, "\"HybridCopySymlink\"")]
+    [InlineData(WorkspaceStrategy.HardLink, "\"HardLink\"")]
+    public void Serialize_WritesStrategyName(WorkspaceStrategy strategy, string expectedJson)
+    {
+        var json = JsonSerializer.Serialize(strategy);
+
+        Assert.Equal(expectedJson, json);
+    }
+
+    /// <summary>
+    /// Verifies that the ordinals written by releases up to v0.0.3 still map to the same strategies.
+    /// </summary>
+    /// <param name="json">The legacy numeric JSON payload.</param>
+    /// <param name="expected">The strategy the payload must resolve to.</param>
+    [Theory]
+    [InlineData("0", WorkspaceStrategy.SymlinkOnly)]
+    [InlineData("1", WorkspaceStrategy.FullCopy)]
+    [InlineData("2", WorkspaceStrategy.HybridCopySymlink)]
+    [InlineData("3", WorkspaceStrategy.HardLink)]
+    public void Deserialize_LegacyNumericValue_ReturnsOriginalStrategy(string json, WorkspaceStrategy expected)
+    {
+        var result = JsonSerializer.Deserialize<WorkspaceStrategy>(json);
+
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that string payloads are still accepted.
+    /// </summary>
+    /// <param name="json">The string JSON payload.</param>
+    /// <param name="expected">The strategy the payload must resolve to.</param>
+    [Theory]
+    [InlineData("\"SymlinkOnly\"", WorkspaceStrategy.SymlinkOnly)]
+    [InlineData("\"FullCopy\"", WorkspaceStrategy.FullCopy)]
+    [InlineData("\"HybridCopySymlink\"", WorkspaceStrategy.HybridCopySymlink)]
+    [InlineData("\"HardLink\"", WorkspaceStrategy.HardLink)]
+    [InlineData("\"hardlink\"", WorkspaceStrategy.HardLink)]
+    public void Deserialize_StringValue_ReturnsMatchingStrategy(string json, WorkspaceStrategy expected)
+    {
+        var result = JsonSerializer.Deserialize<WorkspaceStrategy>(json);
+
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that a round trip preserves the strategy and produces a string payload.
+    /// </summary>
+    /// <param name="strategy">The strategy to round trip.</param>
+    [Theory]
+    [InlineData(WorkspaceStrategy.SymlinkOnly)]
+    [InlineData(WorkspaceStrategy.FullCopy)]
+    [InlineData(WorkspaceStrategy.HybridCopySymlink)]
+    [InlineData(WorkspaceStrategy.HardLink)]
+    public void RoundTrip_PreservesStrategy(WorkspaceStrategy strategy)
+    {
+        var json = JsonSerializer.Serialize(strategy);
+
+        using (var document = JsonDocument.Parse(json))
+        {
+            Assert.Equal(JsonValueKind.String, document.RootElement.ValueKind);
+        }
+
+        Assert.Equal(strategy, JsonSerializer.Deserialize<WorkspaceStrategy>(json));
+    }
+
+    /// <summary>
+    /// Verifies that unrecognised payloads fall back to the default strategy.
+    /// </summary>
+    /// <param name="json">The unrecognised JSON payload.</param>
+    [Theory]
+    [InlineData("999")]
+    [InlineData("\"NotAStrategy\"")]
+    public void Deserialize_UnknownValue_ReturnsHardLink(string json)
+    {
+        var result = JsonSerializer.Deserialize<WorkspaceStrategy>(json);
+
+        Assert.Equal(WorkspaceStrategy.HardLink, result);
+    }
+}

--- a/GenHub/GenHub/Common/Services/AppConfiguration.cs
+++ b/GenHub/GenHub/Common/Services/AppConfiguration.cs
@@ -226,4 +226,11 @@ public class AppConfiguration(IConfiguration? configuration, ILogger<AppConfigur
             ? configured
             : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppConstants.AppName);
     }
+
+    /// <summary>
+    /// Gets the application data path used by releases up to v0.0.3, which stored data under the roaming profile.
+    /// </summary>
+    /// <returns>The legacy application data path as a string.</returns>
+    public string GetLegacyConfiguredDataPath() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppConstants.AppName);
 }

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
@@ -20,6 +21,19 @@ public class ConfigurationProviderService(
     IUserSettingsService userSettings,
     ILogger<ConfigurationProviderService> logger) : IConfigurationProviderService
 {
+    private static readonly string[] LegacyRootDirectories =
+    [
+        DirectoryNames.Profiles,
+        FileTypes.ManifestsDirectory,
+        DirectoryNames.UserData,
+    ];
+
+    private static readonly string[] LegacyRootFiles =
+    [
+        FileTypes.SettingsFileName,
+        FileTypes.WorkspaceMetadataFileName,
+    ];
+
     private readonly IAppConfiguration _appConfig = appConfig ?? throw new ArgumentNullException(nameof(appConfig));
     private readonly IUserSettingsService _userSettings = userSettings ?? throw new ArgumentNullException(nameof(userSettings));
     private readonly ILogger<ConfigurationProviderService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -295,6 +309,7 @@ public class ConfigurationProviderService(
                 if (!_migrated)
                 {
                     // Double-check
+                    MigrateLegacyDataRoot();
                     MigrateContentDirectory();
                     _migrated = true;
                 }
@@ -315,10 +330,10 @@ public class ConfigurationProviderService(
     public string GetRootAppDataPath() => _appConfig.GetConfiguredDataPath();
 
     /// <inheritdoc />
-    public string GetProfilesPath() => Path.Combine(_appConfig.GetConfiguredDataPath(), DirectoryNames.Profiles);
+    public string GetProfilesPath() => Path.Combine(GetApplicationDataPath(), DirectoryNames.Profiles);
 
     /// <inheritdoc />
-    public string GetManifestsPath() => Path.Combine(_appConfig.GetConfiguredDataPath(), FileTypes.ManifestsDirectory);
+    public string GetManifestsPath() => Path.Combine(GetApplicationDataPath(), FileTypes.ManifestsDirectory);
 
     /// <inheritdoc />
     /// <remarks>
@@ -357,6 +372,91 @@ public class ConfigurationProviderService(
             DirectoryNames.Logs.ToLowerInvariant());
     }
 
+    /// <summary>
+    /// Moves the data written by releases that stored everything under the roaming application data
+    /// folder into the current data root, so upgrading users keep their profiles, manifests, tracked
+    /// user data, workspace metadata and settings.
+    /// </summary>
+    /// <param name="legacyRoot">The roaming data root used before the move to local application data.</param>
+    /// <param name="newRoot">The current data root.</param>
+    /// <remarks>
+    /// The CAS pool is deliberately excluded: <see cref="GetCasConfiguration"/> still defaults to the
+    /// legacy location, so moving the pool would orphan it.
+    /// </remarks>
+    internal void MigrateLegacyDataRoot(string legacyRoot, string newRoot)
+    {
+        if (!Directory.Exists(legacyRoot) || IsSamePath(legacyRoot, newRoot))
+        {
+            return;
+        }
+
+        var hasLegacyEntries = LegacyRootDirectories
+            .Select(name => Path.Combine(legacyRoot, name))
+            .Any(Directory.Exists)
+            || LegacyRootFiles
+                .Select(name => Path.Combine(legacyRoot, name))
+                .Any(File.Exists);
+
+        if (!hasLegacyEntries)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Migrating legacy data root {LegacyRoot} to {NewRoot}", legacyRoot, newRoot);
+        Directory.CreateDirectory(newRoot);
+
+        foreach (var name in LegacyRootDirectories)
+        {
+            try
+            {
+                MigrateDirectory(Path.Combine(legacyRoot, name), Path.Combine(newRoot, name));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to migrate legacy directory {Name} from {LegacyRoot}", name, legacyRoot);
+            }
+        }
+
+        foreach (var name in LegacyRootFiles)
+        {
+            try
+            {
+                MigrateFile(Path.Combine(legacyRoot, name), Path.Combine(newRoot, name));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to migrate legacy file {Name} from {LegacyRoot}", name, legacyRoot);
+            }
+        }
+    }
+
+    private static bool IsSamePath(string first, string second)
+    {
+        try
+        {
+            return string.Equals(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(first)),
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(second)),
+                PathHelper.PathComparison);
+        }
+        catch (Exception)
+        {
+            return string.Equals(first, second, PathHelper.PathComparison);
+        }
+    }
+
+    private void MigrateLegacyDataRoot()
+    {
+        try
+        {
+            MigrateLegacyDataRoot(_appConfig.GetLegacyConfiguredDataPath(), _appConfig.GetConfiguredDataPath());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to migrate legacy data root");
+        }
+    }
+
     private void MigrateContentDirectory()
     {
         try
@@ -372,14 +472,14 @@ public class ConfigurationProviderService(
             _logger.LogInformation("Migrating content from {ContentPath} to root {RootPath}", contentPath, rootPath);
 
             // 1. Move Manifests
-            MigrateDirectory(Path.Combine(contentPath, "Manifests"), Path.Combine(rootPath, "Manifests"));
+            MigrateDirectory(Path.Combine(contentPath, FileTypes.ManifestsDirectory), Path.Combine(rootPath, FileTypes.ManifestsDirectory));
 
             // 2. Move UserData
-            MigrateDirectory(Path.Combine(contentPath, "UserData"), Path.Combine(rootPath, "UserData"));
+            MigrateDirectory(Path.Combine(contentPath, DirectoryNames.UserData), Path.Combine(rootPath, DirectoryNames.UserData));
 
             // 3. Move workspaces.json
-            var sourceWorkspaces = Path.Combine(contentPath, "workspaces.json");
-            var destWorkspaces = Path.Combine(rootPath, "workspaces.json");
+            var sourceWorkspaces = Path.Combine(contentPath, FileTypes.WorkspaceMetadataFileName);
+            var destWorkspaces = Path.Combine(rootPath, FileTypes.WorkspaceMetadataFileName);
             if (File.Exists(sourceWorkspaces))
             {
                 if (!File.Exists(destWorkspaces))
@@ -419,19 +519,23 @@ public class ConfigurationProviderService(
 
         if (!Directory.Exists(destDir))
         {
-            Directory.Move(sourceDir, destDir);
-            _logger.LogInformation("Moved {Source} to {Dest}", sourceDir, destDir);
-            return;
+            try
+            {
+                Directory.Move(sourceDir, destDir);
+                _logger.LogInformation("Moved {Source} to {Dest}", sourceDir, destDir);
+                return;
+            }
+            catch (IOException ex)
+            {
+                _logger.LogWarning(ex, "Could not move {Source} to {Dest} directly, falling back to per-entry migration", sourceDir, destDir);
+                Directory.CreateDirectory(destDir);
+            }
         }
 
         // Destination exists, move content
         foreach (var file in Directory.GetFiles(sourceDir))
         {
-            var destFile = Path.Combine(destDir, Path.GetFileName(file));
-            if (!File.Exists(destFile))
-            {
-                File.Move(file, destFile);
-            }
+            MigrateFile(file, Path.Combine(destDir, Path.GetFileName(file)));
         }
 
         foreach (var subDir in Directory.GetDirectories(sourceDir))
@@ -451,5 +555,28 @@ public class ConfigurationProviderService(
         catch
         {
         }
+    }
+
+    private void MigrateFile(string sourceFile, string destFile)
+    {
+        if (!File.Exists(sourceFile))
+        {
+            return;
+        }
+
+        if (File.Exists(destFile))
+        {
+            _logger.LogInformation("Skipping {Source}, {Dest} already exists", sourceFile, destFile);
+            return;
+        }
+
+        var destDir = Path.GetDirectoryName(destFile);
+        if (!string.IsNullOrEmpty(destDir))
+        {
+            Directory.CreateDirectory(destDir);
+        }
+
+        File.Move(sourceFile, destFile);
+        _logger.LogInformation("Moved {Source} to {Dest}", sourceFile, destFile);
     }
 }

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -29,10 +29,20 @@ public class ConfigurationProviderService(
         DirectoryNames.UserData,
     ];
 
-    private static readonly string[] LegacyRootFiles =
+    private static readonly string[] LegacySettingsFileNames =
     [
         FileTypes.SettingsFileName,
-        FileTypes.WorkspaceMetadataFileName,
+        FileTypes.LegacySettingsFileName,
+    ];
+
+    /// <summary>
+    /// The sub-paths of the legacy data root a tracked entry may sit in, most recent layout first so
+    /// that a newer copy wins over an older one when both are present.
+    /// </summary>
+    private static readonly string[] LegacyRootLayouts =
+    [
+        string.Empty,
+        DirectoryNames.LegacyContent,
     ];
 
     private readonly IAppConfiguration _appConfig = appConfig ?? throw new ArgumentNullException(nameof(appConfig));
@@ -303,28 +313,8 @@ public class ConfigurationProviderService(
     /// <inheritdoc />
     public string GetApplicationDataPath()
     {
-        if (!_migrated)
-        {
-            lock (_migrationLock)
-            {
-                if (!_migrated)
-                {
-                    // Double-check
-                    MigrateLegacyDataRoot();
-                    MigrateContentDirectory();
-                    _migrated = true;
-                }
-            }
-        }
-
-        var settings = _userSettings.Get();
-        if (settings.IsExplicitlySet(nameof(UserSettings.ApplicationDataPath)) &&
-            !string.IsNullOrWhiteSpace(settings.ApplicationDataPath))
-        {
-            return settings.ApplicationDataPath;
-        }
-
-        return _appConfig.GetConfiguredDataPath();
+        EnsureLegacyDataMigrated();
+        return ResolveApplicationDataPath();
     }
 
     /// <inheritdoc />
@@ -379,78 +369,142 @@ public class ConfigurationProviderService(
     /// user data, workspace metadata and settings.
     /// </summary>
     /// <param name="legacyRoot">The roaming data root used before the move to local application data.</param>
-    /// <param name="newRoot">The current data root.</param>
+    /// <param name="dataRoot">The root every consumer of <see cref="GetApplicationDataPath"/> reads from.</param>
+    /// <param name="settingsRoot">The root the settings file is read from and written to.</param>
     /// <remarks>
+    /// <para>
+    /// The two destinations differ deliberately. Profiles, manifests, tracked user data and the
+    /// workspace metadata are all resolved through <see cref="GetApplicationDataPath"/>, so they have
+    /// to follow an explicitly configured <see cref="UserSettings.ApplicationDataPath"/> override;
+    /// moving them into the configured root instead would leave them where nothing ever looks. The
+    /// settings file is resolved straight from <see cref="IAppConfiguration.GetConfiguredDataPath"/>
+    /// and therefore has to land there.
+    /// </para>
+    /// <para>
+    /// Releases up to v0.0.3 nested the manifests, tracked user data and workspace metadata under a
+    /// <c>Content</c> directory, so both that layout and the flat one are probed and flattened into
+    /// the destination. Data that a v0.0.3 install kept outside the legacy root, because an
+    /// <see cref="UserSettings.ApplicationDataPath"/> override pointed elsewhere, is out of scope and
+    /// stays where it is.
+    /// </para>
+    /// <para>
     /// The CAS pool is deliberately excluded: <see cref="GetCasConfiguration"/> still defaults to the
     /// legacy location, so moving the pool would orphan it.
+    /// </para>
     /// </remarks>
-    internal void MigrateLegacyDataRoot(string legacyRoot, string newRoot)
+    internal void MigrateLegacyDataRoot(string legacyRoot, string dataRoot, string settingsRoot)
     {
-        if (!Directory.Exists(legacyRoot) || IsSamePath(legacyRoot, newRoot))
+        if (!Directory.Exists(legacyRoot))
         {
             return;
         }
 
-        var hasLegacyEntries = LegacyRootDirectories
-            .Select(name => Path.Combine(legacyRoot, name))
-            .Any(Directory.Exists)
-            || LegacyRootFiles
-                .Select(name => Path.Combine(legacyRoot, name))
-                .Any(File.Exists);
+        var directories = ResolveLegacyDirectories(legacyRoot, dataRoot);
+        var files = ResolveLegacyFiles(legacyRoot, dataRoot, settingsRoot);
 
-        if (!hasLegacyEntries)
+        if (directories.Count == 0 && files.Count == 0)
         {
             return;
         }
 
-        _logger.LogInformation("Migrating legacy data root {LegacyRoot} to {NewRoot}", legacyRoot, newRoot);
-        Directory.CreateDirectory(newRoot);
+        _logger.LogInformation(
+            "Migrating legacy data root {LegacyRoot} into {DataRoot}, settings into {SettingsRoot}",
+            legacyRoot,
+            dataRoot,
+            settingsRoot);
 
-        foreach (var name in LegacyRootDirectories)
+        if (directories.Count > 0)
+        {
+            Directory.CreateDirectory(dataRoot);
+        }
+
+        foreach (var (source, destination) in directories)
         {
             try
             {
-                MigrateDirectory(Path.Combine(legacyRoot, name), Path.Combine(newRoot, name));
+                MigrateDirectory(source, destination);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
             {
-                _logger.LogError(ex, "Failed to migrate legacy directory {Name} from {LegacyRoot}", name, legacyRoot);
+                _logger.LogError(ex, "Failed to migrate legacy directory {Source}", source);
             }
         }
 
-        foreach (var name in LegacyRootFiles)
+        foreach (var (source, destination) in files)
         {
             try
             {
-                MigrateFile(Path.Combine(legacyRoot, name), Path.Combine(newRoot, name));
+                MigrateFile(source, destination);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
             {
-                _logger.LogError(ex, "Failed to migrate legacy file {Name} from {LegacyRoot}", name, legacyRoot);
+                _logger.LogError(ex, "Failed to migrate legacy file {Source}", source);
             }
         }
     }
 
-    private static bool IsSamePath(string first, string second)
+    private static List<(string Source, string Destination)> ResolveLegacyDirectories(string legacyRoot, string dataRoot) =>
+        LegacyRootDirectories
+            .SelectMany(
+                _ => LegacyRootLayouts,
+                (name, layout) => (Source: Path.Combine(legacyRoot, layout, name), Destination: Path.Combine(dataRoot, name)))
+            .Where(entry => Directory.Exists(entry.Source) && !PathHelper.AreSamePath(entry.Source, entry.Destination))
+            .ToList();
+
+    private static List<(string Source, string Destination)> ResolveLegacyFiles(string legacyRoot, string dataRoot, string settingsRoot) =>
+        LegacyRootLayouts
+            .Select(layout => (
+                Source: Path.Combine(legacyRoot, layout, FileTypes.WorkspaceMetadataFileName),
+                Destination: Path.Combine(dataRoot, FileTypes.WorkspaceMetadataFileName)))
+            .Concat(LegacySettingsFileNames
+                .Select(name => (
+                    Source: Path.Combine(legacyRoot, name),
+                    Destination: Path.Combine(settingsRoot, FileTypes.SettingsFileName))))
+            .Where(entry => File.Exists(entry.Source) && !PathHelper.AreSamePath(entry.Source, entry.Destination))
+            .ToList();
+
+    private void EnsureLegacyDataMigrated()
     {
-        try
+        if (_migrated)
         {
-            return string.Equals(
-                Path.TrimEndingDirectorySeparator(Path.GetFullPath(first)),
-                Path.TrimEndingDirectorySeparator(Path.GetFullPath(second)),
-                PathHelper.PathComparison);
+            return;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+
+        lock (_migrationLock)
         {
-            return string.Equals(first, second, PathHelper.PathComparison);
+            if (_migrated)
+            {
+                return;
+            }
+
+            MigrateLegacyDataRoot();
+            MigrateContentDirectory();
+            _migrated = true;
         }
+    }
+
+    /// <summary>
+    /// Resolves the effective data root without triggering the legacy migration, so the migration
+    /// itself can ask where the app will read from.
+    /// </summary>
+    /// <returns>The explicitly configured override when set, otherwise the configured data root.</returns>
+    private string ResolveApplicationDataPath()
+    {
+        var settings = _userSettings.Get();
+        return settings.IsExplicitlySet(nameof(UserSettings.ApplicationDataPath)) &&
+            !string.IsNullOrWhiteSpace(settings.ApplicationDataPath)
+                ? settings.ApplicationDataPath
+                : _appConfig.GetConfiguredDataPath();
     }
 
     private void MigrateLegacyDataRoot()
     {
         try
         {
-            MigrateLegacyDataRoot(_appConfig.GetLegacyConfiguredDataPath(), _appConfig.GetConfiguredDataPath());
+            MigrateLegacyDataRoot(
+                _appConfig.GetLegacyConfiguredDataPath(),
+                ResolveApplicationDataPath(),
+                _appConfig.GetConfiguredDataPath());
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
         {
@@ -462,8 +516,8 @@ public class ConfigurationProviderService(
     {
         try
         {
-            var rootPath = _appConfig.GetConfiguredDataPath();
-            var contentPath = Path.Combine(rootPath, "Content");
+            var rootPath = ResolveApplicationDataPath();
+            var contentPath = Path.Combine(rootPath, DirectoryNames.LegacyContent);
 
             if (!Directory.Exists(contentPath))
             {
@@ -472,51 +526,42 @@ public class ConfigurationProviderService(
 
             _logger.LogInformation("Migrating content from {ContentPath} to root {RootPath}", contentPath, rootPath);
 
-            // 1. Move Manifests
             MigrateDirectory(Path.Combine(contentPath, FileTypes.ManifestsDirectory), Path.Combine(rootPath, FileTypes.ManifestsDirectory));
-
-            // 2. Move UserData
             MigrateDirectory(Path.Combine(contentPath, DirectoryNames.UserData), Path.Combine(rootPath, DirectoryNames.UserData));
+            MigrateFile(
+                Path.Combine(contentPath, FileTypes.WorkspaceMetadataFileName),
+                Path.Combine(rootPath, FileTypes.WorkspaceMetadataFileName));
 
-            // 3. Move workspaces.json
-            var sourceWorkspaces = Path.Combine(contentPath, FileTypes.WorkspaceMetadataFileName);
-            var destWorkspaces = Path.Combine(rootPath, FileTypes.WorkspaceMetadataFileName);
-            if (File.Exists(sourceWorkspaces))
-            {
-                if (!File.Exists(destWorkspaces))
-                {
-                    File.Move(sourceWorkspaces, destWorkspaces);
-                    _logger.LogInformation("Moved workspaces.json to root");
-                }
-                else
-                {
-                    _logger.LogWarning("workspaces.json already exists in root, keeping original in Content (backup)");
-                }
-            }
-
-            // 4. Try to delete Content if empty
-            try
-            {
-                if (Directory.GetFiles(contentPath).Length == 0 && Directory.GetDirectories(contentPath).Length == 0)
-                {
-                    Directory.Delete(contentPath);
-                    _logger.LogInformation("Deleted empty Content directory");
-                }
-            }
-            catch
-            {
-                // Ignore if not empty
-            }
+            TryDeleteEmptyDirectory(contentPath);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
         {
             _logger.LogError(ex, "Failed to migrate Content directory");
         }
     }
 
+    private void TryDeleteEmptyDirectory(string path)
+    {
+        try
+        {
+            if (!Directory.EnumerateFileSystemEntries(path).Any())
+            {
+                Directory.Delete(path);
+                _logger.LogInformation("Deleted empty directory {Path}", path);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+        {
+            _logger.LogDebug(ex, "Could not delete {Path} after migration", path);
+        }
+    }
+
     private void MigrateDirectory(string sourceDir, string destDir)
     {
-        if (!Directory.Exists(sourceDir)) return;
+        if (!Directory.Exists(sourceDir))
+        {
+            return;
+        }
 
         if (!Directory.Exists(destDir))
         {
@@ -533,29 +578,31 @@ public class ConfigurationProviderService(
             }
         }
 
-        // Destination exists, move content
         foreach (var file in Directory.GetFiles(sourceDir))
         {
-            MigrateFile(file, Path.Combine(destDir, Path.GetFileName(file)));
+            try
+            {
+                MigrateFile(file, Path.Combine(destDir, Path.GetFileName(file)));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+            {
+                _logger.LogError(ex, "Failed to migrate {Source}, leaving it in place", file);
+            }
         }
 
         foreach (var subDir in Directory.GetDirectories(sourceDir))
         {
-            var destSubDir = Path.Combine(destDir, Path.GetFileName(subDir));
-            MigrateDirectory(subDir, destSubDir);
-        }
-
-        // Try delete source if empty
-        try
-        {
-            if (!Directory.EnumerateFileSystemEntries(sourceDir).Any())
+            try
             {
-                Directory.Delete(sourceDir);
+                MigrateDirectory(subDir, Path.Combine(destDir, Path.GetFileName(subDir)));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+            {
+                _logger.LogError(ex, "Failed to migrate {Source}, leaving it in place", subDir);
             }
         }
-        catch
-        {
-        }
+
+        TryDeleteEmptyDirectory(sourceDir);
     }
 
     private void MigrateFile(string sourceFile, string destFile)
@@ -577,7 +624,19 @@ public class ConfigurationProviderService(
             Directory.CreateDirectory(destDir);
         }
 
-        File.Move(sourceFile, destFile);
+        try
+        {
+            File.Move(sourceFile, destFile);
+        }
+        catch (IOException ex)
+        {
+            // File.Move cannot cross volumes on every platform; copy and only drop the source once
+            // the copy is on disk so a failure can never lose the file.
+            _logger.LogWarning(ex, "Could not move {Source} to {Dest} directly, copying instead", sourceFile, destFile);
+            File.Copy(sourceFile, destFile, overwrite: false);
+            File.Delete(sourceFile);
+        }
+
         _logger.LogInformation("Moved {Source} to {Dest}", sourceFile, destFile);
     }
 }

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -49,7 +49,14 @@ public class ConfigurationProviderService(
     private readonly IUserSettingsService _userSettings = userSettings ?? throw new ArgumentNullException(nameof(userSettings));
     private readonly ILogger<ConfigurationProviderService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly object _migrationLock = new();
-    private bool _migrated;
+
+    /// <summary>
+    /// Set once the migration has finished. Volatile because the fast path in
+    /// <see cref="EnsureLegacyDataMigrated"/> reads it outside <see cref="_migrationLock"/>: without
+    /// the release/acquire pair a second thread could observe the flag on a weakly ordered
+    /// architecture and read profiles or manifests before the moves that produced them are visible.
+    /// </summary>
+    private volatile bool _migrated;
 
     /// <inheritdoc />
     public string GetWorkspacePath()

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -284,10 +284,11 @@ public class ConfigurationProviderService(
             return settings.ContentDirectories;
         }
 
+        var dataRoot = GetApplicationDataPath();
         return
         [
-            Path.Combine(_appConfig.GetConfiguredDataPath(), FileTypes.ManifestsDirectory),
-            Path.Combine(_appConfig.GetConfiguredDataPath(), "CustomManifests"),
+            Path.Combine(dataRoot, FileTypes.ManifestsDirectory),
+            Path.Combine(dataRoot, DirectoryNames.CustomManifests),
             Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
                 "Command and Conquer Generals Zero Hour Data",

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 using GenHub.Core.Constants;
 using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
@@ -411,7 +412,7 @@ public class ConfigurationProviderService(
             {
                 MigrateDirectory(Path.Combine(legacyRoot, name), Path.Combine(newRoot, name));
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
             {
                 _logger.LogError(ex, "Failed to migrate legacy directory {Name} from {LegacyRoot}", name, legacyRoot);
             }
@@ -423,7 +424,7 @@ public class ConfigurationProviderService(
             {
                 MigrateFile(Path.Combine(legacyRoot, name), Path.Combine(newRoot, name));
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
             {
                 _logger.LogError(ex, "Failed to migrate legacy file {Name} from {LegacyRoot}", name, legacyRoot);
             }
@@ -439,7 +440,7 @@ public class ConfigurationProviderService(
                 Path.TrimEndingDirectorySeparator(Path.GetFullPath(second)),
                 PathHelper.PathComparison);
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
         {
             return string.Equals(first, second, PathHelper.PathComparison);
         }
@@ -451,7 +452,7 @@ public class ConfigurationProviderService(
         {
             MigrateLegacyDataRoot(_appConfig.GetLegacyConfiguredDataPath(), _appConfig.GetConfiguredDataPath());
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
         {
             _logger.LogError(ex, "Failed to migrate legacy data root");
         }

--- a/GenHub/GenHub/Common/Services/UserSettingsService.cs
+++ b/GenHub/GenHub/Common/Services/UserSettingsService.cs
@@ -82,6 +82,29 @@ public class UserSettingsService : IUserSettingsService
         }
     }
 
+    /// <summary>
+    /// What reading a settings file produced, so the caller can tell the absence of a settings file
+    /// apart from a settings file it could not read.
+    /// </summary>
+    private enum SettingsLoadOutcome
+    {
+        /// <summary>
+        /// No settings were there to read, so starting from defaults loses nothing.
+        /// </summary>
+        Absent,
+
+        /// <summary>
+        /// The settings were read from the file.
+        /// </summary>
+        Loaded,
+
+        /// <summary>
+        /// Settings exist but could not be read, so the defaults returned alongside this outcome
+        /// must never be persisted over them.
+        /// </summary>
+        Failed,
+    }
+
     /// <inheritdoc/>
     public UserSettings Get()
     {
@@ -175,7 +198,7 @@ public class UserSettingsService : IUserSettingsService
         if (!settingsLoaded)
         {
             _logger.LogError(
-                "Refusing to save settings to {Path}: initialization failed, so the in-memory settings are defaults rather than the user's values",
+                "Refusing to save settings to {Path}: the existing settings could not be read, so the in-memory settings are defaults rather than the user's values",
                 pathToSave);
             throw new InvalidOperationException(
                 "User settings were never loaded successfully; saving would overwrite the existing settings file with defaults.");
@@ -220,8 +243,8 @@ public class UserSettingsService : IUserSettingsService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path, nameof(path));
         _settingsFilePath = path;
-        _settings = LoadSettings(path);
-        _settingsLoaded = true;
+        _settings = LoadSettings(path, out var outcome);
+        _settingsLoaded = outcome != SettingsLoadOutcome.Failed;
     }
 
     private static void NormalizeAndValidateLocked(UserSettings s, IAppConfiguration appConfig)
@@ -303,13 +326,27 @@ public class UserSettingsService : IUserSettingsService
         };
     }
 
-    private UserSettings LoadSettings(string path)
+    /// <summary>
+    /// Reads the settings at <paramref name="path"/>, falling back to defaults on any failure.
+    /// </summary>
+    /// <param name="path">The settings file to read.</param>
+    /// <param name="outcome">
+    /// Receives what the read produced. A missing or empty file is reported as
+    /// <see cref="SettingsLoadOutcome.Absent"/> because it holds nothing a save could destroy;
+    /// anything else that stops the file from being turned into settings is reported as
+    /// <see cref="SettingsLoadOutcome.Failed"/>.
+    /// </param>
+    /// <returns>The settings that were read, or defaults when they could not be.</returns>
+    private UserSettings LoadSettings(string path, out SettingsLoadOutcome outcome)
     {
+        outcome = SettingsLoadOutcome.Failed;
+
         try
         {
             if (!File.Exists(path))
             {
                 _logger.LogInformation("Settings file not found at {Path}, using defaults", path);
+                outcome = SettingsLoadOutcome.Absent;
                 return new UserSettings();
             }
 
@@ -317,6 +354,7 @@ public class UserSettingsService : IUserSettingsService
             if (string.IsNullOrWhiteSpace(json))
             {
                 _logger.LogWarning("Settings file is empty at {Path}, using defaults", path);
+                outcome = SettingsLoadOutcome.Absent;
                 return new UserSettings();
             }
 
@@ -331,6 +369,7 @@ public class UserSettingsService : IUserSettingsService
             MarkExplicitlySetPropertiesFromJson(settings, json);
 
             _logger.LogInformation("Settings loaded successfully from {Path}", path);
+            outcome = SettingsLoadOutcome.Loaded;
             return settings;
         }
         catch (IOException ex)
@@ -408,6 +447,10 @@ public class UserSettingsService : IUserSettingsService
     /// <remarks>
     /// A failure here leaves <see cref="_settingsLoaded"/> false, which blocks <see cref="SaveAsync"/>
     /// rather than letting the session persist defaults over a settings file that was never read.
+    /// That covers both the exceptions that escape to the outer catch and the ones
+    /// <see cref="LoadSettings"/> swallows, which is why the source it read has to report whether it
+    /// was absent, read, or unreadable: only an unreadable source has values a save could destroy,
+    /// and that holds for the pre-upgrade source just as much as for the current one.
     /// Normalization is applied separately: clamping to an inconsistent configured range is no reason
     /// to discard settings that loaded fine.
     /// </remarks>
@@ -416,14 +459,14 @@ public class UserSettingsService : IUserSettingsService
         try
         {
             var defaultPath = GetDefaultSettingsFilePath();
-            var initialSettings = LoadSettings(ResolveSettingsSourcePath(defaultPath));
+            var initialSettings = LoadSettings(ResolveSettingsSourcePath(defaultPath), out var outcome);
 
             // If the user has a custom path, reload from there; otherwise keep what the default path gave us.
             if (!string.IsNullOrWhiteSpace(initialSettings.SettingsFilePath) &&
                 !PathHelper.AreSamePath(initialSettings.SettingsFilePath, defaultPath))
             {
                 _settingsFilePath = initialSettings.SettingsFilePath;
-                _settings = LoadSettings(_settingsFilePath);
+                _settings = LoadSettings(_settingsFilePath, out outcome);
             }
             else
             {
@@ -431,7 +474,7 @@ public class UserSettingsService : IUserSettingsService
                 _settings = initialSettings;
             }
 
-            _settingsLoaded = true;
+            _settingsLoaded = outcome != SettingsLoadOutcome.Failed;
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Common/Services/UserSettingsService.cs
+++ b/GenHub/GenHub/Common/Services/UserSettingsService.cs
@@ -44,9 +44,8 @@ public class UserSettingsService : IUserSettingsService
     private readonly ILogger<UserSettingsService> _logger;
     private readonly IAppConfiguration _appConfig;
     private readonly object _lock = new();
-    private string _settingsFilePath = string.Empty;
+    private SettingsFileTarget _target = SettingsFileTarget.Unverified(string.Empty);
     private UserSettings _settings = new();
-    private bool _settingsLoaded;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UserSettingsService"/> class.
@@ -63,7 +62,11 @@ public class UserSettingsService : IUserSettingsService
     /// </summary>
     /// <param name="logger">Logger instance.</param>
     /// <param name="appConfig">Application configuration service.</param>
-    /// <param name="initialize">Whether to perform normal initialization.</param>
+    /// <param name="initialize">
+    /// Whether to read the settings from disk. When <see langword="false"/> the service starts from
+    /// defaults with no file it is allowed to write, until <see cref="SetSettingsFilePath"/>
+    /// establishes one.
+    /// </param>
     protected UserSettingsService(ILogger<UserSettingsService> logger, IAppConfiguration appConfig, bool initialize)
     {
         _logger = logger;
@@ -72,13 +75,6 @@ public class UserSettingsService : IUserSettingsService
         if (initialize)
         {
             InitializeSettings();
-        }
-        else
-        {
-            // For testing - set defaults but don't load from file
-            _settingsFilePath = string.Empty;
-            _settings = new UserSettings();
-            _settingsLoaded = true;
         }
     }
 
@@ -129,13 +125,7 @@ public class UserSettingsService : IUserSettingsService
 
             // Only update internal state if no exception occurred
             _settings = settingsCopy;
-
-            // If the settings file path was changed, update the internal field
-            if (!string.IsNullOrWhiteSpace(_settings.SettingsFilePath) &&
-                !PathHelper.AreSamePath(_settings.SettingsFilePath, _settingsFilePath))
-            {
-                _settingsFilePath = _settings.SettingsFilePath;
-            }
+            RetargetLocked(_settings.SettingsFilePath);
 
             _logger.LogDebug("Settings updated in memory");
         }
@@ -152,12 +142,7 @@ public class UserSettingsService : IUserSettingsService
             accepted = applyChanges(_settings);
             if (accepted)
             {
-                // propagate any internal path updates
-                if (!string.IsNullOrWhiteSpace(_settings.SettingsFilePath) &&
-                    !PathHelper.AreSamePath(_settings.SettingsFilePath, _settingsFilePath))
-                {
-                    _settingsFilePath = _settings.SettingsFilePath;
-                }
+                RetargetLocked(_settings.SettingsFilePath);
             }
         }
 
@@ -183,25 +168,29 @@ public class UserSettingsService : IUserSettingsService
     /// </summary>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
     /// <returns>A task that represents the asynchronous save operation.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the settings file the save would write has not been verified as safe to
+    /// overwrite, either because it could not be read or because the in-memory settings came from
+    /// a different file.
+    /// </exception>
     public async Task SaveAsync(CancellationToken cancellationToken = default)
     {
         UserSettings settingsToSave;
-        string pathToSave;
-        bool settingsLoaded;
+        SettingsFileTarget target;
         lock (_lock)
         {
-            pathToSave = _settingsFilePath;
+            target = _target;
             settingsToSave = Get();
-            settingsLoaded = _settingsLoaded;
         }
 
-        if (!settingsLoaded)
+        var pathToSave = target.Path;
+        if (!target.CanWrite)
         {
             _logger.LogError(
-                "Refusing to save settings to {Path}: the existing settings could not be read, so the in-memory settings are defaults rather than the user's values",
+                "Refusing to save settings to {Path}: the settings held in memory were not read from it, so saving would replace its contents with unrelated values",
                 pathToSave);
             throw new InvalidOperationException(
-                "User settings were never loaded successfully; saving would overwrite the existing settings file with defaults.");
+                $"The settings file '{pathToSave}' was never read into the current settings; saving would overwrite it with values that did not come from it.");
         }
 
         try
@@ -235,17 +224,34 @@ public class UserSettingsService : IUserSettingsService
     }
 
     /// <summary>
-    /// Sets the settings file path for testing purposes.
+    /// Adopts <paramref name="path"/> as the settings file, reading it into the in-memory settings.
+    /// This is the "start using this file" move, and it necessarily discards the settings currently
+    /// held in memory, which is why the settings the user is editing are never re-pointed through it.
     /// </summary>
     /// <param name="path">The path to set.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> is null, empty, or consists only of white-space characters.</exception>
     protected void SetSettingsFilePath(string path)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path, nameof(path));
-        _settingsFilePath = path;
-        _settings = LoadSettings(path, out var outcome);
-        _settingsLoaded = outcome != SettingsLoadOutcome.Failed;
+
+        lock (_lock)
+        {
+            _settings = LoadSettings(path, out var outcome);
+            _target = TargetFor(path, outcome);
+        }
     }
+
+    /// <summary>
+    /// Pairs a settings file with what reading it produced, so a path can never be adopted without
+    /// the read that decides whether writing it is safe.
+    /// </summary>
+    /// <param name="path">The settings file that was read.</param>
+    /// <param name="outcome">What reading it produced.</param>
+    /// <returns>The target the service should hold.</returns>
+    private static SettingsFileTarget TargetFor(string path, SettingsLoadOutcome outcome) =>
+        outcome == SettingsLoadOutcome.Failed
+            ? SettingsFileTarget.Unverified(path)
+            : SettingsFileTarget.Verified(path);
 
     private static void NormalizeAndValidateLocked(UserSettings s, IAppConfiguration appConfig)
     {
@@ -389,6 +395,48 @@ public class UserSettingsService : IUserSettingsService
         }
     }
 
+    /// <summary>
+    /// Points saves at <paramref name="path"/> on behalf of a user who edited the settings file
+    /// location, reading it first so the move cannot leave the service treating an unread file as
+    /// safe to overwrite.
+    /// </summary>
+    /// <remarks>
+    /// A path that already holds settings is adopted as the write target but left unverified, so
+    /// <see cref="SaveAsync"/> refuses instead of replacing that file with values derived from a
+    /// different one. Refusing rather than reloading is the only reading of the request that
+    /// destroys nothing: the file keeps its contents and the user keeps the edits they were saving,
+    /// and the ambiguity between "start using this file" and "save my settings there" is theirs to
+    /// resolve. Recovery needs no extra state, because pointing back at the verified file, or at
+    /// the same path once it no longer holds settings, verifies the target again.
+    /// </remarks>
+    /// <param name="path">The requested settings file path. A blank path leaves the target alone.</param>
+    private void RetargetLocked(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        var moved = _target.MoveTo(path);
+        if (moved.CanWrite)
+        {
+            _target = moved;
+            return;
+        }
+
+        LoadSettings(path, out var outcome);
+        if (outcome == SettingsLoadOutcome.Absent)
+        {
+            _target = SettingsFileTarget.Verified(path);
+            return;
+        }
+
+        _logger.LogError(
+            "Refusing to adopt {Path} as the settings file: it already holds settings that the settings in memory were not read from, so saving there would replace them",
+            path);
+        _target = moved;
+    }
+
     private string GetDefaultSettingsFilePath()
     {
         if (_appConfig == null)
@@ -445,7 +493,7 @@ public class UserSettingsService : IUserSettingsService
     /// Loads the settings and resolves the path they are persisted to.
     /// </summary>
     /// <remarks>
-    /// A failure here leaves <see cref="_settingsLoaded"/> false, which blocks <see cref="SaveAsync"/>
+    /// A failure here leaves the target unverified, which blocks <see cref="SaveAsync"/>
     /// rather than letting the session persist defaults over a settings file that was never read.
     /// That covers both the exceptions that escape to the outer catch and the ones
     /// <see cref="LoadSettings"/> swallows, which is why the source it read has to report whether it
@@ -462,25 +510,26 @@ public class UserSettingsService : IUserSettingsService
             var initialSettings = LoadSettings(ResolveSettingsSourcePath(defaultPath), out var outcome);
 
             // If the user has a custom path, reload from there; otherwise keep what the default path gave us.
+            string writePath;
             if (!string.IsNullOrWhiteSpace(initialSettings.SettingsFilePath) &&
                 !PathHelper.AreSamePath(initialSettings.SettingsFilePath, defaultPath))
             {
-                _settingsFilePath = initialSettings.SettingsFilePath;
-                _settings = LoadSettings(_settingsFilePath, out outcome);
+                writePath = initialSettings.SettingsFilePath;
+                _settings = LoadSettings(writePath, out outcome);
             }
             else
             {
-                _settingsFilePath = defaultPath;
+                writePath = defaultPath;
                 _settings = initialSettings;
             }
 
-            _settingsLoaded = outcome != SettingsLoadOutcome.Failed;
+            _target = TargetFor(writePath, outcome);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to initialize settings, continuing with defaults and without persistence");
             _settings = new UserSettings();
-            _settingsLoaded = false;
+            _target = SettingsFileTarget.Unverified(string.Empty);
             return;
         }
 
@@ -495,5 +544,64 @@ public class UserSettingsService : IUserSettingsService
         {
             _logger.LogError(ex, "Failed to normalize settings, keeping the loaded values as they are");
         }
+    }
+
+    /// <summary>
+    /// The settings file a save writes to, paired with the file that was last verified as safe to
+    /// overwrite.
+    /// </summary>
+    /// <remarks>
+    /// The pairing is what makes the guard hold structurally. The two facts live in one immutable
+    /// value with a private constructor, so a caller cannot move the write path and leave a stale
+    /// "already read" flag behind it: the only ways to produce a target are to state that a path was
+    /// verified, to state that it was not, or to move away from a verified path, which drops the
+    /// permission to write with it.
+    /// </remarks>
+    private sealed class SettingsFileTarget
+    {
+        private SettingsFileTarget(string path, string verifiedPath)
+        {
+            Path = path;
+            VerifiedPath = verifiedPath;
+        }
+
+        /// <summary>
+        /// Gets the settings file a save writes to.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Gets the settings file last verified as safe to overwrite, either because it was read
+        /// into the in-memory settings or because it held nothing a save could destroy. Empty when
+        /// no file has been verified.
+        /// </summary>
+        public string VerifiedPath { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether saving writes the file the in-memory settings account
+        /// for rather than an unrelated one.
+        /// </summary>
+        public bool CanWrite => VerifiedPath.Length > 0 && PathHelper.AreSamePath(Path, VerifiedPath);
+
+        /// <summary>
+        /// Creates a target for a file that was read, or that held nothing a save could destroy.
+        /// </summary>
+        /// <param name="path">The settings file.</param>
+        /// <returns>A target that may be written.</returns>
+        public static SettingsFileTarget Verified(string path) => new(path, path);
+
+        /// <summary>
+        /// Creates a target for a file holding settings the in-memory settings do not account for.
+        /// </summary>
+        /// <param name="path">The settings file.</param>
+        /// <returns>A target that must not be written.</returns>
+        public static SettingsFileTarget Unverified(string path) => new(path, string.Empty);
+
+        /// <summary>
+        /// Moves the write path, carrying the verified file rather than the permission to write.
+        /// </summary>
+        /// <param name="path">The settings file to write from now on.</param>
+        /// <returns>The moved target, writable only when it lands back on the verified file.</returns>
+        public SettingsFileTarget MoveTo(string path) => new(path, VerifiedPath);
     }
 }

--- a/GenHub/GenHub/Common/Services/UserSettingsService.cs
+++ b/GenHub/GenHub/Common/Services/UserSettingsService.cs
@@ -334,29 +334,73 @@ public class UserSettingsService : IUserSettingsService
         return Path.Combine(_appConfig.GetConfiguredDataPath(), FileTypes.SettingsFileName);
     }
 
+    /// <summary>
+    /// Resolves the file the settings are read from. When the current data root holds no settings
+    /// file, the pre-upgrade roaming location is read instead so an upgrading user keeps their
+    /// settings on the first launch rather than starting from defaults and then overwriting the
+    /// migrated file on the first save. Writes always target <paramref name="defaultPath"/>; moving
+    /// the file remains the responsibility of the legacy data root migration.
+    /// </summary>
+    /// <param name="defaultPath">The settings file path for the current data root.</param>
+    /// <returns>The path the settings should be read from.</returns>
+    private string ResolveSettingsSourcePath(string defaultPath)
+    {
+        try
+        {
+            if (_appConfig == null || File.Exists(defaultPath))
+            {
+                return defaultPath;
+            }
+
+            var legacyPath = Path.Combine(_appConfig.GetLegacyConfiguredDataPath(), FileTypes.SettingsFileName);
+            if (!string.Equals(legacyPath, defaultPath, StringComparison.OrdinalIgnoreCase) && File.Exists(legacyPath))
+            {
+                _logger.LogInformation(
+                    "No settings file at {DefaultPath}, reading pre-upgrade settings from {LegacyPath}",
+                    defaultPath,
+                    legacyPath);
+                return legacyPath;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to look for pre-upgrade settings, falling back to {DefaultPath}", defaultPath);
+        }
+
+        return defaultPath;
+    }
+
     private void InitializeSettings()
     {
-        // 1. Load from default path to determine if a custom path is set.
-        var defaultPath = GetDefaultSettingsFilePath();
-        var initialSettings = LoadSettings(defaultPath);
+        try
+        {
+            // 1. Load from default path to determine if a custom path is set.
+            var defaultPath = GetDefaultSettingsFilePath();
+            var initialSettings = LoadSettings(ResolveSettingsSourcePath(defaultPath));
 
-        // 2. If user has a custom path, reload from that path. Otherwise, use the settings from the default path.
-        if (!string.IsNullOrWhiteSpace(initialSettings.SettingsFilePath) &&
-            !string.Equals(initialSettings.SettingsFilePath, defaultPath, StringComparison.OrdinalIgnoreCase))
-        {
-            _settingsFilePath = initialSettings.SettingsFilePath;
-            _settings = LoadSettings(_settingsFilePath);
-        }
-        else
-        {
-            _settingsFilePath = defaultPath;
-            _settings = initialSettings;
-        }
+            // 2. If user has a custom path, reload from that path. Otherwise, use the settings from the default path.
+            if (!string.IsNullOrWhiteSpace(initialSettings.SettingsFilePath) &&
+                !string.Equals(initialSettings.SettingsFilePath, defaultPath, StringComparison.OrdinalIgnoreCase))
+            {
+                _settingsFilePath = initialSettings.SettingsFilePath;
+                _settings = LoadSettings(_settingsFilePath);
+            }
+            else
+            {
+                _settingsFilePath = defaultPath;
+                _settings = initialSettings;
+            }
 
-        // Apply validation and normalization
-        lock (_lock)
+            // Apply validation and normalization
+            lock (_lock)
+            {
+                NormalizeAndValidateLocked(_settings, _appConfig);
+            }
+        }
+        catch (Exception ex)
         {
-            NormalizeAndValidateLocked(_settings, _appConfig);
+            _logger.LogError(ex, "Failed to initialize settings, continuing with defaults");
+            _settings = new UserSettings();
         }
     }
 }

--- a/GenHub/GenHub/Common/Services/UserSettingsService.cs
+++ b/GenHub/GenHub/Common/Services/UserSettingsService.cs
@@ -1,10 +1,13 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Security;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Models.Common;
 using Microsoft.Extensions.Logging;
@@ -27,11 +30,23 @@ public class UserSettingsService : IUserSettingsService
         Converters = { new JsonStringEnumConverter() },
     };
 
+    /// <summary>
+    /// The settings file names to look for in the pre-upgrade data root, most recent first.
+    /// Releases up to v0.0.3 combined the data root with the JSON extension rather than the settings
+    /// file name, so their settings file is literally named <c>.json</c>.
+    /// </summary>
+    private static readonly string[] LegacySettingsFileNames =
+    [
+        FileTypes.SettingsFileName,
+        FileTypes.LegacySettingsFileName,
+    ];
+
     private readonly ILogger<UserSettingsService> _logger;
     private readonly IAppConfiguration _appConfig;
     private readonly object _lock = new();
     private string _settingsFilePath = string.Empty;
     private UserSettings _settings = new();
+    private bool _settingsLoaded;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UserSettingsService"/> class.
@@ -63,6 +78,7 @@ public class UserSettingsService : IUserSettingsService
             // For testing - set defaults but don't load from file
             _settingsFilePath = string.Empty;
             _settings = new UserSettings();
+            _settingsLoaded = true;
         }
     }
 
@@ -93,7 +109,7 @@ public class UserSettingsService : IUserSettingsService
 
             // If the settings file path was changed, update the internal field
             if (!string.IsNullOrWhiteSpace(_settings.SettingsFilePath) &&
-                !string.Equals(_settings.SettingsFilePath, _settingsFilePath, StringComparison.OrdinalIgnoreCase))
+                !PathHelper.AreSamePath(_settings.SettingsFilePath, _settingsFilePath))
             {
                 _settingsFilePath = _settings.SettingsFilePath;
             }
@@ -115,7 +131,7 @@ public class UserSettingsService : IUserSettingsService
             {
                 // propagate any internal path updates
                 if (!string.IsNullOrWhiteSpace(_settings.SettingsFilePath) &&
-                    !string.Equals(_settings.SettingsFilePath, _settingsFilePath, StringComparison.OrdinalIgnoreCase))
+                    !PathHelper.AreSamePath(_settings.SettingsFilePath, _settingsFilePath))
                 {
                     _settingsFilePath = _settings.SettingsFilePath;
                 }
@@ -148,10 +164,21 @@ public class UserSettingsService : IUserSettingsService
     {
         UserSettings settingsToSave;
         string pathToSave;
+        bool settingsLoaded;
         lock (_lock)
         {
             pathToSave = _settingsFilePath;
             settingsToSave = Get();
+            settingsLoaded = _settingsLoaded;
+        }
+
+        if (!settingsLoaded)
+        {
+            _logger.LogError(
+                "Refusing to save settings to {Path}: initialization failed, so the in-memory settings are defaults rather than the user's values",
+                pathToSave);
+            throw new InvalidOperationException(
+                "User settings were never loaded successfully; saving would overwrite the existing settings file with defaults.");
         }
 
         try
@@ -194,6 +221,7 @@ public class UserSettingsService : IUserSettingsService
         ArgumentException.ThrowIfNullOrWhiteSpace(path, nameof(path));
         _settingsFilePath = path;
         _settings = LoadSettings(path);
+        _settingsLoaded = true;
     }
 
     private static void NormalizeAndValidateLocked(UserSettings s, IAppConfiguration appConfig)
@@ -352,8 +380,12 @@ public class UserSettingsService : IUserSettingsService
                 return defaultPath;
             }
 
-            var legacyPath = Path.Combine(_appConfig.GetLegacyConfiguredDataPath(), FileTypes.SettingsFileName);
-            if (!string.Equals(legacyPath, defaultPath, StringComparison.OrdinalIgnoreCase) && File.Exists(legacyPath))
+            var legacyRoot = _appConfig.GetLegacyConfiguredDataPath();
+            var legacyPath = LegacySettingsFileNames
+                .Select(name => Path.Combine(legacyRoot, name))
+                .FirstOrDefault(path => !PathHelper.AreSamePath(path, defaultPath) && File.Exists(path));
+
+            if (legacyPath is not null)
             {
                 _logger.LogInformation(
                     "No settings file at {DefaultPath}, reading pre-upgrade settings from {LegacyPath}",
@@ -362,7 +394,7 @@ public class UserSettingsService : IUserSettingsService
                 return legacyPath;
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
         {
             _logger.LogWarning(ex, "Failed to look for pre-upgrade settings, falling back to {DefaultPath}", defaultPath);
         }
@@ -370,17 +402,25 @@ public class UserSettingsService : IUserSettingsService
         return defaultPath;
     }
 
+    /// <summary>
+    /// Loads the settings and resolves the path they are persisted to.
+    /// </summary>
+    /// <remarks>
+    /// A failure here leaves <see cref="_settingsLoaded"/> false, which blocks <see cref="SaveAsync"/>
+    /// rather than letting the session persist defaults over a settings file that was never read.
+    /// Normalization is applied separately: clamping to an inconsistent configured range is no reason
+    /// to discard settings that loaded fine.
+    /// </remarks>
     private void InitializeSettings()
     {
         try
         {
-            // 1. Load from default path to determine if a custom path is set.
             var defaultPath = GetDefaultSettingsFilePath();
             var initialSettings = LoadSettings(ResolveSettingsSourcePath(defaultPath));
 
-            // 2. If user has a custom path, reload from that path. Otherwise, use the settings from the default path.
+            // If the user has a custom path, reload from there; otherwise keep what the default path gave us.
             if (!string.IsNullOrWhiteSpace(initialSettings.SettingsFilePath) &&
-                !string.Equals(initialSettings.SettingsFilePath, defaultPath, StringComparison.OrdinalIgnoreCase))
+                !PathHelper.AreSamePath(initialSettings.SettingsFilePath, defaultPath))
             {
                 _settingsFilePath = initialSettings.SettingsFilePath;
                 _settings = LoadSettings(_settingsFilePath);
@@ -391,16 +431,26 @@ public class UserSettingsService : IUserSettingsService
                 _settings = initialSettings;
             }
 
-            // Apply validation and normalization
+            _settingsLoaded = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize settings, continuing with defaults and without persistence");
+            _settings = new UserSettings();
+            _settingsLoaded = false;
+            return;
+        }
+
+        try
+        {
             lock (_lock)
             {
                 NormalizeAndValidateLocked(_settings, _appConfig);
             }
         }
-        catch (Exception ex)
+        catch (ArgumentException ex)
         {
-            _logger.LogError(ex, "Failed to initialize settings, continuing with defaults");
-            _settings = new UserSettings();
+            _logger.LogError(ex, "Failed to normalize settings, keeping the loaded values as they are");
         }
     }
 }

--- a/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestDiscoveryService.cs
@@ -127,7 +127,7 @@ public class ManifestDiscoveryService(
         // is honoured; a raw SpecialFolder lookup would keep reading the default tree.
         var applicationDataPath = configurationProvider.GetApplicationDataPath();
         var localManifestDir = Path.Combine(applicationDataPath, FileTypes.ManifestsDirectory);
-        var customManifestDir = Path.Combine(applicationDataPath, "CustomManifests");
+        var customManifestDir = Path.Combine(applicationDataPath, DirectoryNames.CustomManifests);
 
         await DiscoverFileSystemManifestsAsync([localManifestDir, customManifestDir], cancellationToken);
 

--- a/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/GenHub/GenHub/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -593,6 +593,10 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to save settings");
+            _notificationService.ShowError(
+                "Settings Not Saved",
+                ex.Message,
+                (int)TimeIntervals.NotificationHideDelay.TotalMilliseconds);
         }
         finally
         {

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -34,9 +34,9 @@ public class UserDataTrackerService(
     private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
 
     private readonly string _userDataTrackingPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData);
-    private readonly string _manifestsPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, "manifests");
-    private readonly string _backupsPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, "backups");
-    private readonly string _indexPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, "index.json");
+    private readonly string _manifestsPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, DirectoryNames.UserDataManifests);
+    private readonly string _backupsPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, DirectoryNames.UserDataBackups);
+    private readonly string _indexPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, FileTypes.UserDataIndexFileName);
 
     private UserDataIndex? _cachedIndex;
 

--- a/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
+++ b/GenHub/GenHub/Features/UserData/Services/UserDataTrackerService.cs
@@ -33,10 +33,10 @@ public class UserDataTrackerService(
     private static readonly SemaphoreSlim IndexLock = new(1, 1);
     private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
 
-    private readonly string _userDataTrackingPath = Path.Combine(configProvider.GetApplicationDataPath(), "UserData");
-    private readonly string _manifestsPath = Path.Combine(configProvider.GetApplicationDataPath(), "UserData", "manifests");
-    private readonly string _backupsPath = Path.Combine(configProvider.GetApplicationDataPath(), "UserData", "backups");
-    private readonly string _indexPath = Path.Combine(configProvider.GetApplicationDataPath(), "UserData", "index.json");
+    private readonly string _userDataTrackingPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData);
+    private readonly string _manifestsPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, "manifests");
+    private readonly string _backupsPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, "backups");
+    private readonly string _indexPath = Path.Combine(configProvider.GetApplicationDataPath(), DirectoryNames.UserData, "index.json");
 
     private UserDataIndex? _cachedIndex;
 

--- a/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
+++ b/GenHub/GenHub/Features/Workspace/WorkspaceManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Storage;
@@ -35,7 +36,7 @@ public class WorkspaceManager(
     private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
 
     // Stores workspace metadata in the application data directory
-    private readonly string _workspaceMetadataPath = Path.Combine(configurationProvider.GetApplicationDataPath(), "workspaces.json");
+    private readonly string _workspaceMetadataPath = Path.Combine(configurationProvider.GetApplicationDataPath(), FileTypes.WorkspaceMetadataFileName);
 
     /// <summary>
     /// Prepares a workspace using the specified configuration and strategy.

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -208,14 +208,21 @@ Constants for unit conversions used throughout the application.
 
 Directory names used for organizing content storage.
 
-| Constant  | Value        | Description                   |
-| --------- | ------------ | ----------------------------- |
-| `Data`    | `"Data"`     | Directory for content data    |
-| `Cache`   | `"Cache"`    | Directory for cache files     |
-| `CasPool` | `"cas-pool"` | Directory for CAS pool        |
-| `Temp`    | `"Temp"`     | Directory for temporary files |
-| `Logs`    | `"Logs"`     | Directory for log files       |
-| `Backups` | `"Backups"`  | Directory for backup files    |
+| Constant            | Value          | Description                                                              |
+| ------------------- | -------------- | ------------------------------------------------------------------------ |
+| `Data`              | `"Data"`       | Directory for content data                                               |
+| `Cache`             | `"Cache"`      | Directory for cache files                                                |
+| `CasPool`           | `"cas-pool"`   | Directory for CAS pool                                                   |
+| `Temp`              | `"Temp"`       | Directory for temporary files                                            |
+| `Logs`              | `"Logs"`       | Directory for log files                                                  |
+| `Backups`           | `"Backups"`    | Directory for backup files                                               |
+| `Profiles`          | `"Profiles"`   | Directory for game profiles                                              |
+| `UserData`          | `"UserData"`   | Directory for tracked user data                                          |
+| `UserDataManifests` | `"manifests"`  | Manifests of tracked user data, nested in `UserData` (exact on-disk case) |
+| `UserDataBackups`   | `"backups"`    | Backups of replaced user data files, nested in `UserData` (exact on-disk case) |
+| `Workspaces`        | `"Workspaces"` | Directory for workspaces                                                 |
+| `ToolWorkspaces`    | `"ToolWorkspaces"` | Directory for tool workspaces                                        |
+| `LegacyContent`     | `"Content"`    | Sub-layout used up to v0.0.3; probed only by the upgrade migration       |
 
 ---
 
@@ -249,11 +256,14 @@ File and directory name constants to prevent typos and ensure consistency.
 
 ### JSON Files
 
-| Constant            | Value             | Description                   |
-| ------------------- | ----------------- | ----------------------------- |
-| `JsonFileExtension` | `".json"`         | File extension for JSON files |
-| `JsonFilePattern`   | `"*.json"`        | File pattern for JSON files   |
-| `SettingsFileName`  | `"settings.json"` | Default settings file name    |
+| Constant                     | Value               | Description                                                           |
+| ---------------------------- | ------------------- | --------------------------------------------------------------------- |
+| `JsonFileExtension`          | `".json"`           | File extension for JSON files                                         |
+| `JsonFilePattern`            | `"*.json"`          | File pattern for JSON files                                           |
+| `SettingsFileName`           | `"settings.json"`   | Default settings file name                                            |
+| `LegacySettingsFileName`     | `".json"`           | Settings file name written up to v0.0.3; probed only by the upgrade migration |
+| `WorkspaceMetadataFileName`  | `"workspaces.json"` | File holding the persisted workspace metadata                         |
+| `UserDataIndexFileName`      | `"index.json"`      | Index of installed user data, nested in `UserData`                    |
 
 ---
 


### PR DESCRIPTION
## Problem

The v0.0.3 -> v0.0.4 upgrade path is broken in three independent ways. Together they mean an upgrading user loses their profiles and settings, and has every workspace rebuilt.

**1. The data root moved with no migration.** Four resolutions in `AppConfiguration` changed from `SpecialFolder.ApplicationData` to `SpecialFolder.LocalApplicationData` (Windows `%APPDATA%\GenHub` -> `%LOCALAPPDATA%\GenHub`; Linux `~/.config` -> `~/.local/share`). The only existing migration, `MigrateContentDirectory`, reshuffles a `Content` subdirectory *within* one root and returns early when it does not exist. So **every** alpha-3 user starts alpha 4 against an empty root and loses profiles, manifests, tracked user data, workspace metadata and settings.

**2. `WorkspaceStrategy` was renumbered.** v0.0.3 had `SymlinkOnly=0, FullCopy=1, HybridCopySymlink=2, HardLink=3`; current `main` has `HardLink=0, SymlinkOnly=1, ...`. Alpha-3 wrote `workspaces.json` with raw **ints** (`WorkspaceManager`'s options have no `JsonStringEnumConverter`) but wrote profiles as **strings** (`GameProfileRepository`'s options do). On upgrade the workspace side is misread by ordinal while the profile side parses correctly by name, so the two disagree, `WorkspaceManager`'s strategy-mismatch check sets `ForceRecreate`, and every existing multi-GB workspace is deleted and rebuilt.

**3. Profiles and manifests ignored the `ApplicationDataPath` override.** `GetProfilesPath()`/`GetManifestsPath()` used `GetConfiguredDataPath()` directly while `GetApplicationDataPath()`, `GetWorkspacePath()` and `GetCachePath()` all honor an explicitly-set override — so a user who relocated their data directory had profiles and manifests resolve somewhere else entirely.

## Changes

- **Restored the original enum ordinals** and added a remark that the numeric values are part of the on-disk format. `JsonWorkspaceStrategyConverter.Write()` now emits the member **name** so a future reordering cannot recur; `Read()` still accepts legacy numbers and strings.
- **New legacy data root migration** (`MigrateLegacyDataRoot`), run inside the existing migration lock ahead of `MigrateContentDirectory`. It no-ops when the legacy root is absent, when both roots resolve to the same path, or when the legacy root holds none of the tracked entries. It migrates exactly the settings file, `Profiles/`, `Manifests/`, `UserData/` and `workspaces.json`, each wrapped so a failure logs and continues rather than breaking startup, and never deletes the legacy root. `MigrateFile` skips any destination that already exists, which makes the whole thing idempotent and non-destructive. `MigrateDirectory` gained an `IOException` fallback to per-entry migration for the cross-volume case.
- **The CAS pool is deliberately excluded.** `GetCasConfiguration` still defaults `CasRootPath` to the legacy roaming location and alpha-3 used the same location, so CAS is currently consistent; moving the pool would orphan multi-GB stores.
- **`GetProfilesPath()`/`GetManifestsPath()`** now route through `GetApplicationDataPath()`.
- **Settings are correct on the first launch, not the second.** `UserSettingsService` builds in its constructor, before anything triggers the migration, so it would have read the empty new root, initialized defaults, and then overwritten the just-migrated file on the first save — destroying the very settings this PR exists to preserve, including `ApplicationDataPath` and `CasRootPath`. It now resolves its *read* path to the legacy file when the current root has none, while writes always target the new root; the move stays solely in the migration. `InitializeSettings` is also now failure-tolerant so it cannot throw out of the constructor.
- Replaced the `"Manifests"`/`"UserData"`/`"workspaces.json"` literals with constants.

## Tests

1638 -> 1681, all passing. Verified the new tests are genuine regression tests: reverting the settings resolution makes exactly the three sequence-specific tests fail.

- legacy `workspaces.json` with raw int strategies deserializes to the correct strategy; legacy profile strings still parse; converter round-trips and reads both encodings
- legacy workspace and profile metadata now **agree** — the comparison that triggered `ForceRecreate`
- `GetProfilesPath`/`GetManifestsPath` honor an explicit override
- migration moves the five tracked entries, is idempotent, does not overwrite existing files, leaves `CasPool` untouched, and no-ops without a legacy root or with identical roots
- first launch loads legacy settings; load -> migrate -> save preserves them; a legacy `ApplicationDataPath` override is honored immediately with no restart; second launch ignores the legacy file; fresh install is unaffected; a throwing legacy lookup still completes construction

## Notes

The migration **moves** rather than copies, matching the existing `MigrateDirectory` behavior, so a user who downgrades to v0.0.3 after upgrading will not find their data in the old location. Copying instead would double disk usage for what may be a large `UserData` tree. Worth a conscious call before release.

Corrected three pre-existing tests that hardcoded the post-renumbering ordinals, and added `AppConfiguration.cs` to the `ApplicationDataPathConventionTests` allowlist since it now legitimately reads the roaming folder to resolve the legacy root.