### PR TITLE
fix(content): bound archive extraction and propagate cancellation from deliverers

### DIFF
--- a/GenHub/Directory.Packages.props
+++ b/GenHub/Directory.Packages.props
@@ -47,7 +47,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="moq" Version="4.20.72" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="SharpCompress" Version="0.42.0" />
+    <PackageVersion Include="SharpCompress" Version="0.48.0" />
     <PackageVersion Include="System.Management" Version="10.0.2" />
     <!-- Image processing for AVIF to TGA conversion (GenPatcher content) -->
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />

--- a/GenHub/GenHub.Core/Constants/CommunityOutpostConstants.cs
+++ b/GenHub/GenHub.Core/Constants/CommunityOutpostConstants.cs
@@ -85,6 +85,22 @@ public static class CommunityOutpostConstants
     /// </summary>
     public const string PatchPageUrl = "https://legi.cc/downloads/genpatcher/";
 
+    /// <summary>
+    /// Maximum number of file entries a downloaded Community Outpost archive may contain.
+    /// </summary>
+    public const int MaxArchiveEntries = 10000;
+
+    /// <summary>
+    /// Maximum number of bytes a single Community Outpost archive entry may expand to (2 GB),
+    /// sized to accommodate the largest shipped BIG files.
+    /// </summary>
+    public const long MaxEntryUncompressedBytes = 2L * 1024 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum aggregate uncompressed bytes a Community Outpost archive may expand to (4 GB).
+    /// </summary>
+    public const long MaxAggregateUncompressedBytes = 4L * 1024 * 1024 * 1024;
+
     /// <summary>Display name for Game Clients content type.</summary>
     public const string ContentTypeGameClients = "Game Clients";
 

--- a/GenHub/GenHub.Core/Constants/CommunityOutpostConstants.cs
+++ b/GenHub/GenHub.Core/Constants/CommunityOutpostConstants.cs
@@ -91,13 +91,13 @@ public static class CommunityOutpostConstants
     public const int MaxArchiveEntries = 10000;
 
     /// <summary>
-    /// Maximum number of bytes a single Community Outpost archive entry may expand to (2 GB),
+    /// Maximum number of bytes a single Community Outpost archive entry may expand to (2 GiB),
     /// sized to accommodate the largest shipped BIG files.
     /// </summary>
     public const long MaxEntryUncompressedBytes = 2L * 1024 * 1024 * 1024;
 
     /// <summary>
-    /// Maximum aggregate uncompressed bytes a Community Outpost archive may expand to (4 GB).
+    /// Maximum aggregate uncompressed bytes a Community Outpost archive may expand to (4 GiB).
     /// </summary>
     public const long MaxAggregateUncompressedBytes = 4L * 1024 * 1024 * 1024;
 

--- a/GenHub/GenHub.Core/Constants/GitHubConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GitHubConstants.cs
@@ -333,6 +333,33 @@ public static class GitHubConstants
     /// <summary>Description for GitHub content deliverer.</summary>
     public const string GitHubDelivererDescription = "Delivers GitHub content including release archives";
 
+    // Archive extraction limits
+    // GitHub caps a single release asset at 2 GiB, so a downloaded archive can never exceed that
+    // compressed. These bounds leave generous headroom above real game content while keeping an
+    // archive that lies about its declared sizes from expanding without limit.
+
+    /// <summary>Maximum number of file entries a downloaded GitHub archive may contain.</summary>
+    public const int MaxArchiveEntries = 50000;
+
+    /// <summary>Maximum number of bytes a single GitHub archive entry may expand to (4 GiB).</summary>
+    public const long MaxEntryUncompressedBytes = 4L * 1024 * 1024 * 1024;
+
+    /// <summary>Maximum aggregate uncompressed bytes a GitHub archive may expand to (16 GiB).</summary>
+    public const long MaxAggregateUncompressedBytes = 16L * 1024 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum factor by which a GitHub archive may expand beyond its own downloaded size. Release
+    /// archives are deflate-compressed game content and executables, which run well under 20:1, so
+    /// this bounds a small archive that claims to hold very little and then inflates without end.
+    /// </summary>
+    public const long MaxArchiveExpansionRatio = 500;
+
+    /// <summary>
+    /// Floor for the ratio-derived expansion budget (8 MiB), so a very small archive still gets
+    /// room for content that compresses unusually well and is judged only by the absolute caps.
+    /// </summary>
+    public const long MinArchiveExpansionBudgetBytes = 8L * 1024 * 1024;
+
     // Metadata keys
 
     /// <summary>Metadata key for repository owner.</summary>

--- a/GenHub/GenHub.Core/Constants/IoConstants.cs
+++ b/GenHub/GenHub.Core/Constants/IoConstants.cs
@@ -15,4 +15,10 @@ public static class IoConstants
     /// themselves reached through links. Bounds the walk on a filesystem that contains a cycle.
     /// </summary>
     public const int MaxSymbolicLinkResolutionDepth = 8;
+
+    /// <summary>
+    /// Suffix appended to a destination path to stage a write beside its final location so the
+    /// existing file is only replaced once the write has completed.
+    /// </summary>
+    public const string StagingFileSuffix = ".genhub-staging";
 }

--- a/GenHub/GenHub.Core/Constants/IoConstants.cs
+++ b/GenHub/GenHub.Core/Constants/IoConstants.cs
@@ -17,8 +17,9 @@ public static class IoConstants
     public const int MaxSymbolicLinkResolutionDepth = 8;
 
     /// <summary>
-    /// Suffix appended to a destination path to stage a write beside its final location so the
-    /// existing file is only replaced once the write has completed.
+    /// Suffix that marks a staging file written beside its final location so the existing file is
+    /// only replaced once the write has completed. The name it is appended to is random rather than
+    /// the destination name, which keeps a staged write from outgrowing the Windows path limit.
     /// </summary>
     public const string StagingFileSuffix = ".genhub-staging";
 }

--- a/GenHub/GenHub.Core/Exceptions/ArchiveExpansionLimitExceededException.cs
+++ b/GenHub/GenHub.Core/Exceptions/ArchiveExpansionLimitExceededException.cs
@@ -41,7 +41,12 @@ public class ArchiveExpansionLimitExceededException : Exception
     /// <param name="entryName">The archive-relative name of the offending entry.</param>
     /// <param name="limitBytes">The number of bytes the entry was allowed to expand to.</param>
     public ArchiveExpansionLimitExceededException(string entryName, long limitBytes)
-        : base($"Archive entry '{entryName}' expanded past the allowed {limitBytes} bytes (potential zip bomb).")
+        : this($"Archive entry '{entryName}' expanded past the allowed {limitBytes} bytes (potential zip bomb).", entryName, limitBytes)
+    {
+    }
+
+    private ArchiveExpansionLimitExceededException(string message, string entryName, long limitBytes)
+        : base(message)
     {
         EntryName = entryName;
         LimitBytes = limitBytes;
@@ -56,4 +61,16 @@ public class ArchiveExpansionLimitExceededException : Exception
     /// Gets the number of bytes the entry was allowed to expand to.
     /// </summary>
     public long LimitBytes { get; }
+
+    /// <summary>
+    /// Creates an exception for an entry refused because the archive-wide expansion budget was
+    /// already spent, so no byte of it was ever read.
+    /// </summary>
+    /// <param name="entryName">The archive-relative name of the refused entry.</param>
+    /// <returns>An exception describing the spent budget.</returns>
+    public static ArchiveExpansionLimitExceededException ForSpentBudget(string entryName) =>
+        new(
+            $"Archive entry '{entryName}' was refused because the archive-wide expansion budget was already spent (potential zip bomb).",
+            entryName,
+            0);
 }

--- a/GenHub/GenHub.Core/Exceptions/ArchiveExpansionLimitExceededException.cs
+++ b/GenHub/GenHub.Core/Exceptions/ArchiveExpansionLimitExceededException.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace GenHub.Core.Exceptions;
+
+/// <summary>
+/// Exception thrown when an archive entry expands past the budget allowed for it, which means the
+/// size declared in the archive headers understated the real decompressed size.
+/// </summary>
+public class ArchiveExpansionLimitExceededException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveExpansionLimitExceededException"/> class.
+    /// </summary>
+    public ArchiveExpansionLimitExceededException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveExpansionLimitExceededException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public ArchiveExpansionLimitExceededException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveExpansionLimitExceededException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
+    public ArchiveExpansionLimitExceededException(string message, Exception? inner)
+        : base(message, inner)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveExpansionLimitExceededException"/> class
+    /// for a named entry that exceeded a byte budget.
+    /// </summary>
+    /// <param name="entryName">The archive-relative name of the offending entry.</param>
+    /// <param name="limitBytes">The number of bytes the entry was allowed to expand to.</param>
+    public ArchiveExpansionLimitExceededException(string entryName, long limitBytes)
+        : base($"Archive entry '{entryName}' expanded past the allowed {limitBytes} bytes (potential zip bomb).")
+    {
+        EntryName = entryName;
+        LimitBytes = limitBytes;
+    }
+
+    /// <summary>
+    /// Gets the archive-relative name of the offending entry.
+    /// </summary>
+    public string EntryName { get; } = string.Empty;
+
+    /// <summary>
+    /// Gets the number of bytes the entry was allowed to expand to.
+    /// </summary>
+    public long LimitBytes { get; }
+}

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -62,4 +62,24 @@ public static class PathHelper
         var parent = Path.GetDirectoryName(path);
         return string.IsNullOrEmpty(parent) ? path : parent;
     }
+
+    /// <summary>
+    /// Determines whether a candidate path resolves to a location inside a base directory.
+    /// Both paths are fully normalized first, so <c>..</c> segments, redundant separators and
+    /// rooted candidates cannot escape the base directory.
+    /// </summary>
+    /// <param name="baseDirectory">The directory that must contain the candidate path.</param>
+    /// <param name="candidatePath">The path to test for containment.</param>
+    /// <returns><see langword="true"/> when the candidate resolves inside the base directory; otherwise, <see langword="false"/>.</returns>
+    public static bool IsPathWithinDirectory(string baseDirectory, string candidatePath)
+    {
+        var normalizedRoot = Path.GetFullPath(baseDirectory);
+        var normalizedTarget = Path.GetFullPath(candidatePath);
+        var relative = Path.GetRelativePath(normalizedRoot, normalizedTarget);
+
+        return !relative.Equals("..", StringComparison.Ordinal) &&
+               !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+               !relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal) &&
+               !Path.IsPathRooted(relative);
+    }
 }

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -66,7 +66,10 @@ public static class PathHelper
     /// <summary>
     /// Determines whether a candidate path resolves to a location inside a base directory.
     /// Both paths are fully normalized first, so <c>..</c> segments, redundant separators and
-    /// rooted candidates cannot escape the base directory.
+    /// rooted candidates cannot escape the base directory. Because normalization is textual and a
+    /// symbolic link or junction redirects a path that reads as contained, both sides are also
+    /// compared after their links are followed; a path that cannot be resolved — because it does
+    /// not exist yet, or the filesystem refuses the query — is compared as written.
     /// </summary>
     /// <param name="baseDirectory">The directory that must contain the candidate path.</param>
     /// <param name="candidatePath">The path to test for containment.</param>
@@ -75,11 +78,62 @@ public static class PathHelper
     {
         var normalizedRoot = Path.GetFullPath(baseDirectory);
         var normalizedTarget = Path.GetFullPath(candidatePath);
+
+        return IsContained(normalizedRoot, normalizedTarget) &&
+               IsContained(FollowLinks(normalizedRoot), FollowLinks(normalizedTarget));
+    }
+
+    private static bool IsContained(string normalizedRoot, string normalizedTarget)
+    {
         var relative = Path.GetRelativePath(normalizedRoot, normalizedTarget);
 
         return !relative.Equals("..", StringComparison.Ordinal) &&
                !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
                !relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal) &&
                !Path.IsPathRooted(relative);
+    }
+
+    private static string FollowLinks(string fullPath)
+    {
+        try
+        {
+            var existing = fullPath;
+            var remainder = string.Empty;
+
+            while (!Directory.Exists(existing) && !File.Exists(existing))
+            {
+                var parent = Path.GetDirectoryName(existing);
+                if (string.IsNullOrEmpty(parent))
+                {
+                    return fullPath;
+                }
+
+                remainder = Path.Combine(Path.GetFileName(existing), remainder);
+                existing = parent;
+            }
+
+            FileSystemInfo info = Directory.Exists(existing)
+                ? new DirectoryInfo(existing)
+                : new FileInfo(existing);
+            var resolved = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? existing;
+
+            return remainder.Length == 0 ? resolved : Path.GetFullPath(Path.Combine(resolved, remainder));
+        }
+        catch (IOException)
+        {
+            return fullPath;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return fullPath;
+        }
+        catch (NotSupportedException)
+        {
+            return fullPath;
+        }
+        catch (ArgumentException)
+        {
+            return fullPath;
+        }
     }
 }

