### PR TITLE
fix: enable executable selection for GameClient, ModdingTool, and Executable in Add Local Content dialog

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/Content/ILocalContentService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/ILocalContentService.cs
@@ -20,6 +20,7 @@ public interface ILocalContentService
     /// <param name="sourcePath">Optional original source path of the content.</param>
     /// <param name="progress">Optional progress reporter for tracking manifest creation.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="entryPoint">Optional relative path of the main executable entry point.</param>
     /// <returns>A result containing the created manifest or errors.</returns>
     Task<OperationResult<ContentManifest>> CreateLocalContentManifestAsync(
         string directoryPath,
@@ -28,7 +29,8 @@ public interface ILocalContentService
         GameType targetGame,
         string? sourcePath = null,
         IProgress<ContentStorageProgress>? progress = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        string? entryPoint = null);
 
     /// <summary>
     /// Adds local content by creating and storing a manifest.
@@ -66,6 +68,7 @@ public interface ILocalContentService
     /// <param name="sourcePath">Optional original source path of the content.</param>
     /// <param name="progress">Optional progress reporter.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="entryPoint">Optional relative path of the main executable entry point.</param>
     /// <returns>A result containing the updated manifest.</returns>
     Task<OperationResult<ContentManifest>> UpdateLocalContentManifestAsync(
         string existingManifestId,
@@ -75,7 +78,8 @@ public interface ILocalContentService
         GameType targetGame,
         string? sourcePath = null,
         IProgress<ContentStorageProgress>? progress = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        string? entryPoint = null);
 
     /// <summary>
     /// Gets the allowed content types for local content creation.

--- a/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ManifestVariantResolver.cs
@@ -166,7 +166,13 @@ public static class ManifestVariantResolver
             files);
     }
 
