### PR TITLE
feat(content): add GeneralsGamePatch2 download option under TheSuperHackers provider

### DIFF
--- a/GenHub/GenHub.Core/Constants/SuperHackersConstants.cs
+++ b/GenHub/GenHub.Core/Constants/SuperHackersConstants.cs
@@ -60,6 +60,21 @@ public static class SuperHackersConstants
     /// </summary>
     public const string GeneralsGameCodeRepo = "GeneralsGameCode";
 
+    /// <summary>
+    /// GitHub owner for Generals game patch 2.
+    /// </summary>
+    public const string GeneralsGamePatch2Owner = "TheSuperHackers";
+
+    /// <summary>
+    /// GitHub repo for Generals game patch 2.
+    /// </summary>
+    public const string GeneralsGamePatch2Repo = "GeneralsGamePatch2";
+
+    /// <summary>
+    /// Display name for Generals game patch 2.
+    /// </summary>
+    public const string GeneralsGamePatch2DisplayName = "Community Patch 2";
+
     // ===== Service Configuration =====
 
     /// <summary>

--- a/GenHub/GenHub.Core/Models/Manifest/ManifestIdJsonConverter.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/ManifestIdJsonConverter.cs
@@ -9,7 +9,7 @@ namespace GenHub.Core.Models.Manifest;
 public sealed class ManifestIdJsonConverter : JsonConverter<ManifestId>
 {
     /// <inheritdoc/>
-    public override ManifestId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override ManifestId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) // skipcq: CS-R1138
     {
         var s = reader.GetString() ?? string.Empty;
         return ManifestId.Create(s);

--- a/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
+++ b/GenHub/GenHub.Core/Serialization/JsonWorkspaceStrategyConverter.cs
@@ -16,7 +16,7 @@ public class JsonWorkspaceStrategyConverter : JsonConverter<WorkspaceStrategy>
     [SuppressMessage("Maintainability", "CS-R1138:Inappropriate ordering of parameters", Justification = "Signature is defined by System.Text.Json.Serialization.JsonConverter<T>.Read")]
     [SuppressMessage("DeepSource", "CS-R1138", Justification = "Signature is defined by System.Text.Json.Serialization.JsonConverter<T>.Read")]
     [SuppressMessage("csharp", "CS-R1138", Justification = "Signature is defined by System.Text.Json.Serialization.JsonConverter<T>.Read")]
-    public override WorkspaceStrategy Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override WorkspaceStrategy Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) // skipcq: CS-R1138
     {
         if (reader.TokenType == JsonTokenType.Number)
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/ConfigurationProviderServiceTests.cs
@@ -836,7 +836,8 @@ public class ConfigurationProviderServiceTests
 
         // Assert
         Assert.Contains("TheSuperHackers/GeneralsGameCode", result);
-        Assert.Single(result);
+        Assert.Contains("TheSuperHackers/GeneralsGamePatch2", result);
+        Assert.Equal(2, result.Count);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -475,4 +475,62 @@ public class ContentOrchestratorTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => orchestrator.AcquireContentAsync(searchResult, progress: null, cts.Token));
     }