--- a/GenHub/GenHub.Core/Utilities/ArchiveEntryName.cs
+++ b/GenHub/GenHub.Core/Utilities/ArchiveEntryName.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+
+namespace GenHub.Core.Utilities;
+
+/// <summary>
+/// Screens archive entry names before they are turned into filesystem paths. Names come from
+/// third-party archives, so a name the host cannot represent has to be refused up front rather
+/// than left to fail somewhere inside the write: an empty name in particular collapses
+/// <see cref="Path.Combine(string, string)"/> onto the extraction directory itself, which puts the
+/// write on the directory instead of on a file inside it.
+/// </summary>
+public static class ArchiveEntryName
+{
+    private static readonly char[] SeparatorChars = ['/', '\\'];
+
+    private static readonly char[] UnusableChars =
+        ['\"', '<', '>', '|', ':', '*', '?', .. Enumerable.Range(0, 32).Select(value => (char)value)];
+
+    private static readonly string[] ReservedDeviceNames =
+    [
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+
+    /// <summary>
+    /// Determines whether an archive entry name can be combined with an extraction directory to
+    /// name a file. A name that resolves to the directory itself is refused, as is one the
+    /// strictest supported host cannot represent, so an archive behaves the same everywhere: that
+    /// rules out reserved device names and the characters Windows forbids, including the colon that
+    /// would otherwise open an NTFS alternate data stream. Traversal in the middle of a name is not
+    /// judged here; that stays with the containment check that follows.
+    /// </summary>
+    /// <param name="entryName">The archive-relative entry name to screen.</param>
+    /// <returns><see langword="true"/> when the name can be extracted; otherwise, <see langword="false"/>.</returns>
+    public static bool IsExtractable([NotNullWhen(true)] string? entryName)
+    {
+        if (string.IsNullOrWhiteSpace(entryName))
+        {
+            return false;
+        }
+
+        if (entryName.EndsWith('/') || entryName.EndsWith('\\'))
+        {
+            return false;
+        }
+
+        var segments = entryName.Split(SeparatorChars, StringSplitOptions.RemoveEmptyEntries);
+
+        return segments.Length > 0 &&
+               segments[^1] is not ("." or "..") &&
+               segments.All(IsExtractableSegment);
+    }
+
+    private static bool IsExtractableSegment(string segment)
+    {
+        if (string.IsNullOrWhiteSpace(segment))
+        {
+            return false;
+        }
+
+        if (segment is not ("." or "..") && (segment.EndsWith('.') || segment.EndsWith(' ')))
+        {
+            return false;
+        }
+
+        if (segment.IndexOfAny(UnusableChars) >= 0)
+        {
+            return false;
+        }
+
+        var deviceName = segment.Split('.')[0];
+
+        return !ReservedDeviceNames.Contains(deviceName, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/GenHub/GenHub.Core/Utilities/BoundedArchiveExtractor.cs
+++ b/GenHub/GenHub.Core/Utilities/BoundedArchiveExtractor.cs
@@ -16,8 +16,9 @@ public static class BoundedArchiveExtractor
 {
     /// <summary>
     /// Copies a decompressed archive entry to <paramref name="destinationPath"/>, aborting as soon as the
-    /// per-entry cap or the remaining archive-wide budget is exhausted. The partially written file is
-    /// deleted before the failure is surfaced.
+    /// per-entry cap or the remaining archive-wide budget is exhausted. When <paramref name="overwrite"/>
+    /// is set the entry is staged beside its destination and moved into place only once the copy has
+    /// completed, so a failure leaves any pre-existing file intact and removes only what this call wrote.
     /// </summary>
     /// <param name="entryStream">The decompressed entry stream to read from.</param>
     /// <param name="destinationPath">The file to write the entry to.</param>
@@ -27,7 +28,7 @@ public static class BoundedArchiveExtractor
     /// <param name="overwrite">Whether an existing destination file may be replaced.</param>
     /// <param name="cancellationToken">Token used to cancel the copy.</param>
     /// <returns>The number of bytes written.</returns>
-    /// <exception cref="ArchiveExpansionLimitExceededException">Thrown when the entry expands past its budget.</exception>
+    /// <exception cref="ArchiveExpansionLimitExceededException">Thrown when the budget is already exhausted or the entry expands past it.</exception>
     public static async Task<long> CopyEntryToFileAsync(
         Stream entryStream,
         string destinationPath,
@@ -40,15 +41,22 @@ public static class BoundedArchiveExtractor
         ArgumentNullException.ThrowIfNull(entryStream);
 
         var limit = Math.Min(maxEntryBytes, remainingAggregateBytes);
+        if (limit <= 0)
+        {
+            throw new ArchiveExpansionLimitExceededException(entryName, limit);
+        }
+
         var buffer = new byte[IoConstants.DefaultFileBufferSize];
         long written = 0;
 
-        var mode = overwrite ? FileMode.Create : FileMode.CreateNew;
-        var destination = new FileStream(destinationPath, mode, FileAccess.Write, FileShare.None);
+        var writePath = overwrite
+            ? $"{destinationPath}{IoConstants.StagingFileSuffix}{Guid.NewGuid():N}"
+            : destinationPath;
+        var destination = new FileStream(writePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
 
         try
         {
-            int read;
+            int read = 0;
             while ((read = await entryStream.ReadAsync(buffer, cancellationToken)) > 0)
             {
                 written += read;
@@ -59,25 +67,31 @@ public static class BoundedArchiveExtractor
 
                 await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
             }
+
+            await destination.DisposeAsync();
+
+            if (overwrite)
+            {
+                File.Move(writePath, destinationPath, overwrite: true);
+            }
         }
         catch
         {
             await destination.DisposeAsync();
-            DeletePartialOutput(destinationPath);
+            DeletePartialOutput(writePath);
             throw;
         }
 
-        await destination.DisposeAsync();
         return written;
     }
 
-    private static void DeletePartialOutput(string destinationPath)
+    private static void DeletePartialOutput(string writePath)
     {
         try
         {
-            if (File.Exists(destinationPath))
+            if (File.Exists(writePath))
             {
-                File.Delete(destinationPath);
+                File.Delete(writePath);
             }
         }
         catch (IOException)

--- a/GenHub/GenHub.Core/Utilities/BoundedArchiveExtractor.cs
+++ b/GenHub/GenHub.Core/Utilities/BoundedArchiveExtractor.cs
@@ -43,15 +43,13 @@ public static class BoundedArchiveExtractor
         var limit = Math.Min(maxEntryBytes, remainingAggregateBytes);
         if (limit <= 0)
         {
-            throw new ArchiveExpansionLimitExceededException(entryName, limit);
+            throw ArchiveExpansionLimitExceededException.ForSpentBudget(entryName);
         }
 
         var buffer = new byte[IoConstants.DefaultFileBufferSize];
         long written = 0;
 
-        var writePath = overwrite
-            ? $"{destinationPath}{IoConstants.StagingFileSuffix}{Guid.NewGuid():N}"
-            : destinationPath;
+        var writePath = overwrite ? BuildStagingPath(destinationPath) : destinationPath;
         var destination = new FileStream(writePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
 
         try
@@ -77,12 +75,36 @@ public static class BoundedArchiveExtractor
         }
         catch
         {
-            await destination.DisposeAsync();
+            await DisposeQuietlyAsync(destination);
             DeletePartialOutput(writePath);
             throw;
         }
 
         return written;
+    }
+
+    private static string BuildStagingPath(string destinationPath)
+    {
+        var directory = Path.GetDirectoryName(destinationPath);
+        var stagingName = Path.GetRandomFileName() + IoConstants.StagingFileSuffix;
+
+        return string.IsNullOrEmpty(directory) ? stagingName : Path.Combine(directory, stagingName);
+    }
+
+    private static async Task DisposeQuietlyAsync(FileStream destination)
+    {
+        try
+        {
+            await destination.DisposeAsync();
+        }
+        catch (IOException)
+        {
+            // The failure being handled is the one worth surfacing, not a flush that fails after it.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // The failure being handled is the one worth surfacing, not a flush that fails after it.
+        }
     }
 
     private static void DeletePartialOutput(string writePath)

--- a/GenHub/GenHub.Core/Utilities/BoundedArchiveExtractor.cs
+++ b/GenHub/GenHub.Core/Utilities/BoundedArchiveExtractor.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Exceptions;
+
+namespace GenHub.Core.Utilities;
+
+/// <summary>
+/// Streams archive entries to disk under an expansion budget. Sizes recorded in archive headers are
+/// attacker-controlled, so the budget is measured against the bytes actually decompressed and the
+/// copy aborts the moment it is exceeded.
+/// </summary>
+public static class BoundedArchiveExtractor
+{
+    /// <summary>
+    /// Copies a decompressed archive entry to <paramref name="destinationPath"/>, aborting as soon as the
+    /// per-entry cap or the remaining archive-wide budget is exhausted. The partially written file is
+    /// deleted before the failure is surfaced.
+    /// </summary>
+    /// <param name="entryStream">The decompressed entry stream to read from.</param>
+    /// <param name="destinationPath">The file to write the entry to.</param>
+    /// <param name="entryName">The archive-relative entry name, used in failure messages.</param>
+    /// <param name="maxEntryBytes">Maximum number of bytes a single entry may expand to.</param>
+    /// <param name="remainingAggregateBytes">Bytes still available in the archive-wide budget.</param>
+    /// <param name="overwrite">Whether an existing destination file may be replaced.</param>
+    /// <param name="cancellationToken">Token used to cancel the copy.</param>
+    /// <returns>The number of bytes written.</returns>
+    /// <exception cref="ArchiveExpansionLimitExceededException">Thrown when the entry expands past its budget.</exception>
+    public static async Task<long> CopyEntryToFileAsync(
+        Stream entryStream,
+        string destinationPath,
+        string entryName,
+        long maxEntryBytes,
+        long remainingAggregateBytes,
+        bool overwrite = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entryStream);
+
+        var limit = Math.Min(maxEntryBytes, remainingAggregateBytes);
+        var buffer = new byte[IoConstants.DefaultFileBufferSize];
+        long written = 0;
+
+        var mode = overwrite ? FileMode.Create : FileMode.CreateNew;
+        var destination = new FileStream(destinationPath, mode, FileAccess.Write, FileShare.None);
+
+        try
+        {
+            int read;
+            while ((read = await entryStream.ReadAsync(buffer, cancellationToken)) > 0)
+            {
+                written += read;
+                if (written > limit)
+                {
+                    throw new ArchiveExpansionLimitExceededException(entryName, limit);
+                }
+
+                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            }
+        }
+        catch
+        {
+            await destination.DisposeAsync();
+            DeletePartialOutput(destinationPath);
+            throw;
+        }
+
+        await destination.DisposeAsync();
+        return written;
+    }
+
+    private static void DeletePartialOutput(string destinationPath)
+    {
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                File.Delete(destinationPath);
+            }
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup; the original failure is the one worth surfacing.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup; the original failure is the one worth surfacing.
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostDelivererTests.cs
@@ -103,16 +103,43 @@ public sealed class CommunityOutpostDelivererTests : IDisposable
     }
 
     /// <summary>
+    /// Refuses an entry whose name cannot name a file before that name is turned into a path. A
+    /// name that resolves to the extract directory itself would otherwise stage the write beside
+    /// that directory rather than inside it, and a colon names an NTFS alternate data stream.
+    /// </summary>
+    /// <param name="entryName">The entry name the archive declares.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData(".")]
+    [InlineData("patch/..")]
+    [InlineData(" ")]
+    [InlineData("payload.big:stream")]
+    public async Task ExtractArchiveAsync_RejectsEntryWithAnUnusableNameAsync(string entryName)
+    {
+        var archivePath = Path.Combine(_workingDirectory, "unusable.zip");
+        CreateArchive(archivePath, entryName);
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InvokeExtractArchiveAsync(archivePath, _extractDirectory));
+
+        Assert.Contains("cannot be extracted to a file", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(Directory.GetFileSystemEntries(_workingDirectory, "*.genhub-staging*"));
+    }
+
+    /// <summary>
     /// Surfaces a cancellation that lands part-way through extraction as a cancellation rather than
     /// as an ordinary extraction failure, so callers can tell a user who changed their mind from a
-    /// hostile or broken archive. The downloaded archive is the only complete copy of the content,
-    /// so it must survive, and the truncated file set must never reach the manifest pool.
+    /// hostile or broken archive. The cancellation is triggered once an early entry has landed on
+    /// disk and while a much larger one is still being written, which is what puts it inside the
+    /// entry loop rather than in front of it. The downloaded archive is the only complete copy of
+    /// the content, so it must survive, and the truncated file set must never reach the manifest
+    /// pool.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task DeliverContentAsync_CancelledDuringExtraction_KeepsArchiveAndRegistersNothingAsync()
+    public async Task DeliverContentAsync_CancelledMidExtraction_KeepsArchiveAndRegistersNothingAsync()
     {
-        const int entryCount = 6;
+        const int largeEntryBytes = 32 * 1024 * 1024;
         var targetDirectory = Path.Combine(_workingDirectory, "target");
         Directory.CreateDirectory(targetDirectory);
 
@@ -126,9 +153,7 @@ public sealed class CommunityOutpostDelivererTests : IDisposable
                 It.IsAny<CancellationToken>()))
             .Returns((Uri _, string destination, string? _, IProgress<DownloadProgress>? _, CancellationToken _) =>
             {
-                CreateArchive(
-                    destination,
-                    Enumerable.Range(0, entryCount).Select(index => $"entry{index}.dat").ToArray());
+                CreateArchive(destination, ("first.dat", 16), ("marker.dat", 16), ("large.dat", largeEntryBytes));
                 return Task.FromResult(DownloadResult.CreateSuccess(destination, 1, TimeSpan.FromSeconds(1)));
             });
 
@@ -146,19 +171,27 @@ public sealed class CommunityOutpostDelivererTests : IDisposable
             ],
         };
 
+        var extractDirectory = Path.Combine(targetDirectory, "extracted");
         using var cancellation = new CancellationTokenSource();
+        var cancelWhenMarkerLands = CancelWhenFileAppearsAsync(
+            Path.Combine(extractDirectory, "marker.dat"),
+            cancellation);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            deliverer.DeliverContentAsync(
-                manifest,
-                targetDirectory,
-                new CancelOnExtractingReport(cancellation),
-                cancellation.Token));
+            deliverer.DeliverContentAsync(manifest, targetDirectory, null, cancellation.Token));
+
+        await cancelWhenMarkerLands;
 
         Assert.True(
             File.Exists(Path.Combine(targetDirectory, "content.zip")),
             "the archive is the only recoverable copy of the content");
-        Assert.True(Directory.GetFiles(targetDirectory, "entry*.dat", SearchOption.AllDirectories).Length < entryCount);
+        Assert.True(
+            File.Exists(Path.Combine(extractDirectory, "first.dat")),
+            "the cancellation has to land after extraction started, not in front of it");
+        Assert.False(
+            File.Exists(Path.Combine(extractDirectory, "large.dat")),
+            "the entry being written when the cancellation landed must not be left behind");
+        Assert.Empty(Directory.GetFileSystemEntries(extractDirectory, "*.genhub-staging*"));
 
         manifestPool.Verify(
             p => p.AddManifestAsync(
@@ -200,6 +233,34 @@ public sealed class CommunityOutpostDelivererTests : IDisposable
         }
     }
 