-    private static bool PathsMatch(string left, string right) =>
+    /// <summary>
+    /// Determines whether two relative file paths match, normalizing directory separators and leading slashes.
+    /// </summary>
+    /// <param name="left">The first relative path.</param>
+    /// <param name="right">The second relative path.</param>
+    /// <returns><c>true</c> if the paths match; otherwise, <c>false</c>.</returns>
+    public static bool PathsMatch(string left, string right) =>
         string.Equals(
             left.Replace('\\', '/').TrimStart('/'),
             right.Replace('\\', '/').TrimStart('/'),

--- a/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
+++ b/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
@@ -105,7 +105,24 @@ public class LocalContentService(
 
             if (!string.IsNullOrWhiteSpace(entryPoint))
             {
-                manifest.EntryPoint = entryPoint.Replace('\\', '/');
+                var normalizedEntryPoint = entryPoint.Replace('\\', '/').TrimStart('/');
+
+                if (Path.IsPathRooted(entryPoint) || normalizedEntryPoint.Contains(".."))
+                {
+                    return OperationResult<ContentManifest>.CreateFailure(
+                        $"Entry point '{entryPoint}' is invalid. It must be a relative path without parent directory traversal ('..').");
+                }
+
+                var matchedFile = manifest.Files.FirstOrDefault(f =>
+                    ManifestVariantResolver.PathsMatch(f.RelativePath, normalizedEntryPoint));
+
+                if (matchedFile == null)
+                {
+                    return OperationResult<ContentManifest>.CreateFailure(
+                        $"Entry point '{entryPoint}' was not found among the files in the directory.");
+                }
+
+                manifest.EntryPoint = matchedFile.RelativePath.Replace('\\', '/');
             }
 
             // Auto-add GameInstallation dependency for GameClient content types

--- a/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
+++ b/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
@@ -107,7 +107,8 @@ public class LocalContentService(
             {
                 var normalizedEntryPoint = entryPoint.Replace('\\', '/').TrimStart('/');
 
-                if (Path.IsPathRooted(entryPoint) || normalizedEntryPoint.Contains(".."))
+                var segments = normalizedEntryPoint.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                if (Path.IsPathRooted(entryPoint) || segments.Any(s => s == ".."))
                 {
                     return OperationResult<ContentManifest>.CreateFailure(
                         $"Entry point '{entryPoint}' is invalid. It must be a relative path without parent directory traversal ('..').");

--- a/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
+++ b/GenHub/GenHub.Core/Services/Content/LocalContentService.cs
@@ -57,7 +57,8 @@ public class LocalContentService(
         GameType targetGame,
         string? sourcePath = null,
         IProgress<ContentStorageProgress>? progress = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? entryPoint = null)
     {
         try
         {
@@ -101,6 +102,11 @@ public class LocalContentService(
 
             var manifest = builder.Build();
             manifest.SourcePath = !string.IsNullOrEmpty(sourcePath) ? sourcePath : directoryPath;
+
+            if (!string.IsNullOrWhiteSpace(entryPoint))
+            {
+                manifest.EntryPoint = entryPoint.Replace('\\', '/');
+            }
 
             // Auto-add GameInstallation dependency for GameClient content types
             // This ensures auto-resolution logic works correctly for locally added clients
@@ -195,13 +201,14 @@ public class LocalContentService(
         GameType targetGame,
         string? sourcePath = null,
         IProgress<ContentStorageProgress>? progress = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? entryPoint = null)
     {
         try
         {
             // 1. Create the new manifest/content
             // We do this FIRST to ensure the new content is valid before deleting the old one
-            var createResult = await CreateLocalContentManifestAsync(directoryPath, name, contentType, targetGame, sourcePath, progress, cancellationToken);
+            var createResult = await CreateLocalContentManifestAsync(directoryPath, name, contentType, targetGame, sourcePath, progress, cancellationToken, entryPoint);
 
             if (!createResult.Success)
             {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/LocalContentServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/LocalContentServiceTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Core.Services.Content;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Content.Services;
+
+/// <summary>
+/// Contains tests for <see cref="LocalContentService"/>.
+/// </summary>
+public class LocalContentServiceTests : IDisposable
+{
+    private readonly Mock<IManifestGenerationService> _manifestGenServiceMock;
+    private readonly Mock<IContentStorageService> _contentStorageServiceMock;
+    private readonly Mock<IContentReconciliationService> _reconciliationServiceMock;
+    private readonly LocalContentService _service;
+    private readonly string _tempDir;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalContentServiceTests"/> class.
+    /// </summary>
+    public LocalContentServiceTests()
+    {
+        _manifestGenServiceMock = new Mock<IManifestGenerationService>();
+        _contentStorageServiceMock = new Mock<IContentStorageService>();
+        _reconciliationServiceMock = new Mock<IContentReconciliationService>();
+
+        _service = new LocalContentService(
+            _manifestGenServiceMock.Object,
+            _contentStorageServiceMock.Object,
+            _reconciliationServiceMock.Object,
+            NullLogger<LocalContentService>.Instance);
+
+        _tempDir = Path.Combine(Path.GetTempPath(), "LocalContentServiceTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Cleans up temporary resources.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup failures
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Verifies that CreateLocalContentManifestAsync sets EntryPoint when provided.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateLocalContentManifestAsync_WithEntryPoint_SetsManifestEntryPoint()
+    {
+        SetupManifestBuilder(ContentType.ModdingTool, GameType.ZeroHour, "FinalBIG");
+
+        var result = await _service.CreateLocalContentManifestAsync(
+            directoryPath: _tempDir,
+            name: "FinalBIG",
+            contentType: ContentType.ModdingTool,
+            targetGame: GameType.ZeroHour,
+            entryPoint: "FinalBIG.exe");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal("FinalBIG.exe", result.Data!.EntryPoint);
+    }
+
+    /// <summary>
+    /// Verifies that CreateLocalContentManifestAsync normalizes backslashes to forward slashes in EntryPoint.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateLocalContentManifestAsync_NormalizesBackslashesInEntryPoint()
+    {
+        SetupManifestBuilder(ContentType.Executable, GameType.ZeroHour, "Tool");
+
+        var result = await _service.CreateLocalContentManifestAsync(
+            directoryPath: _tempDir,
+            name: "Tool",
+            contentType: ContentType.Executable,
+            targetGame: GameType.ZeroHour,
+            entryPoint: "bin\\sub\\tool.exe");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal("bin/sub/tool.exe", result.Data!.EntryPoint);
+    }
+
+    /// <summary>
+    /// Verifies that CreateLocalContentManifestAsync leaves EntryPoint null when not provided.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateLocalContentManifestAsync_WithoutEntryPoint_LeavesEntryPointNull()
+    {
+        SetupManifestBuilder(ContentType.Mod, GameType.ZeroHour, "MyMod");
+
+        var result = await _service.CreateLocalContentManifestAsync(
+            directoryPath: _tempDir,
+            name: "MyMod",
+            contentType: ContentType.Mod,
+            targetGame: GameType.ZeroHour);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Null(result.Data!.EntryPoint);
+    }
+
+    /// <summary>
+    /// Verifies that UpdateLocalContentManifestAsync passes entryPoint through to the created manifest.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task UpdateLocalContentManifestAsync_WithEntryPoint_SetsEntryPointOnUpdatedManifest()
+    {
+        SetupManifestBuilder(ContentType.GameClient, GameType.ZeroHour, "GeneralsClient");
+
+        _reconciliationServiceMock
+            .Setup(x => x.OrchestrateLocalUpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<ContentManifest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentUpdateResult>.CreateSuccess(new ContentUpdateResult()));
+
+        var result = await _service.UpdateLocalContentManifestAsync(
+            existingManifestId: "1.0.local.gameclient.old",
+            name: "GeneralsClient",
+            directoryPath: _tempDir,
+            contentType: ContentType.GameClient,
+            targetGame: GameType.ZeroHour,
+            entryPoint: "generals.exe");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal("generals.exe", result.Data!.EntryPoint);
+    }
+
+    private void SetupManifestBuilder(ContentType contentType, GameType targetGame, string contentName)
+    {
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create($"1.0.local.{contentType.ToString().ToLowerInvariant()}.{contentName.ToLowerInvariant()}"),
+            Name = contentName,
+            ContentType = contentType,
+            TargetGame = targetGame,
+        };
+
+        var builderMock = new Mock<IContentManifestBuilder>();
+        builderMock.Setup(b => b.Build()).Returns(manifest);
+
+        _manifestGenServiceMock
+            .Setup(x => x.CreateContentManifestAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<ContentType>(),
+                It.IsAny<GameType>(),
+                It.IsAny<ContentDependency[]>()))
+            .ReturnsAsync(builderMock.Object);
+
+        _contentStorageServiceMock
+            .Setup(x => x.StoreContentAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/LocalContentServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/LocalContentServiceTests.cs
@@ -73,7 +73,7 @@ public class LocalContentServiceTests : IDisposable
     [Fact]
     public async Task CreateLocalContentManifestAsync_WithEntryPoint_SetsManifestEntryPoint()
     {
-        SetupManifestBuilder(ContentType.ModdingTool, GameType.ZeroHour, "FinalBIG");
+        SetupManifestBuilder(ContentType.ModdingTool, GameType.ZeroHour, "FinalBIG", "FinalBIG.exe");
 
         var result = await _service.CreateLocalContentManifestAsync(
             directoryPath: _tempDir,
@@ -94,7 +94,7 @@ public class LocalContentServiceTests : IDisposable
     [Fact]
     public async Task CreateLocalContentManifestAsync_NormalizesBackslashesInEntryPoint()
     {
-        SetupManifestBuilder(ContentType.Executable, GameType.ZeroHour, "Tool");
+        SetupManifestBuilder(ContentType.Executable, GameType.ZeroHour, "Tool", "bin/sub/tool.exe");
 
         var result = await _service.CreateLocalContentManifestAsync(
             directoryPath: _tempDir,
@@ -106,6 +106,71 @@ public class LocalContentServiceTests : IDisposable
         Assert.True(result.Success);
         Assert.NotNull(result.Data);
         Assert.Equal("bin/sub/tool.exe", result.Data!.EntryPoint);
+    }
+
+    /// <summary>
+    /// Verifies that CreateLocalContentManifestAsync leaves EntryPoint null when passed a whitespace-only value.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateLocalContentManifestAsync_WithWhitespaceOnlyEntryPoint_LeavesEntryPointNull()
+    {
+        SetupManifestBuilder(ContentType.ModdingTool, GameType.ZeroHour, "FinalBIG", "FinalBIG.exe");
+
+        var result = await _service.CreateLocalContentManifestAsync(
+            directoryPath: _tempDir,
+            name: "FinalBIG",
+            contentType: ContentType.ModdingTool,
+            targetGame: GameType.ZeroHour,
+            entryPoint: "   ");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Null(result.Data!.EntryPoint);
+    }
+
+    /// <summary>
+    /// Verifies that CreateLocalContentManifestAsync rejects rooted or parent-traversal entry points.
+    /// </summary>
+    /// <param name="invalidEntryPoint">The invalid entry point path to test.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData("/usr/bin/tool.exe")]
+    [InlineData("../tool.exe")]
+    [InlineData("bin/../../tool.exe")]
+    public async Task CreateLocalContentManifestAsync_WithInvalidEntryPointPath_ReturnsFailure(string invalidEntryPoint)
+    {
+        SetupManifestBuilder(ContentType.Executable, GameType.ZeroHour, "Tool", "tool.exe");
+
+        var result = await _service.CreateLocalContentManifestAsync(
+            directoryPath: _tempDir,
+            name: "Tool",
+            contentType: ContentType.Executable,
+            targetGame: GameType.ZeroHour,
+            entryPoint: invalidEntryPoint);
+
+        Assert.False(result.Success);
+        Assert.Contains("invalid", result.FirstError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies that CreateLocalContentManifestAsync rejects an entry point that does not exist in manifest files.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task CreateLocalContentManifestAsync_WithNonExistentEntryPoint_ReturnsFailure()
+    {
+        SetupManifestBuilder(ContentType.Executable, GameType.ZeroHour, "Tool", "tool.exe");
+
+        var result = await _service.CreateLocalContentManifestAsync(
+            directoryPath: _tempDir,
+            name: "Tool",
+            contentType: ContentType.Executable,
+            targetGame: GameType.ZeroHour,
+            entryPoint: "missing.exe");
+
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.FirstError, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -135,7 +200,7 @@ public class LocalContentServiceTests : IDisposable
     [Fact]
     public async Task UpdateLocalContentManifestAsync_WithEntryPoint_SetsEntryPointOnUpdatedManifest()
     {
-        SetupManifestBuilder(ContentType.GameClient, GameType.ZeroHour, "GeneralsClient");
+        SetupManifestBuilder(ContentType.GameClient, GameType.ZeroHour, "GeneralsClient", "generals.exe");
 
         _reconciliationServiceMock
             .Setup(x => x.OrchestrateLocalUpdateAsync(
@@ -157,14 +222,19 @@ public class LocalContentServiceTests : IDisposable
         Assert.Equal("generals.exe", result.Data!.EntryPoint);
     }
 
-    private void SetupManifestBuilder(ContentType contentType, GameType targetGame, string contentName)
+    private void SetupManifestBuilder(ContentType contentType, GameType targetGame, string contentName, params string[] filePaths)
     {
+        var files = filePaths.Length > 0
+            ? filePaths.Select(f => new ManifestFile { RelativePath = f, IsExecutable = f.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) }).ToList()
+            : new List<ManifestFile>();
+
         var manifest = new ContentManifest
         {
             Id = ManifestId.Create($"1.0.local.{contentType.ToString().ToLowerInvariant()}.{contentName.ToLowerInvariant()}"),
             Name = contentName,
             ContentType = contentType,
             TargetGame = targetGame,
+            Files = files,
         };
 
         var builderMock = new Mock<IContentManifestBuilder>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/LocalContentServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/LocalContentServiceTests.cs
@@ -154,6 +154,30 @@ public class LocalContentServiceTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that CreateLocalContentManifestAsync accepts entry points with double dots in file or folder names.
+    /// </summary>
+    /// <param name="validEntryPoint">The valid entry point path with dots in name.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData("game..exe")]
+    [InlineData("backup..old/tool.exe")]
+    public async Task CreateLocalContentManifestAsync_WithDoubleDotsInName_ReturnsSuccess(string validEntryPoint)
+    {
+        SetupManifestBuilder(ContentType.Executable, GameType.ZeroHour, "Tool", validEntryPoint);
+
+        var result = await _service.CreateLocalContentManifestAsync(
+            directoryPath: _tempDir,
+            name: "Tool",
+            contentType: ContentType.Executable,
+            targetGame: GameType.ZeroHour,
+            entryPoint: validEntryPoint);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal(validEntryPoint, result.Data!.EntryPoint);
+    }
+
+    /// <summary>
     /// Verifies that CreateLocalContentManifestAsync rejects an entry point that does not exist in manifest files.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
@@ -519,11 +519,11 @@ public class AddLocalContentViewModelTests : IDisposable
             Name = "ZH Client",
             ContentType = ContentType.GameClient,
             TargetGame = GameType.ZeroHour,
-            EntryPoint = "bin/tool.exe",
+            EntryPoint = "special.exe",
             Files =
             [
                 new ManifestFile { RelativePath = "special.exe", IsExecutable = true },
-                new ManifestFile { RelativePath = "bin/tool.exe", IsExecutable = true },
+                new ManifestFile { RelativePath = "bin/decoy.exe", IsExecutable = true },
             ],
         };
 
@@ -538,7 +538,7 @@ public class AddLocalContentViewModelTests : IDisposable
                 File.WriteAllText(Path.Combine(targetPath, "special.exe"), "exe");
                 var targetSub = Path.Combine(targetPath, "bin");
                 Directory.CreateDirectory(targetSub);
-                File.WriteAllText(Path.Combine(targetSub, "tool.exe"), "tool");
+                File.WriteAllText(Path.Combine(targetSub, "decoy.exe"), "decoy");
             })
             .ReturnsAsync((ManifestId _, string targetPath, CancellationToken _) => OperationResult<string>.CreateSuccess(targetPath));
 
@@ -573,10 +573,10 @@ public class AddLocalContentViewModelTests : IDisposable
         await vm.LoadFromManifestAsync(item);
 
         Assert.NotNull(vm.SelectedExecutableItem);
-        Assert.Equal("tool.exe", vm.SelectedExecutableItem.Name);
+        Assert.Equal("special.exe", vm.SelectedExecutableItem.Name);
 
         await vm.AddContentCommand.ExecuteAsync(null);
-        Assert.Equal("bin/tool.exe", capturedEntryPoint);
+        Assert.Equal("special.exe", capturedEntryPoint);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
@@ -29,6 +29,7 @@ public class AddLocalContentViewModelTests : IDisposable
     private readonly Mock<IGenLauncherNormalizationService> _normalizationServiceMock;
     private readonly Mock<IDialogService> _dialogServiceMock;
     private readonly List<string> _tempDirectories = [];
+    private readonly List<AddLocalContentViewModel> _viewModels = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AddLocalContentViewModelTests"/> class.
@@ -43,13 +44,22 @@ public class AddLocalContentViewModelTests : IDisposable
         _localContentServiceMock
             .Setup(x => x.AllowedContentTypes)
             .Returns(AddLocalContentViewModel.AllowedContentTypes);
+
+        _normalizationServiceMock
+            .Setup(x => x.DetectGenLauncherFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GenLauncherDetectionResult());
     }
 
     /// <summary>
-    /// Cleans up temporary test directories.
+    /// Cleans up temporary test directories and viewmodels.
     /// </summary>
     public void Dispose()
     {
+        foreach (var vm in _viewModels)
+        {
+            vm.Dispose();
+        }
+
         foreach (var dir in _tempDirectories)
         {
             try
@@ -494,6 +504,155 @@ public class AddLocalContentViewModelTests : IDisposable
         Assert.Equal($"{dirName}/bin/tool.exe", capturedEntryPoint);
     }
 
+    /// <summary>
+    /// Verifies that LoadFromManifestAsync preserves the manifest EntryPoint when reloading for edit.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task LoadFromManifestAsync_PreservesManifestEntryPoint()
+    {
+        var manifestId = ManifestId.Create("1.0.local.gameclient.zh");
+
+        var manifest = new ContentManifest
+        {
+            Id = manifestId,
+            Name = "ZH Client",
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            EntryPoint = "bin/tool.exe",
+            Files =
+            [
+                new ManifestFile { RelativePath = "special.exe", IsExecutable = true },
+                new ManifestFile { RelativePath = "bin/tool.exe", IsExecutable = true },
+            ],
+        };
+
+        _contentStorageServiceMock
+            .Setup(x => x.RetrieveContentAsync(
+                It.IsAny<ManifestId>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<ManifestId, string, CancellationToken>((_, targetPath, _) =>
+            {
+                Directory.CreateDirectory(targetPath);
+                File.WriteAllText(Path.Combine(targetPath, "special.exe"), "exe");
+                var targetSub = Path.Combine(targetPath, "bin");
+                Directory.CreateDirectory(targetSub);
+                File.WriteAllText(Path.Combine(targetSub, "tool.exe"), "tool");
+            })
+            .ReturnsAsync((ManifestId _, string targetPath, CancellationToken _) => OperationResult<string>.CreateSuccess(targetPath));
+
+        var item = new GenHub.Features.GameProfiles.ViewModels.ContentDisplayItem
+        {
+            Id = manifestId.Value,
+            ManifestId = manifestId,
+            DisplayName = "ZH Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.Unknown,
+            Manifest = manifest,
+        };
+
+        var vm = CreateViewModel();
+        await vm.LoadFromManifestAsync(item);
+
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("tool.exe", vm.SelectedExecutableItem.Name);
+    }
+
+    /// <summary>
+    /// Verifies that deleting an unrelated item preserves the previously selected executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteItemAsync_PreservesSelectedExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir, "first.exe"), "first");
+        File.WriteAllText(Path.Combine(tempDir, "second.exe"), "second");
+        File.WriteAllText(Path.Combine(tempDir, "readme.txt"), "readme");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.GameClient;
+        vm.ContentName = "Test Client";
+        await vm.ImportContentAsync(tempDir);
+
+        var secondExe = FindInTree(vm.FileTree, f => f.Name == "second.exe");
+        Assert.NotNull(secondExe);
+        vm.SelectExecutableCommand.Execute(secondExe);
+        Assert.Equal("second.exe", vm.SelectedExecutableItem?.Name);
+
+        var readme = FindInTree(vm.FileTree, f => f.Name == "readme.txt");
+        Assert.NotNull(readme);
+        await vm.DeleteItemCommand.ExecuteAsync(readme);
+
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("second.exe", vm.SelectedExecutableItem.Name);
+    }
+
+    /// <summary>
+    /// Verifies that switching from an executable type to a non-executable type clears the selected executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ContentTypeChanged_FromExecutableToNonExecutable_ClearsSelectedExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir, "game.exe"), "game");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.GameClient;
+        vm.ContentName = "Test Client";
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.NotNull(vm.SelectedExecutableItem);
+
+        vm.SelectedContentType = ContentType.Mod;
+
+        Assert.Null(vm.SelectedExecutableItem);
+    }
+
+    /// <summary>
+    /// Verifies that AddContentCommand with non-executable content type passes null as entryPoint.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task AddContentCommand_WhenNonExecutableType_PassesNullEntryPoint()
+    {
+        var tempDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir, "somefile.txt"), "text");
+
+        string? capturedEntryPoint = "INITIAL";
+        _localContentServiceMock
+            .Setup(x => x.CreateLocalContentManifestAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ContentType>(),
+                It.IsAny<GameType>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?>()))
+            .Callback<string, string, ContentType, GameType, string?, IProgress<ContentStorageProgress>?, CancellationToken, string?>(
+                (_, _, _, _, _, _, _, entryPoint) => capturedEntryPoint = entryPoint)
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest
+            {
+                Id = ManifestId.Create("1.0.local.mod.test"),
+                Name = "My Mod",
+                ContentType = ContentType.Mod,
+                TargetGame = GameType.ZeroHour,
+            }));
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.Mod;
+        vm.ContentName = "My Mod";
+        await vm.ImportContentAsync(tempDir);
+
+        await vm.AddContentCommand.ExecuteAsync(null);
+
+        Assert.Null(capturedEntryPoint);
+    }
+
     private static FileTreeItem? FindInTree(IEnumerable<FileTreeItem> items, Func<FileTreeItem, bool> predicate)
     {
         foreach (var item in items)
@@ -516,11 +675,13 @@ public class AddLocalContentViewModelTests : IDisposable
 
     private AddLocalContentViewModel CreateViewModel()
     {
-        return new AddLocalContentViewModel(
+        var vm = new AddLocalContentViewModel(
             _localContentServiceMock.Object,
             _contentStorageServiceMock.Object,
             _normalizationServiceMock.Object,
             _dialogServiceMock.Object,
             NullLogger<AddLocalContentViewModel>.Instance);
+        _viewModels.Add(vm);
+        return vm;
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
@@ -542,6 +542,22 @@ public class AddLocalContentViewModelTests : IDisposable
             })
             .ReturnsAsync((ManifestId _, string targetPath, CancellationToken _) => OperationResult<string>.CreateSuccess(targetPath));
 
+        string? capturedEntryPoint = null;
+        _localContentServiceMock
+            .Setup(x => x.UpdateLocalContentManifestAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ContentType>(),
+                It.IsAny<GameType>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?>()))
+            .Callback<string, string, string, ContentType, GameType, string?, IProgress<ContentStorageProgress>?, CancellationToken, string?>(
+                (_, _, _, _, _, _, _, _, entryPoint) => capturedEntryPoint = entryPoint)
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
+
         var item = new GenHub.Features.GameProfiles.ViewModels.ContentDisplayItem
         {
             Id = manifestId.Value,
@@ -558,6 +574,9 @@ public class AddLocalContentViewModelTests : IDisposable
 
         Assert.NotNull(vm.SelectedExecutableItem);
         Assert.Equal("tool.exe", vm.SelectedExecutableItem.Name);
+
+        await vm.AddContentCommand.ExecuteAsync(null);
+        Assert.Equal("bin/tool.exe", capturedEntryPoint);
     }
 
     /// <summary>
@@ -588,6 +607,99 @@ public class AddLocalContentViewModelTests : IDisposable
 
         Assert.NotNull(vm.SelectedExecutableItem);
         Assert.Equal("second.exe", vm.SelectedExecutableItem.Name);
+    }
+
+    /// <summary>
+    /// Verifies that deleting the currently selected executable falls back to auto-selecting the remaining executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task DeleteItemAsync_WhenSelectedExecutableDeleted_FallsBackToRemainingExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir, "first.exe"), "first");
+        File.WriteAllText(Path.Combine(tempDir, "second.exe"), "second");
+        File.WriteAllText(Path.Combine(tempDir, "readme.txt"), "readme");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.GameClient;
+        vm.ContentName = "Test Client";
+        await vm.ImportContentAsync(tempDir);
+
+        var secondExe = FindInTree(vm.FileTree, f => f.Name == "second.exe");
+        Assert.NotNull(secondExe);
+        vm.SelectExecutableCommand.Execute(secondExe);
+        Assert.Equal("second.exe", vm.SelectedExecutableItem?.Name);
+
+        await vm.DeleteItemCommand.ExecuteAsync(secondExe);
+
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("first.exe", vm.SelectedExecutableItem.Name);
+    }
+
+    /// <summary>
+    /// Verifies that switching content type away from executable and back preserves the selected entry point.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ContentTypeChanged_SwitchAwayAndBack_PreservesSelectedExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir, "first.exe"), "first");
+        File.WriteAllText(Path.Combine(tempDir, "second.exe"), "second");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.GameClient;
+        vm.ContentName = "Test Client";
+        await vm.ImportContentAsync(tempDir);
+
+        var secondExe = FindInTree(vm.FileTree, f => f.Name == "second.exe");
+        Assert.NotNull(secondExe);
+        vm.SelectExecutableCommand.Execute(secondExe);
+        Assert.Equal("second.exe", vm.SelectedExecutableItem?.Name);
+
+        // Switch to Mod (non-executable type)
+        vm.SelectedContentType = ContentType.Mod;
+        Assert.Null(vm.SelectedExecutableItem);
+
+        // Switch back to GameClient (executable type)
+        vm.SelectedContentType = ContentType.GameClient;
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("second.exe", vm.SelectedExecutableItem.Name);
+    }
+
+    /// <summary>
+    /// Verifies that BuildDirectoryTree prioritizes directories containing executables over non-executable directories.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task BuildDirectoryTree_PrioritizesDirectoriesWithExecutables()
+    {
+        var tempDir = CreateTempDirectory();
+
+        // Create 25 directories named folder01 to folder25
+        for (var i = 1; i <= 25; i++)
+        {
+            var folder = Path.Combine(tempDir, $"folder{i:D2}");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "data.txt"), "content");
+        }
+
+        // Put an executable only in the 25th folder
+        var targetFolder = Path.Combine(tempDir, "folder25");
+        File.WriteAllText(Path.Combine(targetFolder, "game.exe"), "executable");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.GameClient;
+        vm.ContentName = "Test Client";
+        await vm.ImportContentAsync(tempDir);
+
+        var folder25 = FindInTree(vm.FileTree, f => f.Name == "folder25");
+        Assert.NotNull(folder25);
+
+        var exe = FindInTree(folder25.Children, f => f.Name == "game.exe");
+        Assert.NotNull(exe);
+        Assert.True(exe.IsExecutable);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
@@ -1,0 +1,526 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Features.GameProfiles.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.GameProfiles.ViewModels;
+
+/// <summary>
+/// Contains tests for <see cref="AddLocalContentViewModel"/>.
+/// </summary>
+public class AddLocalContentViewModelTests : IDisposable
+{
+    private readonly Mock<ILocalContentService> _localContentServiceMock;
+    private readonly Mock<IContentStorageService> _contentStorageServiceMock;
+    private readonly Mock<IGenLauncherNormalizationService> _normalizationServiceMock;
+    private readonly Mock<IDialogService> _dialogServiceMock;
+    private readonly List<string> _tempDirectories = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddLocalContentViewModelTests"/> class.
+    /// </summary>
+    public AddLocalContentViewModelTests()
+    {
+        _localContentServiceMock = new Mock<ILocalContentService>();
+        _contentStorageServiceMock = new Mock<IContentStorageService>();
+        _normalizationServiceMock = new Mock<IGenLauncherNormalizationService>();
+        _dialogServiceMock = new Mock<IDialogService>();
+
+        _localContentServiceMock
+            .Setup(x => x.AllowedContentTypes)
+            .Returns(AddLocalContentViewModel.AllowedContentTypes);
+    }
+
+    /// <summary>
+    /// Cleans up temporary test directories.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirectories)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Verifies that the ViewModel initializes with proper defaults.
+    /// </summary>
+    [Fact]
+    public void Constructor_InitializesWithDefaultValues()
+    {
+        var vm = CreateViewModel();
+
+        Assert.NotNull(vm);
+        Assert.Equal(ContentType.Mod, vm.SelectedContentType);
+        Assert.Equal(GameType.ZeroHour, vm.SelectedGameType);
+        Assert.Empty(vm.ContentName);
+        Assert.Empty(vm.SourcePath);
+        Assert.Empty(vm.FileTree);
+        Assert.False(vm.IsEditing);
+        Assert.False(vm.CanAdd);
+        Assert.False(vm.ShowExecutableSelection);
+        Assert.Null(vm.SelectedExecutableItem);
+        Assert.Equal(0, vm.ExecutableCount);
+        Assert.Equal("Add Local Content", vm.DialogTitle);
+        Assert.Equal("Add to Library", vm.ActionButtonText);
+        Assert.Contains(ContentType.GameClient, AddLocalContentViewModel.AllowedContentTypes);
+        Assert.Contains(ContentType.ModdingTool, AddLocalContentViewModel.AllowedContentTypes);
+        Assert.Contains(ContentType.Executable, AddLocalContentViewModel.AllowedContentTypes);
+    }
+
+    /// <summary>
+    /// Verifies that PreviewIdleText changes based on SelectedContentType.
+    /// </summary>
+    /// <param name="type">The content type under test.</param>
+    /// <param name="expectedText">The expected idle description text.</param>
+    [Theory]
+    [InlineData(ContentType.Mod, "Import mod content (e.g. .big, .zip)")]
+    [InlineData(ContentType.GameClient, "Import GameClient")]
+    [InlineData(ContentType.Executable, "Import executable")]
+    [InlineData(ContentType.ModdingTool, "Import tool executable")]
+    [InlineData(ContentType.Patch, "Import patch")]
+    [InlineData(ContentType.Addon, "Import addon content")]
+    [InlineData(ContentType.Map, "Import map files")]
+    [InlineData(ContentType.MapPack, "Import map pack files")]
+    [InlineData(ContentType.Mission, "Import mission content")]
+    public void PreviewIdleText_ReturnsExpectedDescriptions(ContentType type, string expectedText)
+    {
+        var vm = CreateViewModel();
+        vm.SelectedContentType = type;
+
+        Assert.Equal(expectedText, vm.PreviewIdleText);
+    }
+
+    /// <summary>
+    /// Verifies that ShowExecutableSelection is true when ExecutableCount > 0 for GameClient, ModdingTool, and Executable.
+    /// </summary>
+    /// <param name="contentType">The content type under test.</param>
+    /// <param name="executableCount">The number of detected executables.</param>
+    /// <param name="expectedShow">The expected boolean indicating whether executable selection is shown.</param>
+    [Theory]
+    [InlineData(ContentType.GameClient, 1, true)]
+    [InlineData(ContentType.GameClient, 2, true)]
+    [InlineData(ContentType.ModdingTool, 1, true)]
+    [InlineData(ContentType.ModdingTool, 2, true)]
+    [InlineData(ContentType.Executable, 1, true)]
+    [InlineData(ContentType.Executable, 2, true)]
+    [InlineData(ContentType.GameClient, 0, false)]
+    [InlineData(ContentType.ModdingTool, 0, false)]
+    [InlineData(ContentType.Executable, 0, false)]
+    [InlineData(ContentType.Mod, 1, false)]
+    [InlineData(ContentType.Mod, 2, false)]
+    [InlineData(ContentType.Patch, 1, false)]
+    [InlineData(ContentType.Map, 1, false)]
+    public void ShowExecutableSelection_EvaluatesCorrectly_BasedOnContentTypeAndExecutableCount(
+        ContentType contentType,
+        int executableCount,
+        bool expectedShow)
+    {
+        var vm = CreateViewModel();
+        vm.SelectedContentType = contentType;
+        vm.ExecutableCount = executableCount;
+
+        Assert.Equal(expectedShow, vm.ShowExecutableSelection);
+    }
+
+    /// <summary>
+    /// Verifies that importing a directory with an executable auto-selects the executable for GameClient.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WithSingleExecutable_ForGameClient_AutoSelectsExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        var exePath = Path.Combine(tempDir, "generals.exe");
+        var dataPath = Path.Combine(tempDir, "data.ini");
+        File.WriteAllText(exePath, "fake-exe-content");
+        File.WriteAllText(dataPath, "fake-data");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.GameClient;
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Equal(1, vm.ExecutableCount);
+        Assert.True(vm.ShowExecutableSelection);
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("generals.exe", vm.SelectedExecutableItem!.Name);
+        Assert.True(vm.SelectedExecutableItem.IsSelectedExecutable);
+    }
+
+    /// <summary>
+    /// Verifies that importing a directory with an executable auto-selects the executable for ModdingTool.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WithSingleExecutable_ForModdingTool_AutoSelectsExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        var exePath = Path.Combine(tempDir, "FinalBIG.exe");
+        var dataPath = Path.Combine(tempDir, "readme.txt");
+        File.WriteAllText(exePath, "fake-exe-content");
+        File.WriteAllText(dataPath, "read me");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.ModdingTool;
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Equal(1, vm.ExecutableCount);
+        Assert.True(vm.ShowExecutableSelection);
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("FinalBIG.exe", vm.SelectedExecutableItem!.Name);
+        Assert.True(vm.SelectedExecutableItem.IsSelectedExecutable);
+    }
+
+    /// <summary>
+    /// Verifies that importing a directory with an executable auto-selects the executable for Executable.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WithSingleExecutable_ForExecutable_AutoSelectsExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        var exePath = Path.Combine(tempDir, "WorldBuilder.exe");
+        File.WriteAllText(exePath, "fake-exe-content");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.Executable;
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Equal(1, vm.ExecutableCount);
+        Assert.True(vm.ShowExecutableSelection);
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("WorldBuilder.exe", vm.SelectedExecutableItem!.Name);
+        Assert.True(vm.SelectedExecutableItem.IsSelectedExecutable);
+    }
+
+    /// <summary>
+    /// Verifies that switching to an executable content type triggers auto-selection if an executable is in the tree.
+    /// </summary>
+    /// <param name="newType">The executable content type to switch to.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData(ContentType.GameClient)]
+    [InlineData(ContentType.ModdingTool)]
+    [InlineData(ContentType.Executable)]
+    public async Task SelectedContentTypeChanged_ToExecutableType_AutoSelectsFirstExecutable(ContentType newType)
+    {
+        var tempDir = CreateTempDirectory();
+        var exePath = Path.Combine(tempDir, "Launcher.exe");
+        File.WriteAllText(exePath, "fake-exe-content");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.Mod;
+
+        await vm.ImportContentAsync(tempDir);
+
+        // When imported as Mod, no auto-selection happened
+        Assert.Null(vm.SelectedExecutableItem);
+        Assert.False(vm.ShowExecutableSelection);
+
+        // Switch to executable type
+        vm.SelectedContentType = newType;
+
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("Launcher.exe", vm.SelectedExecutableItem!.Name);
+        Assert.True(vm.SelectedExecutableItem.IsSelectedExecutable);
+        Assert.True(vm.ShowExecutableSelection);
+    }
+
+    /// <summary>
+    /// Verifies manual selection of an executable via SelectExecutableCommand.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task SelectExecutableCommand_SwitchesSelectedExecutable()
+    {
+        var tempDir = CreateTempDirectory();
+        var exe1Path = Path.Combine(tempDir, "Primary.exe");
+        var exe2Path = Path.Combine(tempDir, "Secondary.exe");
+        File.WriteAllText(exe1Path, "fake-exe-1");
+        File.WriteAllText(exe2Path, "fake-exe-2");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.ModdingTool;
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Equal(2, vm.ExecutableCount);
+        Assert.NotNull(vm.SelectedExecutableItem);
+
+        var initialSelected = vm.SelectedExecutableItem!;
+        var otherItem = FindInTree(vm.FileTree, f => f != initialSelected && f.IsExecutable);
+        Assert.NotNull(otherItem);
+        Assert.False(otherItem!.IsSelectedExecutable);
+
+        // Select the other executable
+        vm.SelectExecutableCommand.Execute(otherItem);
+
+        Assert.Equal(otherItem.Name, vm.SelectedExecutableItem.Name);
+        Assert.True(otherItem.IsSelectedExecutable);
+        Assert.False(initialSelected.IsSelectedExecutable);
+    }
+
+    /// <summary>
+    /// Verifies that SelectExecutableCommand ignores non-executable files.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task SelectExecutableCommand_IgnoresNonExecutableItem()
+    {
+        var tempDir = CreateTempDirectory();
+        var exePath = Path.Combine(tempDir, "Tool.exe");
+        var txtPath = Path.Combine(tempDir, "Doc.txt");
+        File.WriteAllText(exePath, "fake-exe");
+        File.WriteAllText(txtPath, "text");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.Executable;
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Equal("Tool.exe", vm.SelectedExecutableItem?.Name);
+
+        var txtItem = FindInTree(vm.FileTree, f => f.Name == "Doc.txt");
+        Assert.NotNull(txtItem);
+        Assert.False(txtItem!.IsExecutable);
+
+        vm.SelectExecutableCommand.Execute(txtItem);
+
+        // Should still be Tool.exe
+        Assert.Equal("Tool.exe", vm.SelectedExecutableItem?.Name);
+        Assert.False(txtItem.IsSelectedExecutable);
+    }
+
+    /// <summary>
+    /// Verifies that CanAdd validation requires an executable for GameClient, ModdingTool, and Executable.
+    /// </summary>
+    /// <param name="type">The executable content type under test.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData(ContentType.GameClient)]
+    [InlineData(ContentType.ModdingTool)]
+    [InlineData(ContentType.Executable)]
+    public async Task Validation_CanAdd_RequiresExecutable_ForExecutableTypes(ContentType type)
+    {
+        var tempDir = CreateTempDirectory();
+        var txtPath = Path.Combine(tempDir, "config.ini");
+        File.WriteAllText(txtPath, "config");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = type;
+        vm.ContentName = "Test Tool";
+
+        await vm.ImportContentAsync(tempDir);
+
+        // No executable found, so CanAdd should be false
+        Assert.Null(vm.SelectedExecutableItem);
+        Assert.False(vm.CanAdd);
+    }
+
+    /// <summary>
+    /// Verifies that CanAdd is true for non-executable types without an executable.
+    /// </summary>
+    /// <param name="type">The non-executable content type under test.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData(ContentType.Mod)]
+    [InlineData(ContentType.Patch)]
+    [InlineData(ContentType.Addon)]
+    [InlineData(ContentType.Map)]
+    [InlineData(ContentType.MapPack)]
+    [InlineData(ContentType.Mission)]
+    public async Task Validation_CanAdd_DoesNotRequireExecutable_ForNonExecutableTypes(ContentType type)
+    {
+        var tempDir = CreateTempDirectory();
+        var txtPath = Path.Combine(tempDir, "mod_data.big");
+        File.WriteAllText(txtPath, "big archive data");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = type;
+        vm.ContentName = "Test Mod";
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.True(vm.CanAdd);
+    }
+
+    /// <summary>
+    /// Verifies that CanAdd is true when an executable is present for GameClient, ModdingTool, and Executable.
+    /// </summary>
+    /// <param name="type">The executable content type under test.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData(ContentType.GameClient)]
+    [InlineData(ContentType.ModdingTool)]
+    [InlineData(ContentType.Executable)]
+    public async Task Validation_CanAdd_IsTrue_WhenExecutableIsPresent(ContentType type)
+    {
+        var tempDir = CreateTempDirectory();
+        var exePath = Path.Combine(tempDir, "Main.exe");
+        File.WriteAllText(exePath, "exe content");
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = type;
+        vm.ContentName = "Test Item";
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.True(vm.CanAdd);
+    }
+
+    /// <summary>
+    /// Verifies that AddContentCommand forwards the relative entry point to ILocalContentService.CreateLocalContentManifestAsync.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task AddContentCommand_PassesEntryPoint_ToCreateLocalContentManifestAsync()
+    {
+        var tempDir = CreateTempDirectory();
+        var exePath = Path.Combine(tempDir, "Game.exe");
+        File.WriteAllText(exePath, "exe");
+
+        string? capturedEntryPoint = null;
+        _localContentServiceMock
+            .Setup(x => x.CreateLocalContentManifestAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ContentType>(),
+                It.IsAny<GameType>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?>()))
+            .Callback<string, string, ContentType, GameType, string?, IProgress<ContentStorageProgress>?, CancellationToken, string?>(
+                (_, _, _, _, _, _, _, entryPoint) => capturedEntryPoint = entryPoint)
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest
+            {
+                Id = ManifestId.Create("1.0.local.gameclient.test"),
+                Name = "Test Game Client",
+                ContentType = ContentType.GameClient,
+                TargetGame = GameType.ZeroHour,
+                EntryPoint = "Game.exe",
+            }));
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.GameClient;
+        vm.ContentName = "Test Game Client";
+
+        // Import individual file so it lands at the root of staging
+        await vm.ImportContentAsync(exePath);
+
+        Assert.True(vm.CanAdd);
+
+        await vm.AddContentCommand.ExecuteAsync(null);
+
+        Assert.Equal("Game.exe", capturedEntryPoint);
+        Assert.NotNull(vm.CreatedContentItem);
+    }
+
+    /// <summary>
+    /// Verifies that AddContentCommand with nested executable passes correct relative path as entryPoint.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task AddContentCommand_WithNestedExecutable_PassesRelativePathEntryPoint()
+    {
+        var tempDir = CreateTempDirectory();
+        var subDir = Path.Combine(tempDir, "bin");
+        Directory.CreateDirectory(subDir);
+        var exePath = Path.Combine(subDir, "tool.exe");
+        File.WriteAllText(exePath, "tool exe");
+
+        string? capturedEntryPoint = null;
+        _localContentServiceMock
+            .Setup(x => x.CreateLocalContentManifestAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ContentType>(),
+                It.IsAny<GameType>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?>()))
+            .Callback<string, string, ContentType, GameType, string?, IProgress<ContentStorageProgress>?, CancellationToken, string?>(
+                (_, _, _, _, _, _, _, entryPoint) => capturedEntryPoint = entryPoint)
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest
+            {
+                Id = ManifestId.Create("1.0.local.moddingtool.tool"),
+                Name = "My Tool",
+                ContentType = ContentType.ModdingTool,
+                TargetGame = GameType.ZeroHour,
+            }));
+
+        var vm = CreateViewModel();
+        vm.SelectedContentType = ContentType.ModdingTool;
+        vm.ContentName = "My Tool";
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.NotNull(vm.SelectedExecutableItem);
+
+        await vm.AddContentCommand.ExecuteAsync(null);
+
+        var dirName = Path.GetFileName(tempDir);
+        Assert.Equal($"{dirName}/bin/tool.exe", capturedEntryPoint);
+    }
+
+    private static FileTreeItem? FindInTree(IEnumerable<FileTreeItem> items, Func<FileTreeItem, bool> predicate)
+    {
+        foreach (var item in items)
+        {
+            if (predicate(item)) return item;
+            var child = FindInTree(item.Children, predicate);
+            if (child != null) return child;
+        }
+
+        return null;
+    }
+
+    private string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "AddLocalContentVmTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        _tempDirectories.Add(path);
+        return path;
+    }
+
+    private AddLocalContentViewModel CreateViewModel()
+    {
+        return new AddLocalContentViewModel(
+            _localContentServiceMock.Object,
+            _contentStorageServiceMock.Object,
+            _normalizationServiceMock.Object,
+            _dialogServiceMock.Object,
+            NullLogger<AddLocalContentViewModel>.Instance);
+    }
+}

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -542,7 +542,16 @@ public class ProfileLauncherFacade(
         }
 
         var toolDirectoryPath = toolWorkspacePath;