+
+    /// <summary>
+    /// Verifies that SearchAsync deduplicates results by manifest ID, preferring specialized providers.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_DeduplicatesResultsById_PrefersSpecializedProviderOverGitHubAsync()
+    {
+        // Arrange
+        var specializedProviderMock = new Mock<IContentProvider>();
+        var githubProviderMock = new Mock<IContentProvider>();
+
+        const string duplicateId = "github.0.thesuperhackers.patch.generalsgamepatch2";
+
+        var specializedResult = new ContentSearchResult
+        {
+            Id = duplicateId,
+            Name = "TheSuperHackers Patch 2",
+            ProviderName = "thesuperhackers",
+        };
+
+        var githubResult = new ContentSearchResult
+        {
+            Id = duplicateId,
+            Name = "GeneralsGamePatch2",
+            ProviderName = "GitHub",
+        };
+
+        specializedProviderMock.Setup(p => p.IsEnabled).Returns(true);
+        specializedProviderMock.Setup(p => p.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess([specializedResult]));
+
+        githubProviderMock.Setup(p => p.IsEnabled).Returns(true);
+        githubProviderMock.Setup(p => p.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess([githubResult]));
+
+        var orchestrator = new ContentOrchestrator(
+            _loggerMock.Object,
+            [specializedProviderMock.Object, githubProviderMock.Object],
+            [],
+            [],
+            _cacheMock.Object,
+            _contentValidatorMock.Object,
+            _manifestPoolMock.Object,
+            _installationServiceMock.Object,
+            _installationCasPoolServiceMock.Object);
+
+        // Act
+        var result = await orchestrator.SearchAsync(new ContentSearchQuery());
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal("thesuperhackers", items[0].ProviderName);
+        Assert.Equal("TheSuperHackers Patch 2", items[0].Name);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/ContentOrchestratorTests.cs
@@ -487,7 +487,7 @@ public class ContentOrchestratorTests
         var specializedProviderMock = new Mock<IContentProvider>();
         var githubProviderMock = new Mock<IContentProvider>();
 
-        const string duplicateId = "github.0.thesuperhackers.patch.generalsgamepatch2";
+        const string duplicateId = "1.0.thesuperhackers.patch.generalsgamepatch2";
 
         var specializedResult = new ContentSearchResult
         {
@@ -513,7 +513,7 @@ public class ContentOrchestratorTests
 
         var orchestrator = new ContentOrchestrator(
             _loggerMock.Object,
-            [specializedProviderMock.Object, githubProviderMock.Object],
+            [githubProviderMock.Object, specializedProviderMock.Object],
             [],
             [],
             _cacheMock.Object,

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/PublisherManifestFactoryResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/PublisherManifestFactoryResolverTests.cs
@@ -49,7 +49,7 @@ public class PublisherManifestFactoryResolverTests
 
         var manifest = new ContentManifest
         {
-            Id = ManifestId.Create("publisher.thesuperhackers.gameclient.generals"),
+            Id = ManifestId.Create("1.0.thesuperhackers.gameclient.generals"),
             ContentType = ContentType.GameClient,
             Publisher = new PublisherInfo
             {
@@ -87,7 +87,7 @@ public class PublisherManifestFactoryResolverTests
 
         var patchManifest = new ContentManifest
         {
-            Id = ManifestId.Create("github.0.thesuperhackers.patch.generalsgamepatch2"),
+            Id = ManifestId.Create("1.0.thesuperhackers.patch.generalsgamepatch2"),
             ContentType = ContentType.Patch,
             Publisher = new PublisherInfo
             {
@@ -121,7 +121,7 @@ public class PublisherManifestFactoryResolverTests
 
         var patchManifest = new ContentManifest
         {
-            Id = ManifestId.Create("unknown.0.publisher.mod.sample"),
+            Id = ManifestId.Create("1.0.testpublisher.mod.sample"),
             ContentType = ContentType.Mod,
             Publisher = new PublisherInfo
             {
@@ -132,6 +132,40 @@ public class PublisherManifestFactoryResolverTests
 
         // Act
         var result = resolver.ResolveFactory(patchManifest);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies that ResolveFactory returns null when a GameClient manifest has no specialized factory,
+    /// rather than falling back to GitHubManifestFactory.
+    /// </summary>
+    [Fact]
+    public void ResolveFactory_ReturnsNull_WhenGameClientHasNoSpecializedFactory()
+    {
+        // Arrange
+        var gitHubFactory = new GitHubManifestFactory(
+            NullLogger<GitHubManifestFactory>.Instance,
+            _hashProviderMock.Object);
+
+        var resolver = new PublisherManifestFactoryResolver(
+            [gitHubFactory],
+            NullLogger<PublisherManifestFactoryResolver>.Instance);
+
+        var gameClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.0.unknownpublisher.gameclient.generals"),
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo
+            {
+                Name = "UnknownPublisher",
+                PublisherType = "unknownpublisher",
+            },
+        };
+
+        // Act
+        var result = resolver.ResolveFactory(gameClientManifest);
 
         // Assert
         Assert.Null(result);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/PublisherManifestFactoryResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/PublisherManifestFactoryResolverTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Features.Content.Services.Publishers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Content.Services.Publishers;
+
+/// <summary>
+/// Unit tests for <see cref="PublisherManifestFactoryResolver"/>.
+/// </summary>
+public class PublisherManifestFactoryResolverTests
+{
+    private readonly Mock<IFileHashProvider> _hashProviderMock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublisherManifestFactoryResolverTests"/> class.
+    /// </summary>
+    public PublisherManifestFactoryResolverTests()
+    {
+        _hashProviderMock = new Mock<IFileHashProvider>();
+    }
+
+    /// <summary>
+    /// Verifies that ResolveFactory returns the specialized factory when CanHandle matches.
+    /// </summary>
+    [Fact]
+    public void ResolveFactory_ReturnsSpecializedFactory_WhenCanHandleMatches()
+    {
+        // Arrange
+        var superHackersFactory = new SuperHackersManifestFactory(
+            NullLogger<SuperHackersManifestFactory>.Instance,
+            _hashProviderMock.Object);
+
+        var gitHubFactory = new GitHubManifestFactory(
+            NullLogger<GitHubManifestFactory>.Instance,
+            _hashProviderMock.Object);
+
+        var resolver = new PublisherManifestFactoryResolver(
+            [superHackersFactory, gitHubFactory],
+            NullLogger<PublisherManifestFactoryResolver>.Instance);
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("publisher.thesuperhackers.gameclient.generals"),
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo
+            {
+                Name = "TheSuperHackers",
+                PublisherType = PublisherTypeConstants.TheSuperHackers,
+            },
+        };
+
+        // Act
+        var result = resolver.ResolveFactory(manifest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<SuperHackersManifestFactory>(result);
+    }
+
+    /// <summary>
+    /// Verifies that ResolveFactory falls back to GitHubManifestFactory for non-GameClient publisher content.
+    /// </summary>
+    [Fact]
+    public void ResolveFactory_FallsBackToGitHubFactory_WhenSpecializedFactoryCannotHandle()
+    {
+        // Arrange
+        var superHackersFactory = new SuperHackersManifestFactory(
+            NullLogger<SuperHackersManifestFactory>.Instance,
+            _hashProviderMock.Object);
+
+        var gitHubFactory = new GitHubManifestFactory(
+            NullLogger<GitHubManifestFactory>.Instance,
+            _hashProviderMock.Object);
+
+        var resolver = new PublisherManifestFactoryResolver(
+            [superHackersFactory, gitHubFactory],
+            NullLogger<PublisherManifestFactoryResolver>.Instance);
+
+        var patchManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("github.0.thesuperhackers.patch.generalsgamepatch2"),
+            ContentType = ContentType.Patch,
+            Publisher = new PublisherInfo
+            {
+                Name = "TheSuperHackers",
+                PublisherType = PublisherTypeConstants.TheSuperHackers,
+            },
+        };
+
+        // Act
+        var result = resolver.ResolveFactory(patchManifest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<GitHubManifestFactory>(result);
+    }
+
+    /// <summary>
+    /// Verifies that ResolveFactory returns null when no specialized or fallback factory is available.
+    /// </summary>
+    [Fact]
+    public void ResolveFactory_ReturnsNull_WhenNoFactoryMatchesAndNoFallbackAvailable()
+    {
+        // Arrange
+        var superHackersFactory = new SuperHackersManifestFactory(
+            NullLogger<SuperHackersManifestFactory>.Instance,
+            _hashProviderMock.Object);
+
+        var resolver = new PublisherManifestFactoryResolver(
+            [superHackersFactory],
+            NullLogger<PublisherManifestFactoryResolver>.Instance);
+
+        var patchManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("unknown.0.publisher.mod.sample"),
+            ContentType = ContentType.Mod,
+            Publisher = new PublisherInfo
+            {
+                Name = "Unknown",
+                PublisherType = "unknown",
+            },
+        };
+
+        // Act
+        var result = resolver.ResolveFactory(patchManifest);
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
@@ -202,7 +202,7 @@ public class SuperHackersProviderTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
-    public async Task SearchAsync_FiltersByTargetGame_ReturnsOnlyMatchingReleasesAsync()
+    public async Task SearchAsync_FiltersByTargetGame_ReturnsMatchingReleasesAsync()
     {
         // Arrange
         var gameCodeRelease = new GitHubRelease { TagName = "weekly-1", Name = "Weekly 1" };
@@ -220,7 +220,70 @@ public class SuperHackersProviderTests
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(gamePatch2Release);
 
-        var query = new ContentSearchQuery { TargetGame = GameType.Generals };
+        var zeroHourQuery = new ContentSearchQuery { TargetGame = GameType.ZeroHour };
+
+        // Act
+        var result = await _provider.SearchAsync(zeroHourQuery);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal(ContentType.Patch, items[0].ContentType);
+        Assert.Equal(GameType.ZeroHour, items[0].TargetGame);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync filters by author name and github author correctly.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_FiltersByAuthor_ReturnsEmptyWhenAuthorDoesNotMatchAsync()
+    {
+        // Arrange
+        var query = new ContentSearchQuery { AuthorName = "NonExistentAuthor" };
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Empty(items);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync matches on display name and body text.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_MatchesSearchTerm_OnDisplayNameAndBodyAsync()
+    {
+        // Arrange
+        var gamePatch2Release = new GitHubRelease
+        {
+            TagName = "1.0.0",
+            Name = "Patch Release",
+            Body = "Community patch details",
+            HtmlUrl = "https://github.com/TheSuperHackers/GeneralsGamePatch2/releases/tag/1.0.0",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GitHubRelease { TagName = "weekly-1", Name = "Weekly 1", Body = "Engine updates" });
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gamePatch2Release);
+
+        var query = new ContentSearchQuery { SearchTerm = SuperHackersConstants.GeneralsGamePatch2DisplayName };
 
         // Act
         var result = await _provider.SearchAsync(query);
@@ -230,8 +293,37 @@ public class SuperHackersProviderTests
         var items = result.Data?.ToList();
         Assert.NotNull(items);
         Assert.Single(items);
-        Assert.Equal(ContentType.GameClient, items[0].ContentType);
-        Assert.Equal(GameType.Generals, items[0].TargetGame);
+        Assert.Equal(ContentType.Patch, items[0].ContentType);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync returns failure when one target returns null release and the other throws an error.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_WhenOneTargetReturnsNullAndOtherErrors_ReturnsFailureAsync()
+    {
+        // Arrange
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GitHubRelease?)null);
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("API rate limit"));
+
+        var query = new ContentSearchQuery();
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Search failed for SuperHackers targets", result.FirstError);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
@@ -159,4 +159,159 @@ public class SuperHackersProviderTests
         Assert.Single(items);
         Assert.Equal(ContentType.Patch, items[0].ContentType);
     }
+
+    /// <summary>
+    /// Verifies that SearchAsync filters by ContentType correctly.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_FiltersByContentType_ReturnsOnlyMatchingReleasesAsync()
+    {
+        // Arrange
+        var gameCodeRelease = new GitHubRelease { TagName = "weekly-1", Name = "Weekly 1" };
+        var gamePatch2Release = new GitHubRelease { TagName = "1.0.0", Name = "Release 1.0.0" };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameCodeRelease);
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gamePatch2Release);
+
+        var query = new ContentSearchQuery { ContentType = ContentType.Patch };
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal(ContentType.Patch, items[0].ContentType);
+        Assert.Equal("1.0.0", items[0].Version);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync filters by TargetGame correctly.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_FiltersByTargetGame_ReturnsOnlyMatchingReleasesAsync()
+    {
+        // Arrange
+        var gameCodeRelease = new GitHubRelease { TagName = "weekly-1", Name = "Weekly 1" };
+        var gamePatch2Release = new GitHubRelease { TagName = "1.0.0", Name = "Release 1.0.0" };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameCodeRelease);
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gamePatch2Release);
+
+        var query = new ContentSearchQuery { TargetGame = GameType.Generals };
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal(ContentType.GameClient, items[0].ContentType);
+        Assert.Equal(GameType.Generals, items[0].TargetGame);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync returns successful results when one repository fails.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_ReturnsRemainingReleases_WhenOneRepositoryFailsAsync()
+    {
+        // Arrange
+        var gameCodeRelease = new GitHubRelease { TagName = "weekly-1", Name = "Weekly 1" };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameCodeRelease);
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("API error"));
+
+        var query = new ContentSearchQuery();
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal(ContentType.GameClient, items[0].ContentType);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync returns failure when all matching repositories fail.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_ReturnsFailure_WhenAllRepositoriesFailAsync()
+    {
+        // Arrange
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Network failure 1"));
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Network failure 2"));
+
+        var query = new ContentSearchQuery();
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Search failed for SuperHackers targets", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync propagates cancellation.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_PropagatesCancellation_WhenCancellationRequestedAsync()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _provider.SearchAsync(new ContentSearchQuery(), cts.Token));
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
@@ -308,7 +308,7 @@ public class SuperHackersProviderTests
             SuperHackersConstants.GeneralsGameCodeOwner,
             SuperHackersConstants.GeneralsGameCodeRepo,
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync((GitHubRelease?)null);
+            .ReturnsAsync((GitHubRelease)null!);
 
         _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
             SuperHackersConstants.GeneralsGamePatch2Owner,
@@ -410,6 +410,7 @@ public class SuperHackersProviderTests
     /// <summary>
     /// Verifies that SearchAsync falls back to display name and tag name when release name is blank.
     /// </summary>
+    /// <param name="releaseName">The candidate release name to test.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Theory]
     [InlineData(null)]
@@ -421,7 +422,7 @@ public class SuperHackersProviderTests
         var release = new GitHubRelease
         {
             TagName = "alpha-4",
-            Name = releaseName,
+            Name = releaseName ?? string.Empty,
             Body = "Patch notes",
             HtmlUrl = "https://github.com/TheSuperHackers/GeneralsGamePatch2/releases/tag/alpha-4",
             CreatedAt = DateTimeOffset.UtcNow,
@@ -437,7 +438,7 @@ public class SuperHackersProviderTests
             SuperHackersConstants.GeneralsGameCodeOwner,
             SuperHackersConstants.GeneralsGameCodeRepo,
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync((GitHubRelease?)null);
+            .ReturnsAsync((GitHubRelease)null!);
 
         var query = new ContentSearchQuery { ContentType = ContentType.Patch };
 
@@ -479,7 +480,7 @@ public class SuperHackersProviderTests
             SuperHackersConstants.GeneralsGameCodeOwner,
             SuperHackersConstants.GeneralsGameCodeRepo,
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync((GitHubRelease?)null);
+            .ReturnsAsync((GitHubRelease)null!);
 
         var query = new ContentSearchQuery { ContentType = ContentType.Patch };
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.GitHub;
+using GenHub.Core.Interfaces.Providers;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GitHub;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Features.Content.Services.Publishers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Content.Services.Publishers;
+
+/// <summary>
+/// Unit tests for <see cref="SuperHackersProvider"/>.
+/// </summary>
+public class SuperHackersProviderTests
+{
+    private readonly Mock<IProviderDefinitionLoader> _providerDefinitionLoaderMock;
+    private readonly Mock<IGitHubApiClient> _gitHubApiClientMock;
+    private readonly Mock<IContentResolver> _resolverMock;
+    private readonly Mock<IContentDeliverer> _delivererMock;
+    private readonly Mock<IContentValidator> _validatorMock;
+    private readonly SuperHackersProvider _provider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SuperHackersProviderTests"/> class.
+    /// </summary>
+    public SuperHackersProviderTests()
+    {
+        _providerDefinitionLoaderMock = new Mock<IProviderDefinitionLoader>();
+        _gitHubApiClientMock = new Mock<IGitHubApiClient>();
+        _resolverMock = new Mock<IContentResolver>();
+        _delivererMock = new Mock<IContentDeliverer>();
+        _validatorMock = new Mock<IContentValidator>();
+
+        _resolverMock.Setup(r => r.ResolverId).Returns(SuperHackersConstants.ResolverId);
+        _delivererMock.Setup(d => d.SourceName).Returns(ContentSourceNames.GitHubDeliverer);
+
+        _validatorMock.Setup(v => v.ValidateManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult("test", []));
+
+        _provider = new SuperHackersProvider(
+            _providerDefinitionLoaderMock.Object,
+            _gitHubApiClientMock.Object,
+            [_resolverMock.Object],
+            [_delivererMock.Object],
+            _validatorMock.Object,
+            NullLogger<SuperHackersProvider>.Instance);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync returns both GeneralsGameCode and GeneralsGamePatch2 releases when available.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_DiscoversBothGameCodeAndGamePatch2_WhenBothAvailableAsync()
+    {
+        // Arrange
+        var gameCodeRelease = new GitHubRelease
+        {
+            TagName = "weekly-2026-08-01",
+            Name = "Weekly Release 2026-08-01",
+            Body = "Generals and Zero Hour game code updates",
+            HtmlUrl = "https://github.com/TheSuperHackers/GeneralsGameCode/releases/tag/weekly-2026-08-01",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        var gamePatch2Release = new GitHubRelease
+        {
+            TagName = "1.0.0",
+            Name = "Release 1.0.0",
+            Body = "Community Patch 2 to fix and improve Generals and Zero Hour",
+            HtmlUrl = "https://github.com/TheSuperHackers/GeneralsGamePatch2/releases/tag/1.0.0",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameCodeRelease);
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gamePatch2Release);
+
+        var query = new ContentSearchQuery();
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Equal(2, items.Count);
+
+        var gameCodeItem = items.FirstOrDefault(i => i.ContentType == ContentType.GameClient);
+        Assert.NotNull(gameCodeItem);
+        Assert.Equal("weekly-2026-08-01", gameCodeItem.Version);
+        Assert.Equal(SuperHackersConstants.GeneralsGameCodeRepo, gameCodeItem.ResolverMetadata[GitHubConstants.RepoMetadataKey]);
+
+        var gamePatch2Item = items.FirstOrDefault(i => i.ContentType == ContentType.Patch);
+        Assert.NotNull(gamePatch2Item);
+        Assert.Equal("1.0.0", gamePatch2Item.Version);
+        Assert.Equal(SuperHackersConstants.GeneralsGamePatch2Repo, gamePatch2Item.ResolverMetadata[GitHubConstants.RepoMetadataKey]);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync filters properly by repository search term.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_FiltersBySearchTerm_CorrectlyAsync()
+    {
+        // Arrange
+        var gamePatch2Release = new GitHubRelease
+        {
+            TagName = "1.0.0",
+            Name = "Release 1.0.0",
+            Body = "Community Patch 2",
+            HtmlUrl = "https://github.com/TheSuperHackers/GeneralsGamePatch2/releases/tag/1.0.0",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GitHubRelease { TagName = "weekly-1", Name = "Weekly 1" });
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gamePatch2Release);
+
+        var query = new ContentSearchQuery { SearchTerm = "GeneralsGamePatch2" };
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal(ContentType.Patch, items[0].ContentType);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
@@ -406,4 +406,91 @@ public class SuperHackersProviderTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => _provider.SearchAsync(new ContentSearchQuery(), cts.Token));
     }
+
+    /// <summary>
+    /// Verifies that SearchAsync falls back to display name and tag name when release name is blank.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SearchAsync_UsesFallbackName_WhenReleaseNameIsBlankAsync(string? releaseName)
+    {
+        // Arrange
+        var release = new GitHubRelease
+        {
+            TagName = "alpha-4",
+            Name = releaseName,
+            Body = "Patch notes",
+            HtmlUrl = "https://github.com/TheSuperHackers/GeneralsGamePatch2/releases/tag/alpha-4",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(release);
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GitHubRelease?)null);
+
+        var query = new ContentSearchQuery { ContentType = ContentType.Patch };
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal($"{SuperHackersConstants.GeneralsGamePatch2DisplayName} alpha-4", items[0].Name);
+    }
+
+    /// <summary>
+    /// Verifies that SearchAsync preserves the original release name when it is not blank.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SearchAsync_PreservesReleaseName_WhenReleaseNameIsNonBlankAsync()
+    {
+        // Arrange
+        var release = new GitHubRelease
+        {
+            TagName = "alpha-4",
+            Name = "Community Patch 2.0 Alpha 4",
+            Body = "Patch notes",
+            HtmlUrl = "https://github.com/TheSuperHackers/GeneralsGamePatch2/releases/tag/alpha-4",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGamePatch2Owner,
+            SuperHackersConstants.GeneralsGamePatch2Repo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(release);
+
+        _gitHubApiClientMock.Setup(c => c.GetLatestReleaseAsync(
+            SuperHackersConstants.GeneralsGameCodeOwner,
+            SuperHackersConstants.GeneralsGameCodeRepo,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GitHubRelease?)null);
+
+        var query = new ContentSearchQuery { ContentType = ContentType.Patch };
+
+        // Act
+        var result = await _provider.SearchAsync(query);
+
+        // Assert
+        Assert.True(result.Success);
+        var items = result.Data?.ToList();
+        Assert.NotNull(items);
+        Assert.Single(items);
+        Assert.Equal("Community Patch 2.0 Alpha 4", items[0].Name);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
@@ -129,7 +129,7 @@ public class ContentReconciliationServiceTests
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 "profile-1",
-                It.Is<UpdateProfileRequest>(r => r.GameClient != null && r.GameClient.Id == newId),
+                It.Is<UpdateProfileRequest>(r => r.GameClient?.Id == newId),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should update profile with new manifest ID");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Integration/ContentReconciliationServiceTests.cs
@@ -129,7 +129,7 @@ public class ContentReconciliationServiceTests
         _profileManagerMock.Verify(
             x => x.UpdateProfileAsync(
                 "profile-1",
-                It.Is<UpdateProfileRequest>(r => r.GameClient?.Id == newId),
+                It.Is<UpdateProfileRequest>(r => r.GameClient != null && r.GameClient.Id == newId),
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should update profile with new manifest ID");

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -278,7 +278,11 @@ public class ConfigurationProviderService(
             settings.GitHubDiscoveryRepositories != null && settings.GitHubDiscoveryRepositories.Count > 0)
             return settings.GitHubDiscoveryRepositories;
 
-        return ["TheSuperHackers/GeneralsGameCode"];
+        return
+        [
+            $"{SuperHackersConstants.GeneralsGameCodeOwner}/{SuperHackersConstants.GeneralsGameCodeRepo}",
+            $"{SuperHackersConstants.GeneralsGamePatch2Owner}/{SuperHackersConstants.GeneralsGamePatch2Repo}",
+        ];
     }
 
     /// <inheritdoc />

--- a/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
@@ -108,7 +108,7 @@ public class ContentOrchestrator : IContentOrchestrator
         _logger.LogDebug("Starting orchestrated content search with query: {SearchTerm}, ContentType: {ContentType}", query.SearchTerm, query.ContentType);
 
         // Check cache first
-        var cacheKey = $"search::{query.ProviderName}::{query.SearchTerm}::{query.ContentType}::{query.Skip}::{query.Take}::{query.SortOrder}";
+        var cacheKey = $"search::{query.ProviderName}::{query.SearchTerm}::{query.ContentType}::{query.TargetGame}::{query.AuthorName}::{query.GitHubAuthor}::{query.Language}::{query.Skip}::{query.Take}::{query.SortOrder}";
         var cachedResults = await _cache.GetAsync<List<ContentSearchResult>>(cacheKey, cancellationToken);
         if (cachedResults != null)
         {
@@ -192,7 +192,9 @@ public class ContentOrchestrator : IContentOrchestrator
         var deduplicatedResults = allResults
             .GroupBy(r => r.Id, StringComparer.OrdinalIgnoreCase)
             .Select(g => g
-                .OrderByDescending(r => !string.Equals(r.ProviderName, ContentSourceNames.GitHubDiscoverer, StringComparison.OrdinalIgnoreCase) ? 1 : 0)
+                .OrderByDescending(r =>
+                    !string.Equals(r.ProviderName, ContentSourceNames.GitHubDiscoverer, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(r.ProviderName, ContentSourceNames.GitHubReleasesDiscoverer, StringComparison.OrdinalIgnoreCase) ? 1 : 0)
                 .First())
             .ToList();
 

--- a/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentOrchestrator.cs
@@ -187,8 +187,17 @@ public class ContentOrchestrator : IContentOrchestrator
         // than an exception, which would otherwise surface here as an empty successful search.
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Deduplicate results by manifest ID across providers before sorting and pagination,
+        // preferring specialized publisher providers over generic GitHub providers.
+        var deduplicatedResults = allResults
+            .GroupBy(r => r.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g
+                .OrderByDescending(r => !string.Equals(r.ProviderName, ContentSourceNames.GitHubDiscoverer, StringComparison.OrdinalIgnoreCase) ? 1 : 0)
+                .First())
+            .ToList();
+
         // Apply orchestrator-level sorting and pagination
-        var sortedResults = ApplySorting(allResults, query.SortOrder)
+        var sortedResults = ApplySorting(deduplicatedResults, query.SortOrder)
             .Skip(query.Skip)
             .Take(query.Take)
             .ToList();

--- a/GenHub/GenHub/Features/Content/Services/GitHub/GitHubResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/GitHub/GitHubResolver.cs
@@ -186,6 +186,11 @@ public partial class GitHubResolver(
             }
 
             var builtManifest = manifest.Build();
+            if (!string.IsNullOrEmpty(release.TagName))
+            {
+                builtManifest.Version = release.TagName;
+            }
+
             logger.LogInformation("GitHubResolver: Built manifest with ID: {ManifestId}", builtManifest.Id);
             return OperationResult<ContentManifest>.CreateSuccess(builtManifest);
         }
@@ -373,6 +378,11 @@ public partial class GitHubResolver(
             logger.LogInformation("Successfully resolved single release asset: {AssetName}", asset.Name);
 
             var builtManifest = manifest.Build();
+            if (!string.IsNullOrEmpty(tag))
+            {
+                builtManifest.Version = tag;
+            }
+
             logger.LogInformation("GitHubResolver (Single Asset): Built manifest with ID: {ManifestId}", builtManifest.Id);
             return OperationResult<ContentManifest>.CreateSuccess(builtManifest);
         }

--- a/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
-using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using Microsoft.Extensions.Logging;
 
@@ -28,27 +28,30 @@ public class PublisherManifestFactoryResolver(IEnumerable<IPublisherManifestFact
                 "Resolved {FactoryType} for manifest {ManifestId} (Publisher: {Publisher})",
                 factory.GetType().Name,
                 manifest.Id,
-                manifest.Publisher?.PublisherType ?? GameClientConstants.UnknownVersion);
+                manifest.Publisher?.PublisherType ?? "unknown");
             return factory;
         }
 
-        // Fallback to generic GitHub manifest factory for non-GameClient publisher content or generic releases
-        var fallbackFactory = factories.OfType<GitHubManifestFactory>().FirstOrDefault();
-        if (fallbackFactory != null)
+        // Fallback to generic GitHub manifest factory for non-GameClient publisher content (e.g., patches, mods)
+        if (manifest.ContentType != ContentType.GameClient)
         {
-            logger.LogInformation(
-                "Resolved fallback {FactoryType} for manifest {ManifestId} (Publisher: {Publisher}, ContentType: {ContentType})",
-                fallbackFactory.GetType().Name,
-                manifest.Id,
-                manifest.Publisher?.PublisherType ?? GameClientConstants.UnknownVersion,
-                manifest.ContentType);
-            return fallbackFactory;
+            var fallbackFactory = factories.OfType<GitHubManifestFactory>().FirstOrDefault();
+            if (fallbackFactory != null)
+            {
+                logger.LogInformation(
+                    "Resolved fallback {FactoryType} for manifest {ManifestId} (Publisher: {Publisher}, ContentType: {ContentType})",
+                    fallbackFactory.GetType().Name,
+                    manifest.Id,
+                    manifest.Publisher?.PublisherType ?? "unknown",
+                    manifest.ContentType);
+                return fallbackFactory;
+            }
         }
 
         logger.LogWarning(
             "No factory found for manifest {ManifestId} (Publisher: {Publisher}, ContentType: {ContentType})",
             manifest.Id,
-            manifest.Publisher?.PublisherType ?? GameClientConstants.UnknownVersion,
+            manifest.Publisher?.PublisherType ?? "unknown",
             manifest.ContentType);
 
         return null;

--- a/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/PublisherManifestFactoryResolver.cs
@@ -32,6 +32,19 @@ public class PublisherManifestFactoryResolver(IEnumerable<IPublisherManifestFact
             return factory;
         }
 
+        // Fallback to generic GitHub manifest factory for non-GameClient publisher content or generic releases
+        var fallbackFactory = factories.OfType<GitHubManifestFactory>().FirstOrDefault();
+        if (fallbackFactory != null)
+        {
+            logger.LogInformation(
+                "Resolved fallback {FactoryType} for manifest {ManifestId} (Publisher: {Publisher}, ContentType: {ContentType})",
+                fallbackFactory.GetType().Name,
+                manifest.Id,
+                manifest.Publisher?.PublisherType ?? GameClientConstants.UnknownVersion,
+                manifest.ContentType);
+            return fallbackFactory;
+        }
+
         logger.LogWarning(
             "No factory found for manifest {ManifestId} (Publisher: {Publisher}, ContentType: {ContentType})",
             manifest.Id,

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -116,7 +116,7 @@ public class SuperHackersProvider(
                         var result = new ContentSearchResult
                         {
                             Id = manifestId,
-                            Name = latestRelease.Name ?? $"{displayName} {latestRelease.TagName}",
+                            Name = !string.IsNullOrWhiteSpace(latestRelease.Name) ? latestRelease.Name : $"{displayName} {latestRelease.TagName}",
                             Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
                             Version = latestRelease.TagName ?? "latest",
                             AuthorName = owner,

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -73,51 +73,58 @@ public class SuperHackersProvider(
         {
             var results = new List<ContentSearchResult>();
 
-            // Directly fetch latest release from TheSuperHackers/GeneralsGameCode
-            var latestRelease = await gitHubApiClient.GetLatestReleaseAsync(
-                SuperHackersConstants.GeneralsGameCodeOwner,
-                SuperHackersConstants.GeneralsGameCodeRepo,
-                cancellationToken);
-
-            if (latestRelease != null &&
-                (string.IsNullOrWhiteSpace(query.AuthorName) ||
-                 query.AuthorName.Equals(SuperHackersConstants.GeneralsGameCodeOwner, StringComparison.OrdinalIgnoreCase)) &&
-                (string.IsNullOrWhiteSpace(query.SearchTerm) ||
-                 latestRelease.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
-                 SuperHackersConstants.GeneralsGameCodeRepo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
+            var targets = new (string Owner, string Repo, ContentType ContentType, GameType TargetGame)[]
             {
-                // Generate manifest ID
-                var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
-                    SuperHackersConstants.GeneralsGameCodeOwner,
-                    SuperHackersConstants.GeneralsGameCodeRepo,
-                    ContentType.GameClient,
-                    latestRelease.TagName);
+                (SuperHackersConstants.GeneralsGameCodeOwner, SuperHackersConstants.GeneralsGameCodeRepo, ContentType.GameClient, GameType.Generals),
+                (SuperHackersConstants.GeneralsGamePatch2Owner, SuperHackersConstants.GeneralsGamePatch2Repo, ContentType.Patch, GameType.ZeroHour),
+            };
 
-                var result = new ContentSearchResult
+            foreach (var (owner, repo, contentType, targetGame) in targets)
+            {
+                var latestRelease = await gitHubApiClient.GetLatestReleaseAsync(
+                    owner,
+                    repo,
+                    cancellationToken);
+
+                if (latestRelease != null &&
+                    (string.IsNullOrWhiteSpace(query.AuthorName) ||
+                     query.AuthorName.Equals(owner, StringComparison.OrdinalIgnoreCase)) &&
+                    (string.IsNullOrWhiteSpace(query.SearchTerm) ||
+                     latestRelease.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
+                     repo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
                 {
-                    Id = manifestId,
-                    Name = latestRelease.Name ?? $"{SuperHackersConstants.PublisherName} {latestRelease.TagName}",
-                    Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
-                    Version = latestRelease.TagName ?? "latest",
-                    AuthorName = SuperHackersConstants.GeneralsGameCodeOwner,
-                    ContentType = ContentType.GameClient,
-                    TargetGame = GameType.Generals, // Simplification, could infer
-                    IsInferred = false,
-                    ProviderName = SourceName,
-                    RequiresResolution = true,
-                    ResolverId = SuperHackersConstants.ResolverId,
-                    SourceUrl = latestRelease.HtmlUrl,
-                    LastUpdated = latestRelease.PublishedAt?.DateTime ?? latestRelease.CreatedAt.DateTime,
-                    ResolverMetadata =
-                    {
-                        [GitHubConstants.OwnerMetadataKey] = SuperHackersConstants.GeneralsGameCodeOwner,
-                        [GitHubConstants.RepoMetadataKey] = SuperHackersConstants.GeneralsGameCodeRepo,
-                        [GitHubConstants.TagMetadataKey] = latestRelease.TagName ?? "latest",
-                    },
-                };
+                    var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
+                        owner,
+                        repo,
+                        contentType,
+                        latestRelease.TagName);
 
-                result.SetData(latestRelease);
-                results.Add(result);
+                    var result = new ContentSearchResult
+                    {
+                        Id = manifestId,
+                        Name = latestRelease.Name ?? $"{SuperHackersConstants.PublisherName} {latestRelease.TagName}",
+                        Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
+                        Version = latestRelease.TagName ?? "latest",
+                        AuthorName = owner,
+                        ContentType = contentType,
+                        TargetGame = targetGame,
+                        IsInferred = false,
+                        ProviderName = SourceName,
+                        RequiresResolution = true,
+                        ResolverId = SuperHackersConstants.ResolverId,
+                        SourceUrl = latestRelease.HtmlUrl,
+                        LastUpdated = latestRelease.PublishedAt?.DateTime ?? latestRelease.CreatedAt.DateTime,
+                        ResolverMetadata =
+                        {
+                            [GitHubConstants.OwnerMetadataKey] = owner,
+                            [GitHubConstants.RepoMetadataKey] = repo,
+                            [GitHubConstants.TagMetadataKey] = latestRelease.TagName ?? "latest",
+                        },
+                    };
+
+                    result.SetData(latestRelease);
+                    results.Add(result);
+                }
             }
 
             return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(results);

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -75,19 +75,19 @@ public class SuperHackersProvider(
             var results = new List<ContentSearchResult>();
             var errors = new List<string>();
 
-            var targets = new (string Owner, string Repo, ContentType ContentType, GameType TargetGame)[]
+            var targets = new (string Owner, string Repo, ContentType ContentType, GameType? TargetGame, string DisplayName)[]
             {
-                (SuperHackersConstants.GeneralsGameCodeOwner, SuperHackersConstants.GeneralsGameCodeRepo, ContentType.GameClient, GameType.Generals),
-                (SuperHackersConstants.GeneralsGamePatch2Owner, SuperHackersConstants.GeneralsGamePatch2Repo, ContentType.Patch, GameType.ZeroHour),
+                (SuperHackersConstants.GeneralsGameCodeOwner, SuperHackersConstants.GeneralsGameCodeRepo, ContentType.GameClient, GameType.Generals, SuperHackersConstants.PublisherName),
+                (SuperHackersConstants.GeneralsGamePatch2Owner, SuperHackersConstants.GeneralsGamePatch2Repo, ContentType.Patch, null, SuperHackersConstants.GeneralsGamePatch2DisplayName),
             };
 
             var matchingTargets = targets.Where(t =>
                 (!query.ContentType.HasValue || query.ContentType.Value == t.ContentType) &&
-                (!query.TargetGame.HasValue || query.TargetGame.Value == t.TargetGame) &&
+                (!query.TargetGame.HasValue || t.TargetGame == null || query.TargetGame.Value == t.TargetGame.Value) &&
                 (string.IsNullOrWhiteSpace(query.AuthorName) || query.AuthorName.Equals(t.Owner, StringComparison.OrdinalIgnoreCase)) &&
                 (string.IsNullOrWhiteSpace(query.GitHubAuthor) || query.GitHubAuthor.Equals(t.Owner, StringComparison.OrdinalIgnoreCase))).ToList();
 
-            foreach (var (owner, repo, contentType, targetGame) in matchingTargets)
+            foreach (var (owner, repo, contentType, targetGame, displayName) in matchingTargets)
             {
                 try
                 {
@@ -101,7 +101,9 @@ public class SuperHackersProvider(
                     if (latestRelease != null &&
                         (string.IsNullOrWhiteSpace(query.SearchTerm) ||
                          latestRelease.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
-                         repo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
+                         repo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) ||
+                         displayName.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) ||
+                         latestRelease.Body?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true))
                     {
                         var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
                             owner,
@@ -109,15 +111,17 @@ public class SuperHackersProvider(
                             contentType,
                             latestRelease.TagName);
 
+                        var resolvedTargetGame = targetGame ?? query.TargetGame ?? GameType.Unknown;
+
                         var result = new ContentSearchResult
                         {
                             Id = manifestId,
-                            Name = latestRelease.Name ?? $"{SuperHackersConstants.PublisherName} {latestRelease.TagName}",
+                            Name = latestRelease.Name ?? $"{displayName} {latestRelease.TagName}",
                             Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
                             Version = latestRelease.TagName ?? "latest",
                             AuthorName = owner,
                             ContentType = contentType,
-                            TargetGame = targetGame,
+                            TargetGame = resolvedTargetGame,
                             IsInferred = false,
                             ProviderName = SourceName,
                             RequiresResolution = true,
@@ -147,7 +151,7 @@ public class SuperHackersProvider(
                 }
             }
 
-            if (results.Count == 0 && errors.Count > 0 && errors.Count == matchingTargets.Count)
+            if (results.Count == 0 && errors.Count > 0)
             {
                 return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure(
                     $"Search failed for SuperHackers targets: {string.Join("; ", errors)}");

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -71,7 +71,9 @@ public class SuperHackersProvider(
     {
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var results = new List<ContentSearchResult>();
+            var errors = new List<string>();
 
             var targets = new (string Owner, string Repo, ContentType ContentType, GameType TargetGame)[]
             {
@@ -79,55 +81,83 @@ public class SuperHackersProvider(
                 (SuperHackersConstants.GeneralsGamePatch2Owner, SuperHackersConstants.GeneralsGamePatch2Repo, ContentType.Patch, GameType.ZeroHour),
             };
 
-            foreach (var (owner, repo, contentType, targetGame) in targets)
-            {
-                var latestRelease = await gitHubApiClient.GetLatestReleaseAsync(
-                    owner,
-                    repo,
-                    cancellationToken);
+            var matchingTargets = targets.Where(t =>
+                (!query.ContentType.HasValue || query.ContentType.Value == t.ContentType) &&
+                (!query.TargetGame.HasValue || query.TargetGame.Value == t.TargetGame) &&
+                (string.IsNullOrWhiteSpace(query.AuthorName) || query.AuthorName.Equals(t.Owner, StringComparison.OrdinalIgnoreCase)) &&
+                (string.IsNullOrWhiteSpace(query.GitHubAuthor) || query.GitHubAuthor.Equals(t.Owner, StringComparison.OrdinalIgnoreCase))).ToList();
 
-                if (latestRelease != null &&
-                    (string.IsNullOrWhiteSpace(query.AuthorName) ||
-                     query.AuthorName.Equals(owner, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrWhiteSpace(query.SearchTerm) ||
-                     latestRelease.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
-                     repo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
+            foreach (var (owner, repo, contentType, targetGame) in matchingTargets)
+            {
+                try
                 {
-                    var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var latestRelease = await gitHubApiClient.GetLatestReleaseAsync(
                         owner,
                         repo,
-                        contentType,
-                        latestRelease.TagName);
+                        cancellationToken);
 
-                    var result = new ContentSearchResult
+                    if (latestRelease != null &&
+                        (string.IsNullOrWhiteSpace(query.SearchTerm) ||
+                         latestRelease.Name?.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase) == true ||
+                         repo.Contains(query.SearchTerm, StringComparison.OrdinalIgnoreCase)))
                     {
-                        Id = manifestId,
-                        Name = latestRelease.Name ?? $"{SuperHackersConstants.PublisherName} {latestRelease.TagName}",
-                        Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
-                        Version = latestRelease.TagName ?? "latest",
-                        AuthorName = owner,
-                        ContentType = contentType,
-                        TargetGame = targetGame,
-                        IsInferred = false,
-                        ProviderName = SourceName,
-                        RequiresResolution = true,
-                        ResolverId = SuperHackersConstants.ResolverId,
-                        SourceUrl = latestRelease.HtmlUrl,
-                        LastUpdated = latestRelease.PublishedAt?.DateTime ?? latestRelease.CreatedAt.DateTime,
-                        ResolverMetadata =
-                        {
-                            [GitHubConstants.OwnerMetadataKey] = owner,
-                            [GitHubConstants.RepoMetadataKey] = repo,
-                            [GitHubConstants.TagMetadataKey] = latestRelease.TagName ?? "latest",
-                        },
-                    };
+                        var manifestId = ManifestIdGenerator.GenerateGitHubContentId(
+                            owner,
+                            repo,
+                            contentType,
+                            latestRelease.TagName);
 
-                    result.SetData(latestRelease);
-                    results.Add(result);
+                        var result = new ContentSearchResult
+                        {
+                            Id = manifestId,
+                            Name = latestRelease.Name ?? $"{SuperHackersConstants.PublisherName} {latestRelease.TagName}",
+                            Description = latestRelease.Body ?? "SuperHackers release - details available after resolution",
+                            Version = latestRelease.TagName ?? "latest",
+                            AuthorName = owner,
+                            ContentType = contentType,
+                            TargetGame = targetGame,
+                            IsInferred = false,
+                            ProviderName = SourceName,
+                            RequiresResolution = true,
+                            ResolverId = SuperHackersConstants.ResolverId,
+                            SourceUrl = latestRelease.HtmlUrl,
+                            LastUpdated = latestRelease.PublishedAt?.DateTime ?? latestRelease.CreatedAt.DateTime,
+                            ResolverMetadata =
+                            {
+                                [GitHubConstants.OwnerMetadataKey] = owner,
+                                [GitHubConstants.RepoMetadataKey] = repo,
+                                [GitHubConstants.TagMetadataKey] = latestRelease.TagName ?? "latest",
+                            },
+                        };
+
+                        result.SetData(latestRelease);
+                        results.Add(result);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(ex, "Failed to fetch SuperHackers release for {Owner}/{Repo}", owner, repo);
+                    errors.Add($"{owner}/{repo}: {ex.Message}");
                 }
             }
 
+            if (results.Count == 0 && errors.Count > 0 && errors.Count == matchingTargets.Count)
+            {
+                return OperationResult<IEnumerable<ContentSearchResult>>.CreateFailure(
+                    $"Search failed for SuperHackers targets: {string.Join("; ", errors)}");
+            }
+
             return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(results);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
Adds `TheSuperHackers/GeneralsGamePatch2` repository to `SuperHackersProvider` and default GitHub discovery configurations as a GamePatch download option.

### Motivation
TheSuperHackers maintains Community Patch 2.0 at https://github.com/TheSuperHackers/GeneralsGamePatch2 to fix and improve Generals and Zero Hour. This PR adds support for discovering and acquiring `GeneralsGamePatch2` releases under the `thesuperhackers` provider alongside the weekly `GeneralsGameCode` game client releases.

### Changes
- **GenHub.Core**: Added `GeneralsGamePatch2Owner`, `GeneralsGamePatch2Repo`, and `GeneralsGamePatch2DisplayName` constants to `SuperHackersConstants`.
- **GenHub**: Updated `ConfigurationProviderService` to include `TheSuperHackers/GeneralsGamePatch2` in default GitHub discovery repositories.
- **GenHub**: Updated `SuperHackersProvider.SearchAsync` to query and return `GeneralsGamePatch2` releases with `ContentType.Patch`.
- **Tests**: Added `SuperHackersProviderTests` verifying multi-repository discovery and updated `ConfigurationProviderServiceTests`.

### Verification
- [x] Targeted unit test suite executed and passing (`SuperHackersProviderTests` and `ConfigurationProviderServiceTests`)
- [x] Solution builds cleanly with 0 errors and 0 warnings on modified files