+    private static void CreateArchive(string archivePath, params (string EntryName, int ByteCount)[] entries)
+    {
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+        foreach (var (entryName, byteCount) in entries)
+        {
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using var stream = entry.Open();
+            stream.Write(new byte[byteCount]);
+        }
+    }
+
+    private static Task CancelWhenFileAppearsAsync(string path, CancellationTokenSource cancellation)
+    {
+        return Task.Factory.StartNew(
+            () =>
+            {
+                var deadline = DateTime.UtcNow.AddSeconds(30);
+                while (!File.Exists(path) && DateTime.UtcNow < deadline)
+                {
+                }
+
+                cancellation.Cancel();
+            },
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+    }
+
     private static async Task InvokeExtractArchiveAsync(string archivePath, string extractPath)
     {
         var extract = typeof(CommunityOutpostDeliverer).GetMethod(
@@ -208,16 +269,5 @@ public sealed class CommunityOutpostDelivererTests : IDisposable
             ?? throw new InvalidOperationException("CommunityOutpostDeliverer.ExtractArchiveAsync was not found.");
 
         await (Task)extract.Invoke(null, [archivePath, extractPath, CancellationToken.None])!;
-    }
-
-    private sealed class CancelOnExtractingReport(CancellationTokenSource cancellation) : IProgress<ContentAcquisitionProgress>
-    {
-        public void Report(ContentAcquisitionProgress value)
-        {
-            if (value.Phase == ContentAcquisitionPhase.Extracting)
-            {
-                cancellation.Cancel();
-            }
-        }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostDelivererTests.cs
@@ -2,7 +2,17 @@ using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Storage;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
 using GenHub.Features.Content.Services.CommunityOutpost;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace GenHub.Tests.Core.Features.Content.Services.CommunityOutpost;
 
@@ -92,6 +102,93 @@ public sealed class CommunityOutpostDelivererTests : IDisposable
         Assert.Empty(Directory.GetFileSystemEntries(_extractDirectory));
     }
 
+    /// <summary>
+    /// Surfaces a cancellation that lands part-way through extraction as a cancellation rather than
+    /// as an ordinary extraction failure, so callers can tell a user who changed their mind from a
+    /// hostile or broken archive. The downloaded archive is the only complete copy of the content,
+    /// so it must survive, and the truncated file set must never reach the manifest pool.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_CancelledDuringExtraction_KeepsArchiveAndRegistersNothingAsync()
+    {
+        const int entryCount = 6;
+        var targetDirectory = Path.Combine(_workingDirectory, "target");
+        Directory.CreateDirectory(targetDirectory);
+
+        var downloadService = new Mock<IDownloadService>();
+        downloadService
+            .Setup(d => d.DownloadFileAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((Uri _, string destination, string? _, IProgress<DownloadProgress>? _, CancellationToken _) =>
+            {
+                CreateArchive(
+                    destination,
+                    Enumerable.Range(0, entryCount).Select(index => $"entry{index}.dat").ToArray());
+                return Task.FromResult(DownloadResult.CreateSuccess(destination, 1, TimeSpan.FromSeconds(1)));
+            });
+
+        var manifestPool = new Mock<IContentManifestPool>();
+        var deliverer = CreateDeliverer(downloadService.Object, manifestPool.Object);
+        var manifest = new ContentManifest
+        {
+            Files =
+            [
+                new ManifestFile
+                {
+                    RelativePath = "content.zip",
+                    DownloadUrl = "https://legi.cc/gp2/f/cbpr.zip",
+                },
+            ],
+        };
+
+        using var cancellation = new CancellationTokenSource();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            deliverer.DeliverContentAsync(
+                manifest,
+                targetDirectory,
+                new CancelOnExtractingReport(cancellation),
+                cancellation.Token));
+
+        Assert.True(
+            File.Exists(Path.Combine(targetDirectory, "content.zip")),
+            "the archive is the only recoverable copy of the content");
+        Assert.True(Directory.GetFiles(targetDirectory, "entry*.dat", SearchOption.AllDirectories).Length < entryCount);
+
+        manifestPool.Verify(
+            p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static CommunityOutpostDeliverer CreateDeliverer(
+        IDownloadService downloadService,
+        IContentManifestPool manifestPool)
+    {
+        var converter = new CompressedImageToTgaConverter(NullLogger<CompressedImageToTgaConverter>.Instance);
+        var manifestFactory = new CommunityOutpostManifestFactory(
+            NullLogger<CommunityOutpostManifestFactory>.Instance,
+            new Mock<IFileHashProvider>().Object,
+            converter);
+
+        return new CommunityOutpostDeliverer(
+            downloadService,
+            manifestPool,
+            manifestFactory,
+            new Mock<IGameInstallationService>().Object,
+            new Mock<IInstallationCasPoolService>().Object,
+            converter,
+            NullLogger<CommunityOutpostDeliverer>.Instance);
+    }
+
     private static void CreateArchive(string archivePath, params string[] entryNames)
     {
         using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
@@ -111,5 +208,16 @@ public sealed class CommunityOutpostDelivererTests : IDisposable
             ?? throw new InvalidOperationException("CommunityOutpostDeliverer.ExtractArchiveAsync was not found.");
 
         await (Task)extract.Invoke(null, [archivePath, extractPath, CancellationToken.None])!;
+    }
+
+    private sealed class CancelOnExtractingReport(CancellationTokenSource cancellation) : IProgress<ContentAcquisitionProgress>
+    {
+        public void Report(ContentAcquisitionProgress value)
+        {
+            if (value.Phase == ContentAcquisitionPhase.Extracting)
+            {
+                cancellation.Cancel();
+            }
+        }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostDelivererTests.cs
@@ -1,0 +1,115 @@
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using GenHub.Core.Constants;
+using GenHub.Features.Content.Services.CommunityOutpost;
+
+namespace GenHub.Tests.Core.Features.Content.Services.CommunityOutpost;
+
+/// <summary>
+/// Tests the containment and expansion bounds applied to Community Outpost archives, which arrive
+/// from a third-party catalog and are therefore untrusted input.
+/// </summary>
+public sealed class CommunityOutpostDelivererTests : IDisposable
+{
+    private readonly string _workingDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "GenHubCommunityOutpost",
+        Guid.NewGuid().ToString("N"));
+
+    private readonly string _extractDirectory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommunityOutpostDelivererTests"/> class.
+    /// </summary>
+    public CommunityOutpostDelivererTests()
+    {
+        _extractDirectory = Path.Combine(_workingDirectory, "extracted");
+        Directory.CreateDirectory(_extractDirectory);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Directory.Exists(_workingDirectory))
+        {
+            Directory.Delete(_workingDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Extracts entries that stay inside the target directory.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ExtractArchiveAsync_ExtractsEntriesWithinBudgetAsync()
+    {
+        var archivePath = Path.Combine(_workingDirectory, "content.zip");
+        CreateArchive(archivePath, "patch/readme.txt", "generals.big");
+
+        await InvokeExtractArchiveAsync(archivePath, _extractDirectory);
+
+        Assert.True(File.Exists(Path.Combine(_extractDirectory, "patch", "readme.txt")));
+        Assert.True(File.Exists(Path.Combine(_extractDirectory, "generals.big")));
+    }
+
+    /// <summary>
+    /// Refuses an entry whose key climbs out of the extract directory, rather than depending on the
+    /// archive library to block it.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ExtractArchiveAsync_RejectsEntryEscapingTheExtractDirectoryAsync()
+    {
+        var archivePath = Path.Combine(_workingDirectory, "traversal.zip");
+        CreateArchive(archivePath, "../escaped.big");
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InvokeExtractArchiveAsync(archivePath, _extractDirectory));
+
+        Assert.Contains("outside target directory", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(_workingDirectory, "escaped.big")));
+    }
+
+    /// <summary>
+    /// Refuses an archive that declares more entries than the extraction budget allows.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ExtractArchiveAsync_RejectsArchiveOverTheEntryBudgetAsync()
+    {
+        var archivePath = Path.Combine(_workingDirectory, "swarm.zip");
+        var entryNames = Enumerable
+            .Range(0, CommunityOutpostConstants.MaxArchiveEntries + 1)
+            .Select(index => $"entry{index}.dat")
+            .ToArray();
+        CreateArchive(archivePath, entryNames);
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            InvokeExtractArchiveAsync(archivePath, _extractDirectory));
+
+        Assert.Contains("too many entries", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(Directory.GetFileSystemEntries(_extractDirectory));
+    }
+
+    private static void CreateArchive(string archivePath, params string[] entryNames)
+    {
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+        foreach (var entryName in entryNames)
+        {
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using var stream = entry.Open();
+            stream.Write(Encoding.UTF8.GetBytes(entryName));
+        }
+    }
+
+    private static async Task InvokeExtractArchiveAsync(string archivePath, string extractPath)
+    {
+        var extract = typeof(CommunityOutpostDeliverer).GetMethod(
+            "ExtractArchiveAsync",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("CommunityOutpostDeliverer.ExtractArchiveAsync was not found.");
+
+        await (Task)extract.Invoke(null, [archivePath, extractPath, CancellationToken.None])!;
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GitHub/GitHubContentDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GitHub/GitHubContentDelivererTests.cs
@@ -1,14 +1,20 @@
 using FluentAssertions;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Models.Common;
+using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
 using GenHub.Features.Content.Services.GitHub;
 using GenHub.Features.Content.Services.Publishers;
+using GenHub.Tests.Core.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using System.IO.Compression;
 using System.Reflection;
+using System.Text;
 
 namespace GenHub.Tests.Features.Content.Services.GitHub;
 
@@ -82,5 +88,158 @@ public class GitHubContentDelivererTests
         Assert.NotNull(shouldExtract.ToString());
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Surfaces a cancellation that lands part-way through extraction as a cancellation. The
+    /// downloaded archive is the only complete copy of the content, so it must survive, and the
+    /// truncated file set must never reach the manifest pool.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_CancelledDuringExtraction_KeepsArchiveAndRegistersNothingAsync()
+    {
+        var targetDirectory = Path.Combine(Path.GetTempPath(), "GenHubGitHubDeliverer", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(targetDirectory);
+
+        try
+        {
+            const int entryCount = 6;
+            _downloadService
+                .Setup(d => d.DownloadFileAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<IProgress<DownloadProgress>?>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns((Uri _, string destination, string? _, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                {
+                    CreateArchive(destination, entryCount);
+                    return Task.FromResult(DownloadResult.CreateSuccess(destination, 1, TimeSpan.FromSeconds(1)));
+                });
+
+            var deliverer = new GitHubContentDeliverer(
+                _downloadService.Object, _manifestPool.Object, _factoryResolver.Object, _logger.Object);
+            var manifest = new ContentManifest
+            {
+                Files =
+                [
+                    new ManifestFile
+                    {
+                        RelativePath = "release.zip",
+                        DownloadUrl = "https://github.com/user/repo/release.zip",
+                    },
+                ],
+            };
+
+            using var cancellation = new CancellationTokenSource();
+            var progress = new CancelOnFirstReport(cancellation);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                deliverer.DeliverContentAsync(manifest, targetDirectory, progress, cancellation.Token));
+
+            var archivePath = Path.Combine(targetDirectory, "release.zip");
+            File.Exists(archivePath).Should().BeTrue("the archive is the only recoverable copy of the content");
+
+            var extracted = Directory.GetFiles(targetDirectory, "entry*.dat", SearchOption.AllDirectories);
+            extracted.Length.Should().BeLessThan(entryCount);
+
+            _manifestPool.Verify(
+                p => p.AddManifestAsync(
+                    It.IsAny<ContentManifest>(),
+                    It.IsAny<string>(),
+                    It.IsAny<IProgress<ContentStorageProgress>?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+        finally
+        {
+            Directory.Delete(targetDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Fails delivery when an archive understates the size it decompresses to. The lie is only
+    /// visible while inflating, so the copy has to abort mid-stream, drop the partial file, and
+    /// leave the truncated file set out of the manifest pool. The failure is a result, not a
+    /// cancellation, so callers can tell a hostile archive from a user who changed their mind.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_ArchiveUnderstatingItsDeclaredSize_FailsWithoutRegisteringAManifestAsync()
+    {
+        var targetDirectory = Path.Combine(Path.GetTempPath(), "GenHubGitHubDeliverer", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(targetDirectory);
+
+        try
+        {
+            _downloadService
+                .Setup(d => d.DownloadFileAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<IProgress<DownloadProgress>?>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns((Uri _, string destination, string? _, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                {
+                    ArchiveFixtures.CreateWithSpoofedEntrySize(destination, "payload.dat", 12 * 1024 * 1024, 4096);
+                    return Task.FromResult(DownloadResult.CreateSuccess(destination, 1, TimeSpan.FromSeconds(1)));
+                });
+
+            var deliverer = new GitHubContentDeliverer(
+                _downloadService.Object, _manifestPool.Object, _factoryResolver.Object, _logger.Object);
+            var manifest = new ContentManifest
+            {
+                Files =
+                [
+                    new ManifestFile
+                    {
+                        RelativePath = "release.zip",
+                        DownloadUrl = "https://github.com/user/repo/release.zip",
+                    },
+                ],
+            };
+
+            var result = await deliverer.DeliverContentAsync(manifest, targetDirectory, cancellationToken: CancellationToken.None);
+
+            result.Success.Should().BeFalse();
+            result.FirstError.Should().Contain("potential zip bomb");
+
+            File.Exists(Path.Combine(targetDirectory, "payload.dat")).Should().BeFalse("the partial output is removed");
+
+            _manifestPool.Verify(
+                p => p.AddManifestAsync(
+                    It.IsAny<ContentManifest>(),
+                    It.IsAny<string>(),
+                    It.IsAny<IProgress<ContentStorageProgress>?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+        finally
+        {
+            Directory.Delete(targetDirectory, recursive: true);
+        }
+    }
+
+    private static void CreateArchive(string archivePath, int entryCount)
+    {
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+        for (var index = 0; index < entryCount; index++)
+        {
+            var entry = archive.CreateEntry($"entry{index}.dat", CompressionLevel.Optimal);
+            using var stream = entry.Open();
+            stream.Write(Encoding.UTF8.GetBytes($"payload {index}"));
+        }
+    }
+
+    private sealed class CancelOnFirstReport(CancellationTokenSource cancellation) : IProgress<ContentAcquisitionProgress>
+    {
+        public void Report(ContentAcquisitionProgress value)
+        {
+            if (value.Phase == ContentAcquisitionPhase.Extracting)
+            {
+                cancellation.Cancel();
+            }
+        }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GitHub/GitHubContentDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GitHub/GitHubContentDelivererTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Models.Common;
@@ -221,6 +222,130 @@ public class GitHubContentDelivererTests
         }
     }
 
+    /// <summary>
+    /// Refuses an entry whose key climbs out of the target directory rather than trusting the
+    /// archive library to block it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExtractArchiveAsync_RejectsEntryEscapingTheTargetDirectoryAsync()
+    {
+        var root = CreateWorkingDirectory();
+
+        try
+        {
+            var targetDirectory = Path.Combine(root, "target");
+            Directory.CreateDirectory(targetDirectory);
+            var archivePath = Path.Combine(root, "traversal.zip");
+            CreateArchive(archivePath, "../escaped.dat");
+
+            var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                InvokeExtractArchiveAsync(CreateDeliverer(), archivePath, targetDirectory));
+
+            failure.Message.Should().Contain("outside target directory");
+            File.Exists(Path.Combine(root, "escaped.dat")).Should().BeFalse();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Refuses an entry whose name cannot name a file before that name is turned into a path,
+    /// rather than letting the write fail several layers deeper with an unrelated error.
+    /// </summary>
+    /// <param name="entryName">The entry name the archive declares.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [InlineData(".")]
+    [InlineData("assets/..")]
+    [InlineData(" ")]
+    [InlineData("payload.dat:stream")]
+    public async Task ExtractArchiveAsync_RejectsEntryWithAnUnusableNameAsync(string entryName)
+    {
+        var root = CreateWorkingDirectory();
+
+        try
+        {
+            var targetDirectory = Path.Combine(root, "target");
+            Directory.CreateDirectory(targetDirectory);
+            var archivePath = Path.Combine(root, "unusable.zip");
+            CreateArchive(archivePath, entryName);
+
+            var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                InvokeExtractArchiveAsync(CreateDeliverer(), archivePath, targetDirectory));
+
+            failure.Message.Should().Contain("cannot be extracted to a file");
+            Directory.GetFileSystemEntries(root, "*.genhub-staging*").Should().BeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Refuses an archive that declares more entries than the extraction budget allows, before any
+    /// of them is written.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExtractArchiveAsync_RejectsArchiveOverTheEntryBudgetAsync()
+    {
+        var root = CreateWorkingDirectory();
+
+        try
+        {
+            var targetDirectory = Path.Combine(root, "target");
+            Directory.CreateDirectory(targetDirectory);
+            var archivePath = Path.Combine(root, "swarm.zip");
+            CreateArchive(archivePath, GitHubConstants.MaxArchiveEntries + 1);
+
+            var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                InvokeExtractArchiveAsync(CreateDeliverer(), archivePath, targetDirectory));
+
+            failure.Message.Should().Contain("too many entries");
+            Directory.GetFileSystemEntries(targetDirectory).Should().BeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateWorkingDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "GenHubGitHubDeliverer", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        return root;
+    }
+
+    private static async Task InvokeExtractArchiveAsync(
+        GitHubContentDeliverer deliverer,
+        string archivePath,
+        string targetDirectory)
+    {
+        var extract = typeof(GitHubContentDeliverer).GetMethod(
+            "ExtractArchiveAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("GitHubContentDeliverer.ExtractArchiveAsync was not found.");
+
+        await (Task)extract.Invoke(deliverer, [archivePath, targetDirectory, null, CancellationToken.None])!;
+    }
+
+    private static void CreateArchive(string archivePath, params string[] entryNames)
+    {
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+        foreach (var entryName in entryNames)
+        {
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using var stream = entry.Open();
+            stream.Write(Encoding.UTF8.GetBytes("payload"));
+        }
+    }
+
     private static void CreateArchive(string archivePath, int entryCount)
     {
         using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
@@ -231,6 +356,9 @@ public class GitHubContentDelivererTests
             stream.Write(Encoding.UTF8.GetBytes($"payload {index}"));
         }
     }
+
+    private GitHubContentDeliverer CreateDeliverer() =>
+        new(_downloadService.Object, _manifestPool.Object, _factoryResolver.Object, _logger.Object);
 
     private sealed class CancelOnFirstReport(CancellationTokenSource cancellation) : IProgress<ContentAcquisitionProgress>
     {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/MapImportServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/MapImportServiceTests.cs
@@ -135,6 +135,32 @@ public sealed class MapImportServiceTests : IDisposable
         Assert.Single(Directory.GetDirectories(_mapDirectory));
     }
 
+    /// <summary>
+    /// Skips only the map whose directory cannot be created and keeps importing the rest. Creating
+    /// that directory is the first thing done for a map and can fail on its own — here a file
+    /// already occupies the name — so it belongs inside the per-map handler rather than in front of
+    /// it, where one bad name would sink the whole archive.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportFromZipAsync_MapDirectoryThatCannotBeCreated_SkipsOnlyThatMapAsync()
+    {
+        var zipPath = Path.Combine(_workingDirectory, "blocked.zip");
+        CreateZip(
+            zipPath,
+            ("Blocked/blocked.map", "map"),
+            ("Second/second.map", "map"));
+        await File.WriteAllTextAsync(Path.Combine(_mapDirectory, "Blocked"), "not a directory");
+
+        var result = await _service.ImportFromZipAsync(zipPath, GameType.ZeroHour);
+
+        Assert.True(result.Success, string.Join(" ", result.Errors));
+        var imported = Assert.Single(result.ImportedMaps);
+        Assert.Equal("Second", imported.DirectoryName);
+        Assert.NotEmpty(result.Errors);
+        Assert.False(Directory.Exists(Path.Combine(_mapDirectory, "Blocked")));
+    }
+
     private static void CreateZip(string zipPath, params (string EntryName, string Content)[] entries)
     {
         using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/MapImportServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/MapImportServiceTests.cs
@@ -1,0 +1,121 @@
+using System.IO.Compression;
+using System.Net.Http;
+using System.Text;
+using GenHub.Core.Interfaces.Tools.MapManager;
+using GenHub.Core.Models.Enums;
+using GenHub.Features.Tools.MapManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace GenHub.Tests.Core.Features.Tools.Services;
+
+/// <summary>
+/// Tests how map ZIP archives are split into path segments, which drives both the traversal
+/// check and the grouping of a map with its assets.
+/// </summary>
+public sealed class MapImportServiceTests : IDisposable
+{
+    private readonly string _workingDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "GenHubMapImport",
+        Guid.NewGuid().ToString("N"));
+
+    private readonly string _mapDirectory;
+    private readonly MapImportService _service;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MapImportServiceTests"/> class.
+    /// </summary>
+    public MapImportServiceTests()
+    {
+        _mapDirectory = Path.Combine(_workingDirectory, "Maps");
+        Directory.CreateDirectory(_mapDirectory);
+
+        var directoryService = new Mock<IMapDirectoryService>();
+        directoryService.Setup(d => d.GetMapDirectory(It.IsAny<GameType>())).Returns(_mapDirectory);
+
+        _service = new MapImportService(
+            directoryService.Object,
+            new HttpClient(),
+            new MapNameParser(NullLogger<MapNameParser>.Instance),
+            NullLogger<MapImportService>.Instance);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Directory.Exists(_workingDirectory))
+        {
+            Directory.Delete(_workingDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Rejects a backslash-separated traversal segment. Splitting on backslashes is what makes the
+    /// leading <c>..</c> visible as its own segment.
+    /// </summary>
+    [Fact]
+    public void ValidateZip_RejectsBackslashTraversalSegment()
+    {
+        var zipPath = Path.Combine(_workingDirectory, "traversal.zip");
+        CreateZip(zipPath, ("..\\escaped.map", "map"));
+
+        var (isValid, errorMessage) = _service.ValidateZip(zipPath);
+
+        Assert.False(isValid);
+        Assert.Contains("path traversal", errorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves a map and its asset to the same backslash-separated directory. Without splitting on
+    /// backslashes each entry becomes its own directory, and the asset is reported as a directory
+    /// holding no map.
+    /// </summary>
+    [Fact]
+    public void ValidateZip_ResolvesBackslashSeparatedEntriesToTheSameDirectory()
+    {
+        var zipPath = Path.Combine(_workingDirectory, "backslash.zip");
+        CreateZip(
+            zipPath,
+            ("Desert\\desert.map", "map"),
+            ("Desert\\map.tga", "thumbnail"));
+
+        var (isValid, errorMessage) = _service.ValidateZip(zipPath);
+
+        Assert.True(isValid, errorMessage);
+    }
+
+    /// <summary>
+    /// Keeps an apostrophe inside a directory name intact, so the map and its assets stay grouped
+    /// under the directory the archive actually declared.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportFromZipAsync_KeepsDirectoryNamesContainingApostrophesIntactAsync()
+    {
+        var zipPath = Path.Combine(_workingDirectory, "apostrophe.zip");
+        CreateZip(
+            zipPath,
+            ("Bob's Map/bob.map", "map"),
+            ("Bob's Map/map.tga", "thumbnail"));
+
+        var result = await _service.ImportFromZipAsync(zipPath, GameType.ZeroHour);
+
+        Assert.True(result.Success, string.Join(" ", result.Errors));
+        var imported = Assert.Single(result.ImportedMaps);
+        Assert.Equal("Bob's Map", imported.DirectoryName);
+        Assert.True(File.Exists(Path.Combine(_mapDirectory, "Bob's Map", "bob.map")));
+        Assert.True(File.Exists(Path.Combine(_mapDirectory, "Bob's Map", "map.tga")));
+    }
+
+    private static void CreateZip(string zipPath, params (string EntryName, string Content)[] entries)
+    {
+        using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+        foreach (var (entryName, content) in entries)
+        {
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using var stream = entry.Open();
+            stream.Write(Encoding.UTF8.GetBytes(content));
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/MapImportServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/MapImportServiceTests.cs
@@ -108,6 +108,33 @@ public sealed class MapImportServiceTests : IDisposable
         Assert.True(File.Exists(Path.Combine(_mapDirectory, "Bob's Map", "map.tga")));
     }
 
+    /// <summary>
+    /// Surfaces a cancellation that lands part-way through an archive as a cancellation. Maps
+    /// extracted before the cancellation must not be reported as a successful import, because the
+    /// caller would otherwise treat a truncated map set as the whole archive.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportFromZipAsync_CancelledMidArchive_DoesNotReportSuccessAsync()
+    {
+        var zipPath = Path.Combine(_workingDirectory, "cancelled.zip");
+        CreateZip(
+            zipPath,
+            ("First/first.map", "map"),
+            ("Second/second.map", "map"));
+
+        using var cancellation = new CancellationTokenSource();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _service.ImportFromZipAsync(
+                zipPath,
+                GameType.ZeroHour,
+                new CancelOnFirstReport(cancellation),
+                cancellation.Token));
+
+        Assert.Single(Directory.GetDirectories(_mapDirectory));
+    }
+
     private static void CreateZip(string zipPath, params (string EntryName, string Content)[] entries)
     {
         using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
@@ -117,5 +144,10 @@ public sealed class MapImportServiceTests : IDisposable
             using var stream = entry.Open();
             stream.Write(Encoding.UTF8.GetBytes(content));
         }
+    }
+
+    private sealed class CancelOnFirstReport(CancellationTokenSource cancellation) : IProgress<double>
+    {
+        public void Report(double value) => cancellation.Cancel();
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/ReplayImportServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Tools/Services/ReplayImportServiceTests.cs
@@ -1,0 +1,120 @@
+using System.IO.Compression;
+using System.Text;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Tools.ReplayManager;
+using GenHub.Core.Models.Enums;
+using GenHub.Features.Tools.ReplayManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace GenHub.Tests.Core.Features.Tools.Services;
+
+/// <summary>
+/// Tests how a replay archive import behaves when it is interrupted, which decides whether the
+/// caller is told the archive was imported in full.
+/// </summary>
+public sealed class ReplayImportServiceTests : IDisposable
+{
+    private readonly string _workingDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "GenHubReplayImport",
+        Guid.NewGuid().ToString("N"));
+
+    private readonly string _replayDirectory;
+    private readonly ReplayImportService _service;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayImportServiceTests"/> class.
+    /// </summary>
+    public ReplayImportServiceTests()
+    {
+        _replayDirectory = Path.Combine(_workingDirectory, "Replays");
+        Directory.CreateDirectory(_replayDirectory);
+
+        var directoryService = new Mock<IReplayDirectoryService>();
+        directoryService.Setup(d => d.GetReplayDirectory(It.IsAny<GameType>())).Returns(_replayDirectory);
+
+        var zipValidationService = new Mock<IZipValidationService>();
+        zipValidationService.Setup(z => z.ValidateZip(It.IsAny<string>())).Returns((true, null));
+
+        _service = new ReplayImportService(
+            new Mock<IDownloadService>().Object,
+            directoryService.Object,
+            new Mock<IUrlParserService>().Object,
+            zipValidationService.Object,
+            NullLogger<ReplayImportService>.Instance);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Directory.Exists(_workingDirectory))
+        {
+            Directory.Delete(_workingDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Imports every entry of an archive that is never interrupted.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportFromZipAsync_ImportsEveryEntryAsync()
+    {
+        var zipPath = Path.Combine(_workingDirectory, "replays.zip");
+        CreateZip(zipPath, "first.rep", "second.rep");
+
+        var result = await _service.ImportFromZipAsync(zipPath, GameType.ZeroHour);
+
+        Assert.True(result.Success, string.Join(" ", result.Errors));
+        Assert.Equal(2, result.FilesImported);
+    }
+
+    /// <summary>
+    /// Surfaces a cancellation that lands part-way through an archive as a cancellation. Entries
+    /// imported before the cancellation must not be reported as a successful import, because the
+    /// caller would otherwise treat a truncated set of replays as the whole archive.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportFromZipAsync_CancelledMidArchive_DoesNotReportSuccessAsync()
+    {
+        var zipPath = Path.Combine(_workingDirectory, "cancelled.zip");
+        CreateZip(zipPath, "first.rep", "second.rep");
+
+        using var cancellation = new CancellationTokenSource();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _service.ImportFromZipAsync(
+                zipPath,
+                GameType.ZeroHour,
+                new CancelOnceAnEntryIsImported(cancellation),
+                cancellation.Token));
+
+        Assert.Single(Directory.GetFiles(_replayDirectory));
+    }
+
+    private static void CreateZip(string zipPath, params string[] entryNames)
+    {
+        using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+        foreach (var entryName in entryNames)
+        {
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using var stream = entry.Open();
+            stream.Write(Encoding.UTF8.GetBytes(entryName));
+        }
+    }
+
+    private sealed class CancelOnceAnEntryIsImported(CancellationTokenSource cancellation) : IProgress<double>
+    {
+        private int _reports;
+
+        public void Report(double value)
+        {
+            if (++_reports > 1)
+            {
+                cancellation.Cancel();
+            }
+        }
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -34,4 +34,51 @@ public sealed class PathHelperTests
 
         Assert.Equal(OperatingSystem.IsWindows(), pathsAreEqual);
     }
+
+    /// <summary>
+    /// Accepts the base directory itself and anything nested beneath it.
+    /// </summary>
+    /// <param name="relativeCandidate">A candidate path relative to the base directory.</param>
+    [Theory]
+    [InlineData("")]
+    [InlineData("file.dat")]
+    [InlineData("nested/deeper/file.dat")]
+    [InlineData("nested/../file.dat")]
+    public void IsPathWithinDirectory_AcceptsContainedPaths(string relativeCandidate)
+    {
+        var baseDirectory = Path.Combine(Path.GetTempPath(), "GenHubContainment");
+        var candidate = Path.Combine(baseDirectory, relativeCandidate);
+
+        Assert.True(PathHelper.IsPathWithinDirectory(baseDirectory, candidate));
+    }
+
+    /// <summary>
+    /// Rejects traversal segments, escapes that only appear after normalization, and sibling
+    /// directories that merely share a name prefix with the base directory.
+    /// </summary>
+    /// <param name="relativeCandidate">A candidate path relative to the base directory.</param>
+    [Theory]
+    [InlineData("..")]
+    [InlineData("../escaped.dat")]
+    [InlineData("nested/../../escaped.dat")]
+    [InlineData("../GenHubContainmentEvil/escaped.dat")]
+    public void IsPathWithinDirectory_RejectsEscapingPaths(string relativeCandidate)
+    {
+        var baseDirectory = Path.Combine(Path.GetTempPath(), "GenHubContainment");
+        var candidate = Path.Combine(baseDirectory, relativeCandidate);
+
+        Assert.False(PathHelper.IsPathWithinDirectory(baseDirectory, candidate));
+    }
+
+    /// <summary>
+    /// Rejects a rooted candidate that resolves outside the base directory.
+    /// </summary>
+    [Fact]
+    public void IsPathWithinDirectory_RejectsAbsolutePathOutsideBase()
+    {
+        var baseDirectory = Path.Combine(Path.GetTempPath(), "GenHubContainment");
+        var candidate = Path.Combine(Path.GetTempPath(), "GenHubElsewhere", "escaped.dat");
+
+        Assert.False(PathHelper.IsPathWithinDirectory(baseDirectory, candidate));
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -81,4 +81,92 @@ public sealed class PathHelperTests
 
         Assert.False(PathHelper.IsPathWithinDirectory(baseDirectory, candidate));
     }
+
+    /// <summary>
+    /// Rejects a candidate that reads as contained but leaves the base directory through a symbolic
+    /// link, which textual normalization alone cannot see. GenHub builds symlinked workspaces, so a
+    /// link inside a directory being written to is an ordinary shape rather than a contrived one.
+    /// </summary>
+    [Fact]
+    public void IsPathWithinDirectory_RejectsCandidateLeavingThroughASymbolicLink()
+    {
+        var root = CreateWorkingDirectory();
+
+        try
+        {
+            var baseDirectory = Path.Combine(root, "extract");
+            var outside = Path.Combine(root, "outside");
+            Directory.CreateDirectory(baseDirectory);
+            Directory.CreateDirectory(outside);
+
+            if (!TryCreateDirectorySymbolicLink(Path.Combine(baseDirectory, "link"), outside))
+            {
+                return;
+            }
+
+            var candidate = Path.Combine(baseDirectory, "link", "escaped.dat");
+
+            Assert.False(PathHelper.IsPathWithinDirectory(baseDirectory, candidate));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Accepts a candidate beneath a symbolic link that stays inside the base directory, so
+    /// following links tightens the check without refusing content a link merely reorganizes.
+    /// </summary>
+    [Fact]
+    public void IsPathWithinDirectory_AcceptsCandidateBehindASymbolicLinkThatStaysInside()
+    {
+        var root = CreateWorkingDirectory();
+
+        try
+        {
+            var baseDirectory = Path.Combine(root, "extract");
+            var inside = Path.Combine(baseDirectory, "real");
+            Directory.CreateDirectory(inside);
+
+            if (!TryCreateDirectorySymbolicLink(Path.Combine(baseDirectory, "link"), inside))
+            {
+                return;
+            }
+
+            var candidate = Path.Combine(baseDirectory, "link", "contained.dat");
+
+            Assert.True(PathHelper.IsPathWithinDirectory(baseDirectory, candidate));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateWorkingDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "GenHubContainmentLinks", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        return root;
+    }
+
+    private static bool TryCreateDirectorySymbolicLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ArchiveFixtures.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ArchiveFixtures.cs
@@ -1,0 +1,50 @@
+using System.IO.Compression;
+
+namespace GenHub.Tests.Core.Infrastructure;
+
+/// <summary>
+/// Builds archive fixtures for extraction tests.
+/// </summary>
+internal static class ArchiveFixtures
+{
+    private const int EndOfCentralDirectoryLength = 22;
+    private const int CentralDirectoryOffsetField = 16;
+    private const int CentralUncompressedSizeField = 24;
+    private const int CentralLocalHeaderOffsetField = 42;
+    private const int LocalUncompressedSizeField = 22;
+
+    /// <summary>
+    /// Writes a single-entry archive that advertises a harmless size and then inflates to a much
+    /// larger one, which is the shape of a hostile archive that only gives itself away part-way
+    /// through decompression.
+    /// </summary>
+    /// <param name="archivePath">The archive to write.</param>
+    /// <param name="entryName">The name of the single entry.</param>
+    /// <param name="actualBytes">The number of bytes the entry really decompresses to.</param>
+    /// <param name="declaredBytes">The size the archive headers advertise.</param>
+    public static void CreateWithSpoofedEntrySize(
+        string archivePath,
+        string entryName,
+        int actualBytes,
+        int declaredBytes)
+    {
+        using (var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using var entryStream = entry.Open();
+            entryStream.Write(new byte[actualBytes]);
+        }
+
+        // Rewrite the uncompressed-size fields in both the central directory record and the local
+        // file header. Offsets follow the ZIP layout: the end-of-central-directory record ends the
+        // file and points at the central directory, whose record points back at the local header.
+        var bytes = File.ReadAllBytes(archivePath);
+        var endOfCentralDirectory = bytes.Length - EndOfCentralDirectoryLength;
+        var centralDirectory = BitConverter.ToInt32(bytes, endOfCentralDirectory + CentralDirectoryOffsetField);
+        var localHeader = BitConverter.ToInt32(bytes, centralDirectory + CentralLocalHeaderOffsetField);
+
+        BitConverter.GetBytes(declaredBytes).CopyTo(bytes, centralDirectory + CentralUncompressedSizeField);
+        BitConverter.GetBytes(declaredBytes).CopyTo(bytes, localHeader + LocalUncompressedSizeField);
+        File.WriteAllBytes(archivePath, bytes);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ArchiveFixtures.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ArchiveFixtures.cs
@@ -12,6 +12,9 @@ internal static class ArchiveFixtures
     private const int CentralUncompressedSizeField = 24;
     private const int CentralLocalHeaderOffsetField = 42;
     private const int LocalUncompressedSizeField = 22;
+    private const int EndOfCentralDirectorySignature = 0x06054b50;
+    private const int CentralDirectorySignature = 0x02014b50;
+    private const int LocalFileHeaderSignature = 0x04034b50;
 
     /// <summary>
     /// Writes a single-entry archive that advertises a harmless size and then inflates to a much
@@ -40,11 +43,27 @@ internal static class ArchiveFixtures
         // file and points at the central directory, whose record points back at the local header.
         var bytes = File.ReadAllBytes(archivePath);
         var endOfCentralDirectory = bytes.Length - EndOfCentralDirectoryLength;
+        RequireSignature(bytes, endOfCentralDirectory, EndOfCentralDirectorySignature, "end-of-central-directory record");
+
         var centralDirectory = BitConverter.ToInt32(bytes, endOfCentralDirectory + CentralDirectoryOffsetField);
+        RequireSignature(bytes, centralDirectory, CentralDirectorySignature, "central directory record");
+
         var localHeader = BitConverter.ToInt32(bytes, centralDirectory + CentralLocalHeaderOffsetField);
+        RequireSignature(bytes, localHeader, LocalFileHeaderSignature, "local file header");
 
         BitConverter.GetBytes(declaredBytes).CopyTo(bytes, centralDirectory + CentralUncompressedSizeField);
         BitConverter.GetBytes(declaredBytes).CopyTo(bytes, localHeader + LocalUncompressedSizeField);
         File.WriteAllBytes(archivePath, bytes);
+    }
+
+    private static void RequireSignature(byte[] bytes, int offset, int signature, string recordName)
+    {
+        if (offset < 0 || offset + sizeof(int) > bytes.Length ||
+            BitConverter.ToInt32(bytes, offset) != signature)
+        {
+            throw new InvalidOperationException(
+                $"Expected a ZIP {recordName} at offset {offset}. The layout written by ZipFile has drifted, " +
+                "so patching these offsets would corrupt the fixture instead of resizing its entry.");
+        }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ArchiveEntryNameTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/ArchiveEntryNameTests.cs
@@ -1,0 +1,75 @@
+using GenHub.Core.Utilities;
+
+namespace GenHub.Tests.Core.Utilities;
+
+/// <summary>
+/// Tests the screening applied to archive entry names before they become filesystem paths.
+/// </summary>
+public class ArchiveEntryNameTests
+{
+    /// <summary>
+    /// Accepts the ordinary relative names archives are made of, including the traversal segments
+    /// that the containment check rather than this screen is responsible for.
+    /// </summary>
+    /// <param name="entryName">The entry name under test.</param>
+    [Theory]
+    [InlineData("readme.txt")]
+    [InlineData("patch/readme.txt")]
+    [InlineData("patch\\readme.txt")]
+    [InlineData("Bob's Map/bob.map")]
+    [InlineData("patch/../readme.txt")]
+    [InlineData("../escaped.big")]
+    public void IsExtractable_AcceptsNamesThatCanNameAFile(string entryName)
+    {
+        Assert.True(ArchiveEntryName.IsExtractable(entryName));
+    }
+
+    /// <summary>
+    /// Refuses names that cannot name a file. These are the dangerous ones: combined with the
+    /// extraction directory they resolve to that directory itself, so the write would land on the
+    /// directory rather than inside it, and the containment check sees nothing wrong.
+    /// </summary>
+    /// <param name="entryName">The entry name under test.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("/")]
+    [InlineData("patch/")]
+    [InlineData("patch\\")]
+    [InlineData("patch/ /readme.txt")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("patch/.")]
+    [InlineData("patch/..")]
+    public void IsExtractable_RefusesNamesThatCannotNameAFile(string? entryName)
+    {
+        Assert.False(ArchiveEntryName.IsExtractable(entryName));
+    }
+
+    /// <summary>
+    /// Refuses names the strictest supported host cannot represent, so an archive is extracted the
+    /// same way everywhere. The colon matters most: on NTFS it names an alternate data stream, which
+    /// writes content that ordinary directory listings never show.
+    /// </summary>
+    /// <param name="entryName">The entry name under test.</param>
+    [Theory]
+    [InlineData("readme.txt:stream")]
+    [InlineData("patch/readme.txt:stream")]
+    [InlineData("bad|name.dat")]
+    [InlineData("bad<name.dat")]
+    [InlineData("bad>name.dat")]
+    [InlineData("bad?name.dat")]
+    [InlineData("bad*name.dat")]
+    [InlineData("bad\"name.dat")]
+    [InlineData("bad\u0001name.dat")]
+    [InlineData("trailing.")]
+    [InlineData("trailing ")]
+    [InlineData("CON")]
+    [InlineData("nul.txt")]
+    [InlineData("patch/LPT1.dat")]
+    public void IsExtractable_RefusesNamesTheStrictestHostCannotRepresent(string entryName)
+    {
+        Assert.False(ArchiveEntryName.IsExtractable(entryName));
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BoundedArchiveExtractorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BoundedArchiveExtractorTests.cs
@@ -124,6 +124,80 @@ public sealed class BoundedArchiveExtractorTests : IDisposable
     }
 
     /// <summary>
+    /// Leaves the existing destination untouched when an overwriting copy fails part-way through.
+    /// The replacement is staged beside the destination, so the only file removed is the one this
+    /// call wrote.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_KeepsExistingFileWhenOverwritingCopyFailsAsync()
+    {
+        var destination = Path.Combine(_workingDirectory, "replaced.dat");
+        await File.WriteAllTextAsync(destination, "original");
+        using var source = new MemoryStream(new byte[64 * 1024]);
+
+        await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                source,
+                destination,
+                "replaced.dat",
+                maxEntryBytes: 1024,
+                remainingAggregateBytes: long.MaxValue,
+                overwrite: true));
+
+        Assert.Equal("original", await File.ReadAllTextAsync(destination));
+        Assert.Equal([destination], Directory.GetFiles(_workingDirectory));
+    }
+
+    /// <summary>
+    /// Replaces the existing destination once an overwriting copy completes, leaving no staging
+    /// file behind.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_ReplacesExistingFileWhenOverwriteAllowedAsync()
+    {
+        var destination = Path.Combine(_workingDirectory, "replaced.dat");
+        await File.WriteAllTextAsync(destination, "original");
+        using var source = new MemoryStream(Encoding.UTF8.GetBytes("replacement"));
+
+        var written = await BoundedArchiveExtractor.CopyEntryToFileAsync(
+            source,
+            destination,
+            "replaced.dat",
+            maxEntryBytes: 1024,
+            remainingAggregateBytes: 1024,
+            overwrite: true);
+
+        Assert.Equal("replacement".Length, written);
+        Assert.Equal("replacement", await File.ReadAllTextAsync(destination));
+        Assert.Equal([destination], Directory.GetFiles(_workingDirectory));
+    }
+
+    /// <summary>
+    /// Rejects an entry once the archive-wide budget is spent, even when the entry is empty and so
+    /// never reaches the read loop where the running total is checked.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_RejectsEmptyEntryOnceAggregateBudgetIsSpentAsync()
+    {
+        using var source = new MemoryStream([]);
+        var destination = Path.Combine(_workingDirectory, "empty.dat");
+
+        var failure = await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                source,
+                destination,
+                "empty.dat",
+                maxEntryBytes: 1024,
+                remainingAggregateBytes: 0));
+
+        Assert.Equal("empty.dat", failure.EntryName);
+        Assert.False(File.Exists(destination));
+    }
+
+    /// <summary>
     /// Rejects an archive entry whose central-directory header understates its real size. The
     /// archive claims four kilobytes and inflates to twelve megabytes, which is only visible while
     /// decompressing, so the copy must abort mid-stream and leave no partial output behind.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BoundedArchiveExtractorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BoundedArchiveExtractorTests.cs
@@ -1,0 +1,160 @@
+using System.IO.Compression;
+using System.Text;
+using GenHub.Core.Exceptions;
+using GenHub.Core.Utilities;
+using GenHub.Tests.Core.Infrastructure;
+using SharpCompress.Archives;
+
+namespace GenHub.Tests.Core.Utilities;
+
+/// <summary>
+/// Tests that archive entries are bounded by the bytes they actually expand to.
+/// </summary>
+public sealed class BoundedArchiveExtractorTests : IDisposable
+{
+    private readonly string _workingDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "GenHubBoundedExtractor",
+        Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundedArchiveExtractorTests"/> class.
+    /// </summary>
+    public BoundedArchiveExtractorTests()
+    {
+        Directory.CreateDirectory(_workingDirectory);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Directory.Exists(_workingDirectory))
+        {
+            Directory.Delete(_workingDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Writes the whole entry and reports the byte count when it fits inside both budgets.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_WritesEntryWithinBudgetAsync()
+    {
+        var payload = Encoding.UTF8.GetBytes("map contents");
+        using var source = new MemoryStream(payload);
+        var destination = Path.Combine(_workingDirectory, "entry.dat");
+
+        var written = await BoundedArchiveExtractor.CopyEntryToFileAsync(
+            source,
+            destination,
+            "entry.dat",
+            maxEntryBytes: 1024,
+            remainingAggregateBytes: 1024);
+
+        Assert.Equal(payload.Length, written);
+        Assert.Equal(payload, await File.ReadAllBytesAsync(destination));
+    }
+
+    /// <summary>
+    /// Aborts and removes the partial output when an entry expands past its own cap.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_RejectsEntryOverPerEntryCapAndDeletesPartialOutputAsync()
+    {
+        using var source = new MemoryStream(new byte[64 * 1024]);
+        var destination = Path.Combine(_workingDirectory, "bomb.dat");
+
+        var failure = await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                source,
+                destination,
+                "bomb.dat",
+                maxEntryBytes: 1024,
+                remainingAggregateBytes: long.MaxValue));
+
+        Assert.Equal("bomb.dat", failure.EntryName);
+        Assert.Equal(1024, failure.LimitBytes);
+        Assert.False(File.Exists(destination));
+    }
+
+    /// <summary>
+    /// Aborts when an entry fits its own cap but exhausts what remains of the archive-wide budget.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_RejectsEntryOverRemainingAggregateBudgetAsync()
+    {
+        using var source = new MemoryStream(new byte[64 * 1024]);
+        var destination = Path.Combine(_workingDirectory, "aggregate.dat");
+
+        var failure = await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                source,
+                destination,
+                "aggregate.dat",
+                maxEntryBytes: long.MaxValue,
+                remainingAggregateBytes: 2048));
+
+        Assert.Equal(2048, failure.LimitBytes);
+        Assert.False(File.Exists(destination));
+    }
+
+    /// <summary>
+    /// Leaves an existing destination untouched when overwriting is not permitted.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_KeepsExistingFileWhenOverwriteNotAllowedAsync()
+    {
+        var destination = Path.Combine(_workingDirectory, "existing.dat");
+        await File.WriteAllTextAsync(destination, "original");
+        using var source = new MemoryStream(Encoding.UTF8.GetBytes("replacement"));
+
+        await Assert.ThrowsAsync<IOException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                source,
+                destination,
+                "existing.dat",
+                maxEntryBytes: 1024,
+                remainingAggregateBytes: 1024));
+
+        Assert.Equal("original", await File.ReadAllTextAsync(destination));
+    }
+
+    /// <summary>
+    /// Rejects an archive entry whose central-directory header understates its real size. The
+    /// archive claims four kilobytes and inflates to twelve megabytes, which is only visible while
+    /// decompressing, so the copy must abort mid-stream and leave no partial output behind.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_RejectsArchiveThatUnderstatesItsDeclaredSizeAsync()
+    {
+        const int actualBytes = 12 * 1024 * 1024;
+        const int declaredBytes = 4096;
+        const long entryCap = 1024 * 1024;
+
+        var archivePath = Path.Combine(_workingDirectory, "spoofed.zip");
+        ArchiveFixtures.CreateWithSpoofedEntrySize(archivePath, "bomb.dat", actualBytes, declaredBytes);
+
+        using var archive = ArchiveFactory.OpenArchive(archivePath);
+        var entry = archive.Entries.First(e => !e.IsDirectory);
+        Assert.Equal(declaredBytes, entry.Size);
+
+        var destination = Path.Combine(_workingDirectory, "bomb.extracted");
+        await using var entryStream = entry.OpenEntryStream();
+
+        var failure = await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                entryStream,
+                destination,
+                entry.Key ?? string.Empty,
+                maxEntryBytes: entryCap,
+                remainingAggregateBytes: long.MaxValue));
+
+        Assert.Equal(entryCap, failure.LimitBytes);
+        Assert.False(File.Exists(destination));
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BoundedArchiveExtractorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BoundedArchiveExtractorTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Text;
+using GenHub.Core.Constants;
 using GenHub.Core.Exceptions;
 using GenHub.Core.Utilities;
 using GenHub.Tests.Core.Infrastructure;
@@ -198,6 +199,110 @@ public sealed class BoundedArchiveExtractorTests : IDisposable
     }
 
     /// <summary>
+    /// Shrinks the archive-wide budget across the entries of one archive the way its callers do, so
+    /// an entry that fits its own cap comfortably is still refused once earlier entries have spent
+    /// what the archive was allowed. Only the surviving entries are left on disk.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_ShrinksTheAggregateBudgetAcrossEntriesAsync()
+    {
+        const long aggregateBudget = 4096;
+        const long entryCap = 4096;
+        int[] entrySizes = [3000, 1000, 200];
+        long expandedBytes = 0;
+
+        for (var index = 0; index < entrySizes.Length - 1; index++)
+        {
+            using var source = new MemoryStream(new byte[entrySizes[index]]);
+            expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                source,
+                Path.Combine(_workingDirectory, $"entry{index}.dat"),
+                $"entry{index}.dat",
+                entryCap,
+                aggregateBudget - expandedBytes);
+        }
+
+        Assert.Equal(4000, expandedBytes);
+
+        using var lastSource = new MemoryStream(new byte[entrySizes[^1]]);
+        var lastDestination = Path.Combine(_workingDirectory, "entry2.dat");
+
+        var failure = await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                lastSource,
+                lastDestination,
+                "entry2.dat",
+                entryCap,
+                aggregateBudget - expandedBytes));
+
+        Assert.Equal(aggregateBudget - expandedBytes, failure.LimitBytes);
+        Assert.False(File.Exists(lastDestination));
+        Assert.Equal(2, Directory.GetFiles(_workingDirectory).Length);
+    }
+
+    /// <summary>
+    /// Names the exhausted budget rather than the entry when the archive had nothing left to spend,
+    /// so a diagnostic does not report an entry as expanding past a limit of zero bytes.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_ReportsASpentBudgetSeparatelyFromAnOversizedEntryAsync()
+    {
+        using var spent = new MemoryStream(new byte[16]);
+        using var oversized = new MemoryStream(new byte[64 * 1024]);
+
+        var spentFailure = await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                spent,
+                Path.Combine(_workingDirectory, "spent.dat"),
+                "spent.dat",
+                maxEntryBytes: 1024,
+                remainingAggregateBytes: 0));
+
+        var oversizedFailure = await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                oversized,
+                Path.Combine(_workingDirectory, "oversized.dat"),
+                "oversized.dat",
+                maxEntryBytes: 1024,
+                remainingAggregateBytes: long.MaxValue));
+
+        Assert.Contains("budget was already spent", spentFailure.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("expanded past", spentFailure.Message, StringComparison.Ordinal);
+        Assert.Contains("expanded past the allowed 1024 bytes", oversizedFailure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Stages an overwriting write under a name of its own rather than one built from the
+    /// destination, so a destination close to the Windows path limit is not pushed past it by the
+    /// staging name alone.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CopyEntryToFileAsync_StagesUnderANameThatDoesNotGrowWithTheDestinationAsync()
+    {
+        var destination = Path.Combine(_workingDirectory, new string('n', 120) + ".dat");
+        await File.WriteAllTextAsync(destination, "original");
+        using var source = new DirectoryObservingStream(_workingDirectory, 64 * 1024);
+
+        await Assert.ThrowsAsync<ArchiveExpansionLimitExceededException>(() =>
+            BoundedArchiveExtractor.CopyEntryToFileAsync(
+                source,
+                destination,
+                "long.dat",
+                maxEntryBytes: 1024,
+                remainingAggregateBytes: long.MaxValue,
+                overwrite: true));
+
+        var staged = Assert.Single(source.ObservedFiles.Where(file => file != destination).Distinct());
+        Assert.EndsWith(IoConstants.StagingFileSuffix, staged, StringComparison.Ordinal);
+        Assert.True(
+            staged.Length < destination.Length,
+            $"the staging path '{staged}' is longer than the destination it replaces");
+    }
+
+    /// <summary>
     /// Rejects an archive entry whose central-directory header understates its real size. The
     /// archive claims four kilobytes and inflates to twelve megabytes, which is only visible while
     /// decompressing, so the copy must abort mid-stream and leave no partial output behind.
@@ -230,5 +335,18 @@ public sealed class BoundedArchiveExtractorTests : IDisposable
 
         Assert.Equal(entryCap, failure.LimitBytes);
         Assert.False(File.Exists(destination));
+    }
+
+    private sealed class DirectoryObservingStream(string directory, int length)
+        : MemoryStream(new byte[length])
+    {
+        public List<string> ObservedFiles { get; } = [];
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ObservedFiles.AddRange(Directory.GetFiles(directory));
+
+            return base.ReadAsync(buffer, cancellationToken);
+        }
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -113,7 +113,13 @@ public class CommunityOutpostDeliverer(
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.Key ?? string.Empty));
+                    if (!ArchiveEntryName.IsExtractable(entry.Key))
+                    {
+                        throw new InvalidOperationException(
+                            $"Archive entry '{entry.Key}' has a name that cannot be extracted to a file.");
+                    }
+
+                    var destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.Key));
                     if (!PathHelper.IsPathWithinDirectory(extractPath, destinationPath))
                     {
                         throw new InvalidOperationException(
@@ -130,7 +136,7 @@ public class CommunityOutpostDeliverer(
                     expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
                         entryStream,
                         destinationPath,
-                        entry.Key ?? string.Empty,
+                        entry.Key,
                         CommunityOutpostConstants.MaxEntryUncompressedBytes,
                         CommunityOutpostConstants.MaxAggregateUncompressedBytes - expandedBytes,
                         overwrite: true,

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -295,6 +295,13 @@ public class CommunityOutpostDeliverer(
             {
                 await ExtractArchiveAsync(archivePath, extractPath, cancellationToken);
             }
+            catch (OperationCanceledException)
+            {
+                logger.LogInformation(
+                    "Extraction of {Path} was cancelled; the downloaded archive is left in place",
+                    archivePath);
+                throw;
+            }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to extract archive from {Path}", archivePath);
@@ -411,6 +418,10 @@ public class CommunityOutpostDeliverer(
                 manifests.Count);
 
             return OperationResult<ContentManifest>.CreateSuccess(primaryManifest);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -831,7 +842,7 @@ public class CommunityOutpostDeliverer(
                     // Ignore cleanup errors
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogError(ex, "Failed to process dependency {Name}", dep.Name);
             }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostDeliverer.cs
@@ -1,4 +1,5 @@
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.GameInstallations;
@@ -13,8 +14,6 @@ using GenHub.Core.Models.Results;
 using GenHub.Core.Utilities;
 using Microsoft.Extensions.Logging;
 using SharpCompress.Archives;
-using SharpCompress.Archives.SevenZip;
-using SharpCompress.Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -81,7 +80,9 @@ public class CommunityOutpostDeliverer(
 
     /// <summary>
     /// Extracts an archive (ZIP, 7z, etc.) asynchronously using SharpCompress.
-    /// Automatically detects format.
+    /// Automatically detects format. Catalog archives are third-party input, so every entry is
+    /// confined to <paramref name="extractPath"/> and the archive is held to entry-count and
+    /// expansion budgets measured against the bytes actually decompressed.
     /// </summary>
     private static async Task ExtractArchiveAsync(
         string archivePath,
@@ -89,7 +90,7 @@ public class CommunityOutpostDeliverer(
         CancellationToken cancellationToken)
     {
         await Task.Run(
-            () =>
+            async () =>
             {
                 var fileInfo = new FileInfo(archivePath);
                 if (!fileInfo.Exists || fileInfo.Length == 0)
@@ -97,18 +98,43 @@ public class CommunityOutpostDeliverer(
                     throw new FileNotFoundException($"Archive file not found or empty: {archivePath}");
                 }
 
-                using var archive = ArchiveFactory.Open(fileInfo);
-                foreach (var entry in archive.Entries.Where(e => !e.IsDirectory))
+                using var archive = ArchiveFactory.OpenArchive(fileInfo);
+                var fileEntries = archive.Entries.Where(e => !e.IsDirectory).ToList();
+
+                if (fileEntries.Count > CommunityOutpostConstants.MaxArchiveEntries)
+                {
+                    throw new InvalidOperationException(
+                        $"Archive contains too many entries ({fileEntries.Count} > {CommunityOutpostConstants.MaxArchiveEntries}).");
+                }
+
+                long expandedBytes = 0;
+
+                foreach (var entry in fileEntries)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    entry.WriteToDirectory(
-                        extractPath,
-                        new ExtractionOptions
-                        {
-                            ExtractFullPath = true,
-                            Overwrite = true,
-                        });
+                    var destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.Key ?? string.Empty));
+                    if (!PathHelper.IsPathWithinDirectory(extractPath, destinationPath))
+                    {
+                        throw new InvalidOperationException(
+                            $"Zip slip vulnerability detected: entry '{entry.Key}' attempts to extract outside target directory.");
+                    }
+
+                    var destinationDir = Path.GetDirectoryName(destinationPath);
+                    if (!string.IsNullOrEmpty(destinationDir))
+                    {
+                        Directory.CreateDirectory(destinationDir);
+                    }
+
+                    await using var entryStream = entry.OpenEntryStream();
+                    expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                        entryStream,
+                        destinationPath,
+                        entry.Key ?? string.Empty,
+                        CommunityOutpostConstants.MaxEntryUncompressedBytes,
+                        CommunityOutpostConstants.MaxAggregateUncompressedBytes - expandedBytes,
+                        overwrite: true,
+                        cancellationToken);
                 }
             },
             cancellationToken);

--- a/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentStorageService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.Storage;
@@ -47,7 +48,7 @@ public class ContentStorageService : IContentStorageService
                 try
                 {
                     var fullPath = Path.GetFullPath(Path.Combine(baseDirectory, file.RelativePath));
-                    if (!IsPathWithinDirectory(normalizedBase, fullPath))
+                    if (!PathHelper.IsPathWithinDirectory(normalizedBase, fullPath))
                     {
                         return OperationResult<bool>.CreateFailure($"File {file.RelativePath} attempts path traversal outside base directory");
                     }
@@ -72,7 +73,7 @@ public class ContentStorageService : IContentStorageService
                             ? Path.GetFullPath(file.SourcePath)
                             : Path.GetFullPath(Path.Combine(baseDirectory, file.SourcePath));
 
-                        if (!IsPathWithinDirectory(normalizedBase, fullSource))
+                        if (!PathHelper.IsPathWithinDirectory(normalizedBase, fullSource))
                         {
                             return OperationResult<bool>.CreateFailure($"File {file.RelativePath} specifies SourcePath {file.SourcePath} which traverses outside base directory");
                         }
@@ -86,15 +87,6 @@ public class ContentStorageService : IContentStorageService
         }
 
         return OperationResult<bool>.CreateSuccess(true);
-    }
-
-    private static bool IsPathWithinDirectory(string normalizedBase, string fullPath)
-    {
-        var relative = Path.GetRelativePath(normalizedBase, fullPath);
-        return !relative.Equals("..", StringComparison.Ordinal) &&
-               !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
-               !relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal) &&
-               !Path.IsPathRooted(relative);
     }
 
     private static async Task<string> CalculateFileHashAsync(string filePath, CancellationToken cancellationToken)

--- a/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.Manifest;
@@ -14,10 +15,10 @@ using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
+using GenHub.Core.Utilities;
 using GenHub.Features.Content.Services.Publishers;
 using Microsoft.Extensions.Logging;
 using SharpCompress.Archives;
-using SharpCompress.Common;
 
 namespace GenHub.Features.Content.Services.GitHub;
 
@@ -162,6 +163,13 @@ public class GitHubContentDeliverer(
                         logger.LogInformation("Extracted {ArchiveFile}", Path.GetFileName(archiveFile));
                         File.Delete(archiveFile);
                     }
+                    catch (OperationCanceledException)
+                    {
+                        logger.LogInformation(
+                            "Extraction of {ArchiveFile} was cancelled; the downloaded archive is left in place",
+                            Path.GetFileName(archiveFile));
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         logger.LogError(ex, "Failed to extract {ArchiveFile}", Path.GetFileName(archiveFile));
@@ -181,6 +189,10 @@ public class GitHubContentDeliverer(
 
             // For content without archives, return original manifest
             return OperationResult<ContentManifest>.CreateSuccess(packageManifest);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -243,17 +255,6 @@ public class GitHubContentDeliverer(
                ext == FileTypes.TarFileExtension ||
                ext == FileTypes.GzipFileExtension ||
                ext == FileTypes.RarFileExtension;
-    }
-
-    private static bool IsPathWithinDirectory(string normalizedBase, string fullPath)
-    {
-        var normalizedRoot = Path.GetFullPath(normalizedBase);
-        var normalizedTarget = Path.GetFullPath(fullPath);
-        var relative = Path.GetRelativePath(normalizedRoot, normalizedTarget);
-        return !relative.Equals("..", StringComparison.Ordinal) &&
-               !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
-               !relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal) &&
-               !Path.IsPathRooted(relative);
     }
 
     /// <summary>
@@ -365,7 +366,9 @@ public class GitHubContentDeliverer(
     }
 
     /// <summary>
-    /// Extracts an archive file asynchronously to prevent UI blocking.
+    /// Extracts an archive file asynchronously to prevent UI blocking. Release archives are remote
+    /// input, so every entry is confined to <paramref name="targetDirectory"/> and the archive is
+    /// held to entry-count and expansion budgets measured against the bytes actually decompressed.
     /// </summary>
     /// <param name="archiveFile">Path to the archive file.</param>
     /// <param name="targetDirectory">Directory to extract files to.</param>
@@ -379,21 +382,32 @@ public class GitHubContentDeliverer(
         CancellationToken cancellationToken)
     {
         await Task.Run(
-            () =>
+            async () =>
             {
-                using var archive = ArchiveFactory.Open(new FileInfo(archiveFile));
-                int totalEntries = archive.Entries.Count(e => !e.IsDirectory);
-                int currentEntry = 0;
+                using var archive = ArchiveFactory.OpenArchive(new FileInfo(archiveFile));
+                var fileEntries = archive.Entries.Where(e => !e.IsDirectory).ToList();
 
-                foreach (var entry in archive.Entries.Where(e => !e.IsDirectory))
+                if (fileEntries.Count > GitHubConstants.MaxArchiveEntries)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        break;
-                    }
+                    throw new InvalidOperationException(
+                        $"Archive contains too many entries ({fileEntries.Count} > {GitHubConstants.MaxArchiveEntries}).");
+                }
+
+                int totalEntries = fileEntries.Count;
+                int currentEntry = 0;
+                long expandedBytes = 0;
+                long expansionBudget = Math.Min(
+                    GitHubConstants.MaxAggregateUncompressedBytes,
+                    Math.Max(
+                        GitHubConstants.MinArchiveExpansionBudgetBytes,
+                        new FileInfo(archiveFile).Length * GitHubConstants.MaxArchiveExpansionRatio));
+
+                foreach (var entry in fileEntries)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     var destinationPath = Path.GetFullPath(Path.Combine(targetDirectory, entry.Key ?? string.Empty));
-                    if (!IsPathWithinDirectory(targetDirectory, destinationPath))
+                    if (!PathHelper.IsPathWithinDirectory(targetDirectory, destinationPath))
                     {
                         throw new InvalidOperationException($"Zip slip vulnerability detected: entry '{entry.Key}' attempts to extract outside target directory.");
                     }
@@ -404,13 +418,17 @@ public class GitHubContentDeliverer(
                         Directory.CreateDirectory(destinationDir);
                     }
 
-                    entry.WriteToFile(
-                        destinationPath,
-                        new ExtractionOptions
-                        {
-                            ExtractFullPath = true,
-                            Overwrite = true,
-                        });
+                    await using (var entryStream = entry.OpenEntryStream())
+                    {
+                        expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                            entryStream,
+                            destinationPath,
+                            entry.Key ?? string.Empty,
+                            GitHubConstants.MaxEntryUncompressedBytes,
+                            expansionBudget - expandedBytes,
+                            overwrite: true,
+                            cancellationToken);
+                    }
 
                     currentEntry++;
 

--- a/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentDeliverer.cs
@@ -406,7 +406,13 @@ public class GitHubContentDeliverer(
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var destinationPath = Path.GetFullPath(Path.Combine(targetDirectory, entry.Key ?? string.Empty));
+                    if (!ArchiveEntryName.IsExtractable(entry.Key))
+                    {
+                        throw new InvalidOperationException(
+                            $"Archive entry '{entry.Key}' has a name that cannot be extracted to a file.");
+                    }
+
+                    var destinationPath = Path.GetFullPath(Path.Combine(targetDirectory, entry.Key));
                     if (!PathHelper.IsPathWithinDirectory(targetDirectory, destinationPath))
                     {
                         throw new InvalidOperationException($"Zip slip vulnerability detected: entry '{entry.Key}' attempts to extract outside target directory.");
@@ -423,7 +429,7 @@ public class GitHubContentDeliverer(
                         expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
                             entryStream,
                             destinationPath,
-                            entry.Key ?? string.Empty,
+                            entry.Key,
                             GitHubConstants.MaxEntryUncompressedBytes,
                             expansionBudget - expandedBytes,
                             overwrite: true,

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
@@ -1,7 +1,9 @@
 using GenHub.Core.Constants;
+using GenHub.Core.Exceptions;
 using GenHub.Core.Interfaces.Tools.MapManager;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Tools.MapManager;
+using GenHub.Core.Utilities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -23,7 +25,7 @@ public sealed class MapImportService(
     MapNameParser mapNameParser,
     ILogger<MapImportService> logger) : IMapImportService
 {
-    private static readonly char[] PathSeparators = ['/', '\''];
+    private static readonly char[] PathSeparators = ['/', '\\'];
 
     /// <inheritdoc />
     public async Task<ImportResult> ImportFromUrlAsync(
@@ -226,7 +228,7 @@ public sealed class MapImportService(
         CancellationToken ct = default)
     {
         return await Task.Run(
-            () =>
+            async () =>
             {
                 var result = new ImportResult();
                 var (isValid, errorMessage) = ValidateZip(zipPath);
@@ -256,6 +258,7 @@ public sealed class MapImportService(
 
                     int totalMaps = 0;
                     int processedMaps = 0;
+                    long expandedBytes = 0;
 
                     // Count total maps for progress
                     foreach (var group in entriesByDirectory)
@@ -290,37 +293,66 @@ public sealed class MapImportService(
                             var mapDirPath = GetUniqueDirectoryPath(Path.Combine(targetDir, mapDirName));
                             Directory.CreateDirectory(mapDirPath);
 
-                            // Extract the .map file
                             var mapDestPath = Path.Combine(mapDirPath, mapEntry.Name);
-                            mapEntry.ExtractToFile(mapDestPath, false);
-
                             var assetFiles = new List<string>();
                             string? thumbnailPath = null;
 
-                            // Extract related asset files from the same directory in the ZIP
-                            if (!string.IsNullOrEmpty(directoryName))
+                            try
                             {
-                                var assetEntries = entries.Where(e =>
-                                    !e.Name.EndsWith(".map", StringComparison.OrdinalIgnoreCase) &&
-                                    MapManagerConstants.AllowedExtensions.Contains(Path.GetExtension(e.Name), StringComparer.OrdinalIgnoreCase));
-
-                                foreach (var assetEntry in assetEntries)
+                                await using (var mapStream = mapEntry.Open())
                                 {
-                                    var assetDestPath = Path.Combine(mapDirPath, assetEntry.Name);
-                                    if (!File.Exists(assetDestPath))
-                                    {
-                                        assetEntry.ExtractToFile(assetDestPath, false);
-                                    }
+                                    expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                                        mapStream,
+                                        mapDestPath,
+                                        mapEntry.FullName,
+                                        IMapImportService.MaxMapSizeBytes,
+                                        MapManagerConstants.MaxAggregateUncompressedBytes - expandedBytes,
+                                        cancellationToken: ct);
+                                }
 
-                                    assetFiles.Add(assetDestPath);
+                                // Extract related asset files from the same directory in the ZIP
+                                if (!string.IsNullOrEmpty(directoryName))
+                                {
+                                    var assetEntries = entries.Where(e =>
+                                        !e.Name.EndsWith(".map", StringComparison.OrdinalIgnoreCase) &&
+                                        MapManagerConstants.AllowedExtensions.Contains(Path.GetExtension(e.Name), StringComparer.OrdinalIgnoreCase));
 
-                                    // Check for thumbnail
-                                    if (assetEntry.Name.Equals(MapManagerConstants.DefaultThumbnailName, StringComparison.OrdinalIgnoreCase) ||
-                                        (thumbnailPath == null && assetEntry.Name.EndsWith(".tga", StringComparison.OrdinalIgnoreCase)))
+                                    foreach (var assetEntry in assetEntries)
                                     {
-                                        thumbnailPath = assetDestPath;
+                                        var assetDestPath = Path.Combine(mapDirPath, assetEntry.Name);
+                                        if (!File.Exists(assetDestPath))
+                                        {
+                                            await using var assetStream = assetEntry.Open();
+                                            expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                                                assetStream,
+                                                assetDestPath,
+                                                assetEntry.FullName,
+                                                MapManagerConstants.MaxAssetSizeBytes,
+                                                MapManagerConstants.MaxAggregateUncompressedBytes - expandedBytes,
+                                                cancellationToken: ct);
+                                        }
+
+                                        assetFiles.Add(assetDestPath);
+
+                                        // Check for thumbnail
+                                        if (assetEntry.Name.Equals(MapManagerConstants.DefaultThumbnailName, StringComparison.OrdinalIgnoreCase) ||
+                                            (thumbnailPath == null && assetEntry.Name.EndsWith(".tga", StringComparison.OrdinalIgnoreCase)))
+                                        {
+                                            thumbnailPath = assetDestPath;
+                                        }
                                     }
                                 }
+                            }
+                            catch (ArchiveExpansionLimitExceededException ex)
+                            {
+                                logger.LogWarning(
+                                    "Discarding map {Entry} from {ZipPath}: {Reason}",
+                                    mapEntry.FullName,
+                                    zipPath,
+                                    ex.Message);
+                                result.Errors.Add(ex.Message);
+                                DeleteDirectoryBestEffort(mapDirPath);
+                                continue;
                             }
 
                             var totalSize = new FileInfo(mapDestPath).Length + assetFiles.Sum(f => new FileInfo(f).Length);
@@ -541,6 +573,25 @@ public sealed class MapImportService(
         }
 
         return $"map_{Guid.NewGuid():N}.zip";
+    }
+
+    private static void DeleteDirectoryBestEffort(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup
+        }
     }
 
     private static string GetUniqueFilePath(string path)

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
@@ -99,7 +99,7 @@ public sealed class MapImportService(
                 result = await ImportFromFilesAsync([tempPath], targetVersion, ct);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Failed to import from URL: {Url}", url);
             result.Errors.Add($"Import failed: {ex.Message}");
@@ -209,7 +209,7 @@ public sealed class MapImportService(
                 };
                 result.ImportedMaps.Add(mapFile);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogError(ex, "Failed to import file: {FilePath}", filePath);
                 result.Errors.Add($"Failed to import {Path.GetFileName(filePath)}: {ex.Message}");
@@ -274,6 +274,8 @@ public sealed class MapImportService(
 
                         foreach (var mapEntry in mapEntries)
                         {
+                            ct.ThrowIfCancellationRequested();
+
                             if (mapEntry.Length > IMapImportService.MaxMapSizeBytes)
                             {
                                 result.Errors.Add($"Map too large: {mapEntry.Name}");
@@ -383,6 +385,11 @@ public sealed class MapImportService(
                     }
 
                     progress?.Report(1.0);
+                }
+                catch (OperationCanceledException)
+                {
+                    logger.LogInformation("Import from ZIP was cancelled: {ZipPath}", zipPath);
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
@@ -292,8 +292,6 @@ public sealed class MapImportService(
                             }
 
                             var mapDirPath = GetUniqueDirectoryPath(Path.Combine(targetDir, mapDirName));
-                            Directory.CreateDirectory(mapDirPath);
-
                             var mapDestPath = Path.Combine(mapDirPath, mapEntry.Name);
                             var assetFiles = new List<string>();
                             string? thumbnailPath = null;
@@ -302,6 +300,8 @@ public sealed class MapImportService(
 
                             try
                             {
+                                Directory.CreateDirectory(mapDirPath);
+
                                 await using (var mapStream = mapEntry.Open())
                                 {
                                     mapExpandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(

--- a/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
+++ b/GenHub/GenHub/Features/Tools/MapManager/Services/MapImportService.cs
@@ -1,5 +1,4 @@
 using GenHub.Core.Constants;
-using GenHub.Core.Exceptions;
 using GenHub.Core.Interfaces.Tools.MapManager;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Tools.MapManager;
@@ -299,16 +298,18 @@ public sealed class MapImportService(
                             var assetFiles = new List<string>();
                             string? thumbnailPath = null;
 
+                            long mapExpandedBytes = 0;
+
                             try
                             {
                                 await using (var mapStream = mapEntry.Open())
                                 {
-                                    expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                                    mapExpandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
                                         mapStream,
                                         mapDestPath,
                                         mapEntry.FullName,
                                         IMapImportService.MaxMapSizeBytes,
-                                        MapManagerConstants.MaxAggregateUncompressedBytes - expandedBytes,
+                                        MapManagerConstants.MaxAggregateUncompressedBytes - expandedBytes - mapExpandedBytes,
                                         cancellationToken: ct);
                                 }
 
@@ -325,12 +326,12 @@ public sealed class MapImportService(
                                         if (!File.Exists(assetDestPath))
                                         {
                                             await using var assetStream = assetEntry.Open();
-                                            expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                                            mapExpandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
                                                 assetStream,
                                                 assetDestPath,
                                                 assetEntry.FullName,
                                                 MapManagerConstants.MaxAssetSizeBytes,
-                                                MapManagerConstants.MaxAggregateUncompressedBytes - expandedBytes,
+                                                MapManagerConstants.MaxAggregateUncompressedBytes - expandedBytes - mapExpandedBytes,
                                                 cancellationToken: ct);
                                         }
 
@@ -344,8 +345,10 @@ public sealed class MapImportService(
                                         }
                                     }
                                 }
+
+                                expandedBytes += mapExpandedBytes;
                             }
-                            catch (ArchiveExpansionLimitExceededException ex)
+                            catch (Exception ex) when (ex is not OperationCanceledException)
                             {
                                 logger.LogWarning(
                                     "Discarding map {Entry} from {ZipPath}: {Reason}",

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
@@ -11,6 +11,7 @@ using GenHub.Core.Interfaces.Tools.ReplayManager;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Tools.ReplayManager;
+using GenHub.Core.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace GenHub.Features.Tools.ReplayManager.Services;
@@ -218,21 +219,34 @@ public sealed class ReplayImportService(
             var entries = archive.Entries.Where(e => !string.IsNullOrEmpty(e.Name)).ToList();
             int total = entries.Count;
             int count = 0;
+            long expandedBytes = 0;
+
+            directoryService.EnsureDirectoryExists(targetVersion);
+            var targetDir = directoryService.GetReplayDirectory(targetVersion);
 
             foreach (var entry in entries)
             {
                 count++;
                 progress?.Report((double)count / total);
 
-                using var stream = entry.Open();
-                var result = await ImportFromStreamAsync(stream, entry.Name, targetVersion, ct);
-                if (result.Success)
+                var targetPath = GetUniquePath(Path.Combine(targetDir, Path.GetFileName(entry.Name)));
+
+                try
                 {
-                    imported.AddRange(result.ImportedFiles);
+                    await using var stream = entry.Open();
+                    expandedBytes += await BoundedArchiveExtractor.CopyEntryToFileAsync(
+                        stream,
+                        targetPath,
+                        entry.FullName,
+                        ReplayManagerConstants.MaxReplaySizeBytes,
+                        ReplayManagerConstants.MaxAggregateUncompressedBytes - expandedBytes,
+                        cancellationToken: ct);
+                    imported.Add(targetPath);
                 }
-                else
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    errors.AddRange(result.Errors);
+                    logger.LogWarning(ex, "Discarding replay entry {Entry} from {ZipPath}", entry.FullName, zipPath);
+                    errors.Add(ex.Message);
                     skipped++;
                 }
             }

--- a/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
+++ b/GenHub/GenHub/Features/Tools/ReplayManager/Services/ReplayImportService.cs
@@ -172,7 +172,7 @@ public sealed class ReplayImportService(
                     skipped++;
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 errors.Add($"Failed to import {Path.GetFileName(path)}: {ex.Message}");
                 skipped++;
@@ -226,6 +226,8 @@ public sealed class ReplayImportService(
 
             foreach (var entry in entries)
             {
+                ct.ThrowIfCancellationRequested();
+
                 count++;
                 progress?.Report((double)count / total);
 
@@ -250,6 +252,11 @@ public sealed class ReplayImportService(
                     skipped++;
                 }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("Import from ZIP {ZipPath} was cancelled", zipPath);
+            throw;
         }
         catch (Exception ex)
         {
@@ -293,7 +300,7 @@ public sealed class ReplayImportService(
                 ImportedFiles = [targetPath],
             };
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, LogMessages.FailedToImportStream, fileName);
             return new ImportResult { Success = false, FilesImported = 0, FilesSkipped = 1, Errors = [ex.Message] };

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -831,6 +831,7 @@ public static string FromInstallationType(GameInstallationType installationType)
 ## IoConstants Class
 
 - `DefaultFileBufferSize`: 4096
+- `StagingFileSuffix`: ".genhub-staging"
 
 ---
 


### PR DESCRIPTION
## Problem

Five defects in archive handling, across both remote content delivery and local imports.

**1. A cancelled GitHub extraction reported success.** `ExtractArchiveAsync` handled cancellation with a mid-loop `break`. The `Task.Run(..., cancellationToken)` wrapper only honors the token *before* the delegate starts, so the break completed the task successfully — the caller then logged success, **deleted the downloaded archive**, and registered the truncated file set as a complete manifest. Unrecoverable locally, because the archive was already gone.

**2. `PathSeparators` contained an apostrophe, not a backslash.** `['/', '\'']` — an escaped `'` (0x27) where `'\\'` was intended. Backslash-separated zip entries were therefore never split, so the segment-based traversal check could not see `..\` segments, and a legitimate name containing an apostrophe (`Bob's Map/bob.map`) was mis-split and mis-grouped.

**3. Expansion limits trusted attacker-declared sizes.** The map and replay validators checked `entry.Length` / `entry.CompressedLength` — the ZIP central-directory *declared* values — then extracted with unbounded `ExtractToFile`/`CopyTo`.

**4. Community Outpost extraction had no containment check or expansion bound of its own.** It called `WriteToDirectory` with `ExtractFullPath = true` on archives fetched from a third-party catalog and its mirrors, relying on undocumented library behavior for traversal safety, with no size or count caps.

**5. SharpCompress 0.42.0** is subject to [GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338) (`NU1902` is raised on every build today).

### Verified while fixing

`System.IO.Compression`'s `ZipArchiveEntry.Open()` **clamps** reads at the declared uncompressed size — a zip patched to declare 4 KB while holding 12 MB yields exactly 4096 bytes. **SharpCompress does not clamp**: the same archive inflates the full 12,582,912 bytes. So the header-trust hole is genuinely exploitable on the SharpCompress deliverers (GitHub, Community Outpost), while on the `System.IO.Compression` importers the bounded copy is defense in depth plus a real fix for asset amplification, where an asset shared by N maps is written N times but counted once.

## Changes

- **Cancellation** — `ThrowIfCancellationRequested()` replaces the `break`, with `catch (OperationCanceledException) { throw; }` ahead of the per-archive and method-level handlers so the archive is kept and nothing reaches the manifest pool.
- **Shared helpers, three duplicates removed.** `BoundedArchiveExtractor.CopyEntryToFileAsync` (in `GenHub.Core/Utilities`, alongside the existing `ZipValidation`) streams an entry against `min(perEntryCap, remainingAggregate)`, aborts mid-stream, deletes the partial output and throws `ArchiveExpansionLimitExceededException`. It takes a plain `Stream`, so Core needs no SharpCompress reference and both `System.IO.Compression` and SharpCompress callers share it. The containment check moved into the existing `PathHelper.IsPathWithinDirectory`, replacing copies in `GitHubContentDeliverer` and `ContentStorageService`.
- **All four extraction paths are now bounded and containment-checked**: map import, replay import, Community Outpost (both the main package and the dependency-archive call site), and GitHub.
- **Typo fixed** to `['/', '\\']`, with the surrounding grouping and validation re-checked for both separators now that splitting actually works.
- **SharpCompress 0.48.0.** Not drop-in: `ArchiveFactory.Open` was renamed to `ArchiveFactory.OpenArchive` (the async surface took the old names). Two call sites updated; `NU1902` is gone.

## Caps

GitHub caps a single release asset at 2 GiB, which anchors the numbers. GitHub uses `min(16 GiB, max(8 MiB, archiveSize × 500))` — a ratio-derived budget matters because absolute caps alone do nothing against a 12 KB bomb. Real deflate release content runs 2–20:1 against a 500:1 limit.

Community Outpost deliberately keeps **absolute** caps only (2 GiB entry / 4 GiB aggregate / 10,000 entries) rather than a ratio. Its payloads are 7z/LZMA over BIG files with internal padding, where the realistic ceiling is not predictable and a badly chosen ratio would reject legitimate catalog content in the field. Happy to mirror the ratio there if you'd rather.

## Tests

1638 -> 1660, fully green. Confirmed discriminating: reverting each source fix fails exactly the intended tests.

- containment helper accepts contained paths and rejects `..`, traversal, normalized-escape, sibling-prefix and absolute-outside paths
- bounded copy honors per-entry and aggregate budgets, deletes partial output, and rejects an archive whose central directory and local header are patched to declare 4 KB while inflating to 12 MB
- backslash traversal rejected; backslash-separated entries resolve to one directory; apostrophes in names stay intact
- Community Outpost rejects an escaping entry and an over-budget archive
- GitHub: cancelling mid-extraction propagates, keeps the archive and registers nothing; a size-understating archive fails **without** registering a manifest and is distinguishable from cancellation