-        var toolExecutable = toolManifest.Files?.FirstOrDefault(f => f.IsExecutable)
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(toolManifest);
+        ManifestFile? toolExecutable = null;
+        if (resolution.Success && resolution.RelativePath != null)
+        {
+            toolExecutable = toolManifest.Files?.FirstOrDefault(f =>
+                f.RelativePath.Equals(resolution.RelativePath, StringComparison.OrdinalIgnoreCase) ||
+                f.RelativePath.Replace('\\', '/').Equals(resolution.RelativePath.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase));
+        }
+
+        toolExecutable ??= toolManifest.Files?.FirstOrDefault(f => f.IsExecutable)
             ?? toolManifest.Files?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
 
         if (toolExecutable == null)

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -636,11 +636,10 @@ public class ProfileLauncherFacade(
     {
         var resolvedFiles = ManifestVariantResolver.ResolveFiles(toolManifest);
         var resolution = ManifestVariantResolver.ResolveEntryPoint(toolManifest);
-        ManifestFile? toolExecutable = null;
 
         if (resolution.Success && resolution.RelativePath != null)
         {
-            toolExecutable = resolvedFiles?.FirstOrDefault(f =>
+            var toolExecutable = resolvedFiles?.FirstOrDefault(f =>
                 ManifestVariantResolver.PathsMatch(f.RelativePath, resolution.RelativePath));
 
             if (toolExecutable != null)
@@ -659,18 +658,16 @@ public class ProfileLauncherFacade(
                     toolManifest.Id,
                     resolution.Reason);
             }
-        }
-        else
-        {
-            logger.LogWarning(
-                "[Launch] Entry point resolution for tool manifest '{ManifestId}' did not succeed: {Resolution}",
-                toolManifest.Id,
-                resolution);
+
+            return toolExecutable;
         }
 
-        return toolExecutable
-            ?? resolvedFiles?.FirstOrDefault(f => f.IsExecutable)
-            ?? resolvedFiles?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+        logger.LogWarning(
+            "[Launch] Entry point resolution for tool manifest '{ManifestId}' did not succeed: {Resolution}",
+            toolManifest.Id,
+            resolution);
+
+        return null;
     }
 
     private Process? StartToolProcess(string toolExecutablePath, string toolDirectoryPath, GameProfile profile)
@@ -698,9 +695,15 @@ public class ProfileLauncherFacade(
         catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 740)
         {
             logger.LogWarning("Tool requires elevation (Error 740). Retrying with UseShellExecute=true and Verb='runas'. Environment variables will be ignored.");
-            processStartInfo.UseShellExecute = true;
-            processStartInfo.Verb = "runas";
-            return Process.Start(processStartInfo);
+            var elevatedStartInfo = new ProcessStartInfo
+            {
+                FileName = toolExecutablePath,
+                WorkingDirectory = toolDirectoryPath,
+                Arguments = profile.CommandLineArguments ?? string.Empty,
+                UseShellExecute = true,
+                Verb = "runas",
+            };
+            return Process.Start(elevatedStartInfo);
         }
     }
 

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -542,17 +542,41 @@ public class ProfileLauncherFacade(
         }
 
         var toolDirectoryPath = toolWorkspacePath;
+        var resolvedFiles = ManifestVariantResolver.ResolveFiles(toolManifest);
         var resolution = ManifestVariantResolver.ResolveEntryPoint(toolManifest);
         ManifestFile? toolExecutable = null;
         if (resolution.Success && resolution.RelativePath != null)
         {
-            toolExecutable = toolManifest.Files?.FirstOrDefault(f =>
-                f.RelativePath.Equals(resolution.RelativePath, StringComparison.OrdinalIgnoreCase) ||
-                f.RelativePath.Replace('\\', '/').Equals(resolution.RelativePath.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase));
+            toolExecutable = resolvedFiles?.FirstOrDefault(f =>
+                ManifestVariantResolver.PathsMatch(f.RelativePath, resolution.RelativePath));
+
+            if (toolExecutable != null)
+            {
+                logger.LogInformation(
+                    "[Launch] Tool executable resolved for manifest {ManifestId}: {RelativePath} ({Reason})",
+                    toolManifest.Id,
+                    toolExecutable.RelativePath,
+                    resolution.Reason);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "[Launch] Entry point '{RelativePath}' resolved for tool manifest {ManifestId} ({Reason}) but not found in resolved files",
+                    resolution.RelativePath,
+                    toolManifest.Id,
+                    resolution.Reason);
+            }
+        }
+        else
+        {
+            logger.LogWarning(
+                "[Launch] Entry point resolution for tool manifest '{ManifestId}' did not succeed: {Resolution}",
+                toolManifest.Id,
+                resolution);
         }
 
-        toolExecutable ??= toolManifest.Files?.FirstOrDefault(f => f.IsExecutable)
-            ?? toolManifest.Files?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+        toolExecutable ??= resolvedFiles?.FirstOrDefault(f => f.IsExecutable)
+            ?? resolvedFiles?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
 
         if (toolExecutable == null)
         {

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -523,13 +523,17 @@ public class ProfileLauncherFacade(
             notificationService.ShowSuccess(
                 ProfileValidationConstants.ToolLaunchSuccessTitle,
                 $"Successfully launched '{profile.Name}'",
-                NotificationDurations.Short);
+                NotificationDurations.Medium);
 
             return ProfileOperationResult<GameLaunchInfo>.CreateSuccess(toolLaunchInfo);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "[Launch] Unexpected error launching tool for profile {ProfileId}", profileId);
+            notificationService.ShowError(
+                ProfileValidationConstants.ToolLaunchFailedTitle,
+                $"Failed to launch '{profile.Name}': {ex.Message}",
+                NotificationDurations.VeryLong);
             return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
                 $"Tool launch failed: {ex.Message}");
         }

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -451,132 +451,25 @@ public class ProfileLauncherFacade(
     {
         logger.LogInformation("[Launch] Detected Tool profile, launching tool directly");
 
-        // Get the tool manifest
-        if (string.IsNullOrWhiteSpace(profile.ToolContentId))
-        {
-            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(ProfileValidationConstants.ToolProfileMissingContentId);
-        }
-
-        if (!ManifestId.TryCreate(profile.ToolContentId, out var toolManifestId))
+        var manifestResult = await ResolveToolManifestAsync(profile, cancellationToken);
+        if (manifestResult.Failed || manifestResult.Data == null)
         {
             return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                $"{ProfileValidationConstants.InvalidToolContentId}: {profile.ToolContentId}");
+                manifestResult.FirstError ?? ProfileValidationConstants.FailedToLoadToolManifest);
         }
 
-        var toolManifestResult = await manifestPool.GetManifestAsync(
-            toolManifestId,
-            cancellationToken);
-
-        if (toolManifestResult.Failed || toolManifestResult.Data == null)
-        {
-            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                $"{ProfileValidationConstants.FailedToLoadToolManifest}: {toolManifestResult.FirstError}");
-        }
-
-        var toolManifest = toolManifestResult.Data;
+        var toolManifest = manifestResult.Data;
         logger.LogDebug("[Launch] Tool manifest loaded: {ManifestId}", toolManifest.Id);
 
-        var toolDirectory = await manifestPool.GetContentDirectoryAsync(toolManifest.Id, cancellationToken);
-        string toolWorkspacePath = string.Empty;
-        string? actualWorkspaceId = null;
-
-        if (toolDirectory.Success && !string.IsNullOrEmpty(toolDirectory.Data))
+        var workspaceResult = await ResolveToolWorkspaceAsync(profile, toolManifest, cancellationToken);
+        if (workspaceResult.Failed)
         {
-            toolWorkspacePath = toolDirectory.Data;
-            logger.LogInformation("[Launch] Using existing tool directory: {Path}", toolWorkspacePath);
-        }
-        else
-        {
-            logger.LogInformation("[Launch] Tool content requires hydration, using WorkspaceManager");
-
-            var dummyGameClient = new GenHub.Core.Models.GameClients.GameClient
-            {
-                Name = toolManifest.Name,
-                GameType = toolManifest.TargetGame,
-            };
-
-            var appDataBase = configurationProvider.GetApplicationDataPath();
-            if (!Directory.Exists(appDataBase))
-            {
-                Directory.CreateDirectory(appDataBase);
-            }
-
-            var baseDetails = appDataBase;
-
-            var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? [], cancellationToken);
-            var allManifests = resolutionResult.Success ? resolutionResult.ResolvedManifests : [toolManifest];
-
-            var requestedToolStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
-            var effectiveToolStrategy = ResolveSupportedWorkspaceStrategy(requestedToolStrategy);
-
-            if (effectiveToolStrategy != requestedToolStrategy)
-            {
-                logger.LogInformation(
-                    "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink: symlinks are unavailable in this environment",
-                    requestedToolStrategy);
-            }
-
-            actualWorkspaceId = $"{ProfileConstants.ToolProfileWorkspaceIdPrefix}-{profile.Id}";
-            var workspaceConfig = new WorkspaceConfiguration
-            {
-                Id = actualWorkspaceId,
-                Manifests = [.. allManifests],
-                GameClient = dummyGameClient,
-                Strategy = effectiveToolStrategy,
-                ForceRecreate = false,
-                ValidateAfterPreparation = true,
-                BaseInstallationPath = baseDetails,
-                WorkspaceRootPath = Path.Combine(appDataBase, DirectoryNames.ToolWorkspaces),
-                SkipCleanup = false,
-            };
-
-            var prepareResult = await workspaceManager.PrepareWorkspaceAsync(workspaceConfig, progress: null, skipCleanup: false, cancellationToken: cancellationToken);
-            if (prepareResult.Failed)
-            {
-                return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
-                    $"{ProfileValidationConstants.FailedToPrepareToolWorkspace}: {prepareResult.FirstError}");
-            }
-
-            toolWorkspacePath = prepareResult.Data!.WorkspacePath;
-            logger.LogInformation("[Launch] Tool workspace prepared at: {Path}", toolWorkspacePath);
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                workspaceResult.FirstError ?? ProfileValidationConstants.FailedToPrepareToolWorkspace);
         }
 
-        var toolDirectoryPath = toolWorkspacePath;
-        var resolvedFiles = ManifestVariantResolver.ResolveFiles(toolManifest);
-        var resolution = ManifestVariantResolver.ResolveEntryPoint(toolManifest);
-        ManifestFile? toolExecutable = null;
-        if (resolution.Success && resolution.RelativePath != null)
-        {
-            toolExecutable = resolvedFiles?.FirstOrDefault(f =>
-                ManifestVariantResolver.PathsMatch(f.RelativePath, resolution.RelativePath));
-
-            if (toolExecutable != null)
-            {
-                logger.LogInformation(
-                    "[Launch] Tool executable resolved for manifest {ManifestId}: {RelativePath} ({Reason})",
-                    toolManifest.Id,
-                    toolExecutable.RelativePath,
-                    resolution.Reason);
-            }
-            else
-            {
-                logger.LogWarning(
-                    "[Launch] Entry point '{RelativePath}' resolved for tool manifest {ManifestId} ({Reason}) but not found in resolved files",
-                    resolution.RelativePath,
-                    toolManifest.Id,
-                    resolution.Reason);
-            }
-        }
-        else
-        {
-            logger.LogWarning(
-                "[Launch] Entry point resolution for tool manifest '{ManifestId}' did not succeed: {Resolution}",
-                toolManifest.Id,
-                resolution);
-        }
-
-        toolExecutable ??= resolvedFiles?.FirstOrDefault(f => f.IsExecutable)
-            ?? resolvedFiles?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+        var (toolDirectoryPath, actualWorkspaceId) = workspaceResult.Data;
+        var toolExecutable = ResolveToolExecutable(toolManifest);
 
         if (toolExecutable == null)
         {
@@ -597,35 +490,7 @@ public class ProfileLauncherFacade(
 
         try
         {
-            var processStartInfo = new ProcessStartInfo
-            {
-                FileName = toolExecutablePath,
-                WorkingDirectory = toolDirectoryPath,
-                Arguments = profile.CommandLineArguments ?? string.Empty,
-                UseShellExecute = false,
-            };
-
-            if (profile.EnvironmentVariables != null)
-            {
-                foreach (var envVar in profile.EnvironmentVariables)
-                {
-                    processStartInfo.EnvironmentVariables[envVar.Key] = envVar.Value;
-                }
-            }
-
-            Process? process = null;
-            try
-            {
-                process = Process.Start(processStartInfo);
-            }
-            catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 740)
-            {
-                logger.LogWarning("Tool requires elevation (Error 740). Retrying with UseShellExecute=true and Verb='runas'. Environment variables will be ignored.");
-                processStartInfo.UseShellExecute = true;
-                processStartInfo.Verb = "runas";
-                process = Process.Start(processStartInfo);
-            }
-
+            var process = StartToolProcess(toolExecutablePath, toolDirectoryPath, profile);
             if (process == null)
             {
                 return ProfileOperationResult<GameLaunchInfo>.CreateFailure(ProfileValidationConstants.ToolProcessStartFailed);
@@ -658,18 +523,180 @@ public class ProfileLauncherFacade(
             notificationService.ShowSuccess(
                 ProfileValidationConstants.ToolLaunchSuccessTitle,
                 $"Successfully launched '{profile.Name}'",
-                NotificationDurations.Medium);
+                NotificationDurations.Short);
 
             return ProfileOperationResult<GameLaunchInfo>.CreateSuccess(toolLaunchInfo);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "[Launch] Tool launch failed");
-            notificationService.ShowError(
-                ProfileValidationConstants.ToolLaunchFailedTitle,
-                $"Failed to launch '{profile.Name}': {ex.Message}",
-                NotificationDurations.VeryLong);
-            return ProfileOperationResult<GameLaunchInfo>.CreateFailure($"Tool launch failed: {ex.Message}");
+            logger.LogError(ex, "[Launch] Unexpected error launching tool for profile {ProfileId}", profileId);
+            return ProfileOperationResult<GameLaunchInfo>.CreateFailure(
+                $"Tool launch failed: {ex.Message}");
+        }
+    }
+
+    private async Task<ProfileOperationResult<ContentManifest>> ResolveToolManifestAsync(
+        GameProfile profile,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(profile.ToolContentId))
+        {
+            return ProfileOperationResult<ContentManifest>.CreateFailure(ProfileValidationConstants.ToolProfileMissingContentId);
+        }
+
+        if (!ManifestId.TryCreate(profile.ToolContentId, out var toolManifestId))
+        {
+            return ProfileOperationResult<ContentManifest>.CreateFailure(
+                $"{ProfileValidationConstants.InvalidToolContentId}: {profile.ToolContentId}");
+        }
+
+        var toolManifestResult = await manifestPool.GetManifestAsync(
+            toolManifestId,
+            cancellationToken);
+
+        if (toolManifestResult.Failed || toolManifestResult.Data == null)
+        {
+            return ProfileOperationResult<ContentManifest>.CreateFailure(
+                $"{ProfileValidationConstants.FailedToLoadToolManifest}: {toolManifestResult.FirstError}");
+        }
+
+        return ProfileOperationResult<ContentManifest>.CreateSuccess(toolManifestResult.Data);
+    }
+
+    private async Task<ProfileOperationResult<(string WorkspacePath, string? WorkspaceId)>> ResolveToolWorkspaceAsync(
+        GameProfile profile,
+        ContentManifest toolManifest,
+        CancellationToken cancellationToken)
+    {
+        var toolDirectory = await manifestPool.GetContentDirectoryAsync(toolManifest.Id, cancellationToken);
+        if (toolDirectory.Success && !string.IsNullOrEmpty(toolDirectory.Data))
+        {
+            logger.LogInformation("[Launch] Using existing tool directory: {Path}", toolDirectory.Data);
+            return ProfileOperationResult<(string, string?)>.CreateSuccess((toolDirectory.Data, null));
+        }
+
+        logger.LogInformation("[Launch] Tool content requires hydration, using WorkspaceManager");
+
+        var dummyGameClient = new GenHub.Core.Models.GameClients.GameClient
+        {
+            Name = toolManifest.Name,
+            GameType = toolManifest.TargetGame,
+        };
+
+        var appDataBase = configurationProvider.GetApplicationDataPath();
+        if (!Directory.Exists(appDataBase))
+        {
+            Directory.CreateDirectory(appDataBase);
+        }
+
+        var resolutionResult = await dependencyResolver.ResolveDependenciesWithManifestsAsync(profile.EnabledContentIds ?? [], cancellationToken);
+        var allManifests = resolutionResult.Success ? resolutionResult.ResolvedManifests : [toolManifest];
+
+        var requestedToolStrategy = profile.WorkspaceStrategy ?? configurationProvider.GetDefaultWorkspaceStrategy();
+        var effectiveToolStrategy = ResolveSupportedWorkspaceStrategy(requestedToolStrategy);
+
+        if (effectiveToolStrategy != requestedToolStrategy)
+        {
+            logger.LogInformation(
+                "[Launch] Tool workspace - Switching from {OriginalStrategy} to HardLink: symlinks are unavailable in this environment",
+                requestedToolStrategy);
+        }
+
+        var actualWorkspaceId = $"{ProfileConstants.ToolProfileWorkspaceIdPrefix}-{profile.Id}";
+        var workspaceConfig = new WorkspaceConfiguration
+        {
+            Id = actualWorkspaceId,
+            Manifests = [.. allManifests],
+            GameClient = dummyGameClient,
+            Strategy = effectiveToolStrategy,
+            ForceRecreate = false,
+            ValidateAfterPreparation = true,
+            BaseInstallationPath = appDataBase,
+            WorkspaceRootPath = Path.Combine(appDataBase, DirectoryNames.ToolWorkspaces),
+            SkipCleanup = false,
+        };
+
+        var prepareResult = await workspaceManager.PrepareWorkspaceAsync(workspaceConfig, progress: null, skipCleanup: false, cancellationToken: cancellationToken);
+        if (prepareResult.Failed)
+        {
+            return ProfileOperationResult<(string, string?)>.CreateFailure(
+                $"{ProfileValidationConstants.FailedToPrepareToolWorkspace}: {prepareResult.FirstError}");
+        }
+
+        var toolWorkspacePath = prepareResult.Data!.WorkspacePath;
+        logger.LogInformation("[Launch] Tool workspace prepared at: {Path}", toolWorkspacePath);
+        return ProfileOperationResult<(string, string?)>.CreateSuccess((toolWorkspacePath, actualWorkspaceId));
+    }
+
+    private ManifestFile? ResolveToolExecutable(ContentManifest toolManifest)
+    {
+        var resolvedFiles = ManifestVariantResolver.ResolveFiles(toolManifest);
+        var resolution = ManifestVariantResolver.ResolveEntryPoint(toolManifest);
+        ManifestFile? toolExecutable = null;
+
+        if (resolution.Success && resolution.RelativePath != null)
+        {
+            toolExecutable = resolvedFiles?.FirstOrDefault(f =>
+                ManifestVariantResolver.PathsMatch(f.RelativePath, resolution.RelativePath));
+
+            if (toolExecutable != null)
+            {
+                logger.LogInformation(
+                    "[Launch] Tool executable resolved for manifest {ManifestId}: {RelativePath} ({Reason})",
+                    toolManifest.Id,
+                    toolExecutable.RelativePath,
+                    resolution.Reason);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "[Launch] Entry point '{RelativePath}' resolved for tool manifest {ManifestId} ({Reason}) but not found in resolved files",
+                    resolution.RelativePath,
+                    toolManifest.Id,
+                    resolution.Reason);
+            }
+        }
+        else
+        {
+            logger.LogWarning(
+                "[Launch] Entry point resolution for tool manifest '{ManifestId}' did not succeed: {Resolution}",
+                toolManifest.Id,
+                resolution);
+        }
+
+        return toolExecutable
+            ?? resolvedFiles?.FirstOrDefault(f => f.IsExecutable)
+            ?? resolvedFiles?.FirstOrDefault(f => f.RelativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private Process? StartToolProcess(string toolExecutablePath, string toolDirectoryPath, GameProfile profile)
+    {
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = toolExecutablePath,
+            WorkingDirectory = toolDirectoryPath,
+            Arguments = profile.CommandLineArguments ?? string.Empty,
+            UseShellExecute = false,
+        };
+
+        if (profile.EnvironmentVariables != null)
+        {
+            foreach (var envVar in profile.EnvironmentVariables)
+            {
+                processStartInfo.EnvironmentVariables[envVar.Key] = envVar.Value;
+            }
+        }
+
+        try
+        {
+            return Process.Start(processStartInfo);
+        }
+        catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 740)
+        {
+            logger.LogWarning("Tool requires elevation (Error 740). Retrying with UseShellExecute=true and Verb='runas'. Environment variables will be ignored.");
+            processStartInfo.UseShellExecute = true;
+            processStartInfo.Verb = "runas";
+            return Process.Start(processStartInfo);
         }
     }
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -80,7 +80,12 @@ public partial class AddLocalContentViewModel(
         return null;
     }
 
-    protected static int CountExecutables(IEnumerable<FileTreeItem> items)
+    /// <summary>
+    /// Counts the total number of executables in the given file tree items recursively.
+    /// </summary>
+    /// <param name="items">The file tree items to inspect.</param>
+    /// <returns>The total number of executable files found.</returns>
+    internal static int CountExecutables(IEnumerable<FileTreeItem> items)
     {
         int count = 0;
         foreach (var item in items)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -56,6 +56,9 @@ public partial class AddLocalContentViewModel(
         ContentType.Mission,
     ];
 
+    private static bool RequiresExecutable(ContentType contentType) =>
+        contentType is ContentType.GameClient or ContentType.ModdingTool or ContentType.Executable;
+
     private static FileTreeItem? FindFirstExecutable(IEnumerable<FileTreeItem> items)
     {
         foreach (var item in items)
@@ -177,7 +180,7 @@ public partial class AddLocalContentViewModel(
     private bool _isDemoMode;
 
     /// <summary>
-    /// Gets or sets the selected executable item (for Executable/ModdingTool content type).
+    /// Gets or sets the selected executable item (for GameClient/Executable/ModdingTool content type).
     /// </summary>
     [ObservableProperty]
     private FileTreeItem? _selectedExecutableItem;
@@ -192,7 +195,7 @@ public partial class AddLocalContentViewModel(
     /// <summary>
     /// Gets a value indicating whether the executable selection should be shown.
     /// </summary>
-    public bool ShowExecutableSelection => (SelectedContentType == ContentType.ModdingTool || SelectedContentType == ContentType.Executable) && ExecutableCount > 1;
+    public bool ShowExecutableSelection => RequiresExecutable(SelectedContentType) && ExecutableCount > 0;
 
     /// <summary>
     /// Gets the text to display in the preview area when no content is loaded.
@@ -640,6 +643,19 @@ public partial class AddLocalContentViewModel(
 
             _cts = new CancellationTokenSource();
 
+            string? entryPoint = null;
+            if (SelectedExecutableItem != null && !string.IsNullOrWhiteSpace(SelectedExecutableItem.FullPath))
+            {
+                try
+                {
+                    entryPoint = Path.GetRelativePath(_stagingPath, SelectedExecutableItem.FullPath).Replace('\\', '/');
+                }
+                catch
+                {
+                    entryPoint = SelectedExecutableItem.Name;
+                }
+            }
+
             // Preserve SourcePath metadata if available
             // Note: We no longer write to "source.path" file to avoid polluting the content.
             // Instead we pass the SourcePath directly to the service.
@@ -652,7 +668,8 @@ public partial class AddLocalContentViewModel(
                     targetGame,
                     SourcePath,
                     progress,
-                    _cts.Token)
+                    _cts.Token,
+                    entryPoint)
                 : await localContentService.CreateLocalContentManifestAsync(
                     _stagingPath,
                     ContentName,
@@ -660,7 +677,8 @@ public partial class AddLocalContentViewModel(
                     targetGame,
                     SourcePath,
                     progress,
-                    _cts.Token);
+                    _cts.Token,
+                    entryPoint);
 
             if (result.Success)
             {
@@ -792,7 +810,7 @@ public partial class AddLocalContentViewModel(
             ExecutableCount = CountExecutables(FileTree);
 
             // Auto-select first executable if content type requires it
-            if (SelectedContentType == ContentType.ModdingTool || SelectedContentType == ContentType.Executable)
+            if (RequiresExecutable(SelectedContentType))
             {
                 AutoSelectFirstExecutable();
             }
@@ -816,8 +834,8 @@ public partial class AddLocalContentViewModel(
         var stagingExists = Directory.Exists(_stagingPath);
         var stagingHasEntries = stagingExists && Directory.EnumerateFileSystemEntries(_stagingPath).Any();
 
-        // For ModdingTool (Tool) and Executable, we also need an executable selected
-        var requiresExecutable = SelectedContentType == ContentType.ModdingTool || SelectedContentType == ContentType.Executable;
+        // For GameClient, ModdingTool (Tool), and Executable, we also need an executable selected
+        var requiresExecutable = RequiresExecutable(SelectedContentType);
         var hasExecutableIfNeeded = !requiresExecutable || SelectedExecutableItem != null;
 
         CanAdd = hasName && (hasFiles || stagingHasEntries) && hasExecutableIfNeeded;
@@ -842,8 +860,8 @@ public partial class AddLocalContentViewModel(
         OnPropertyChanged(nameof(ShowExecutableSelection));
         OnPropertyChanged(nameof(PreviewIdleText));
 
-        // Auto-select first executable if switching to ModdingTool or Executable
-        if ((value == ContentType.ModdingTool || value == ContentType.Executable) && SelectedExecutableItem == null)
+        // Auto-select first executable if switching to a content type that requires it
+        if (RequiresExecutable(value) && SelectedExecutableItem == null)
         {
             AutoSelectFirstExecutable();
         }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -58,6 +58,23 @@ public partial class AddLocalContentViewModel(
         ContentType.Mission,
     ];
 
+    /// <summary>
+    /// Counts the total number of executables in the given file tree items recursively.
+    /// </summary>
+    /// <param name="items">The file tree items to inspect.</param>
+    /// <returns>The total number of executable files found.</returns>
+    internal static int CountExecutables(IEnumerable<FileTreeItem> items)
+    {
+        int count = 0;
+        foreach (var item in items)
+        {
+            if (item.IsExecutable) count++;
+            count += CountExecutables(item.Children);
+        }
+
+        return count;
+    }
+
     private static bool RequiresExecutable(ContentType contentType) =>
         contentType is ContentType.GameClient or ContentType.ModdingTool or ContentType.Executable;
 
@@ -78,23 +95,6 @@ public partial class AddLocalContentViewModel(
         }
 
         return null;
-    }
-
-    /// <summary>
-    /// Counts the total number of executables in the given file tree items recursively.
-    /// </summary>
-    /// <param name="items">The file tree items to inspect.</param>
-    /// <returns>The total number of executable files found.</returns>
-    internal static int CountExecutables(IEnumerable<FileTreeItem> items)
-    {
-        int count = 0;
-        foreach (var item in items)
-        {
-            if (item.IsExecutable) count++;
-            count += CountExecutables(item.Children);
-        }
-
-        return count;
     }
 
     private readonly string _stagingPath = Path.Combine(Path.GetTempPath(), "GenHub_Staging_" + Guid.NewGuid());

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -12,6 +12,8 @@ using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace GenHub.Features.GameProfiles.ViewModels;
@@ -29,7 +31,7 @@ public partial class AddLocalContentViewModel(
     IContentStorageService? contentStorageService,
     IGenLauncherNormalizationService? genLauncherNormalizationService,
     IDialogService? dialogService,
-    ILogger<AddLocalContentViewModel>? logger = null) : ObservableObject
+    ILogger<AddLocalContentViewModel>? logger = null) : ObservableObject, IDisposable
 {
     /// <summary>
     /// Gets the list of available game types.
@@ -93,6 +95,7 @@ public partial class AddLocalContentViewModel(
     private readonly string _stagingPath = Path.Combine(Path.GetTempPath(), "GenHub_Staging_" + Guid.NewGuid());
 
     private string? _originalManifestId;
+    private string? _pendingEntryPoint;
 
     /// <summary>
     /// Gets a value indicating whether we are editing existing content.
@@ -258,6 +261,7 @@ public partial class AddLocalContentViewModel(
             StatusMessage = "Loading existing content...";
 
             _originalManifestId = item.ManifestId.Value;
+            _pendingEntryPoint = item.Manifest?.EntryPoint;
             ContentName = item.DisplayName ?? string.Empty;
             SelectedContentType = item.ContentType;
             SelectedGameType = item.GameType;
@@ -490,6 +494,15 @@ public partial class AddLocalContentViewModel(
         }
     }
 
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cts?.Dispose();
+        _cts = null;
+        CleanupStaging();
+        GC.SuppressFinalize(this);
+    }
+
     private static List<FileTreeItem> BuildDirectoryTree(DirectoryInfo dir)
     {
         var items = new List<FileTreeItem>();
@@ -507,7 +520,13 @@ public partial class AddLocalContentViewModel(
             });
         }
 
-        foreach (var f in dir.GetFiles().Take(50))
+        var files = dir.GetFiles();
+        var prioritizedFiles = files
+            .OrderByDescending(f => ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(f.Name) || f.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+            .ThenBy(f => f.Name)
+            .Take(50);
+
+        foreach (var f in prioritizedFiles)
         {
             items.Add(new FileTreeItem { Name = f.Name, IsFile = true, FullPath = f.FullName });
         }
@@ -644,14 +663,15 @@ public partial class AddLocalContentViewModel(
             _cts = new CancellationTokenSource();
 
             string? entryPoint = null;
-            if (SelectedExecutableItem != null && !string.IsNullOrWhiteSpace(SelectedExecutableItem.FullPath))
+            if (RequiresExecutable(SelectedContentType) && SelectedExecutableItem != null && !string.IsNullOrWhiteSpace(SelectedExecutableItem.FullPath))
             {
                 try
                 {
                     entryPoint = Path.GetRelativePath(_stagingPath, SelectedExecutableItem.FullPath).Replace('\\', '/');
                 }
-                catch
+                catch (Exception ex)
                 {
+                    logger?.LogWarning(ex, "Failed to determine relative path for selected executable '{FullPath}'. Falling back to file name '{Name}'", SelectedExecutableItem.FullPath, SelectedExecutableItem.Name);
                     entryPoint = SelectedExecutableItem.Name;
                 }
             }
@@ -788,12 +808,52 @@ public partial class AddLocalContentViewModel(
         }
     }
 
+    private FileTreeItem? FindFileItemByRelativePath(IEnumerable<FileTreeItem> items, string relativePath)
+    {
+        var normalizedTarget = relativePath.Replace('\\', '/').TrimStart('/');
+        foreach (var item in items)
+        {
+            if (item.IsFile)
+            {
+                var itemRel = Path.GetRelativePath(_stagingPath, item.FullPath).Replace('\\', '/').TrimStart('/');
+                if (ManifestVariantResolver.PathsMatch(itemRel, normalizedTarget))
+                {
+                    return item;
+                }
+            }
+            else
+            {
+                var found = FindFileItemByRelativePath(item.Children, relativePath);
+                if (found != null) return found;
+            }
+        }
+
+        return null;
+    }
+
     private async Task RefreshStagingTreeAsync()
     {
         bool wasBusy = IsBusy;
         try
         {
             if (!wasBusy) IsBusy = true;
+
+            string? previousRelativePath = null;
+            if (SelectedExecutableItem != null && !string.IsNullOrWhiteSpace(SelectedExecutableItem.FullPath))
+            {
+                try
+                {
+                    previousRelativePath = Path.GetRelativePath(_stagingPath, SelectedExecutableItem.FullPath).Replace('\\', '/');
+                }
+                catch
+                {
+                    // Ignore path calculation error
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(_pendingEntryPoint))
+            {
+                previousRelativePath = _pendingEntryPoint;
+            }
 
             FileTree.Clear();
             SelectedExecutableItem = null; // Clear previous selection on refresh
@@ -809,10 +869,28 @@ public partial class AddLocalContentViewModel(
 
             ExecutableCount = CountExecutables(FileTree);
 
-            // Auto-select first executable if content type requires it
+            // Reselect previously selected executable or auto-select first if content type requires it
             if (RequiresExecutable(SelectedContentType))
             {
-                AutoSelectFirstExecutable();
+                FileTreeItem? matchedItem = null;
+                if (!string.IsNullOrWhiteSpace(previousRelativePath))
+                {
+                    matchedItem = FindFileItemByRelativePath(FileTree, previousRelativePath);
+                }
+
+                if (matchedItem != null && matchedItem.IsExecutable)
+                {
+                    SelectedExecutableItem = matchedItem;
+                    _pendingEntryPoint = null;
+                }
+                else
+                {
+                    AutoSelectFirstExecutable();
+                }
+            }
+            else
+            {
+                SelectedExecutableItem = null;
             }
 
             Validate();
@@ -860,10 +938,18 @@ public partial class AddLocalContentViewModel(
         OnPropertyChanged(nameof(ShowExecutableSelection));
         OnPropertyChanged(nameof(PreviewIdleText));
 
-        // Auto-select first executable if switching to a content type that requires it
-        if (RequiresExecutable(value) && SelectedExecutableItem == null)
+        // Auto-select first executable if switching to a content type that requires it,
+        // or clear selection when switching to a non-executable content type
+        if (RequiresExecutable(value))
         {
-            AutoSelectFirstExecutable();
+            if (SelectedExecutableItem == null)
+            {
+                AutoSelectFirstExecutable();
+            }
+        }
+        else
+        {
+            SelectedExecutableItem = null;
         }
 
         Validate();

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -509,14 +509,50 @@ public partial class AddLocalContentViewModel(
     }
 
     private static List<FileTreeItem> BuildDirectoryTree(DirectoryInfo dir)
+        => BuildDirectoryTree(dir, CollectExecutableDirectories(dir));
+
+    private static HashSet<string> CollectExecutableDirectories(DirectoryInfo root)
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            foreach (var file in root.EnumerateFiles("*", SearchOption.AllDirectories))
+            {
+                if (!ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(file.Name)
+                    && !file.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                for (var d = file.Directory; d != null; d = d.Parent)
+                {
+                    if (!result.Add(d.FullName))
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // ignore inaccessible directories
+        }
+
+        return result;
+    }
+
+    private static List<FileTreeItem> BuildDirectoryTree(DirectoryInfo dir, HashSet<string> executableDirs)
     {
         var items = new List<FileTreeItem>();
 
-        if (!dir.Exists) return items;
+        if (!dir.Exists)
+        {
+            return items;
+        }
 
         var subDirs = dir.GetDirectories();
         var prioritizedDirs = subDirs
-            .OrderByDescending(DirectoryContainsExecutable)
+            .OrderByDescending(d => executableDirs.Contains(d.FullName))
             .ThenBy(d => d.Name)
             .Take(20);
 
@@ -527,7 +563,7 @@ public partial class AddLocalContentViewModel(
                 Name = d.Name,
                 IsFile = false,
                 FullPath = d.FullName,
-                Children = new ObservableCollection<FileTreeItem>(BuildDirectoryTree(d)),
+                Children = new ObservableCollection<FileTreeItem>(BuildDirectoryTree(d, executableDirs)),
             });
         }
 
@@ -543,19 +579,6 @@ public partial class AddLocalContentViewModel(
         }
 
         return items;
-    }
-
-    private static bool DirectoryContainsExecutable(DirectoryInfo dir)
-    {
-        try
-        {
-            return dir.EnumerateFiles("*", SearchOption.AllDirectories)
-                .Any(f => ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(f.Name) || f.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase));
-        }
-        catch
-        {
-            return false;
-        }
     }
 
     private static void CopyDirectory(DirectoryInfo source, DirectoryInfo target)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -80,7 +80,7 @@ public partial class AddLocalContentViewModel(
         return null;
     }
 
-    private static int CountExecutables(IEnumerable<FileTreeItem> items)
+    protected static int CountExecutables(IEnumerable<FileTreeItem> items)
     {
         int count = 0;
         foreach (var item in items)
@@ -509,7 +509,13 @@ public partial class AddLocalContentViewModel(
 
         if (!dir.Exists) return items;
 
-        foreach (var d in dir.GetDirectories().Take(20))
+        var subDirs = dir.GetDirectories();
+        var prioritizedDirs = subDirs
+            .OrderByDescending(DirectoryContainsExecutable)
+            .ThenBy(d => d.Name)
+            .Take(20);
+
+        foreach (var d in prioritizedDirs)
         {
             items.Add(new FileTreeItem
             {
@@ -532,6 +538,19 @@ public partial class AddLocalContentViewModel(
         }
 
         return items;
+    }
+
+    private static bool DirectoryContainsExecutable(DirectoryInfo dir)
+    {
+        try
+        {
+            return dir.EnumerateFiles("*", SearchOption.AllDirectories)
+                .Any(f => ExecutableFileClassifier.IsLegacyLaunchCandidateFromName(f.Name) || f.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase));
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static void CopyDirectory(DirectoryInfo source, DirectoryInfo target)
@@ -885,6 +904,7 @@ public partial class AddLocalContentViewModel(
                 }
                 else
                 {
+                    _pendingEntryPoint = null;
                     AutoSelectFirstExecutable();
                 }
             }
@@ -944,11 +964,37 @@ public partial class AddLocalContentViewModel(
         {
             if (SelectedExecutableItem == null)
             {
-                AutoSelectFirstExecutable();
+                FileTreeItem? matchedItem = null;
+                if (!string.IsNullOrWhiteSpace(_pendingEntryPoint))
+                {
+                    matchedItem = FindFileItemByRelativePath(FileTree, _pendingEntryPoint);
+                }
+
+                if (matchedItem != null && matchedItem.IsExecutable)
+                {
+                    SelectedExecutableItem = matchedItem;
+                    _pendingEntryPoint = null;
+                }
+                else
+                {
+                    AutoSelectFirstExecutable();
+                }
             }
         }
         else
         {
+            if (SelectedExecutableItem != null && !string.IsNullOrWhiteSpace(SelectedExecutableItem.FullPath))
+            {
+                try
+                {
+                    _pendingEntryPoint = Path.GetRelativePath(_stagingPath, SelectedExecutableItem.FullPath).Replace('\\', '/');
+                }
+                catch
+                {
+                    // Ignore path calculation error
+                }
+            }
+
             SelectedExecutableItem = null;
         }
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoAddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/DemoAddLocalContentViewModel.cs
@@ -147,6 +147,7 @@ public partial class DemoAddLocalContentViewModel : AddLocalContentViewModel
         };
 
         FileTree.Add(modFolder);
+        ExecutableCount = CountExecutables(FileTree);
 
         // Set status message
         StatusMessage = "Demo content ready. Click buttons to see what they do!";

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/FileTreeItem.cs
@@ -14,17 +14,23 @@ public partial class FileTreeItem : ObservableObject
     /// <summary>
     /// Gets or sets the name of the file or directory.
     /// </summary>
-    public string Name { get; set; } = string.Empty;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsExecutable))]
+    private string _name = string.Empty;
 
     /// <summary>
     /// Gets or sets a value indicating whether this item is a file.
     /// </summary>
-    public bool IsFile { get; set; }
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsExecutable))]
+    private bool _isFile;
 
     /// <summary>
     /// Gets or sets the full path of the file or directory.
     /// </summary>
-    public string FullPath { get; set; } = string.Empty;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsExecutable))]
+    private string _fullPath = string.Empty;
 
     /// <summary>
     /// Gets or sets the children of this item (for directories).

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -699,7 +699,7 @@ public partial class GameProfileSettingsViewModel
 
             if (dialogOwner == null) return;
 
-            var vm = new AddLocalContentViewModel(
+            using var vm = new AddLocalContentViewModel(
                 _localContentService,
                 _contentStorageService,
                 _genLauncherNormalizationService,
@@ -767,7 +767,7 @@ public partial class GameProfileSettingsViewModel
 
             if (owner == null) return;
 
-            var vm = new AddLocalContentViewModel(
+            using var vm = new AddLocalContentViewModel(
                 _localContentService,
                 _contentStorageService,
                 _genLauncherNormalizationService,

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml
@@ -199,6 +199,7 @@
                                                 Classes="icon-btn"
                                                 Padding="4,2"
                                                 Margin="5,0,0,0"
+                                                AutomationProperties.Name="Select as main executable"
                                                 ToolTip.Tip="Select as main executable">
                                             <Button.IsVisible>
                                                 <MultiBinding Converter="{x:Static conv:MultiBooleanAndConverter.Instance}">

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml
@@ -13,6 +13,7 @@
         <conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <conv:InvertedBoolToVisibilityConverter x:Key="InvertedBoolToVisibilityConverter" />
         <conv:BoolToTextConverter x:Key="BoolToTextConverter" />
+        <conv:ExecutableHighlightConverter x:Key="ExecutableHighlightConverter" />
     </UserControl.Resources>
 
     <UserControl.Styles>
@@ -115,7 +116,13 @@
                         <ComboBox ItemsSource="{Binding AllowedContentTypes}"
                                   SelectedItem="{Binding SelectedContentType}"
                                   HorizontalAlignment="Stretch"
-                                  Classes="glass"/>
+                                  Classes="glass">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={x:Static conv:ContentTypeDisplayConverter.Instance}}"/>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                     </StackPanel>
 
                      <!-- Target Game -->
@@ -157,7 +164,7 @@
                             <TextBlock Text="CONTENT PREVIEW" FontSize="11" FontWeight="Bold" Foreground="#80FFFFFF" LetterSpacing="1"/>
                         </Border>
 
-                        <TreeView Grid.Row="1" ItemsSource="{Binding FileTree}" Background="Transparent" Foreground="#DDDDDD" Margin="5">
+                        <TreeView Grid.Row="1" ItemsSource="{Binding FileTree}" Background="Transparent" Foreground="#DDDDDD" Margin="5" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                             <TreeView.Styles>
                                 <Style Selector="TreeViewItem">
                                     <Setter Property="MinHeight" Value="24"/>
@@ -166,8 +173,8 @@
                             </TreeView.Styles>
                             <TreeView.ItemTemplate>
                                 <TreeDataTemplate ItemsSource="{Binding Children}">
-                                    <Grid ColumnDefinitions="*,Auto" Background="Transparent">
-                                        <DockPanel LastChildFill="True">
+                                    <Grid ColumnDefinitions="*,Auto,Auto" Background="Transparent" Margin="0,0,10,0">
+                                        <DockPanel Grid.Column="0" LastChildFill="True">
                                             <TextBlock DockPanel.Dock="Left"
                                                        Text="{Binding IsFile, Converter={StaticResource BoolToTextConverter}, ConverterParameter='📄|📁'}"
                                                        Opacity="0.7"
@@ -175,15 +182,43 @@
                                             <TextBlock Text="{Binding Name}"
                                                        VerticalAlignment="Center"
                                                        TextTrimming="CharacterEllipsis"
-                                                       ToolTip.Tip="{Binding Name}"/>
+                                                       ToolTip.Tip="{Binding Name}">
+                                                <TextBlock.Foreground>
+                                                    <MultiBinding Converter="{StaticResource ExecutableHighlightConverter}">
+                                                        <Binding Path="IsExecutable"/>
+                                                        <Binding Path="IsSelectedExecutable"/>
+                                                    </MultiBinding>
+                                                </TextBlock.Foreground>
+                                            </TextBlock>
                                         </DockPanel>
 
+                                        <!-- Select as Executable button (only for executable files when content type requires executable selection) -->
                                         <Button Grid.Column="1"
+                                                Command="{Binding ((vm:AddLocalContentViewModel)DataContext).SelectExecutableCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                CommandParameter="{Binding}"
+                                                Classes="icon-btn"
+                                                Padding="4,2"
+                                                Margin="5,0,0,0"
+                                                ToolTip.Tip="Select as main executable">
+                                            <Button.IsVisible>
+                                                <MultiBinding Converter="{x:Static conv:MultiBooleanAndConverter.Instance}">
+                                                    <Binding Path="IsExecutable"/>
+                                                    <Binding Path="((vm:AddLocalContentViewModel)DataContext).ShowExecutableSelection" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
+                                                </MultiBinding>
+                                            </Button.IsVisible>
+                                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                                <TextBlock Text="▶" FontSize="10"/>
+                                                <TextBlock Text="{Binding IsSelectedExecutable, Converter={StaticResource BoolToTextConverter}, ConverterParameter='Selected|Select'}" FontSize="10"/>
+                                            </StackPanel>
+                                        </Button>
+
+                                        <!-- Remove Item button -->
+                                        <Button Grid.Column="2"
                                                 Command="{Binding ((vm:AddLocalContentViewModel)DataContext).DeleteItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                 CommandParameter="{Binding}"
                                                 Classes="icon-btn"
                                                 Padding="4,2"
-                                                Margin="10,0,25,0"
+                                                Margin="10,0,0,0"
                                                 ToolTip.Tip="Remove Item">
                                             <TextBlock Text="✕" FontSize="10"/>
                                         </Button>
@@ -195,7 +230,7 @@
                         <!-- Empty State Overlay -->
                         <StackPanel Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="10" IsVisible="{Binding !FileTree.Count}">
                             <TextBlock Text="No Content Loaded" Foreground="#40FFFFFF" FontSize="16" HorizontalAlignment="Center"/>
-                            <TextBlock Text="Select a source to preview structure" Foreground="#30FFFFFF" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding PreviewIdleText}" Foreground="#30FFFFFF" FontSize="12" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentView.axaml.cs
@@ -34,6 +34,13 @@ public partial class AddLocalContentView : UserControl
         InitializeBrowseActions();
     }
 
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        (DataContext as IDisposable)?.Dispose();
+    }
+
     /// <summary>
     /// Called when the data context changes.
     /// </summary>

--- a/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Views/AddLocalContentWindow.axaml.cs
@@ -32,6 +32,13 @@ public partial class AddLocalContentWindow : Window
     }
 
     /// <inheritdoc />
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        (DataContext as IDisposable)?.Dispose();
+    }
+
+    /// <inheritdoc />
     protected override void OnDataContextChanged(EventArgs e)
     {
         base.OnDataContextChanged(e);

--- a/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
+++ b/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
@@ -479,7 +479,11 @@ public class MockLocalContentService : ILocalContentService
     /// <inheritdoc/>
     public Task<OperationResult<ContentManifest>> CreateLocalContentManifestAsync(string directoryPath, string name, ContentType contentType, GameType targetGame, string? sourcePath = null, IProgress<ContentStorageProgress>? progress = null, CancellationToken cancellationToken = default, string? entryPoint = null)
     {
-         return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath, EntryPoint = entryPoint }));
+        var normalizedEntryPoint = !string.IsNullOrWhiteSpace(entryPoint)
+            ? entryPoint.Replace('\\', '/').TrimStart('/')
+            : null;
+
+        return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath, EntryPoint = normalizedEntryPoint }));
     }
 
     /// <inheritdoc/>
@@ -488,7 +492,11 @@ public class MockLocalContentService : ILocalContentService
     /// <inheritdoc/>
     public Task<OperationResult<ContentManifest>> UpdateLocalContentManifestAsync(string existingManifestId, string name, string directoryPath, ContentType contentType, GameType targetGame, string? sourcePath = null, IProgress<ContentStorageProgress>? progress = null, CancellationToken cancellationToken = default, string? entryPoint = null)
     {
-        return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath, EntryPoint = entryPoint }));
+        var normalizedEntryPoint = !string.IsNullOrWhiteSpace(entryPoint)
+            ? entryPoint.Replace('\\', '/').TrimStart('/')
+            : null;
+
+        return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath, EntryPoint = normalizedEntryPoint }));
     }
 }
 

--- a/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
+++ b/GenHub/GenHub/Features/Info/Services/MockToolServices.cs
@@ -457,7 +457,18 @@ public class MockMapPackService : IMapPackService
 public class MockLocalContentService : ILocalContentService
 {
     /// <inheritdoc/>
-    public IReadOnlyList<ContentType> AllowedContentTypes => [ContentType.Mod, ContentType.Map, ContentType.GameClient];
+    public IReadOnlyList<ContentType> AllowedContentTypes =>
+    [
+        ContentType.Mod,
+        ContentType.GameClient,
+        ContentType.Executable,
+        ContentType.ModdingTool,
+        ContentType.Patch,
+        ContentType.Addon,
+        ContentType.Map,
+        ContentType.MapPack,
+        ContentType.Mission,
+    ];
 
     /// <inheritdoc/>
     public Task<OperationResult<ContentManifest>> AddLocalContentAsync(string name, string directoryPath, ContentType contentType, GameType targetGame, CancellationToken cancellationToken = default)
@@ -466,18 +477,18 @@ public class MockLocalContentService : ILocalContentService
     }
 
     /// <inheritdoc/>
-    public Task<OperationResult<ContentManifest>> CreateLocalContentManifestAsync(string directoryPath, string name, ContentType contentType, GameType targetGame, string? sourcePath = null, IProgress<ContentStorageProgress>? progress = null, CancellationToken cancellationToken = default)
+    public Task<OperationResult<ContentManifest>> CreateLocalContentManifestAsync(string directoryPath, string name, ContentType contentType, GameType targetGame, string? sourcePath = null, IProgress<ContentStorageProgress>? progress = null, CancellationToken cancellationToken = default, string? entryPoint = null)
     {
-         return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath }));
+         return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath, EntryPoint = entryPoint }));
     }
 
     /// <inheritdoc/>
     public Task<OperationResult> DeleteLocalContentAsync(string manifestId, CancellationToken cancellationToken = default) => Task.FromResult(OperationResult.CreateSuccess());
 
     /// <inheritdoc/>
-    public Task<OperationResult<ContentManifest>> UpdateLocalContentManifestAsync(string existingManifestId, string name, string directoryPath, ContentType contentType, GameType targetGame, string? sourcePath = null, IProgress<ContentStorageProgress>? progress = null, CancellationToken cancellationToken = default)
+    public Task<OperationResult<ContentManifest>> UpdateLocalContentManifestAsync(string existingManifestId, string name, string directoryPath, ContentType contentType, GameType targetGame, string? sourcePath = null, IProgress<ContentStorageProgress>? progress = null, CancellationToken cancellationToken = default, string? entryPoint = null)
     {
-        return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath }));
+        return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(new ContentManifest { Name = name, ContentType = contentType, TargetGame = targetGame, SourcePath = sourcePath, EntryPoint = entryPoint }));
     }
 }
 

--- a/GenHub/GenHub/Infrastructure/Converters/ExecutableHighlightConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/ExecutableHighlightConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Avalonia;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 
@@ -11,7 +12,6 @@ namespace GenHub.Infrastructure.Converters;
 /// </summary>
 public class ExecutableHighlightConverter : IMultiValueConverter
 {
-    private static readonly SolidColorBrush DefaultBrush = new(Color.Parse("#DDDDDD"));
     private static readonly SolidColorBrush ExecutableBrush = new(Color.Parse("#90CAF9")); // Light blue for executables
     private static readonly SolidColorBrush SelectedExecutableBrush = new(Color.Parse("#4CAF50")); // Green for selected
 
@@ -20,7 +20,7 @@ public class ExecutableHighlightConverter : IMultiValueConverter
     {
         if (values.Count < 2)
         {
-            return DefaultBrush;
+            return AvaloniaProperty.UnsetValue;
         }
 
         var isExecutable = values[0] is true;
@@ -36,6 +36,6 @@ public class ExecutableHighlightConverter : IMultiValueConverter
             return ExecutableBrush;
         }
 
-        return DefaultBrush;
+        return AvaloniaProperty.UnsetValue;
     }
 }


### PR DESCRIPTION
## Summary
Fixes an issue where users were unable to select the main `.exe` file when importing a local folder or files for `GameClient`, `ModdingTool`, and `Executable` content types.

### Root Cause
During earlier UI refactoring when extracting `AddLocalContentView.axaml` as a `UserControl`, the `TreeDataTemplate` executable selection button (`▶ Selected` / `▶ Select`) and `ExecutableHighlightConverter` foreground binding on tree items were inadvertently omitted. Additionally, `AddLocalContentViewModel` and related services only handled `ModdingTool` and `Executable`, missing `GameClient`, and did not pass the selected `EntryPoint` to manifest creation/updating.

### Changes
1. **View (`AddLocalContentView.axaml`)**:
   - Added `ExecutableHighlightConverter` resource for green/blue highlighting of executable items in the content preview tree.
   - Added "Select as Executable" button to `TreeDataTemplate` for executable files when the content type requires an executable.
   - Reconnected `ContentTypeDisplayConverter` on the content type `ComboBox`.
   - Restored dynamic `PreviewIdleText` on the empty state overlay.
2. **ViewModel (`AddLocalContentViewModel.cs`)**:
   - Extended executable requirements, auto-selection, and validation to `ContentType.GameClient`, `ContentType.ModdingTool`, and `ContentType.Executable` via `RequiresExecutable()`.
   - Calculated relative path for `SelectedExecutableItem` and forwarded as `entryPoint` to `ILocalContentService`.
3. **Core Services (`ILocalContentService.cs`, `LocalContentService.cs`, `MockToolServices.cs`)**:
   - Added `string? entryPoint = null` parameter to `CreateLocalContentManifestAsync` and `UpdateLocalContentManifestAsync` and set `manifest.EntryPoint` accordingly.
4. **Launcher (`ProfileLauncherFacade.cs`)**:
   - Prioritized `ManifestVariantResolver.ResolveEntryPoint(toolManifest)` when launching tools.
5. **Testing**:
   - Added comprehensive unit tests in `AddLocalContentViewModelTests.cs` covering auto-selection, manual selection, validation, and entry point forwarding across all content types.
   - Added unit tests in `LocalContentServiceTests.cs` for entry point normalization and propagation.