### PR TITLE
feat(content): implement manifest installation instructions execution and GeneralsOnline EAC registration

### DIFF
--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -153,4 +153,7 @@ public static class GeneralsOnlineConstants
 
     /// <summary>Status message displayed to the user during Easy Anti-Cheat installation.</summary>
     public const string EacStatusMessage = "Installing AntiCheat";
+
+    /// <summary>Unique step key identifying Easy Anti-Cheat installation for Generals Online.</summary>
+    public const string EacStepKey = "generalsonline:eac:fc1cc0d936424212b645105f084d08b0";
 }

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -140,7 +140,7 @@ public static class GeneralsOnlineConstants
     public const string EacStatusMessage = "Installing AntiCheat";
 
     /// <summary>Unique step key identifying Easy Anti-Cheat installation for Generals Online.</summary>
-    public const string EacStepKey = "generalsonline:eac:fc1cc0d936424212b645105f084d08b0";
+    public const string EacStepKey = PublisherType + ":eac:" + EacProductId;
 
     // ===== Content Tags =====
 

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -125,21 +125,6 @@ public static class GeneralsOnlineConstants
     /// <summary>Description for Generals Online deliverer.</summary>
     public const string DelivererDescription = "Delivers Generals Online content via ZIP extraction and CAS storage";
 
-    // ===== Content Tags =====
-
-    /// <summary>Content tags for search and categorization.</summary>
-    public static readonly string[] Tags = ["multiplayer", "online", "community", "enhancement"];
-
-    /// <summary>
-    /// Default tags for MapPack manifests.
-    /// </summary>
-    public static readonly string[] MapPackTags = ["mappack", "generalsonline", "quickmatch", "competitive"];
-
-    /// <summary>
-    /// Default tags for GameData patch manifests.
-    /// </summary>
-    public static readonly string[] GameDataTags = ["patch", "generalsonline"];
-
     // ===== Easy Anti-Cheat Installation =====
 
     /// <summary>Product ID registered with Epic Online Services Easy Anti-Cheat for Generals Online.</summary>
@@ -156,4 +141,19 @@ public static class GeneralsOnlineConstants
 
     /// <summary>Unique step key identifying Easy Anti-Cheat installation for Generals Online.</summary>
     public const string EacStepKey = "generalsonline:eac:fc1cc0d936424212b645105f084d08b0";
+
+    // ===== Content Tags =====
+
+    /// <summary>Content tags for search and categorization.</summary>
+    public static readonly string[] Tags = ["multiplayer", "online", "community", "enhancement"];
+
+    /// <summary>
+    /// Default tags for MapPack manifests.
+    /// </summary>
+    public static readonly string[] MapPackTags = ["mappack", "generalsonline", "quickmatch", "competitive"];
+
+    /// <summary>
+    /// Default tags for GameData patch manifests.
+    /// </summary>
+    public static readonly string[] GameDataTags = ["patch", "generalsonline"];
 }

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -139,4 +139,18 @@ public static class GeneralsOnlineConstants
     /// Default tags for GameData patch manifests.
     /// </summary>
     public static readonly string[] GameDataTags = ["patch", "generalsonline"];
+
+    // ===== Easy Anti-Cheat Installation =====
+
+    /// <summary>Product ID registered with Epic Online Services Easy Anti-Cheat for Generals Online.</summary>
+    public const string EacProductId = "fc1cc0d936424212b645105f084d08b0";
+
+    /// <summary>Setup command passed to EasyAntiCheat_EOS_Setup.exe.</summary>
+    public const string EacInstallCommand = "install";
+
+    /// <summary>Display name for the Easy Anti-Cheat installation step.</summary>
+    public const string EacStepName = "Install Easy Anti-Cheat";
+
+    /// <summary>Status message displayed to the user during Easy Anti-Cheat installation.</summary>
+    public const string EacStatusMessage = "Installing AntiCheat";
 }

--- a/GenHub/GenHub.Core/Constants/PublisherTypeConstants.cs
+++ b/GenHub/GenHub.Core/Constants/PublisherTypeConstants.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using GenHub.Core.Extensions.GameInstallations;
 using GenHub.Core.Models.Enums;
 
@@ -58,6 +60,20 @@ public static class PublisherTypeConstants
 
     /// <summary>Art of Defense Maps community site.</summary>
     public const string AODMaps = "aodmaps";
+
+    /// <summary>GenHub internal system content publisher.</summary>
+    public const string GenHubInternal = "genhub";
+
+    /// <summary>
+    /// Set of publisher identifiers trusted to execute installation steps (e.g. installers).
+    /// </summary>
+    public static readonly IReadOnlySet<string> TrustedExecutablePublishers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        GeneralsOnline,
+        CommunityOutpost,
+        TheSuperHackers,
+        GenHubInternal,
+    };
 
     /// <summary>
     /// Maps GameInstallationType enum to publisher type string.

--- a/GenHub/GenHub.Core/Constants/PublisherTypeConstants.cs
+++ b/GenHub/GenHub.Core/Constants/PublisherTypeConstants.cs
@@ -72,7 +72,6 @@ public static class PublisherTypeConstants
         GeneralsOnline,
         CommunityOutpost,
         TheSuperHackers,
-        GenHubInternal,
     };
 
     /// <summary>

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -87,11 +87,37 @@ public static class PathHelper
                 fullContainer += Path.DirectorySeparatorChar;
             }
 
-            return fullCandidate.StartsWith(fullContainer, PathComparison) ||
+            var isContained = fullCandidate.StartsWith(fullContainer, PathComparison) ||
                    string.Equals(
                        fullCandidate.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
                        fullContainer.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
                        PathComparison);
+
+            if (!isContained)
+            {
+                return false;
+            }
+
+            if (File.Exists(fullCandidate))
+            {
+                var fileInfo = new FileInfo(fullCandidate);
+                var target = fileInfo.ResolveLinkTarget(returnFinalTarget: true);
+                if (target != null)
+                {
+                    return IsPathContainedIn(target.FullName, fullContainer);
+                }
+            }
+            else if (Directory.Exists(fullCandidate))
+            {
+                var dirInfo = new DirectoryInfo(fullCandidate);
+                var target = dirInfo.ResolveLinkTarget(returnFinalTarget: true);
+                if (target != null)
+                {
+                    return IsPathContainedIn(target.FullName, fullContainer);
+                }
+            }
+
+            return true;
         }
         catch
         {

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -64,6 +64,42 @@ public static class PathHelper
     }
 
     /// <summary>
+    /// Determines whether the candidate path is contained within the specified container directory.
+    /// Prevents directory traversal and sibling prefix false positives.
+    /// </summary>
+    /// <param name="candidatePath">The candidate file or directory path to check.</param>
+    /// <param name="containerDirectory">The directory that must contain the candidate path.</param>
+    /// <returns><see langword="true"/> if candidatePath resolves inside containerDirectory; otherwise, <see langword="false"/>.</returns>
+    public static bool IsPathContainedIn(string candidatePath, string containerDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(candidatePath) || string.IsNullOrWhiteSpace(containerDirectory))
+        {
+            return false;
+        }
+
+        try
+        {
+            var fullCandidate = Path.GetFullPath(candidatePath);
+            var fullContainer = Path.GetFullPath(containerDirectory);
+
+            if (!fullContainer.EndsWith(Path.DirectorySeparatorChar) && !fullContainer.EndsWith(Path.AltDirectorySeparatorChar))
+            {
+                fullContainer += Path.DirectorySeparatorChar;
+            }
+
+            return fullCandidate.StartsWith(fullContainer, PathComparison) ||
+                   string.Equals(
+                       fullCandidate.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                       fullContainer.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                       PathComparison);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Determines whether a candidate path resolves to a location inside a base directory.
     /// Both paths are fully normalized first, so <c>..</c> segments, redundant separators and
     /// rooted candidates cannot escape the base directory. Because normalization is textual and a
@@ -81,6 +117,24 @@ public static class PathHelper
 
         return IsContained(normalizedRoot, normalizedTarget) &&
                IsContained(FollowLinks(normalizedRoot), FollowLinks(normalizedTarget));
+    }
+
+    /// <summary>
+    /// Normalizes a relative path by standardizing directory separators and removing leading separators.
+    /// </summary>
+    /// <param name="relativePath">The relative path to normalize.</param>
+    /// <returns>The normalized relative path.</returns>
+    public static string NormalizeRelativePath(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            return string.Empty;
+        }
+
+        return relativePath
+            .Replace('\\', '/')
+            .TrimStart('/')
+            .Replace('/', Path.DirectorySeparatorChar);
     }
 
     private static bool IsContained(string normalizedRoot, string normalizedTarget)

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -123,8 +123,13 @@ public static class PathHelper
                !Path.IsPathRooted(relative);
     }
 
-    private static string FollowLinks(string fullPath)
+    private static string FollowLinks(string fullPath, int maxDepth = 32)
     {
+        if (maxDepth <= 0)
+        {
+            return fullPath;
+        }
+
         try
         {
             var normalized = Path.GetFullPath(fullPath);
@@ -158,7 +163,7 @@ public static class PathHelper
                     var target = info.ResolveLinkTarget(returnFinalTarget: true);
                     if (target != null)
                     {
-                        current = target.FullName;
+                        current = FollowLinks(target.FullName, maxDepth - 1);
                     }
                 }
             }

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -96,26 +96,6 @@ public static class PathHelper
     }
 
     /// <summary>
-    /// Determines whether a candidate path resolves to a location inside a base directory.
-    /// Both paths are fully normalized first, so <c>..</c> segments, redundant separators and
-    /// rooted candidates cannot escape the base directory. Because normalization is textual and a
-    /// symbolic link or junction redirects a path that reads as contained, both sides are also
-    /// compared after their links are followed; a path that cannot be resolved — because it does
-    /// not exist yet, or the filesystem refuses the query — is compared as written.
-    /// </summary>
-    /// <param name="baseDirectory">The directory that must contain the candidate path.</param>
-    /// <param name="candidatePath">The path to test for containment.</param>
-    /// <returns><see langword="true"/> when the candidate resolves inside the base directory; otherwise, <see langword="false"/>.</returns>
-    public static bool IsPathWithinDirectory(string baseDirectory, string candidatePath)
-    {
-        var normalizedRoot = Path.GetFullPath(baseDirectory);
-        var normalizedTarget = Path.GetFullPath(candidatePath);
-
-        return IsContained(normalizedRoot, normalizedTarget) &&
-               IsContained(FollowLinks(normalizedRoot), FollowLinks(normalizedTarget));
-    }
-
-    /// <summary>
     /// Normalizes a relative path by standardizing directory separators and removing leading separators.
     /// </summary>
     /// <param name="relativePath">The relative path to normalize.</param>

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -64,60 +64,30 @@ public static class PathHelper
     }
 
     /// <summary>
-    /// Determines whether the candidate path is contained within the specified container directory.
-    /// Prevents directory traversal and sibling prefix false positives.
+    /// Determines whether a candidate path resolves to a location inside a base directory.
+    /// Both paths are fully normalized first, so <c>..</c> segments, redundant separators and
+    /// rooted candidates cannot escape the base directory. Because normalization is textual and a
+    /// symbolic link or junction redirects a path that reads as contained, both sides are also
+    /// compared after their links are followed; a path that cannot be resolved — because it does
+    /// not exist yet, or the filesystem refuses the query — is compared as written.
     /// </summary>
-    /// <param name="candidatePath">The candidate file or directory path to check.</param>
-    /// <param name="containerDirectory">The directory that must contain the candidate path.</param>
-    /// <returns><see langword="true"/> if candidatePath resolves inside containerDirectory; otherwise, <see langword="false"/>.</returns>
-    public static bool IsPathContainedIn(string candidatePath, string containerDirectory)
+    /// <param name="baseDirectory">The directory that must contain the candidate path.</param>
+    /// <param name="candidatePath">The path to test for containment.</param>
+    /// <returns><see langword="true"/> when the candidate resolves inside the base directory; otherwise, <see langword="false"/>.</returns>
+    public static bool IsPathWithinDirectory(string baseDirectory, string candidatePath)
     {
-        if (string.IsNullOrWhiteSpace(candidatePath) || string.IsNullOrWhiteSpace(containerDirectory))
+        if (string.IsNullOrWhiteSpace(baseDirectory) || string.IsNullOrWhiteSpace(candidatePath))
         {
             return false;
         }
 
         try
         {
-            var fullCandidate = Path.GetFullPath(candidatePath);
-            var fullContainer = Path.GetFullPath(containerDirectory);
+            var normalizedRoot = Path.GetFullPath(baseDirectory);
+            var normalizedTarget = Path.GetFullPath(candidatePath);
 
-            if (!fullContainer.EndsWith(Path.DirectorySeparatorChar) && !fullContainer.EndsWith(Path.AltDirectorySeparatorChar))
-            {
-                fullContainer += Path.DirectorySeparatorChar;
-            }
-
-            var isContained = fullCandidate.StartsWith(fullContainer, PathComparison) ||
-                   string.Equals(
-                       fullCandidate.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
-                       fullContainer.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
-                       PathComparison);
-
-            if (!isContained)
-            {
-                return false;
-            }
-
-            if (File.Exists(fullCandidate))
-            {
-                var fileInfo = new FileInfo(fullCandidate);
-                var target = fileInfo.ResolveLinkTarget(returnFinalTarget: true);
-                if (target != null)
-                {
-                    return IsPathContainedIn(target.FullName, fullContainer);
-                }
-            }
-            else if (Directory.Exists(fullCandidate))
-            {
-                var dirInfo = new DirectoryInfo(fullCandidate);
-                var target = dirInfo.ResolveLinkTarget(returnFinalTarget: true);
-                if (target != null)
-                {
-                    return IsPathContainedIn(target.FullName, fullContainer);
-                }
-            }
-
-            return true;
+            return IsContained(normalizedRoot, normalizedTarget) &&
+                   IsContained(FollowLinks(normalizedRoot), FollowLinks(normalizedTarget));
         }
         catch
         {

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -43,7 +43,23 @@ public static class PathHelper
                 Path.TrimEndingDirectorySeparator(Path.GetFullPath(second)),
                 PathComparison);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+        catch (IOException)
+        {
+            return string.Equals(first, second, PathComparison);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return string.Equals(first, second, PathComparison);
+        }
+        catch (SecurityException)
+        {
+            return string.Equals(first, second, PathComparison);
+        }
+        catch (NotSupportedException)
+        {
+            return string.Equals(first, second, PathComparison);
+        }
+        catch (ArgumentException)
         {
             return string.Equals(first, second, PathComparison);
         }
@@ -170,7 +186,23 @@ public static class PathHelper
 
             return Path.GetFullPath(current);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or ArgumentException or SecurityException)
+        catch (IOException)
+        {
+            return fullPath;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return fullPath;
+        }
+        catch (SecurityException)
+        {
+            return fullPath;
+        }
+        catch (NotSupportedException)
+        {
+            return fullPath;
+        }
+        catch (ArgumentException)
         {
             return fullPath;
         }

--- a/GenHub/GenHub.Core/Helpers/PathHelper.cs
+++ b/GenHub/GenHub.Core/Helpers/PathHelper.cs
@@ -127,41 +127,45 @@ public static class PathHelper
     {
         try
         {
-            var existing = fullPath;
-            var remainder = string.Empty;
-
-            while (!Directory.Exists(existing) && !File.Exists(existing))
+            var normalized = Path.GetFullPath(fullPath);
+            var root = Path.GetPathRoot(normalized);
+            if (string.IsNullOrEmpty(root))
             {
-                var parent = Path.GetDirectoryName(existing);
-                if (string.IsNullOrEmpty(parent))
-                {
-                    return fullPath;
-                }
-
-                remainder = Path.Combine(Path.GetFileName(existing), remainder);
-                existing = parent;
+                return normalized;
             }
 
-            FileSystemInfo info = Directory.Exists(existing)
-                ? new DirectoryInfo(existing)
-                : new FileInfo(existing);
-            var resolved = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? existing;
+            var relativeFromRoot = Path.GetRelativePath(root, normalized);
+            if (relativeFromRoot == "." || relativeFromRoot.Length == 0)
+            {
+                return root;
+            }
 
-            return remainder.Length == 0 ? resolved : Path.GetFullPath(Path.Combine(resolved, remainder));
+            var segments = relativeFromRoot.Split(
+                [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                StringSplitOptions.RemoveEmptyEntries);
+
+            var current = root;
+            foreach (var segment in segments)
+            {
+                current = Path.Combine(current, segment);
+
+                if (Directory.Exists(current) || File.Exists(current))
+                {
+                    FileSystemInfo info = Directory.Exists(current)
+                        ? new DirectoryInfo(current)
+                        : new FileInfo(current);
+
+                    var target = info.ResolveLinkTarget(returnFinalTarget: true);
+                    if (target != null)
+                    {
+                        current = target.FullName;
+                    }
+                }
+            }
+
+            return Path.GetFullPath(current);
         }
-        catch (IOException)
-        {
-            return fullPath;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return fullPath;
-        }
-        catch (NotSupportedException)
-        {
-            return fullPath;
-        }
-        catch (ArgumentException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or ArgumentException or SecurityException)
         {
             return fullPath;
         }

--- a/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
@@ -13,46 +13,18 @@ namespace GenHub.Core.Interfaces.Content;
 public interface IInstallationInstructionsService
 {
     /// <summary>
-    /// Executes pre-installation steps for the specified manifest.
-    /// </summary>
-    /// <param name="manifest">The content manifest declaring pre-installation steps.</param>
-    /// <param name="workingDirectory">The working directory containing the content files.</param>
-    /// <param name="progress">Optional progress reporter for acquisition status.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A result indicating whether all pre-installation steps succeeded.</returns>
-    Task<OperationResult> ExecutePreInstallStepsAsync(
-        ContentManifest manifest,
-        string workingDirectory,
-        IProgress<ContentAcquisitionProgress>? progress = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Executes pre-installation steps for the specified manifest, optionally forcing run-once steps.
-    /// </summary>
-    /// <param name="manifest">The content manifest declaring pre-installation steps.</param>
-    /// <param name="workingDirectory">The working directory containing the content files.</param>
-    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
-    /// <param name="progress">Optional progress reporter for acquisition status.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A result indicating whether all pre-installation steps succeeded.</returns>
-    Task<OperationResult> ExecutePreInstallStepsAsync(
-        ContentManifest manifest,
-        string workingDirectory,
-        bool force,
-        IProgress<ContentAcquisitionProgress>? progress = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Executes post-installation steps for the specified manifest.
     /// </summary>
     /// <param name="manifest">The content manifest declaring post-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="providerSource">The provider source name supplying the content, used for step authorization.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A result indicating whether all post-installation steps succeeded.</returns>
     Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        string? providerSource = null,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
@@ -61,6 +33,7 @@ public interface IInstallationInstructionsService
     /// </summary>
     /// <param name="manifest">The content manifest declaring post-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="providerSource">The provider source name supplying the content, used for step authorization.</param>
     /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
@@ -68,6 +41,7 @@ public interface IInstallationInstructionsService
     Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        string? providerSource,
         bool force,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default);

--- a/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
@@ -13,22 +13,6 @@ namespace GenHub.Core.Interfaces.Content;
 public interface IInstallationInstructionsService
 {
     /// <summary>
-    /// Executes post-installation steps for the specified manifest.
-    /// </summary>
-    /// <param name="manifest">The content manifest declaring post-installation steps.</param>
-    /// <param name="workingDirectory">The working directory containing the content files.</param>
-    /// <param name="providerSource">The provider source name supplying the content, used for step authorization.</param>
-    /// <param name="progress">Optional progress reporter for acquisition status.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A result indicating whether all post-installation steps succeeded.</returns>
-    Task<OperationResult> ExecutePostInstallStepsAsync(
-        ContentManifest manifest,
-        string workingDirectory,
-        string? providerSource = null,
-        IProgress<ContentAcquisitionProgress>? progress = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Executes post-installation steps for the specified manifest, optionally forcing run-once steps.
     /// </summary>
     /// <param name="manifest">The content manifest declaring post-installation steps.</param>
@@ -41,8 +25,8 @@ public interface IInstallationInstructionsService
     Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
-        string? providerSource,
-        bool force,
+        string? providerSource = null,
+        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
@@ -17,15 +17,15 @@ public interface IInstallationInstructionsService
     /// </summary>
     /// <param name="manifest">The content manifest declaring pre-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
-    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
+    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A result indicating whether all pre-installation steps succeeded.</returns>
     Task<OperationResult> ExecutePreInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
-        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
+        bool force = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -33,14 +33,14 @@ public interface IInstallationInstructionsService
     /// </summary>
     /// <param name="manifest">The content manifest declaring post-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
-    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
+    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A result indicating whether all post-installation steps succeeded.</returns>
     Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
-        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
+        bool force = false,
         CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
@@ -18,14 +18,28 @@ public interface IInstallationInstructionsService
     /// <param name="manifest">The content manifest declaring pre-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
-    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A result indicating whether all pre-installation steps succeeded.</returns>
     Task<OperationResult> ExecutePreInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
         IProgress<ContentAcquisitionProgress>? progress = null,
-        bool force = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes pre-installation steps for the specified manifest, optionally forcing run-once steps.
+    /// </summary>
+    /// <param name="manifest">The content manifest declaring pre-installation steps.</param>
+    /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
+    /// <param name="progress">Optional progress reporter for acquisition status.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating whether all pre-installation steps succeeded.</returns>
+    Task<OperationResult> ExecutePreInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        bool force,
+        IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -34,13 +48,27 @@ public interface IInstallationInstructionsService
     /// <param name="manifest">The content manifest declaring post-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
-    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A result indicating whether all post-installation steps succeeded.</returns>
     Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
         IProgress<ContentAcquisitionProgress>? progress = null,
-        bool force = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes post-installation steps for the specified manifest, optionally forcing run-once steps.
+    /// </summary>
+    /// <param name="manifest">The content manifest declaring post-installation steps.</param>
+    /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
+    /// <param name="progress">Optional progress reporter for acquisition status.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating whether all post-installation steps succeeded.</returns>
+    Task<OperationResult> ExecutePostInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        bool force,
+        IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
@@ -17,12 +17,14 @@ public interface IInstallationInstructionsService
     /// </summary>
     /// <param name="manifest">The content manifest declaring pre-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A result indicating whether all pre-installation steps succeeded.</returns>
     Task<OperationResult> ExecutePreInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
@@ -31,12 +33,14 @@ public interface IInstallationInstructionsService
     /// </summary>
     /// <param name="manifest">The content manifest declaring post-installation steps.</param>
     /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="force">Whether to force execution of steps marked as run-once even if already executed.</param>
     /// <param name="progress">Optional progress reporter for acquisition status.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A result indicating whether all post-installation steps succeeded.</returns>
     Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IInstallationInstructionsService.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Service for validating and executing manifest-declared installation steps.
+/// </summary>
+public interface IInstallationInstructionsService
+{
+    /// <summary>
+    /// Executes pre-installation steps for the specified manifest.
+    /// </summary>
+    /// <param name="manifest">The content manifest declaring pre-installation steps.</param>
+    /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="progress">Optional progress reporter for acquisition status.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating whether all pre-installation steps succeeded.</returns>
+    Task<OperationResult> ExecutePreInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes post-installation steps for the specified manifest.
+    /// </summary>
+    /// <param name="manifest">The content manifest declaring post-installation steps.</param>
+    /// <param name="workingDirectory">The working directory containing the content files.</param>
+    /// <param name="progress">Optional progress reporter for acquisition status.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating whether all post-installation steps succeeded.</returns>
+    Task<OperationResult> ExecutePostInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}

--- a/GenHub/GenHub.Core/Interfaces/Content/IInstallationStepPrecondition.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/IInstallationStepPrecondition.cs
@@ -1,0 +1,27 @@
+using GenHub.Core.Models.Manifest;
+
+namespace GenHub.Core.Interfaces.Content;
+
+/// <summary>
+/// Defines a precondition or environment check for an installation step.
+/// Allows domain-specific probes (e.g. system service or installed anti-cheat detection)
+/// to determine whether a step is already satisfied.
+/// </summary>
+public interface IInstallationStepPrecondition
+{
+    /// <summary>
+    /// Determines whether this precondition can handle the specified installation step.
+    /// </summary>
+    /// <param name="step">The installation step to inspect.</param>
+    /// <param name="manifest">The content manifest declaring the step.</param>
+    /// <returns><see langword="true"/> if this precondition applies to the step; otherwise, <see langword="false"/>.</returns>
+    bool CanHandle(InstallationStep step, ContentManifest manifest);
+
+    /// <summary>
+    /// Determines whether the step's goal is already fulfilled in the local environment.
+    /// </summary>
+    /// <param name="step">The installation step to evaluate.</param>
+    /// <param name="manifest">The content manifest declaring the step.</param>
+    /// <returns><see langword="true"/> if the step is already fulfilled; otherwise, <see langword="false"/>.</returns>
+    bool IsAlreadyFulfilled(InstallationStep step, ContentManifest manifest);
+}

--- a/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
+++ b/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
@@ -207,26 +207,65 @@ public interface IContentManifestBuilder
     IContentManifestBuilder WithInstallationInstructions(WorkspaceStrategy workspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy);
 
     /// <summary>
+    /// Sets the complete installation instructions object for the manifest.
+    /// </summary>
+    /// <param name="installationInstructions">The installation instructions object.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    IContentManifestBuilder WithInstallationInstructions(InstallationInstructions installationInstructions);
+
+    /// <summary>
     /// Adds a pre-installation step.
     /// </summary>
     /// <param name="name">Step name.</param>
-    /// <param name="command">Command to execute.</param>
-    /// <param name="arguments">Command arguments.</param>
-    /// <param name="workingDirectory">Working directory for the command.</param>
+    /// <param name="kind">The kind of installation step to execute.</param>
+    /// <param name="targetRelativePath">Target relative path within workspace.</param>
+    /// <param name="arguments">Command arguments for executable steps.</param>
+    /// <param name="destinationRelativePath">Destination relative path for rename operations.</param>
     /// <param name="requiresElevation">Whether elevation is required.</param>
+    /// <param name="statusMessage">Optional user-facing status message.</param>
     /// <returns>The builder instance for chaining.</returns>
-    IContentManifestBuilder AddPreInstallStep(string name, string command, List<string>? arguments = null, string workingDirectory = "", bool requiresElevation = false);
+    IContentManifestBuilder AddPreInstallStep(
+        string name,
+        InstallationStepKind kind,
+        string? targetRelativePath = null,
+        List<string>? arguments = null,
+        string? destinationRelativePath = null,
+        bool requiresElevation = false,
+        string? statusMessage = null);
+
+    /// <summary>
+    /// Adds a pre-installation step using an existing <see cref="InstallationStep"/> instance.
+    /// </summary>
+    /// <param name="step">The installation step to add.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    IContentManifestBuilder AddPreInstallStep(InstallationStep step);
 
     /// <summary>
     /// Adds a post-installation step.
     /// </summary>
     /// <param name="name">Step name.</param>
-    /// <param name="command">Command to execute.</param>
-    /// <param name="arguments">Command arguments.</param>
-    /// <param name="workingDirectory">Working directory for the command.</param>
+    /// <param name="kind">The kind of installation step to execute.</param>
+    /// <param name="targetRelativePath">Target relative path within workspace.</param>
+    /// <param name="arguments">Command arguments for executable steps.</param>
+    /// <param name="destinationRelativePath">Destination relative path for rename operations.</param>
     /// <param name="requiresElevation">Whether elevation is required.</param>
+    /// <param name="statusMessage">Optional user-facing status message.</param>
     /// <returns>The builder instance for chaining.</returns>
-    IContentManifestBuilder AddPostInstallStep(string name, string command, List<string>? arguments = null, string workingDirectory = "", bool requiresElevation = false);
+    IContentManifestBuilder AddPostInstallStep(
+        string name,
+        InstallationStepKind kind,
+        string? targetRelativePath = null,
+        List<string>? arguments = null,
+        string? destinationRelativePath = null,
+        bool requiresElevation = false,
+        string? statusMessage = null);
+
+    /// <summary>
+    /// Adds a post-installation step using an existing <see cref="InstallationStep"/> instance.
+    /// </summary>
+    /// <param name="step">The installation step to add.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    IContentManifestBuilder AddPostInstallStep(InstallationStep step);
 
     /// <summary>
     /// Adds a content reference for cross-publisher linking.

--- a/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
+++ b/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
@@ -214,37 +214,6 @@ public interface IContentManifestBuilder
     IContentManifestBuilder WithInstallationInstructions(InstallationInstructions installationInstructions);
 
     /// <summary>
-    /// Adds a pre-installation step.
-    /// </summary>
-    /// <param name="name">Step name.</param>
-    /// <param name="kind">The kind of installation step to execute.</param>
-    /// <param name="targetRelativePath">Target relative path within workspace.</param>
-    /// <param name="arguments">Command arguments for executable steps.</param>
-    /// <param name="destinationRelativePath">Destination relative path for rename operations.</param>
-    /// <param name="requiresElevation">Whether elevation is required.</param>
-    /// <param name="statusMessage">Optional user-facing status message.</param>
-    /// <param name="runOnce">Whether to execute only once and skip on future updates.</param>
-    /// <param name="stepKey">Optional unique step key for tracking execution.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IContentManifestBuilder AddPreInstallStep(
-        string name,
-        InstallationStepKind kind,
-        string? targetRelativePath = null,
-        List<string>? arguments = null,
-        string? destinationRelativePath = null,
-        bool requiresElevation = false,
-        string? statusMessage = null,
-        bool runOnce = false,
-        string? stepKey = null);
-
-    /// <summary>
-    /// Adds a pre-installation step using an existing <see cref="InstallationStep"/> instance.
-    /// </summary>
-    /// <param name="step">The installation step to add.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IContentManifestBuilder AddPreInstallStep(InstallationStep step);
-
-    /// <summary>
     /// Adds a post-installation step.
     /// </summary>
     /// <param name="name">Step name.</param>

--- a/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
+++ b/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
@@ -87,6 +87,13 @@ public interface IContentManifestBuilder
     IContentManifestBuilder WithPublisher(string name, string website = "", string supportUrl = "", string contactEmail = "", string publisherType = "");
 
     /// <summary>
+    /// Sets publisher information from an existing <see cref="PublisherInfo"/> instance.
+    /// </summary>
+    /// <param name="publisher">The publisher information.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    IContentManifestBuilder WithPublisher(PublisherInfo publisher);
+
+    /// <summary>
     /// Sets content metadata.
     /// </summary>
     /// <param name="description">Content description.</param>
@@ -259,6 +266,13 @@ public interface IContentManifestBuilder
         ContentType contentType,
         string minVersion = "",
         string maxVersion = "");
+
+    /// <summary>
+    /// Sets content references for cross-publisher linking.
+    /// </summary>
+    /// <param name="contentReferences">The collection of content references.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    IContentManifestBuilder WithContentReferences(IEnumerable<ContentReference> contentReferences);
 
     /// <summary>
     /// Adds a file patching operation to the manifest.

--- a/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
+++ b/GenHub/GenHub.Core/Interfaces/Manifest/IContentManifestBuilder.cs
@@ -223,6 +223,8 @@ public interface IContentManifestBuilder
     /// <param name="destinationRelativePath">Destination relative path for rename operations.</param>
     /// <param name="requiresElevation">Whether elevation is required.</param>
     /// <param name="statusMessage">Optional user-facing status message.</param>
+    /// <param name="runOnce">Whether to execute only once and skip on future updates.</param>
+    /// <param name="stepKey">Optional unique step key for tracking execution.</param>
     /// <returns>The builder instance for chaining.</returns>
     IContentManifestBuilder AddPreInstallStep(
         string name,
@@ -231,7 +233,9 @@ public interface IContentManifestBuilder
         List<string>? arguments = null,
         string? destinationRelativePath = null,
         bool requiresElevation = false,
-        string? statusMessage = null);
+        string? statusMessage = null,
+        bool runOnce = false,
+        string? stepKey = null);
 
     /// <summary>
     /// Adds a pre-installation step using an existing <see cref="InstallationStep"/> instance.
@@ -250,6 +254,8 @@ public interface IContentManifestBuilder
     /// <param name="destinationRelativePath">Destination relative path for rename operations.</param>
     /// <param name="requiresElevation">Whether elevation is required.</param>
     /// <param name="statusMessage">Optional user-facing status message.</param>
+    /// <param name="runOnce">Whether to execute only once and skip on future updates.</param>
+    /// <param name="stepKey">Optional unique step key for tracking execution.</param>
     /// <returns>The builder instance for chaining.</returns>
     IContentManifestBuilder AddPostInstallStep(
         string name,
@@ -258,7 +264,9 @@ public interface IContentManifestBuilder
         List<string>? arguments = null,
         string? destinationRelativePath = null,
         bool requiresElevation = false,
-        string? statusMessage = null);
+        string? statusMessage = null,
+        bool runOnce = false,
+        string? stepKey = null);
 
     /// <summary>
     /// Adds a post-installation step using an existing <see cref="InstallationStep"/> instance.

--- a/GenHub/GenHub.Core/Models/Common/UserSettings.cs
+++ b/GenHub/GenHub.Core/Models/Common/UserSettings.cs
@@ -114,7 +114,7 @@ public class UserSettings
     /// <returns><see langword="true"/> if already executed; otherwise, <see langword="false"/>.</returns>
     public bool IsInstallationStepExecuted(string stepKey)
     {
-        return !string.IsNullOrWhiteSpace(stepKey) && ExecutedInstallationSteps.Contains(stepKey);
+        return !string.IsNullOrWhiteSpace(stepKey) && (ExecutedInstallationSteps?.Contains(stepKey) ?? false);
     }
 
     /// <summary>
@@ -125,6 +125,7 @@ public class UserSettings
     {
         if (!string.IsNullOrWhiteSpace(stepKey))
         {
+            ExecutedInstallationSteps ??= [];
             ExecutedInstallationSteps.Add(stepKey);
         }
     }

--- a/GenHub/GenHub.Core/Models/Common/UserSettings.cs
+++ b/GenHub/GenHub.Core/Models/Common/UserSettings.cs
@@ -95,11 +95,38 @@ public class UserSettings
     /// </summary>
     public CasConfiguration CasConfiguration { get; set; } = new();
 
+    /// <summary>
+    /// Gets or sets the collection of installation step keys that have been executed on this machine.
+    /// </summary>
+    public HashSet<string> ExecutedInstallationSteps { get; set; } = [];
+
     /// <summary>Marks a property as explicitly set by the user.</summary>
     /// <param name="propertyName">The name of the property to mark as explicitly set.</param>
     public void MarkAsExplicitlySet(string propertyName)
     {
         ExplicitlySetProperties.Add(propertyName);
+    }
+
+    /// <summary>
+    /// Checks whether an installation step key has already been recorded as executed.
+    /// </summary>
+    /// <param name="stepKey">The unique installation step key.</param>
+    /// <returns><see langword="true"/> if already executed; otherwise, <see langword="false"/>.</returns>
+    public bool IsInstallationStepExecuted(string stepKey)
+    {
+        return !string.IsNullOrWhiteSpace(stepKey) && ExecutedInstallationSteps.Contains(stepKey);
+    }
+
+    /// <summary>
+    /// Records that an installation step key has been executed.
+    /// </summary>
+    /// <param name="stepKey">The unique installation step key.</param>
+    public void RecordInstallationStepExecuted(string stepKey)
+    {
+        if (!string.IsNullOrWhiteSpace(stepKey))
+        {
+            ExecutedInstallationSteps.Add(stepKey);
+        }
     }
 
     /// <summary>Checks if a property was explicitly set by the user.</summary>

--- a/GenHub/GenHub.Core/Models/Common/UserSettings.cs
+++ b/GenHub/GenHub.Core/Models/Common/UserSettings.cs
@@ -114,7 +114,7 @@ public class UserSettings
     /// <returns><see langword="true"/> if already executed; otherwise, <see langword="false"/>.</returns>
     public bool IsInstallationStepExecuted(string stepKey)
     {
-        return !string.IsNullOrWhiteSpace(stepKey) && (ExecutedInstallationSteps?.Contains(stepKey) ?? false);
+        return !string.IsNullOrWhiteSpace(stepKey) && ExecutedInstallationSteps != null && ExecutedInstallationSteps.Contains(stepKey);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Models/Common/UserSettings.cs
+++ b/GenHub/GenHub.Core/Models/Common/UserSettings.cs
@@ -208,6 +208,7 @@ public class UserSettings
             UseInstallationAdjacentStorage = UseInstallationAdjacentStorage,
             ExplicitlySetProperties = [.. ExplicitlySetProperties],
             CasConfiguration = (CasConfiguration?)CasConfiguration?.Clone() ?? new CasConfiguration(),
+            ExecutedInstallationSteps = ExecutedInstallationSteps != null ? [.. ExecutedInstallationSteps] : [],
             SkippedUpdateVersions = SkippedUpdateVersions != null ? new Dictionary<string, string>(SkippedUpdateVersions) : [],
             PreferredUpdateStrategy = PreferredUpdateStrategy,
             PublisherSubscriptions = PublisherSubscriptions != null

--- a/GenHub/GenHub.Core/Models/Enums/InstallationStepKind.cs
+++ b/GenHub/GenHub.Core/Models/Enums/InstallationStepKind.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace GenHub.Core.Models.Enums;
 
 /// <summary>
 /// Defines the supported kind of installation operation in manifest-declared installation steps.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum InstallationStepKind
 {
     /// <summary>

--- a/GenHub/GenHub.Core/Models/Enums/InstallationStepKind.cs
+++ b/GenHub/GenHub.Core/Models/Enums/InstallationStepKind.cs
@@ -1,0 +1,27 @@
+namespace GenHub.Core.Models.Enums;
+
+/// <summary>
+/// Defines the supported kind of installation operation in manifest-declared installation steps.
+/// </summary>
+public enum InstallationStepKind
+{
+    /// <summary>
+    /// Installation step kind is unknown or undefined (default).
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Runs a verified installer executable that exists within the manifest and workspace.
+    /// </summary>
+    RunVerifiedInstaller = 1,
+
+    /// <summary>
+    /// Removes a file within the workspace.
+    /// </summary>
+    RemoveFile = 2,
+
+    /// <summary>
+    /// Renames or moves a file within the workspace.
+    /// </summary>
+    RenameFile = 3,
+}

--- a/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
+++ b/GenHub/GenHub.Core/Models/GeneralsOnline/GeneralsOnlineRelease.cs
@@ -37,6 +37,12 @@ public class GeneralsOnlineRelease
     public long? PortableSize { get; init; }
 
     /// <summary>
+    /// Gets SHA256 hash of the portable ZIP package for file verification.
+    /// Null when hash is unknown (e.g., from latest.txt API).
+    /// </summary>
+    public string? Sha256 { get; init; }
+
+    /// <summary>
     /// Gets release changelog/notes.
     /// </summary>
     public string? Changelog { get; init; }

--- a/GenHub/GenHub.Core/Models/Manifest/InstallationInstructions.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/InstallationInstructions.cs
@@ -11,11 +11,6 @@ namespace GenHub.Core.Models.Manifest;
 public class InstallationInstructions
 {
     /// <summary>
-    /// Gets or sets the steps to run before installation.
-    /// </summary>
-    public List<InstallationStep> PreInstallSteps { get; set; } = [];
-
-    /// <summary>
     /// Gets or sets the steps to run after installation.
     /// </summary>
     public List<InstallationStep> PostInstallSteps { get; set; } = [];

--- a/GenHub/GenHub.Core/Models/Manifest/InstallationStep.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/InstallationStep.cs
@@ -49,4 +49,15 @@ public class InstallationStep
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? StatusMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional unique key identifying this installation step for execution tracking across updates.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StepKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this step should only run once and be skipped on subsequent updates if already executed.
+    /// </summary>
+    public bool RunOnce { get; set; }
 }

--- a/GenHub/GenHub.Core/Models/Manifest/InstallationStep.cs
+++ b/GenHub/GenHub.Core/Models/Manifest/InstallationStep.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GenHub.Core.Models.Enums;
+
 namespace GenHub.Core.Models.Manifest;
 
 /// <summary>
-/// Individual installation step with commands and conditions.
+/// Individual installation step with typed operation kind and structured parameters.
 /// </summary>
 public class InstallationStep
 {
@@ -11,22 +15,38 @@ public class InstallationStep
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the command to execute.
+    /// Gets or sets the kind of installation operation to execute.
     /// </summary>
-    public string Command { get; set; } = string.Empty;
+    public InstallationStepKind Kind { get; set; } = InstallationStepKind.Unknown;
 
     /// <summary>
-    /// Gets or sets the arguments for the command.
+    /// Gets or sets the relative path of the target file to act upon in the delivered workspace or manifest.
     /// </summary>
-    public List<string> Arguments { get; set; } = new();
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TargetRelativePath { get; set; }
 
     /// <summary>
-    /// Gets or sets the working directory for the command.
+    /// Gets or sets the destination relative path when renaming or moving a file.
+    /// Only used when <see cref="Kind"/> is <see cref="InstallationStepKind.RenameFile"/>.
     /// </summary>
-    public string? WorkingDirectory { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DestinationRelativePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the arguments for executable steps.
+    /// Only used when <see cref="Kind"/> is <see cref="InstallationStepKind.RunVerifiedInstaller"/>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Arguments { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the step requires elevation.
     /// </summary>
     public bool RequiresElevation { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional user-facing status message to display in notifications or progress.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StatusMessage { get; set; }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Manifest;
@@ -6,6 +10,7 @@ using GenHub.Core.Models.Validation;
 using GenHub.Features.Content.Services.ContentProviders;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Xunit;
 
 namespace GenHub.Tests.Core.Features.Content;
 
@@ -15,14 +20,15 @@ namespace GenHub.Tests.Core.Features.Content;
 public class BaseContentProviderTests
 {
     /// <summary>
-    /// Verifies that PrepareContentAsync validates manifest before preparation.
+    /// Verifies that PrepareContentAsync validates manifest before preparation and executes post-install steps.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task PrepareContentAsync_ValidatesManifestBeforePreparationAsync()
+    public async Task PrepareContentAsync_ValidatesManifestAndExecutesPostInstallStepsAsync()
     {
         // Arrange
         var validatorMock = new Mock<IContentValidator>();
+        var instructionsMock = new Mock<IInstallationInstructionsService>();
         var loggerMock = new Mock<ILogger>();
         var discovererMock = new Mock<IContentDiscoverer>();
         var resolverMock = new Mock<IContentResolver>();
@@ -40,7 +46,20 @@ public class BaseContentProviderTests
             })
             .ReturnsAsync(validationResult);
 
-        var provider = new TestContentProvider(validatorMock.Object, loggerMock.Object, discovererMock.Object, resolverMock.Object, delivererMock.Object);
+        instructionsMock.Setup(i => i.ExecutePostInstallStepsAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult.CreateSuccess());
+
+        var provider = new TestContentProvider(
+            validatorMock.Object,
+            instructionsMock.Object,
+            loggerMock.Object,
+            discovererMock.Object,
+            resolverMock.Object,
+            delivererMock.Object);
 
         // Act
         var result = await provider.PrepareContentAsync(manifest, "/tmp/test");
@@ -48,7 +67,52 @@ public class BaseContentProviderTests
         // Assert
         Assert.True(result.Success);
         validatorMock.Verify(v => v.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()), Times.Once);
+        instructionsMock.Verify(i => i.ExecutePostInstallStepsAsync(manifest, "/tmp/test", It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
         validatorMock.Verify(v => v.ValidateAllAsync(It.IsAny<string>(), manifest, It.IsAny<IProgress<ValidationProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that PrepareContentAsync fails when post-install steps fail.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task PrepareContentAsync_FailsWhenPostInstallStepsFailAsync()
+    {
+        // Arrange
+        var validatorMock = new Mock<IContentValidator>();
+        var instructionsMock = new Mock<IInstallationInstructionsService>();
+        var loggerMock = new Mock<ILogger>();
+        var discovererMock = new Mock<IContentDiscoverer>();
+        var resolverMock = new Mock<IContentResolver>();
+        var delivererMock = new Mock<IContentDeliverer>();
+
+        var manifest = new ContentManifest { Id = "1.0.genhub.mod.content", Name = "Test" };
+        var validationResult = new ValidationResult(manifest.Id, new List<ValidationIssue>());
+
+        validatorMock.Setup(v => v.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validationResult);
+
+        instructionsMock.Setup(i => i.ExecutePostInstallStepsAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult.CreateFailure("Post-install step execution error"));
+
+        var provider = new TestContentProvider(
+            validatorMock.Object,
+            instructionsMock.Object,
+            loggerMock.Object,
+            discovererMock.Object,
+            resolverMock.Object,
+            delivererMock.Object);
+
+        // Act
+        var result = await provider.PrepareContentAsync(manifest, "/tmp/test");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Post-install step execution error", result.FirstError);
     }
 
     /// <summary>
@@ -60,6 +124,7 @@ public class BaseContentProviderTests
     {
         // Arrange
         var validatorMock = new Mock<IContentValidator>();
+        var instructionsMock = new Mock<IInstallationInstructionsService>();
         var loggerMock = new Mock<ILogger>();
         var discovererMock = new Mock<IContentDiscoverer>();
         var resolverMock = new Mock<IContentResolver>();
@@ -75,7 +140,13 @@ public class BaseContentProviderTests
         validatorMock.Setup(v => v.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()))
             .ReturnsAsync(validationResult);
 
-        var provider = new TestContentProvider(validatorMock.Object, loggerMock.Object, discovererMock.Object, resolverMock.Object, delivererMock.Object);
+        var provider = new TestContentProvider(
+            validatorMock.Object,
+            instructionsMock.Object,
+            loggerMock.Object,
+            discovererMock.Object,
+            resolverMock.Object,
+            delivererMock.Object);
 
         // Act
         var result = await provider.PrepareContentAsync(manifest, "/tmp/test");
@@ -96,11 +167,12 @@ public class BaseContentProviderTests
 
         public TestContentProvider(
             IContentValidator validator,
+            IInstallationInstructionsService instructionsService,
             ILogger logger,
             IContentDiscoverer discoverer,
             IContentResolver resolver,
             IContentDeliverer deliverer)
-            : base(validator, logger)
+            : base(validator, instructionsService, logger)
         {
             _discoverer = discoverer;
             _resolver = resolver;
@@ -116,12 +188,6 @@ public class BaseContentProviderTests
         protected override IContentResolver Resolver => _resolver;
 
         protected override IContentDeliverer Deliverer => _deliverer;
-
-        public override Task<OperationResult<ContentManifest>> GetValidatedContentAsync(string contentId, CancellationToken cancellationToken = default)
-        {
-            var manifest = new ContentManifest { Id = contentId, Name = $"Content {contentId}" };
-            return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(manifest));
-        }
 
         protected override Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
             ContentManifest manifest, string workingDirectory, IProgress<ContentAcquisitionProgress>? progress, CancellationToken cancellationToken)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -158,10 +158,7 @@ public class BaseContentProviderTests
             delivererMock.Object);
 
         // Act & Assert
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-        {
-            await provider.PrepareContentAsync(manifest, "/tmp/test");
-        });
+        await Assert.ThrowsAsync<OperationCanceledException>(() => provider.PrepareContentAsync(manifest, "/tmp/test"));
 
         Assert.True(provider.RollbackCalled);
     }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
 using GenHub.Core.Models.Validation;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -187,6 +187,8 @@ public class BaseContentProviderTests
 
         protected override IContentResolver Resolver => _resolver;
 
+        protected override IContentDeliverer Deliverer => _deliverer;
+
         public override Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
             string contentId,
             CancellationToken cancellationToken = default)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -12,6 +12,7 @@ using GenHub.Features.Content.Services.ContentProviders;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
 
 namespace GenHub.Tests.Core.Features.Content;
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -187,7 +187,21 @@ public class BaseContentProviderTests
 
         protected override IContentResolver Resolver => _resolver;
 
-        protected override IContentDeliverer Deliverer => _deliverer;
+        public override Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
+            string contentId,
+            CancellationToken cancellationToken = default)
+        {
+            var manifest = new ContentManifest
+            {
+                Id = ManifestId.Create(contentId),
+                Name = "Test Content",
+                Version = "1.0.0",
+                ContentType = ContentType.Map,
+                TargetGame = GameType.Generals,
+            };
+
+            return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(manifest));
+        }
 
         protected override Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
             ContentManifest manifest, string workingDirectory, IProgress<ContentAcquisitionProgress>? progress, CancellationToken cancellationToken)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -51,6 +51,7 @@ public class BaseContentProviderTests
         instructionsMock.Setup(i => i.ExecutePostInstallStepsAsync(
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
+                It.IsAny<string?>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult.CreateSuccess());
@@ -69,12 +70,12 @@ public class BaseContentProviderTests
         // Assert
         Assert.True(result.Success);
         validatorMock.Verify(v => v.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()), Times.Once);
-        instructionsMock.Verify(i => i.ExecutePostInstallStepsAsync(manifest, "/tmp/test", It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
+        instructionsMock.Verify(i => i.ExecutePostInstallStepsAsync(manifest, "/tmp/test", "Test Provider", It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
         validatorMock.Verify(v => v.ValidateAllAsync(It.IsAny<string>(), manifest, It.IsAny<IProgress<ValidationProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>
-    /// Verifies that PrepareContentAsync fails when post-install steps fail.
+    /// Verifies that PrepareContentAsync fails and triggers rollback when post-install steps fail.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
@@ -97,6 +98,7 @@ public class BaseContentProviderTests
         instructionsMock.Setup(i => i.ExecutePostInstallStepsAsync(
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
+                It.IsAny<string?>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult.CreateFailure("Post-install step execution error"));
@@ -115,6 +117,53 @@ public class BaseContentProviderTests
         // Assert
         Assert.False(result.Success);
         Assert.Contains("Post-install step execution error", result.FirstError);
+        Assert.True(provider.RollbackCalled);
+    }
+
+    /// <summary>
+    /// Verifies that PrepareContentAsync triggers rollback when post-install steps are canceled.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task PrepareContentAsync_CancelsAndTriggersRollbackAsync()
+    {
+        // Arrange
+        var validatorMock = new Mock<IContentValidator>();
+        var instructionsMock = new Mock<IInstallationInstructionsService>();
+        var loggerMock = new Mock<ILogger>();
+        var discovererMock = new Mock<IContentDiscoverer>();
+        var resolverMock = new Mock<IContentResolver>();
+        var delivererMock = new Mock<IContentDeliverer>();
+
+        var manifest = new ContentManifest { Id = "1.0.genhub.mod.content", Name = "Test" };
+        var validationResult = new ValidationResult(manifest.Id, new List<ValidationIssue>());
+
+        validatorMock.Setup(v => v.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validationResult);
+
+        instructionsMock.Setup(i => i.ExecutePostInstallStepsAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var provider = new TestContentProvider(
+            validatorMock.Object,
+            instructionsMock.Object,
+            loggerMock.Object,
+            discovererMock.Object,
+            resolverMock.Object,
+            delivererMock.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await provider.PrepareContentAsync(manifest, "/tmp/test");
+        });
+
+        Assert.True(provider.RollbackCalled);
     }
 
     /// <summary>
@@ -167,6 +216,8 @@ public class BaseContentProviderTests
         private readonly IContentResolver _resolver;
         private readonly IContentDeliverer _deliverer;
 
+        public bool RollbackCalled { get; private set; }
+
         public TestContentProvider(
             IContentValidator validator,
             IInstallationInstructionsService instructionsService,
@@ -211,6 +262,16 @@ public class BaseContentProviderTests
             ContentManifest manifest, string workingDirectory, IProgress<ContentAcquisitionProgress>? progress, CancellationToken cancellationToken)
         {
             return Task.FromResult(OperationResult<ContentManifest>.CreateSuccess(manifest));
+        }
+
+        protected override Task RollbackPreparedContentAsync(
+            ContentManifest originalManifest,
+            ContentManifest preparedManifest,
+            string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            RollbackCalled = true;
+            return Task.CompletedTask;
         }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/BaseContentProviderTests.cs
@@ -52,6 +52,7 @@ public class BaseContentProviderTests
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
                 It.IsAny<string?>(),
+                It.IsAny<bool>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult.CreateSuccess());
@@ -70,7 +71,7 @@ public class BaseContentProviderTests
         // Assert
         Assert.True(result.Success);
         validatorMock.Verify(v => v.ValidateManifestAsync(manifest, It.IsAny<CancellationToken>()), Times.Once);
-        instructionsMock.Verify(i => i.ExecutePostInstallStepsAsync(manifest, "/tmp/test", "Test Provider", It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
+        instructionsMock.Verify(i => i.ExecutePostInstallStepsAsync(manifest, "/tmp/test", "Test Provider", false, It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
         validatorMock.Verify(v => v.ValidateAllAsync(It.IsAny<string>(), manifest, It.IsAny<IProgress<ValidationProgress>>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -99,6 +100,7 @@ public class BaseContentProviderTests
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
                 It.IsAny<string?>(),
+                It.IsAny<bool>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult.CreateFailure("Post-install step execution error"));
@@ -145,6 +147,7 @@ public class BaseContentProviderTests
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
                 It.IsAny<string?>(),
+                It.IsAny<bool>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException());

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
@@ -50,6 +50,7 @@ public class GitHubContentProviderTests
         instructionsMock.Setup(i => i.ExecutePostInstallStepsAsync(
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
+                It.IsAny<string?>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult.CreateSuccess());

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
@@ -46,12 +46,21 @@ public class GitHubContentProviderTests
         _validatorMock.Setup(v => v.ValidateAllAsync(It.IsAny<string>(), It.IsAny<ContentManifest>(), It.IsAny<IProgress<ValidationProgress>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult("test", []));
 
+        var instructionsMock = new Mock<IInstallationInstructionsService>();
+        instructionsMock.Setup(i => i.ExecutePostInstallStepsAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult.CreateSuccess());
+
         _provider = new GitHubContentProvider(
             [_discovererMock.Object],
             [_resolverMock.Object],
             [_delivererMock.Object],
             _loggerMock.Object,
-            _validatorMock.Object);
+            _validatorMock.Object,
+            instructionsMock.Object);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/GitHubContentProviderTests.cs
@@ -51,6 +51,7 @@ public class GitHubContentProviderTests
                 It.IsAny<ContentManifest>(),
                 It.IsAny<string>(),
                 It.IsAny<string?>(),
+                It.IsAny<bool>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(OperationResult.CreateSuccess());

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -88,17 +88,17 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
     }
 
     /// <summary>
-    /// Verifies that executing installer steps from an untrusted publisher fails.
+    /// Verifies that executing installer steps from an untrusted provider fails even if manifest metadata claims to be trusted.
     /// </summary>
     /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task ExecutePostInstallStepsAsync_UntrustedPublisher_FailsExecution()
+    public async Task ExecutePostInstallStepsAsync_UntrustedProvider_FailsExecution()
     {
         var manifest = CreateBaseManifest();
         manifest.Publisher = new PublisherInfo
         {
-            Name = "Untrusted Publisher",
-            PublisherType = "untrusted_source",
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
         };
         manifest.InstallationInstructions = new InstallationInstructions
         {
@@ -113,7 +113,35 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        // Manifest claims GeneralsOnline, but providerSource is untrusted
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: "untrusted_source");
+
+        Assert.False(result.Success);
+        Assert.Contains("not authorized to execute installation steps", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that mutating steps like RemoveFile and RenameFile fail when provider is untrusted.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_UntrustedProvider_MutatingSteps_FailExecution()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Delete Something",
+                    Kind = InstallationStepKind.RemoveFile,
+                    TargetRelativePath = "important.dat",
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: "untrusted_source");
 
         Assert.False(result.Success);
         Assert.Contains("not authorized to execute installation steps", result.FirstError);
@@ -145,7 +173,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.False(result.Success);
         Assert.Contains("escapes the working directory", result.FirstError);
@@ -182,7 +210,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.False(result.Success);
         Assert.Contains("not declared in manifest files", result.FirstError);
@@ -230,7 +258,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.False(result.Success);
         Assert.Contains("Integrity verification failed", result.FirstError);
@@ -261,7 +289,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.True(result.Success);
         Assert.False(File.Exists(fullPath));
@@ -298,7 +326,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.True(result.Success);
         Assert.False(File.Exists(sourceFullPath));
@@ -364,7 +392,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.True(result.Success);
         Assert.True(_userSettings.IsInstallationStepExecuted(GeneralsOnlineConstants.EacStepKey));
@@ -420,7 +448,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         // Mark as already executed
         _userSettings.RecordInstallationStepExecuted(GeneralsOnlineConstants.EacStepKey);
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.True(result.Success);
 
@@ -491,7 +519,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         _userSettings.RecordInstallationStepExecuted(GeneralsOnlineConstants.EacStepKey);
 
         // Force execution
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, force: true);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline, force: true);
 
         Assert.True(result.Success);
         _notificationServiceMock.Verify(
@@ -523,10 +551,121 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             ],
         };
 
-        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
 
         Assert.False(result.Success);
         Assert.Contains("Unsupported installation step kind", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that elevated steps fail with an unsupported result on non-Windows platforms.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_ElevationOnNonWindows_ReturnsFailure()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var scriptName = "elevated_script.sh";
+        var fullPath = Path.Combine(_tempDirectory, scriptName);
+        File.WriteAllText(fullPath, "#!/bin/sh\nexit 0\n");
+        File.SetUnixFileMode(fullPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        const string expectedHash = "elevated_hash";
+        _hashProviderMock
+            .Setup(h => h.ComputeFileHashAsync(fullPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedHash);
+
+        var manifest = CreateBaseManifest();
+        manifest.Files =
+        [
+            new ManifestFile
+            {
+                RelativePath = scriptName,
+                Hash = expectedHash,
+            },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Elevated Step",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = scriptName,
+                    RequiresElevation = true,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.False(result.Success);
+        Assert.Contains("requires administrator elevation, which is only supported on Windows", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that caller cancellation terminates the running child installer process.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_CallerCancellation_TerminatesProcessAndThrows()
+    {
+        var scriptName = OperatingSystem.IsWindows() ? "sleep_installer.bat" : "sleep_installer.sh";
+        var fullPath = Path.Combine(_tempDirectory, scriptName);
+
+        if (OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(fullPath, "@echo off\r\nping -n 30 127.0.0.1 > nul\r\n");
+        }
+        else
+        {
+            File.WriteAllText(fullPath, "#!/bin/sh\nsleep 30\n");
+            File.SetUnixFileMode(fullPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        const string expectedHash = "sleep_hash";
+        _hashProviderMock
+            .Setup(h => h.ComputeFileHashAsync(fullPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedHash);
+
+        var manifest = CreateBaseManifest();
+        manifest.Files =
+        [
+            new ManifestFile
+            {
+                RelativePath = scriptName,
+                Hash = expectedHash,
+            },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Long Running Step",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = scriptName,
+                },
+            ],
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await _service.ExecutePostInstallStepsAsync(
+                manifest,
+                _tempDirectory,
+                providerSource: PublisherTypeConstants.GeneralsOnline,
+                cancellationToken: cts.Token);
+        });
     }
 
     private static ContentManifest CreateBaseManifest() => new()

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
@@ -24,6 +25,8 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
     private readonly string _tempDirectory;
     private readonly Mock<IFileHashProvider> _hashProviderMock;
     private readonly Mock<INotificationService> _notificationServiceMock;
+    private readonly Mock<IUserSettingsService> _userSettingsServiceMock;
+    private readonly UserSettings _userSettings;
     private readonly InstallationInstructionsService _service;
 
     public InstallationInstructionsServiceTests()
@@ -33,10 +36,17 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
 
         _hashProviderMock = new Mock<IFileHashProvider>();
         _notificationServiceMock = new Mock<INotificationService>();
+        _userSettingsServiceMock = new Mock<IUserSettingsService>();
+        _userSettings = new UserSettings();
+
+        _userSettingsServiceMock.Setup(u => u.Get()).Returns(_userSettings);
+        _userSettingsServiceMock.Setup(u => u.Update(It.IsAny<Action<UserSettings>>()))
+            .Callback<Action<UserSettings>>(action => action(_userSettings));
 
         _service = new InstallationInstructionsService(
             _hashProviderMock.Object,
             _notificationServiceMock.Object,
+            _userSettingsServiceMock.Object,
             NullLogger<InstallationInstructionsService>.Instance);
     }
 
@@ -247,6 +257,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                     Kind = InstallationStepKind.RenameFile,
                     TargetRelativePath = sourceFile,
                     DestinationRelativePath = destFile,
+                    StepKey = "test_rename_step",
                 },
             ],
         };
@@ -257,6 +268,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.False(File.Exists(sourceFullPath));
         Assert.True(File.Exists(destFullPath));
         Assert.Equal("hello world", File.ReadAllText(destFullPath));
+        Assert.True(_userSettings.IsInstallationStepExecuted("test_rename_step"));
     }
 
     [Fact]
@@ -295,6 +307,8 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                     Kind = InstallationStepKind.RunVerifiedInstaller,
                     TargetRelativePath = scriptName,
                     StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                    StepKey = GeneralsOnlineConstants.EacStepKey,
+                    RunOnce = true,
                 },
             ],
         };
@@ -302,6 +316,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
 
         Assert.True(result.Success);
+        Assert.True(_userSettings.IsInstallationStepExecuted(GeneralsOnlineConstants.EacStepKey));
         _notificationServiceMock.Verify(
             n => n.ShowInfo(
                 GeneralsOnlineConstants.EacStepName,
@@ -313,6 +328,102 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             n => n.ShowSuccess(
                 "Installation Step Completed",
                 It.Is<string>(msg => msg.Contains(GeneralsOnlineConstants.EacStepName)),
+                It.IsAny<int?>(),
+                It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RunOnceStepAlreadyExecuted_SkipsExecution()
+    {
+        var scriptName = "installer.bat";
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        };
+        manifest.Files =
+        [
+            new ManifestFile { RelativePath = scriptName },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = GeneralsOnlineConstants.EacStepName,
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = scriptName,
+                    StepKey = GeneralsOnlineConstants.EacStepKey,
+                    RunOnce = true,
+                },
+            ],
+        };
+
+        // Mark as already executed
+        _userSettings.RecordInstallationStepExecuted(GeneralsOnlineConstants.EacStepKey);
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.True(result.Success);
+        // Notification should NOT be shown for skipped step
+        _notificationServiceMock.Verify(
+            n => n.ShowInfo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RunOnceStepWithForceTrue_ExecutesEvenIfRecorded()
+    {
+        var scriptName = OperatingSystem.IsWindows() ? "test_force_installer.bat" : "test_force_installer.sh";
+        var fullPath = Path.Combine(_tempDirectory, scriptName);
+        var scriptContent = OperatingSystem.IsWindows() ? "@exit 0" : "#!/bin/sh\nexit 0\n";
+        File.WriteAllText(fullPath, scriptContent);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(fullPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        };
+        manifest.Files =
+        [
+            new ManifestFile { RelativePath = scriptName },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = GeneralsOnlineConstants.EacStepName,
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = scriptName,
+                    StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                    StepKey = GeneralsOnlineConstants.EacStepKey,
+                    RunOnce = true,
+                },
+            ],
+        };
+
+        // Mark as already executed in settings
+        _userSettings.RecordInstallationStepExecuted(GeneralsOnlineConstants.EacStepKey);
+
+        // Force execution
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, force: true);
+
+        Assert.True(result.Success);
+        _notificationServiceMock.Verify(
+            n => n.ShowInfo(
+                GeneralsOnlineConstants.EacStepName,
+                GeneralsOnlineConstants.EacStatusMessage,
                 It.IsAny<int?>(),
                 It.IsAny<bool>()),
             Times.Once);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -423,6 +423,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
 
         Assert.True(result.Success);
+
         // Notification should NOT be shown for skipped step
         _notificationServiceMock.Verify(
             n => n.ShowInfo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Features.Content.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.Content;
+
+/// <summary>
+/// Unit tests for <see cref="InstallationInstructionsService"/>.
+/// </summary>
+public sealed class InstallationInstructionsServiceTests : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly Mock<IFileHashProvider> _hashProviderMock;
+    private readonly Mock<INotificationService> _notificationServiceMock;
+    private readonly InstallationInstructionsService _service;
+
+    public InstallationInstructionsServiceTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"genhub-inst-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        _hashProviderMock = new Mock<IFileHashProvider>();
+        _notificationServiceMock = new Mock<INotificationService>();
+
+        _service = new InstallationInstructionsService(
+            _hashProviderMock.Object,
+            _notificationServiceMock.Object,
+            NullLogger<InstallationInstructionsService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            try
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+            catch
+            {
+                // Ignore cleanup error
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_NullOrEmptySteps_ReturnsSuccess()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions();
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_UntrustedPublisher_FailsExecution()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            Name = "Untrusted Publisher",
+            PublisherType = "untrusted_source",
+        };
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Run Malicious Executable",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = "malicious.exe",
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.False(result.Success);
+        Assert.Contains("not authorized to execute installation steps", result.FirstError);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_PathTraversalTarget_FailsExecution()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        };
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Traverse Path",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = @"../../outside.exe",
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.False(result.Success);
+        Assert.Contains("escapes the working directory", result.FirstError);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_FileNotInManifest_FailsExecution()
+    {
+        var targetFile = "installer.exe";
+        var fullPath = Path.Combine(_tempDirectory, targetFile);
+        File.WriteAllText(fullPath, "binary content");
+
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        };
+        manifest.Files = []; // Empty files list - installer not declared
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Run Undeclared Installer",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = targetFile,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.False(result.Success);
+        Assert.Contains("not declared in manifest files", result.FirstError);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_HashMismatch_FailsExecution()
+    {
+        var targetFile = "installer.exe";
+        var fullPath = Path.Combine(_tempDirectory, targetFile);
+        File.WriteAllText(fullPath, "binary content");
+
+        _hashProviderMock
+            .Setup(h => h.ComputeFileHashAsync(fullPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("actual_hash_value");
+
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        };
+        manifest.Files =
+        [
+            new ManifestFile
+            {
+                RelativePath = targetFile,
+                Hash = "expected_different_hash",
+            },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Run Corrupted Installer",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = targetFile,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.False(result.Success);
+        Assert.Contains("Integrity verification failed", result.FirstError);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RemoveFile_DeletesTargetFile()
+    {
+        var fileToRemove = "temp_cache.tmp";
+        var fullPath = Path.Combine(_tempDirectory, fileToRemove);
+        File.WriteAllText(fullPath, "temporary content");
+
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Remove Cache",
+                    Kind = InstallationStepKind.RemoveFile,
+                    TargetRelativePath = fileToRemove,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.True(result.Success);
+        Assert.False(File.Exists(fullPath));
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RenameFile_MovesTargetFile()
+    {
+        var sourceFile = "source.txt";
+        var destFile = Path.Combine("subfolder", "dest.txt");
+        var sourceFullPath = Path.Combine(_tempDirectory, sourceFile);
+        var destFullPath = Path.Combine(_tempDirectory, destFile);
+
+        File.WriteAllText(sourceFullPath, "hello world");
+
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Rename File",
+                    Kind = InstallationStepKind.RenameFile,
+                    TargetRelativePath = sourceFile,
+                    DestinationRelativePath = destFile,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.True(result.Success);
+        Assert.False(File.Exists(sourceFullPath));
+        Assert.True(File.Exists(destFullPath));
+        Assert.Equal("hello world", File.ReadAllText(destFullPath));
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RunsInstallerAndDispatchesNotification()
+    {
+        var scriptName = OperatingSystem.IsWindows() ? "test_installer.bat" : "test_installer.sh";
+        var fullPath = Path.Combine(_tempDirectory, scriptName);
+        var scriptContent = OperatingSystem.IsWindows() ? "@exit 0" : "#!/bin/sh\nexit 0\n";
+        File.WriteAllText(fullPath, scriptContent);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(fullPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        };
+        manifest.Files =
+        [
+            new ManifestFile
+            {
+                RelativePath = scriptName,
+            },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = GeneralsOnlineConstants.EacStepName,
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = scriptName,
+                    StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.True(result.Success);
+        _notificationServiceMock.Verify(
+            n => n.ShowInfo(
+                GeneralsOnlineConstants.EacStepName,
+                GeneralsOnlineConstants.EacStatusMessage,
+                It.IsAny<int?>(),
+                It.IsAny<bool>()),
+            Times.Once);
+        _notificationServiceMock.Verify(
+            n => n.ShowSuccess(
+                "Installation Step Completed",
+                It.Is<string>(msg => msg.Contains(GeneralsOnlineConstants.EacStepName)),
+                It.IsAny<int?>(),
+                It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_UnknownKind_ReturnsFailure()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Unknown Step",
+                    Kind = InstallationStepKind.Unknown,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory);
+
+        Assert.False(result.Success);
+        Assert.Contains("Unsupported installation step kind", result.FirstError);
+    }
+
+    private static ContentManifest CreateBaseManifest() => new()
+    {
+        Id = "1.0.test.gameclient.variant",
+        Name = "Test Manifest",
+        Version = "1.0.0",
+        ContentType = ContentType.GameClient,
+        TargetGame = GameType.ZeroHour,
+    };
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -658,14 +658,12 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(200));
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
-        {
-            await _service.ExecutePostInstallStepsAsync(
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _service.ExecutePostInstallStepsAsync(
                 manifest,
                 _tempDirectory,
                 providerSource: PublisherTypeConstants.GeneralsOnline,
-                cancellationToken: cts.Token);
-        });
+                cancellationToken: cts.Token));
     }
 
     private static ContentManifest CreateBaseManifest() => new()

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -626,18 +626,102 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
     }
 
     /// <summary>
-    /// Verifies that caller cancellation terminates the running child installer process.
+    /// Verifies that remove file steps reject paths that escape the working directory.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RemoveFile_PathTraversalTarget_FailsExecution()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Remove Escape",
+                    Kind = InstallationStepKind.RemoveFile,
+                    TargetRelativePath = "../../outside.tmp",
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.False(result.Success);
+        Assert.Contains("escapes the working directory", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that rename file steps reject source paths that escape the working directory.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RenameFile_SourcePathTraversal_FailsExecution()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Rename Source Escape",
+                    Kind = InstallationStepKind.RenameFile,
+                    TargetRelativePath = "../../outside.tmp",
+                    DestinationRelativePath = "dest.tmp",
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.False(result.Success);
+        Assert.Contains("escapes the working directory", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that rename file steps reject destination paths that escape the working directory.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RenameFile_DestinationPathTraversal_FailsExecution()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Rename Destination Escape",
+                    Kind = InstallationStepKind.RenameFile,
+                    TargetRelativePath = "source.tmp",
+                    DestinationRelativePath = "../../outside.tmp",
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(manifest, _tempDirectory, providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.False(result.Success);
+        Assert.Contains("escapes the working directory", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that cancellation token terminates the running process and throws OperationCanceledException.
     /// </summary>
     /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_CallerCancellation_TerminatesProcessAndThrows()
     {
-        var scriptName = OperatingSystem.IsWindows() ? "sleep_installer.bat" : "sleep_installer.sh";
+        var scriptName = OperatingSystem.IsWindows() ? "sleep_installer.exe" : "sleep_installer.sh";
         var fullPath = Path.Combine(_tempDirectory, scriptName);
 
         if (OperatingSystem.IsWindows())
         {
-            File.WriteAllText(fullPath, "@echo off\r\nping -n 30 127.0.0.1 > nul\r\n");
+            var systemCmd = Path.Combine(Environment.SystemDirectory, "cmd.exe");
+            File.Copy(systemCmd, fullPath, overwrite: true);
         }
         else
         {
@@ -668,6 +752,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                     Name = "Long Running Step",
                     Kind = InstallationStepKind.RunVerifiedInstaller,
                     TargetRelativePath = scriptName,
+                    Arguments = OperatingSystem.IsWindows() ? ["/c", "ping", "-n", "30", "127.0.0.1"] : [],
                 },
             ],
         };

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -121,12 +121,19 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
     }
 
     /// <summary>
-    /// Verifies that mutating steps like RemoveFile and RenameFile fail when provider is untrusted.
+    /// Verifies that mutating steps like RemoveFile and RenameFile fail and do not modify files on disk when provider is untrusted.
     /// </summary>
     /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_UntrustedProvider_MutatingSteps_FailExecution()
     {
+        var importantFilePath = Path.Combine(_tempDirectory, "important.dat");
+        var sourceFilePath = Path.Combine(_tempDirectory, "source.dat");
+        var destFilePath = Path.Combine(_tempDirectory, "dest.dat");
+
+        await File.WriteAllTextAsync(importantFilePath, "important content");
+        await File.WriteAllTextAsync(sourceFilePath, "source content");
+
         var manifest = CreateBaseManifest();
         manifest.InstallationInstructions = new InstallationInstructions
         {
@@ -138,6 +145,13 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                     Kind = InstallationStepKind.RemoveFile,
                     TargetRelativePath = "important.dat",
                 },
+                new InstallationStep
+                {
+                    Name = "Rename Something",
+                    Kind = InstallationStepKind.RenameFile,
+                    TargetRelativePath = "source.dat",
+                    DestinationRelativePath = "dest.dat",
+                },
             ],
         };
 
@@ -145,6 +159,9 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
 
         Assert.False(result.Success);
         Assert.Contains("not authorized to execute installation steps", result.FirstError);
+        Assert.True(File.Exists(importantFilePath));
+        Assert.True(File.Exists(sourceFilePath));
+        Assert.False(File.Exists(destFilePath));
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -14,6 +14,7 @@ using GenHub.Features.Content.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
 
 namespace GenHub.Tests.Core.Features.Content;
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -29,6 +29,9 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
     private readonly UserSettings _userSettings;
     private readonly InstallationInstructionsService _service;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InstallationInstructionsServiceTests"/> class.
+    /// </summary>
     public InstallationInstructionsServiceTests()
     {
         _tempDirectory = Path.Combine(Path.GetTempPath(), $"genhub-inst-tests-{Guid.NewGuid():N}");
@@ -50,6 +53,9 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             NullLogger<InstallationInstructionsService>.Instance);
     }
 
+    /// <summary>
+    /// Cleans up temporary resources after test execution.
+    /// </summary>
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))
@@ -65,6 +71,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// Verifies that executing post-install steps succeeds when no steps are declared.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_NullOrEmptySteps_ReturnsSuccess()
     {
@@ -76,6 +86,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.True(result.Success);
     }
 
+    /// <summary>
+    /// Verifies that executing installer steps from an untrusted publisher fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_UntrustedPublisher_FailsExecution()
     {
@@ -104,6 +118,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.Contains("not authorized to execute installation steps", result.FirstError);
     }
 
+    /// <summary>
+    /// Verifies that paths attempting directory traversal are rejected.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_PathTraversalTarget_FailsExecution()
     {
@@ -132,6 +150,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.Contains("escapes the working directory", result.FirstError);
     }
 
+    /// <summary>
+    /// Verifies that installer executables not declared in the manifest files list fail.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_FileNotInManifest_FailsExecution()
     {
@@ -165,6 +187,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.Contains("not declared in manifest files", result.FirstError);
     }
 
+    /// <summary>
+    /// Verifies that hash mismatch during installer integrity check fails execution.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_HashMismatch_FailsExecution()
     {
@@ -209,6 +235,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.Contains("Integrity verification failed", result.FirstError);
     }
 
+    /// <summary>
+    /// Verifies that remove file steps successfully delete the target file.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_RemoveFile_DeletesTargetFile()
     {
@@ -236,6 +266,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.False(File.Exists(fullPath));
     }
 
+    /// <summary>
+    /// Verifies that rename file steps successfully move target files.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_RenameFile_MovesTargetFile()
     {
@@ -258,6 +292,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                     TargetRelativePath = sourceFile,
                     DestinationRelativePath = destFile,
                     StepKey = "test_rename_step",
+                    RunOnce = true,
                 },
             ],
         };
@@ -271,18 +306,31 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.True(_userSettings.IsInstallationStepExecuted("test_rename_step"));
     }
 
+    /// <summary>
+    /// Verifies that verified installer execution runs and dispatches user notifications.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_RunsInstallerAndDispatchesNotification()
     {
-        var scriptName = OperatingSystem.IsWindows() ? "test_installer.bat" : "test_installer.sh";
+        var scriptName = OperatingSystem.IsWindows() ? "test_installer.exe" : "test_installer.sh";
         var fullPath = Path.Combine(_tempDirectory, scriptName);
-        var scriptContent = OperatingSystem.IsWindows() ? "@exit 0" : "#!/bin/sh\nexit 0\n";
-        File.WriteAllText(fullPath, scriptContent);
 
-        if (!OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
+            var systemCmd = Path.Combine(Environment.SystemDirectory, "cmd.exe");
+            File.Copy(systemCmd, fullPath, overwrite: true);
+        }
+        else
+        {
+            File.WriteAllText(fullPath, "#!/bin/sh\nexit 0\n");
             File.SetUnixFileMode(fullPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
         }
+
+        const string expectedHash = "test_installer_hash";
+        _hashProviderMock
+            .Setup(h => h.ComputeFileHashAsync(fullPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedHash);
 
         var manifest = CreateBaseManifest();
         manifest.Publisher = new PublisherInfo
@@ -295,6 +343,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             new ManifestFile
             {
                 RelativePath = scriptName,
+                Hash = expectedHash,
             },
         ];
         manifest.InstallationInstructions = new InstallationInstructions
@@ -306,6 +355,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                     Name = GeneralsOnlineConstants.EacStepName,
                     Kind = InstallationStepKind.RunVerifiedInstaller,
                     TargetRelativePath = scriptName,
+                    Arguments = OperatingSystem.IsWindows() ? ["/c", "exit", "0"] : [],
                     StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
                     StepKey = GeneralsOnlineConstants.EacStepKey,
                     RunOnce = true,
@@ -333,6 +383,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             Times.Once);
     }
 
+    /// <summary>
+    /// Verifies that run-once steps already recorded in user settings are skipped.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_RunOnceStepAlreadyExecuted_SkipsExecution()
     {
@@ -374,18 +428,31 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             Times.Never);
     }
 
+    /// <summary>
+    /// Verifies that forcing execution re-runs run-once steps even if recorded in settings.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_RunOnceStepWithForceTrue_ExecutesEvenIfRecorded()
     {
-        var scriptName = OperatingSystem.IsWindows() ? "test_force_installer.bat" : "test_force_installer.sh";
+        var scriptName = OperatingSystem.IsWindows() ? "test_force_installer.exe" : "test_force_installer.sh";
         var fullPath = Path.Combine(_tempDirectory, scriptName);
-        var scriptContent = OperatingSystem.IsWindows() ? "@exit 0" : "#!/bin/sh\nexit 0\n";
-        File.WriteAllText(fullPath, scriptContent);
 
-        if (!OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
+            var systemCmd = Path.Combine(Environment.SystemDirectory, "cmd.exe");
+            File.Copy(systemCmd, fullPath, overwrite: true);
+        }
+        else
+        {
+            File.WriteAllText(fullPath, "#!/bin/sh\nexit 0\n");
             File.SetUnixFileMode(fullPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
         }
+
+        const string expectedHash = "test_force_hash";
+        _hashProviderMock
+            .Setup(h => h.ComputeFileHashAsync(fullPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedHash);
 
         var manifest = CreateBaseManifest();
         manifest.Publisher = new PublisherInfo
@@ -395,7 +462,11 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         };
         manifest.Files =
         [
-            new ManifestFile { RelativePath = scriptName },
+            new ManifestFile
+            {
+                RelativePath = scriptName,
+                Hash = expectedHash,
+            },
         ];
         manifest.InstallationInstructions = new InstallationInstructions
         {
@@ -406,6 +477,7 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                     Name = GeneralsOnlineConstants.EacStepName,
                     Kind = InstallationStepKind.RunVerifiedInstaller,
                     TargetRelativePath = scriptName,
+                    Arguments = OperatingSystem.IsWindows() ? ["/c", "exit", "0"] : [],
                     StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
                     StepKey = GeneralsOnlineConstants.EacStepKey,
                     RunOnce = true,
@@ -429,6 +501,10 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
             Times.Once);
     }
 
+    /// <summary>
+    /// Verifies that unknown installation step kinds return failure.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
     public async Task ExecutePostInstallStepsAsync_UnknownKind_ReturnsFailure()
     {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -911,6 +911,84 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
         Assert.Contains("failed with exit code", result.FirstError);
     }
 
+    /// <summary>
+    /// Verifies that a successful RunOnce step persists its key immediately even if a subsequent step fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RunOnceStep_PersistsKeyImmediatelyEvenIfLaterStepFails()
+    {
+        var successFile = "success.tmp";
+        var fullPath = Path.Combine(_tempDirectory, successFile);
+        await File.WriteAllTextAsync(fullPath, "temporary");
+
+        const string step1Key = "step:runonce:first";
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Step 1 Remove",
+                    Kind = InstallationStepKind.RemoveFile,
+                    TargetRelativePath = successFile,
+                    StepKey = step1Key,
+                    RunOnce = true,
+                },
+                new InstallationStep
+                {
+                    Name = "Step 2 Unknown Kind",
+                    Kind = InstallationStepKind.Unknown,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(
+            manifest,
+            _tempDirectory,
+            providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.False(result.Success);
+        Assert.False(File.Exists(fullPath));
+        Assert.True(_userSettings.IsInstallationStepExecuted(step1Key));
+        _userSettingsServiceMock.Verify(u => u.SaveAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    /// <summary>
+    /// Verifies that an already-executed RunOnce step is skipped without failing provider authorization.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_RunOnceAlreadyExecuted_DoesNotFailAuthorizationForUntrustedProvider()
+    {
+        const string stepKey = "step:untrusted:runonce";
+        _userSettings.RecordInstallationStepExecuted(stepKey);
+
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Already Executed Step",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = "installer.exe",
+                    StepKey = stepKey,
+                    RunOnce = true,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(
+            manifest,
+            _tempDirectory,
+            providerSource: "untrusted_source");
+
+        Assert.True(result.Success);
+    }
+
     private static ContentManifest CreateBaseManifest() => new()
     {
         Id = "1.0.test.gameclient.variant",

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/InstallationInstructionsServiceTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.Notifications;
 using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Content;
@@ -766,6 +767,148 @@ public sealed class InstallationInstructionsServiceTests : IDisposable
                 _tempDirectory,
                 providerSource: PublisherTypeConstants.GeneralsOnline,
                 cancellationToken: cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that when a precondition is fulfilled, execution is skipped and the step key is recorded.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_PreconditionFulfilled_SkipsExecutionAndRecordsStepKey()
+    {
+        var preconditionMock = new Mock<IInstallationStepPrecondition>();
+        preconditionMock.Setup(p => p.CanHandle(It.IsAny<InstallationStep>(), It.IsAny<ContentManifest>())).Returns(true);
+        preconditionMock.Setup(p => p.IsAlreadyFulfilled(It.IsAny<InstallationStep>(), It.IsAny<ContentManifest>())).Returns(true);
+
+        var serviceWithPrecondition = new InstallationInstructionsService(
+            _hashProviderMock.Object,
+            _notificationServiceMock.Object,
+            _userSettingsServiceMock.Object,
+            [preconditionMock.Object],
+            NullLogger<InstallationInstructionsService>.Instance);
+
+        const string stepKey = "test:precondition:step";
+        var manifest = CreateBaseManifest();
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Preconditioned Step",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = "nonexistent.exe",
+                    StepKey = stepKey,
+                    RunOnce = true,
+                },
+            ],
+        };
+
+        var result = await serviceWithPrecondition.ExecutePostInstallStepsAsync(
+            manifest,
+            _tempDirectory,
+            providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.True(result.Success);
+        Assert.True(_userSettings.IsInstallationStepExecuted(stepKey));
+    }
+
+    /// <summary>
+    /// Verifies that verification fails when a step target file has no declared hash in the manifest.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_NoDeclaredHash_FailsVerification()
+    {
+        var scriptName = "installer_nohash.exe";
+        var fullPath = Path.Combine(_tempDirectory, scriptName);
+        File.WriteAllText(fullPath, "binary content");
+
+        var manifest = CreateBaseManifest();
+        manifest.Files =
+        [
+            new ManifestFile
+            {
+                RelativePath = scriptName,
+                Hash = string.Empty,
+            },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "No Hash Step",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = scriptName,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(
+            manifest,
+            _tempDirectory,
+            providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.False(result.Success);
+        Assert.Contains("has no declared hash", result.FirstError);
+    }
+
+    /// <summary>
+    /// Verifies that an installer process exiting with a non-zero exit code produces an execution failure.
+    /// </summary>
+    /// <returns>A task representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task ExecutePostInstallStepsAsync_NonZeroExitCode_FailsExecution()
+    {
+        var scriptName = OperatingSystem.IsWindows() ? "exit_error.cmd" : "exit_error.sh";
+        var fullPath = Path.Combine(_tempDirectory, scriptName);
+
+        if (OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(fullPath, "exit /b 42\r\n");
+        }
+        else
+        {
+            File.WriteAllText(fullPath, "#!/bin/sh\nexit 42\n");
+            File.SetUnixFileMode(fullPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        const string expectedHash = "exit_error_hash";
+        _hashProviderMock
+            .Setup(h => h.ComputeFileHashAsync(fullPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedHash);
+
+        var manifest = CreateBaseManifest();
+        manifest.Files =
+        [
+            new ManifestFile
+            {
+                RelativePath = scriptName,
+                Hash = expectedHash,
+            },
+        ];
+        manifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Failing Step",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = scriptName,
+                },
+            ],
+        };
+
+        var result = await _service.ExecutePostInstallStepsAsync(
+            manifest,
+            _tempDirectory,
+            providerSource: PublisherTypeConstants.GeneralsOnline);
+
+        Assert.False(result.Success);
+        Assert.Contains("failed with exit code", result.FirstError);
     }
 
     private static ContentManifest CreateBaseManifest() => new()

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/EasyAntiCheatPreconditionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/EasyAntiCheatPreconditionTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using GenHub.Core.Constants;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Features.Content.Services.GeneralsOnline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Unit tests for <see cref="EasyAntiCheatPrecondition"/>.
+/// </summary>
+public sealed class EasyAntiCheatPreconditionTests
+{
+    private readonly EasyAntiCheatPrecondition _precondition = new(NullLogger<EasyAntiCheatPrecondition>.Instance);
+
+    /// <summary>
+    /// Verifies that CanHandle returns false when step or manifest is null.
+    /// </summary>
+    [Fact]
+    public void CanHandle_NullStepOrManifest_ReturnsFalse()
+    {
+        var manifest = CreateBaseManifest();
+        var step = CreateEacStep();
+
+        Assert.False(_precondition.CanHandle(null!, manifest));
+        Assert.False(_precondition.CanHandle(step, null!));
+    }
+
+    /// <summary>
+    /// Verifies that CanHandle returns false when step kind is not RunVerifiedInstaller.
+    /// </summary>
+    [Fact]
+    public void CanHandle_NonInstallerKind_ReturnsFalse()
+    {
+        var manifest = CreateBaseManifest();
+        var step = new InstallationStep
+        {
+            Name = "Remove File Step",
+            Kind = InstallationStepKind.RemoveFile,
+            TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+        };
+
+        Assert.False(_precondition.CanHandle(step, manifest));
+    }
+
+    /// <summary>
+    /// Verifies that CanHandle returns false when publisher type is not GeneralsOnline.
+    /// </summary>
+    [Fact]
+    public void CanHandle_NonGeneralsOnlinePublisher_ReturnsFalse()
+    {
+        var manifest = CreateBaseManifest();
+        manifest.Publisher = new PublisherInfo
+        {
+            PublisherType = "OtherPublisher",
+        };
+
+        var step = CreateEacStep();
+
+        Assert.False(_precondition.CanHandle(step, manifest));
+    }
+
+    /// <summary>
+    /// Verifies that CanHandle returns false when executable name does not match EAC setup executable.
+    /// </summary>
+    [Fact]
+    public void CanHandle_NonEacExecutable_ReturnsFalse()
+    {
+        var manifest = CreateBaseManifest();
+        var step = new InstallationStep
+        {
+            Name = "Other Executable",
+            Kind = InstallationStepKind.RunVerifiedInstaller,
+            TargetRelativePath = "other_installer.exe",
+        };
+
+        Assert.False(_precondition.CanHandle(step, manifest));
+    }
+
+    /// <summary>
+    /// Verifies that IsAlreadyFulfilled returns false on non-Windows platforms.
+    /// </summary>
+    [Fact]
+    public void IsAlreadyFulfilled_NonWindows_ReturnsFalse()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var manifest = CreateBaseManifest();
+        var step = CreateEacStep();
+
+        Assert.False(_precondition.IsAlreadyFulfilled(step, manifest));
+    }
+
+    /// <summary>
+    /// Verifies that CanHandle behavior matches operating system requirements.
+    /// </summary>
+    [Fact]
+    public void CanHandle_ValidStep_MatchesOperatingSystem()
+    {
+        var manifest = CreateBaseManifest();
+        var step = CreateEacStep();
+
+        var result = _precondition.CanHandle(step, manifest);
+        Assert.Equal(OperatingSystem.IsWindows(), result);
+    }
+
+    private static ContentManifest CreateBaseManifest() => new()
+    {
+        Id = "1.0.test.gameclient.variant",
+        Name = "Generals Online",
+        Version = "1.0.0",
+        ContentType = ContentType.GameClient,
+        TargetGame = GameType.ZeroHour,
+        Publisher = new PublisherInfo
+        {
+            Name = GeneralsOnlineConstants.PublisherName,
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+        },
+    };
+
+    private static InstallationStep CreateEacStep() => new()
+    {
+        Name = GeneralsOnlineConstants.EacStepName,
+        Kind = InstallationStepKind.RunVerifiedInstaller,
+        TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+        Arguments = ["install", GeneralsOnlineConstants.EacProductId],
+        StepKey = GeneralsOnlineConstants.EacStepKey,
+        RunOnce = true,
+    };
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineDelivererTests.cs
@@ -561,6 +561,74 @@ public class GeneralsOnlineDelivererTests : IDisposable
         Assert.False(Directory.Exists(Path.Combine(targetDir, "extracted")));
     }
 
+    /// <summary>
+    /// Verifies that DeliverContentAsync passes the declared expected hash to IDownloadService.DownloadFileAsync.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DeliverContentAsync_WithDeclaredHash_PassesExpectedHashToDownloadServiceAsync()
+    {
+        // Arrange
+        const string expectedHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        var zipPath = Path.Combine(_tempDir, "test_hash.zip");
+        CreateTestZip(zipPath);
+
+        string? capturedExpectedHash = null;
+        _downloadServiceMock
+            .Setup(d => d.DownloadFileAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Uri, string, string?, IProgress<DownloadProgress>?, CancellationToken>((url, path, hash, prog, token) =>
+            {
+                capturedExpectedHash = hash;
+                File.Copy(zipPath, path, true);
+            })
+            .ReturnsAsync(DownloadResult.CreateSuccess(zipPath, 100, TimeSpan.FromSeconds(1)));
+
+        _manifestPoolMock
+            .Setup(p => p.AddManifestAsync(
+                It.IsAny<ContentManifest>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<ContentStorageProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        var manifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.1015255.generalsonline.gameclient.60hz"),
+            Name = GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = "101525_QFE5",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = PublisherTypeConstants.GeneralsOnline },
+            Files =
+            [
+                new ManifestFile
+                {
+                    DownloadUrl = "https://example.com/GeneralsOnline_101525_QFE5.zip",
+                    SourceType = ContentSourceType.RemoteDownload,
+                    Hash = expectedHash,
+                },
+            ],
+            InstallationInstructions = new InstallationInstructions
+            {
+                DownloadHash = expectedHash,
+            },
+        };
+
+        var targetDir = Path.Combine(_tempDir, "hash_delivery");
+        Directory.CreateDirectory(targetDir);
+
+        // Act
+        var result = await _deliverer.DeliverContentAsync(manifest, targetDir);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(expectedHash, capturedExpectedHash);
+    }
+
     private static void CreateTestZip(string zipPath)
     {
         using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParserTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParserTests.cs
@@ -1,5 +1,6 @@
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Providers;
+using GenHub.Core.Models.GeneralsOnline;
 using GenHub.Core.Models.Providers;
 using GenHub.Features.Content.Services.GeneralsOnline;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -90,5 +91,35 @@ public class GeneralsOnlineJsonCatalogParserTests
         Assert.True(result.Success);
         var item = result.Data.First();
         Assert.Equal("111825_QFE2", item.Version);
+    }
+
+    /// <summary>
+    /// Tests that ParseAsync correctly populates the SHA256 hash when present in the API response.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ParseAsync_WithSha256_PopulatesSha256OnReleaseAsync()
+    {
+        // Arrange
+        const string expectedSha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        var json = $@"{{
+            ""version"": ""111825_QFE2"",
+            ""download_url"": ""https://example.com/download.zip"",
+            ""size"": 123456,
+            ""sha256"": ""{expectedSha256}"",
+            ""release_notes"": ""Fixes stuff""
+        }}";
+
+        var wrapper = $"{{\"source\":\"manifest\",\"data\":{json}}}";
+
+        // Act
+        var result = await _parser.ParseAsync(wrapper, _provider);
+
+        // Assert
+        Assert.True(result.Success);
+        var item = result.Data.First();
+        var release = item.GetData<GeneralsOnlineRelease>();
+        Assert.NotNull(release);
+        Assert.Equal(expectedSha256, release.Sha256);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
@@ -175,6 +175,69 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
         Assert.Null(eacStep);
     }
 
+    /// <summary>
+    /// Verifies that an inherited EAC step is not duplicated when EAC portable layout already contains the setup executable.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_InheritedEacStep_SetupExecutablePresent_DoesNotDuplicateEacStepAsync()
+    {
+        WriteEacPortableLayout();
+
+        var originalManifest = CreateOriginalManifest();
+        originalManifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = GeneralsOnlineConstants.EacStepName,
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+                },
+            ],
+        };
+
+        var gameClient = await CreateGameClientManifestAsync(originalManifest);
+
+        Assert.NotNull(gameClient.InstallationInstructions);
+        var eacSteps = gameClient.InstallationInstructions.PostInstallSteps.Where(s =>
+            string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.Single(eacSteps);
+    }
+
+    /// <summary>
+    /// Verifies that an inherited EAC step is dropped when the setup executable is absent in extracted content.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_InheritedEacStep_SetupExecutableAbsent_DropsEacStepAsync()
+    {
+        WriteFile(GameClientConstants.GeneralsOnline60HzExecutable);
+        WriteFile("libcurl.dll");
+
+        var originalManifest = CreateOriginalManifest();
+        originalManifest.InstallationInstructions = new InstallationInstructions
+        {
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = GeneralsOnlineConstants.EacStepName,
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+                },
+            ],
+        };
+
+        var gameClient = await CreateGameClientManifestAsync(originalManifest);
+
+        Assert.NotNull(gameClient.InstallationInstructions);
+        var eacStep = gameClient.InstallationInstructions.PostInstallSteps.FirstOrDefault(s =>
+            string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase));
+        Assert.Null(eacStep);
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {
@@ -216,7 +279,7 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
         File.WriteAllText(fullPath, relativePath);
     }
 
-    private async Task<ContentManifest> CreateGameClientManifestAsync()
+    private async Task<ContentManifest> CreateGameClientManifestAsync(ContentManifest? originalManifest = null)
     {
         var providerLoader = new Mock<IProviderDefinitionLoader>();
         var factory = new GeneralsOnlineManifestFactory(
@@ -224,7 +287,7 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
             providerLoader.Object);
 
         var manifests = await factory.CreateManifestsFromExtractedContentAsync(
-            CreateOriginalManifest(),
+            originalManifest ?? CreateOriginalManifest(),
             _extractedDirectory);
 
         return manifests.Single(manifest => manifest.ContentType == ContentType.GameClient);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
@@ -148,6 +148,8 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
         Assert.Equal(InstallationStepKind.RunVerifiedInstaller, eacStep.Kind);
         Assert.Equal(GameClientConstants.GeneralsOnlineEacSetupExecutable, eacStep.TargetRelativePath);
         Assert.True(eacStep.RequiresElevation);
+        Assert.True(eacStep.RunOnce);
+        Assert.Equal(GeneralsOnlineConstants.EacStepKey, eacStep.StepKey);
         Assert.Equal(GeneralsOnlineConstants.EacStatusMessage, eacStep.StatusMessage);
         Assert.NotNull(eacStep.Arguments);
         Assert.Equal(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryEacTests.cs
@@ -129,6 +129,50 @@ public class GeneralsOnlineManifestFactoryEacTests : IDisposable
             ignoreCase: true);
     }
 
+    /// <summary>
+    /// Verifies that EAC portable layout configures a post-install step to run the verified EAC setup executable.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_EacLayout_ConfiguresEacPostInstallStepAsync()
+    {
+        WriteEacPortableLayout();
+
+        var gameClient = await CreateGameClientManifestAsync();
+
+        Assert.NotNull(gameClient.InstallationInstructions);
+        var postSteps = gameClient.InstallationInstructions.PostInstallSteps;
+        var eacStep = Assert.Single(postSteps);
+
+        Assert.Equal(GeneralsOnlineConstants.EacStepName, eacStep.Name);
+        Assert.Equal(InstallationStepKind.RunVerifiedInstaller, eacStep.Kind);
+        Assert.Equal(GameClientConstants.GeneralsOnlineEacSetupExecutable, eacStep.TargetRelativePath);
+        Assert.True(eacStep.RequiresElevation);
+        Assert.Equal(GeneralsOnlineConstants.EacStatusMessage, eacStep.StatusMessage);
+        Assert.NotNull(eacStep.Arguments);
+        Assert.Equal(
+            [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
+            eacStep.Arguments);
+    }
+
+    /// <summary>
+    /// Verifies that Pre-EAC portable layout does not configure an EAC post-install step when setup executable is absent.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateManifestsFromExtractedContentAsync_PreEacLayout_DoesNotConfigureEacPostInstallStepAsync()
+    {
+        WriteFile(GameClientConstants.GeneralsOnline60HzExecutable);
+        WriteFile("libcurl.dll");
+
+        var gameClient = await CreateGameClientManifestAsync();
+
+        Assert.NotNull(gameClient.InstallationInstructions);
+        var eacStep = gameClient.InstallationInstructions.PostInstallSteps.FirstOrDefault(s =>
+            string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase));
+        Assert.Null(eacStep);
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -401,4 +401,33 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
         var resolvedClientDep = resolvedDeps.First(d => d.DependencyType == ContentType.GameClient);
         Assert.Equal(expectedClientId.Value, resolvedClientDep.Id.Value);
     }
+
+    /// <summary>
+    /// Verifies that CreateManifests propagates Sha256 to file hash and installation instructions download hash.
+    /// </summary>
+    [Fact]
+    public void CreateManifests_WithSha256_SetsFileHashAndDownloadHash()
+    {
+        // Arrange
+        const string expectedHash = "abc123hash";
+        var release = new GeneralsOnlineRelease
+        {
+            Version = "101525_QFE5",
+            ReleaseDate = DateTime.UtcNow,
+            PortableUrl = "https://example.com/GeneralsOnline_portable_101525_QFE5.zip",
+            PortableSize = 1048576,
+            Sha256 = expectedHash,
+            Changelog = "https://example.com/changelog",
+        };
+
+        // Act
+        var manifests = _factory.CreateManifests(release);
+
+        // Assert
+        var gameClient = manifests.FirstOrDefault(m => m.ContentType == ContentType.GameClient);
+        Assert.NotNull(gameClient);
+        Assert.Equal(expectedHash, gameClient.InstallationInstructions?.DownloadHash);
+        var zipFile = Assert.Single(gameClient.Files);
+        Assert.Equal(expectedHash, zipFile.Hash);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
@@ -30,6 +30,7 @@ public class SuperHackersProviderTests
     private readonly Mock<IContentResolver> _resolverMock;
     private readonly Mock<IContentDeliverer> _delivererMock;
     private readonly Mock<IContentValidator> _validatorMock;
+    private readonly Mock<IInstallationInstructionsService> _instructionsServiceMock;
     private readonly SuperHackersProvider _provider;
 
     /// <summary>
@@ -42,12 +43,22 @@ public class SuperHackersProviderTests
         _resolverMock = new Mock<IContentResolver>();
         _delivererMock = new Mock<IContentDeliverer>();
         _validatorMock = new Mock<IContentValidator>();
+        _instructionsServiceMock = new Mock<IInstallationInstructionsService>();
 
         _resolverMock.Setup(r => r.ResolverId).Returns(SuperHackersConstants.ResolverId);
         _delivererMock.Setup(d => d.SourceName).Returns(ContentSourceNames.GitHubDeliverer);
 
         _validatorMock.Setup(v => v.ValidateManifestAsync(It.IsAny<ContentManifest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult("test", []));
+
+        _instructionsServiceMock.Setup(s => s.ExecutePostInstallStepsAsync(
+            It.IsAny<ContentManifest>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<bool>(),
+            It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult.CreateSuccess());
 
         _provider = new SuperHackersProvider(
             _providerDefinitionLoaderMock.Object,
@@ -56,7 +67,7 @@ public class SuperHackersProviderTests
             [_delivererMock.Object],
             _validatorMock.Object,
             NullLogger<SuperHackersProvider>.Instance,
-            new Mock<IInstallationInstructionsService>().Object);
+            _instructionsServiceMock.Object);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/Publishers/SuperHackersProviderTests.cs
@@ -55,7 +55,8 @@ public class SuperHackersProviderTests
             [_resolverMock.Object],
             [_delivererMock.Object],
             _validatorMock.Object,
-            NullLogger<SuperHackersProvider>.Instance);
+            NullLogger<SuperHackersProvider>.Instance,
+            new Mock<IInstallationInstructionsService>().Object);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
@@ -337,7 +337,8 @@ public class GameProfileLauncherViewModelTests
             [resolverMock.Object],
             [delivererMock.Object],
             new Mock<GenHub.Core.Interfaces.Content.IContentValidator>().Object,
-            NullLogger<SuperHackersProvider>.Instance);
+            NullLogger<SuperHackersProvider>.Instance,
+            new Mock<IInstallationInstructionsService>().Object);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
@@ -209,6 +209,78 @@ public class ContentManifestBuilderTests
     }
 
     /// <summary>
+    /// Tests that WithInstallationInstructions sets the full installation instructions object.
+    /// </summary>
+    [Fact]
+    public void WithInstallationInstructions_SetsCompleteObject()
+    {
+        var instructions = new InstallationInstructions
+        {
+            WorkspaceStrategy = WorkspaceStrategy.IsolatedDirectory,
+            DownloadHash = "abc123hash",
+            PostInstallSteps =
+            [
+                new InstallationStep
+                {
+                    Name = "Step 1",
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = "setup.exe",
+                },
+            ],
+        };
+
+        var result = _builder
+            .WithBasicInfo("Test Publisher", "Test Name", "1")
+            .WithInstallationInstructions(instructions)
+            .Build();
+
+        Assert.NotNull(result.InstallationInstructions);
+        Assert.Equal(WorkspaceStrategy.IsolatedDirectory, result.InstallationInstructions.WorkspaceStrategy);
+        Assert.Equal("abc123hash", result.InstallationInstructions.DownloadHash);
+        Assert.Single(result.InstallationInstructions.PostInstallSteps);
+        Assert.Equal("Step 1", result.InstallationInstructions.PostInstallSteps[0].Name);
+    }
+
+    /// <summary>
+    /// Tests that AddPostInstallStep adds a structured installation step.
+    /// </summary>
+    [Fact]
+    public void AddPostInstallStep_AddsStepCorrectly()
+    {
+        var result = _builder
+            .WithBasicInfo("Test Publisher", "Test Name", "1")
+            .AddPostInstallStep("EAC Setup", InstallationStepKind.RunVerifiedInstaller, "EasyAntiCheat_EOS_Setup.exe", ["install", "12345"], requiresElevation: true, statusMessage: "Installing AntiCheat")
+            .Build();
+
+        Assert.NotNull(result.InstallationInstructions);
+        var step = Assert.Single(result.InstallationInstructions.PostInstallSteps);
+        Assert.Equal("EAC Setup", step.Name);
+        Assert.Equal(InstallationStepKind.RunVerifiedInstaller, step.Kind);
+        Assert.Equal("EasyAntiCheat_EOS_Setup.exe", step.TargetRelativePath);
+        Assert.True(step.RequiresElevation);
+        Assert.Equal("Installing AntiCheat", step.StatusMessage);
+        Assert.Equal(["install", "12345"], step.Arguments);
+    }
+
+    /// <summary>
+    /// Tests that AddPreInstallStep adds a structured installation step.
+    /// </summary>
+    [Fact]
+    public void AddPreInstallStep_AddsStepCorrectly()
+    {
+        var result = _builder
+            .WithBasicInfo("Test Publisher", "Test Name", "1")
+            .AddPreInstallStep("Clean Old File", InstallationStepKind.RemoveFile, "old_file.tmp")
+            .Build();
+
+        Assert.NotNull(result.InstallationInstructions);
+        var step = Assert.Single(result.InstallationInstructions.PreInstallSteps);
+        Assert.Equal("Clean Old File", step.Name);
+        Assert.Equal(InstallationStepKind.RemoveFile, step.Kind);
+        Assert.Equal("old_file.tmp", step.TargetRelativePath);
+    }
+
+    /// <summary>
     /// Tests that Build returns a valid manifest with minimal configuration.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
@@ -216,7 +216,7 @@ public class ContentManifestBuilderTests
     {
         var instructions = new InstallationInstructions
         {
-            WorkspaceStrategy = WorkspaceStrategy.IsolatedDirectory,
+            WorkspaceStrategy = WorkspaceStrategy.FullCopy,
             DownloadHash = "abc123hash",
             PostInstallSteps =
             [
@@ -235,7 +235,7 @@ public class ContentManifestBuilderTests
             .Build();
 
         Assert.NotNull(result.InstallationInstructions);
-        Assert.Equal(WorkspaceStrategy.IsolatedDirectory, result.InstallationInstructions.WorkspaceStrategy);
+        Assert.Equal(WorkspaceStrategy.FullCopy, result.InstallationInstructions.WorkspaceStrategy);
         Assert.Equal("abc123hash", result.InstallationInstructions.DownloadHash);
         Assert.Single(result.InstallationInstructions.PostInstallSteps);
         Assert.Equal("Step 1", result.InstallationInstructions.PostInstallSteps[0].Name);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ContentManifestBuilderTests.cs
@@ -263,24 +263,6 @@ public class ContentManifestBuilderTests
     }
 
     /// <summary>
-    /// Tests that AddPreInstallStep adds a structured installation step.
-    /// </summary>
-    [Fact]
-    public void AddPreInstallStep_AddsStepCorrectly()
-    {
-        var result = _builder
-            .WithBasicInfo("Test Publisher", "Test Name", "1")
-            .AddPreInstallStep("Clean Old File", InstallationStepKind.RemoveFile, "old_file.tmp")
-            .Build();
-
-        Assert.NotNull(result.InstallationInstructions);
-        var step = Assert.Single(result.InstallationInstructions.PreInstallSteps);
-        Assert.Equal("Clean Old File", step.Name);
-        Assert.Equal(InstallationStepKind.RemoveFile, step.Kind);
-        Assert.Equal("old_file.tmp", step.TargetRelativePath);
-    }
-
-    /// <summary>
     /// Tests that Build returns a valid manifest with minimal configuration.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -145,49 +145,6 @@ public sealed class PathHelperTests
     }
 
     /// <summary>
-    /// Verifies that IsPathContainedIn correctly identifies paths inside a container directory.
-    /// </summary>
-    [Fact]
-    public void IsPathContainedIn_ReturnsTrue_ForValidDescendants()
-    {
-        var container = Path.Combine(Path.GetTempPath(), "GenHubWorkspace");
-        var childFile = Path.Combine(container, "subfolder", "file.exe");
-
-        var result = PathHelper.IsPathContainedIn(childFile, container);
-
-        Assert.True(result);
-    }
-
-    /// <summary>
-    /// Verifies that IsPathContainedIn returns false when a path attempts directory traversal outside container.
-    /// </summary>
-    [Fact]
-    public void IsPathContainedIn_ReturnsFalse_ForPathTraversal()
-    {
-        var container = Path.Combine(Path.GetTempPath(), "GenHubWorkspace");
-        var escapedFile = Path.Combine(container, "..", "escaped.exe");
-
-        var result = PathHelper.IsPathContainedIn(escapedFile, container);
-
-        Assert.False(result);
-    }
-
-    /// <summary>
-    /// Verifies that IsPathContainedIn returns false for sibling directory with common prefix.
-    /// </summary>
-    [Fact]
-    public void IsPathContainedIn_ReturnsFalse_ForSiblingDirectoryWithSharedPrefix()
-    {
-        var temp = Path.GetTempPath();
-        var container = Path.Combine(temp, "GenHubWorkspace");
-        var sibling = Path.Combine(temp, "GenHubWorkspaceSibling", "file.exe");
-
-        var result = PathHelper.IsPathContainedIn(sibling, container);
-
-        Assert.False(result);
-    }
-
-    /// <summary>
     /// Verifies that NormalizeRelativePath standardizes path separators.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -179,6 +179,38 @@ public sealed class PathHelperTests
     }
 
     /// <summary>
+    /// Rejects a candidate that is a direct file symbolic link pointing to a file outside the base directory.
+    /// </summary>
+    [Fact]
+    public void IsPathWithinDirectory_RejectsCandidateThatIsDirectFileSymbolicLink_PointingOutside()
+    {
+        var root = CreateWorkingDirectory();
+
+        try
+        {
+            var baseDirectory = Path.Combine(root, "extract");
+            var outside = Path.Combine(root, "outside");
+            Directory.CreateDirectory(baseDirectory);
+            Directory.CreateDirectory(outside);
+
+            var outsideFile = Path.Combine(outside, "secret.dat");
+            File.WriteAllText(outsideFile, "secret");
+
+            var linkFile = Path.Combine(baseDirectory, "link_file.dat");
+            if (!TryCreateFileSymbolicLink(linkFile, outsideFile))
+            {
+                return;
+            }
+
+            Assert.False(PathHelper.IsPathWithinDirectory(baseDirectory, linkFile));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
     /// Verifies that NormalizeRelativePath standardizes path separators.
     /// </summary>
     [Fact]
@@ -212,6 +244,20 @@ public sealed class PathHelperTests
             return false;
         }
         catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryCreateFileSymbolicLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            File.CreateSymbolicLink(linkPath, targetPath);
+
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {
             return false;
         }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -144,6 +144,62 @@ public sealed class PathHelperTests
         }
     }
 
+    /// <summary>
+    /// Verifies that IsPathContainedIn correctly identifies paths inside a container directory.
+    /// </summary>
+    [Fact]
+    public void IsPathContainedIn_ReturnsTrue_ForValidDescendants()
+    {
+        var container = Path.Combine(Path.GetTempPath(), "GenHubWorkspace");
+        var childFile = Path.Combine(container, "subfolder", "file.exe");
+
+        var result = PathHelper.IsPathContainedIn(childFile, container);
+
+        Assert.True(result);
+    }
+
+    /// <summary>
+    /// Verifies that IsPathContainedIn returns false when a path attempts directory traversal outside container.
+    /// </summary>
+    [Fact]
+    public void IsPathContainedIn_ReturnsFalse_ForPathTraversal()
+    {
+        var container = Path.Combine(Path.GetTempPath(), "GenHubWorkspace");
+        var escapedFile = Path.Combine(container, "..", "escaped.exe");
+
+        var result = PathHelper.IsPathContainedIn(escapedFile, container);
+
+        Assert.False(result);
+    }
+
+    /// <summary>
+    /// Verifies that IsPathContainedIn returns false for sibling directory with common prefix.
+    /// </summary>
+    [Fact]
+    public void IsPathContainedIn_ReturnsFalse_ForSiblingDirectoryWithSharedPrefix()
+    {
+        var temp = Path.GetTempPath();
+        var container = Path.Combine(temp, "GenHubWorkspace");
+        var sibling = Path.Combine(temp, "GenHubWorkspaceSibling", "file.exe");
+
+        var result = PathHelper.IsPathContainedIn(sibling, container);
+
+        Assert.False(result);
+    }
+
+    /// <summary>
+    /// Verifies that NormalizeRelativePath standardizes path separators.
+    /// </summary>
+    [Fact]
+    public void NormalizeRelativePath_StandardizesSeparators()
+    {
+        var input = @"folder\subfolder/file.exe";
+        var normalized = PathHelper.NormalizeRelativePath(input);
+
+        var expected = Path.Combine("folder", "subfolder", "file.exe");
+        Assert.Equal(expected, normalized);
+    }
+
     private static string CreateWorkingDirectory()
     {
         var root = Path.Combine(Path.GetTempPath(), "GenHubContainmentLinks", Guid.NewGuid().ToString("N"));

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -115,6 +115,40 @@ public sealed class PathHelperTests
     }
 
     /// <summary>
+    /// Rejects a candidate that leaves the base directory through an intermediate symbolic link
+    /// when the target file on the outside destination already exists on disk.
+    /// </summary>
+    [Fact]
+    public void IsPathWithinDirectory_RejectsCandidateLeavingThroughASymbolicLink_WhenOutsideTargetFileExists()
+    {
+        var root = CreateWorkingDirectory();
+
+        try
+        {
+            var baseDirectory = Path.Combine(root, "extract");
+            var outside = Path.Combine(root, "outside");
+            Directory.CreateDirectory(baseDirectory);
+            Directory.CreateDirectory(outside);
+
+            var outsideFile = Path.Combine(outside, "installer.exe");
+            File.WriteAllText(outsideFile, "payload");
+
+            if (!TryCreateDirectorySymbolicLink(Path.Combine(baseDirectory, "link"), outside))
+            {
+                return;
+            }
+
+            var candidate = Path.Combine(baseDirectory, "link", "installer.exe");
+
+            Assert.False(PathHelper.IsPathWithinDirectory(baseDirectory, candidate));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
     /// Accepts a candidate beneath a symbolic link that stays inside the base directory, so
     /// following links tightens the check without refusing content a link merely reorganizes.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/PathHelperTests.cs
@@ -257,7 +257,15 @@ public sealed class PathHelperTests
 
             return true;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
         {
             return false;
         }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProvider.cs
@@ -32,8 +32,9 @@ public class CommunityOutpostProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService,
     ILogger<CommunityOutpostProvider> logger)
-    : BaseContentProvider(contentValidator, logger)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private readonly IProviderDefinitionLoader _providerDefinitionLoader = providerDefinitionLoader;
 

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProvider.cs
@@ -25,6 +25,7 @@ namespace GenHub.Features.Content.Services.CommunityOutpost;
 /// <param name="resolvers">Available content resolvers.</param>
 /// <param name="deliverers">Available content deliverers.</param>
 /// <param name="contentValidator">The content validator.</param>
+/// <param name="installationInstructionsService">The installation instructions service.</param>
 /// <param name="logger">The logger.</param>
 public class CommunityOutpostProvider(
     IProviderDefinitionLoader providerDefinitionLoader,

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProvider.cs
@@ -37,8 +37,6 @@ public class CommunityOutpostProvider(
     ILogger<CommunityOutpostProvider> logger)
     : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
-    private readonly IProviderDefinitionLoader _providerDefinitionLoader = providerDefinitionLoader;
-
     private readonly IContentDiscoverer _discoverer = discoverers.FirstOrDefault(d =>
             d.SourceName.Contains(CommunityOutpostConstants.PublisherType, StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException("No Community Outpost discoverer found");
@@ -129,7 +127,7 @@ public class CommunityOutpostProvider(
         }
 
         // Try to get from the loader (it should already be loaded at startup)
-        _cachedProviderDefinition = _providerDefinitionLoader.GetProvider(CommunityOutpostConstants.PublisherId);
+        _cachedProviderDefinition = providerDefinitionLoader.GetProvider(CommunityOutpostConstants.PublisherId);
 
         if (_cachedProviderDefinition == null)
         {

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/FileSystemDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/FileSystemDeliverer.cs
@@ -173,7 +173,7 @@ public class FileSystemDeliverer(
             // Add installation instructions if present
             if (packageManifest.InstallationInstructions != null)
             {
-                manifestBuilder.WithInstallationInstructions(packageManifest.InstallationInstructions.WorkspaceStrategy);
+                manifestBuilder.WithInstallationInstructions(packageManifest.InstallationInstructions);
             }
 
             var deliveredManifest = manifestBuilder.Build();

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/FileSystemDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/FileSystemDeliverer.cs
@@ -122,7 +122,8 @@ public class FileSystemDeliverer(
                     packageManifest.Publisher?.Name ?? string.Empty,
                     packageManifest.Publisher?.Website ?? string.Empty,
                     packageManifest.Publisher?.SupportUrl ?? string.Empty,
-                    packageManifest.Publisher?.ContactEmail ?? string.Empty)
+                    packageManifest.Publisher?.ContactEmail ?? string.Empty,
+                    packageManifest.Publisher?.PublisherType ?? string.Empty)
                 .WithMetadata(
                     packageManifest.Metadata?.Description ?? string.Empty,
                     packageManifest.Metadata?.Tags,

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
@@ -131,39 +131,40 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
                         $"Failed to download {file.RelativePath}: {downloadResult.FirstError}");
                 }
 
-                // Add the delivered file using the builder preserving hash
-                if (!string.IsNullOrEmpty(file.Hash))
+                // Add the delivered file preserving InstallTarget, DownloadUrl, and hash
+                var fileInfo = new FileInfo(localPath);
+                var deliveredFile = new ManifestFile
                 {
-                    var fileInfo = new FileInfo(localPath);
-                    await deliveredManifest.AddContentAddressableFileAsync(
-                        file.RelativePath,
-                        file.Hash,
-                        fileInfo.Exists ? fileInfo.Length : file.Size,
-                        isExecutable: file.IsExecutable,
-                        permissions: file.Permissions);
-                }
-                else
-                {
-                    await deliveredManifest.AddRemoteFileAsync(
-                        file.RelativePath,
-                        file.DownloadUrl ?? string.Empty,
-                        ContentSourceType.ContentAddressable,
-                        isExecutable: file.IsExecutable,
-                        permissions: file.Permissions);
-                }
+                    RelativePath = file.RelativePath,
+                    SourceType = ContentSourceType.ContentAddressable,
+                    InstallTarget = file.InstallTarget,
+                    IsExecutable = file.IsExecutable,
+                    Hash = !string.IsNullOrEmpty(file.Hash) ? file.Hash : string.Empty,
+                    DownloadUrl = file.DownloadUrl,
+                    Size = fileInfo.Exists ? fileInfo.Length : file.Size,
+                    Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
+                };
+                deliveredManifest.AddFile(deliveredFile);
 
                 processedFiles++;
             }
 
-            // Add any other files (without DownloadUrl) as-is
+            // Add any other files (without DownloadUrl) preserving metadata
             foreach (var file in packageManifest.Files.Where(f => string.IsNullOrEmpty(f.DownloadUrl)))
             {
-                await deliveredManifest.AddLocalFileAsync(
-                    file.RelativePath,
-                    file.SourcePath ?? string.Empty,
-                    ContentSourceType.ContentAddressable,
-                    isExecutable: file.IsExecutable,
-                    permissions: file.Permissions);
+                var otherFile = new ManifestFile
+                {
+                    RelativePath = file.RelativePath,
+                    SourcePath = file.SourcePath ?? string.Empty,
+                    SourceType = ContentSourceType.ContentAddressable,
+                    InstallTarget = file.InstallTarget,
+                    IsExecutable = file.IsExecutable,
+                    Hash = file.Hash,
+                    DownloadUrl = file.DownloadUrl,
+                    Size = file.Size,
+                    Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
+                };
+                deliveredManifest.AddFile(otherFile);
             }
 
             // Add required directories

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
@@ -158,7 +158,7 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
             // Add installation instructions if present
             if (packageManifest.InstallationInstructions != null)
             {
-                deliveredManifest.WithInstallationInstructions(packageManifest.InstallationInstructions.WorkspaceStrategy);
+                deliveredManifest.WithInstallationInstructions(packageManifest.InstallationInstructions);
             }
 
             return OperationResult<ContentManifest>.CreateSuccess(deliveredManifest.Build());

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -19,12 +20,11 @@ namespace GenHub.Features.Content.Services.ContentDeliverers;
 /// Delivers remote HTTP content.
 /// Pure delivery - downloads and extracts content.
 /// </summary>
-public class HttpContentDeliverer(IDownloadService downloadService, IContentManifestBuilder manifestBuilder, ILogger<HttpContentDeliverer> logger) : IContentDeliverer
+public class HttpContentDeliverer(
+    IDownloadService downloadService,
+    IContentManifestBuilder manifestBuilder,
+    ILogger<HttpContentDeliverer> logger) : IContentDeliverer
 {
-    private readonly IDownloadService _downloadService = downloadService;
-    private readonly IContentManifestBuilder _manifestBuilder = manifestBuilder;
-    private readonly ILogger<HttpContentDeliverer> _logger = logger;
-
     /// <inheritdoc />
     public string SourceName => ContentSourceNames.HttpDeliverer;
 
@@ -56,121 +56,25 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
     {
         try
         {
-            // Extract publisher from the manifest ID (3rd segment)
-            var idSegments = packageManifest.Id.Value.Split('.');
-            var publisherId = idSegments.Length >= 3 ? idSegments[2] : "unknown";
-
-            var manifestVersionInt = int.TryParse(packageManifest.Version, out var parsedVersion) ? parsedVersion : 0;
-            var deliveredManifest = _manifestBuilder
-                .WithBasicInfo(publisherId, packageManifest.Name, manifestVersionInt)
-                .WithContentType(packageManifest.ContentType, packageManifest.TargetGame)
-                .WithPublisher(
-                    packageManifest.Publisher?.Name ?? string.Empty,
-                    packageManifest.Publisher?.Website ?? string.Empty,
-                    packageManifest.Publisher?.SupportUrl ?? string.Empty,
-                    packageManifest.Publisher?.ContactEmail ?? string.Empty,
-                    packageManifest.Publisher?.PublisherType ?? string.Empty)
-                .WithMetadata(
-                    packageManifest.Metadata?.Description ?? string.Empty,
-                    packageManifest.Metadata?.Tags,
-                    packageManifest.Metadata?.IconUrl ?? string.Empty,
-                    packageManifest.Metadata?.ScreenshotUrls,
-                    packageManifest.Metadata?.ChangelogUrl ?? string.Empty);
-
-            // Add dependencies
-            foreach (var dep in packageManifest.Dependencies)
-            {
-                deliveredManifest.AddDependency(
-                    dep.Id,
-                    dep.Name,
-                    dep.DependencyType,
-                    dep.InstallBehavior,
-                    dep.MinVersion ?? string.Empty,
-                    dep.MaxVersion ?? string.Empty,
-                    dep.CompatibleVersions,
-                    dep.IsExclusive,
-                    dep.ConflictsWith);
-            }
+            var deliveredManifest = InitializeManifestBuilder(packageManifest);
 
             var filesToDownload = packageManifest.Files.Where(f => !string.IsNullOrEmpty(f.DownloadUrl)).ToList();
-            var totalFiles = filesToDownload.Count;
-            var processedFiles = 0;
+            var downloadResult = await DownloadDeliveredFilesAsync(
+                deliveredManifest,
+                filesToDownload,
+                targetDirectory,
+                progress,
+                cancellationToken);
 
-            // Download and add files
-            foreach (var file in filesToDownload)
+            if (!downloadResult.Success)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var localPath = Path.Combine(targetDirectory, file.RelativePath);
-
-                // Ensure directory exists
-                var directory = Path.GetDirectoryName(localPath);
-                if (!string.IsNullOrEmpty(directory))
-                {
-                    Directory.CreateDirectory(directory);
-                }
-
-                // Report progress
-                progress?.Report(new ContentAcquisitionProgress
-                {
-                    Phase = ContentAcquisitionPhase.Downloading,
-                    ProgressPercentage = (double)processedFiles / totalFiles * 100,
-                    CurrentOperation = $"Downloading {file.RelativePath}",
-                    CurrentFile = file.RelativePath,
-                    FilesProcessed = processedFiles,
-                    TotalFiles = totalFiles,
-                });
-
-                // Download the file
-                var downloadResult = await _downloadService.DownloadFileAsync(
-                    new Uri(file.DownloadUrl!), localPath, file.Hash, null, cancellationToken);
-
-                if (!downloadResult.Success)
-                {
-                    return OperationResult<ContentManifest>.CreateFailure(
-                        $"Failed to download {file.RelativePath}: {downloadResult.FirstError}");
-                }
-
-                // Add the delivered file preserving InstallTarget, DownloadUrl, and hash
-                var fileInfo = new FileInfo(localPath);
-                var deliveredFile = new ManifestFile
-                {
-                    RelativePath = file.RelativePath,
-                    SourceType = ContentSourceType.ContentAddressable,
-                    InstallTarget = file.InstallTarget,
-                    IsExecutable = file.IsExecutable,
-                    Hash = !string.IsNullOrEmpty(file.Hash) ? file.Hash : string.Empty,
-                    DownloadUrl = file.DownloadUrl,
-                    Size = fileInfo.Exists ? fileInfo.Length : file.Size,
-                    Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
-                };
-                deliveredManifest.AddFile(deliveredFile);
-
-                processedFiles++;
+                return OperationResult<ContentManifest>.CreateFailure(downloadResult.Errors);
             }
 
-            // Add any other files (without DownloadUrl) preserving metadata
-            foreach (var file in packageManifest.Files.Where(f => string.IsNullOrEmpty(f.DownloadUrl)))
-            {
-                var otherFile = new ManifestFile
-                {
-                    RelativePath = file.RelativePath,
-                    SourcePath = file.SourcePath ?? string.Empty,
-                    SourceType = ContentSourceType.ContentAddressable,
-                    InstallTarget = file.InstallTarget,
-                    IsExecutable = file.IsExecutable,
-                    Hash = file.Hash,
-                    DownloadUrl = file.DownloadUrl,
-                    Size = file.Size,
-                    Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
-                };
-                deliveredManifest.AddFile(otherFile);
-            }
+            AddNonDownloadFiles(deliveredManifest, packageManifest.Files.Where(f => string.IsNullOrEmpty(f.DownloadUrl)));
 
-            // Add required directories
             deliveredManifest.AddRequiredDirectories([.. packageManifest.RequiredDirectories]);
 
-            // Add installation instructions if present
             if (packageManifest.InstallationInstructions != null)
             {
                 deliveredManifest.WithInstallationInstructions(packageManifest.InstallationInstructions);
@@ -178,9 +82,13 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
 
             return OperationResult<ContentManifest>.CreateSuccess(deliveredManifest.Build());
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to deliver HTTP content for manifest {ManifestId}", packageManifest.Id);
+            logger.LogError(ex, "Failed to deliver HTTP content for manifest {ManifestId}", packageManifest.Id);
             return OperationResult<ContentManifest>.CreateFailure($"Content delivery failed: {ex.Message}");
         }
     }
@@ -205,8 +113,136 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Validation failed for HTTP content manifest {ManifestId}", manifest.Id);
+            logger.LogError(ex, "Validation failed for HTTP content manifest {ManifestId}", manifest.Id);
             return Task.FromResult(OperationResult<bool>.CreateFailure($"Validation failed: {ex.Message}"));
         }
+    }
+
+    private static void AddDeliveredFile(
+        IContentManifestBuilder deliveredManifest,
+        ManifestFile file,
+        string localPath)
+    {
+        var fileInfo = new FileInfo(localPath);
+        var deliveredFile = new ManifestFile
+        {
+            RelativePath = file.RelativePath,
+            SourceType = ContentSourceType.ContentAddressable,
+            InstallTarget = file.InstallTarget,
+            IsExecutable = file.IsExecutable,
+            Hash = !string.IsNullOrEmpty(file.Hash) ? file.Hash : string.Empty,
+            DownloadUrl = file.DownloadUrl,
+            Size = fileInfo.Exists ? fileInfo.Length : file.Size,
+            Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
+        };
+        deliveredManifest.AddFile(deliveredFile);
+    }
+
+    private static void AddNonDownloadFiles(
+        IContentManifestBuilder deliveredManifest,
+        IEnumerable<ManifestFile> files)
+    {
+        foreach (var file in files)
+        {
+            var otherFile = new ManifestFile
+            {
+                RelativePath = file.RelativePath,
+                SourcePath = file.SourcePath ?? string.Empty,
+                SourceType = ContentSourceType.ContentAddressable,
+                InstallTarget = file.InstallTarget,
+                IsExecutable = file.IsExecutable,
+                Hash = file.Hash,
+                DownloadUrl = file.DownloadUrl,
+                Size = file.Size,
+                Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
+            };
+            deliveredManifest.AddFile(otherFile);
+        }
+    }
+
+    private IContentManifestBuilder InitializeManifestBuilder(ContentManifest packageManifest)
+    {
+        var idSegments = packageManifest.Id.Value.Split('.');
+        var publisherId = idSegments.Length >= 3 ? idSegments[2] : "unknown";
+        var manifestVersionInt = int.TryParse(packageManifest.Version, out var parsedVersion) ? parsedVersion : 0;
+
+        var builder = manifestBuilder
+            .WithBasicInfo(publisherId, packageManifest.Name, manifestVersionInt)
+            .WithContentType(packageManifest.ContentType, packageManifest.TargetGame)
+            .WithPublisher(
+                packageManifest.Publisher?.Name ?? string.Empty,
+                packageManifest.Publisher?.Website ?? string.Empty,
+                packageManifest.Publisher?.SupportUrl ?? string.Empty,
+                packageManifest.Publisher?.ContactEmail ?? string.Empty,
+                packageManifest.Publisher?.PublisherType ?? string.Empty)
+            .WithMetadata(
+                packageManifest.Metadata?.Description ?? string.Empty,
+                packageManifest.Metadata?.Tags,
+                packageManifest.Metadata?.IconUrl ?? string.Empty,
+                packageManifest.Metadata?.ScreenshotUrls,
+                packageManifest.Metadata?.ChangelogUrl ?? string.Empty);
+
+        foreach (var dep in packageManifest.Dependencies)
+        {
+            builder.AddDependency(
+                dep.Id,
+                dep.Name,
+                dep.DependencyType,
+                dep.InstallBehavior,
+                dep.MinVersion ?? string.Empty,
+                dep.MaxVersion ?? string.Empty,
+                dep.CompatibleVersions,
+                dep.IsExclusive,
+                dep.ConflictsWith);
+        }
+
+        return builder;
+    }
+
+    private async Task<OperationResult<bool>> DownloadDeliveredFilesAsync(
+        IContentManifestBuilder deliveredManifest,
+        IReadOnlyList<ManifestFile> filesToDownload,
+        string targetDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var totalFiles = filesToDownload.Count;
+        var processedFiles = 0;
+
+        foreach (var file in filesToDownload)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var localPath = Path.Combine(targetDirectory, file.RelativePath);
+            var directory = Path.GetDirectoryName(localPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.Downloading,
+                ProgressPercentage = totalFiles > 0 ? (double)processedFiles / totalFiles * 100 : 100,
+                CurrentOperation = $"Downloading {file.RelativePath}",
+                CurrentFile = file.RelativePath,
+                FilesProcessed = processedFiles,
+                TotalFiles = totalFiles,
+            });
+
+            var downloadResult = await downloadService.DownloadFileAsync(
+                new Uri(file.DownloadUrl!), localPath, file.Hash, null, cancellationToken);
+
+            if (!downloadResult.Success)
+            {
+                return OperationResult<bool>.CreateFailure(
+                    $"Failed to download {file.RelativePath}: {downloadResult.FirstError}");
+            }
+
+            AddDeliveredFile(deliveredManifest, file, localPath);
+            processedFiles++;
+        }
+
+        return OperationResult<bool>.CreateSuccess(true);
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
@@ -68,7 +68,8 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
                     packageManifest.Publisher?.Name ?? string.Empty,
                     packageManifest.Publisher?.Website ?? string.Empty,
                     packageManifest.Publisher?.SupportUrl ?? string.Empty,
-                    packageManifest.Publisher?.ContactEmail ?? string.Empty)
+                    packageManifest.Publisher?.ContactEmail ?? string.Empty,
+                    packageManifest.Publisher?.PublisherType ?? string.Empty)
                 .WithMetadata(
                     packageManifest.Metadata?.Description ?? string.Empty,
                     packageManifest.Metadata?.Tags,
@@ -130,13 +131,26 @@ public class HttpContentDeliverer(IDownloadService downloadService, IContentMani
                         $"Failed to download {file.RelativePath}: {downloadResult.FirstError}");
                 }
 
-                // Add the delivered file using the builder
-                await deliveredManifest.AddRemoteFileAsync(
-                    file.RelativePath,
-                    file.DownloadUrl ?? string.Empty,
-                    ContentSourceType.ContentAddressable,
-                    isExecutable: file.IsExecutable,
-                    permissions: file.Permissions);
+                // Add the delivered file using the builder preserving hash
+                if (!string.IsNullOrEmpty(file.Hash))
+                {
+                    var fileInfo = new FileInfo(localPath);
+                    await deliveredManifest.AddContentAddressableFileAsync(
+                        file.RelativePath,
+                        file.Hash,
+                        fileInfo.Exists ? fileInfo.Length : file.Size,
+                        isExecutable: file.IsExecutable,
+                        permissions: file.Permissions);
+                }
+                else
+                {
+                    await deliveredManifest.AddRemoteFileAsync(
+                        file.RelativePath,
+                        file.DownloadUrl ?? string.Empty,
+                        ContentSourceType.ContentAddressable,
+                        isExecutable: file.IsExecutable,
+                        permissions: file.Permissions);
+                }
 
                 processedFiles++;
             }

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
@@ -130,6 +130,9 @@ public class HttpContentDeliverer(
             SourceType = ContentSourceType.ContentAddressable,
             InstallTarget = file.InstallTarget,
             IsExecutable = file.IsExecutable,
+            IsRequired = file.IsRequired,
+            PackageInfo = file.PackageInfo,
+            PatchSourceFile = file.PatchSourceFile,
             Hash = !string.IsNullOrEmpty(file.Hash) ? file.Hash : string.Empty,
             DownloadUrl = file.DownloadUrl,
             Size = fileInfo.Exists ? fileInfo.Length : file.Size,
@@ -151,6 +154,9 @@ public class HttpContentDeliverer(
                 SourceType = ContentSourceType.ContentAddressable,
                 InstallTarget = file.InstallTarget,
                 IsExecutable = file.IsExecutable,
+                IsRequired = file.IsRequired,
+                PackageInfo = file.PackageInfo,
+                PatchSourceFile = file.PatchSourceFile,
                 Hash = file.Hash,
                 DownloadUrl = file.DownloadUrl,
                 Size = file.Size,
@@ -168,19 +174,29 @@ public class HttpContentDeliverer(
 
         var builder = manifestBuilder
             .WithBasicInfo(publisherId, packageManifest.Name, manifestVersionInt)
-            .WithContentType(packageManifest.ContentType, packageManifest.TargetGame)
-            .WithPublisher(
-                packageManifest.Publisher?.Name ?? string.Empty,
-                packageManifest.Publisher?.Website ?? string.Empty,
-                packageManifest.Publisher?.SupportUrl ?? string.Empty,
-                packageManifest.Publisher?.ContactEmail ?? string.Empty,
-                packageManifest.Publisher?.PublisherType ?? string.Empty)
-            .WithMetadata(
-                packageManifest.Metadata?.Description ?? string.Empty,
-                packageManifest.Metadata?.Tags,
-                packageManifest.Metadata?.IconUrl ?? string.Empty,
-                packageManifest.Metadata?.ScreenshotUrls,
-                packageManifest.Metadata?.ChangelogUrl ?? string.Empty);
+            .WithContentType(packageManifest.ContentType, packageManifest.TargetGame);
+
+        if (packageManifest.Publisher != null)
+        {
+            builder.WithPublisher(packageManifest.Publisher);
+        }
+
+        builder.WithMetadata(
+            packageManifest.Metadata?.Description ?? string.Empty,
+            packageManifest.Metadata?.Tags,
+            packageManifest.Metadata?.IconUrl ?? string.Empty,
+            packageManifest.Metadata?.ScreenshotUrls,
+            packageManifest.Metadata?.ChangelogUrl ?? string.Empty);
+
+        if (packageManifest.ContentReferences is { Count: > 0 })
+        {
+            builder.WithContentReferences(packageManifest.ContentReferences);
+        }
+
+        if (packageManifest.InstallationInstructions != null)
+        {
+            builder.WithInstallationInstructions(packageManifest.InstallationInstructions);
+        }
 
         foreach (var dep in packageManifest.Dependencies)
         {

--- a/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentDeliverers/HttpContentDeliverer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -20,11 +19,12 @@ namespace GenHub.Features.Content.Services.ContentDeliverers;
 /// Delivers remote HTTP content.
 /// Pure delivery - downloads and extracts content.
 /// </summary>
-public class HttpContentDeliverer(
-    IDownloadService downloadService,
-    IContentManifestBuilder manifestBuilder,
-    ILogger<HttpContentDeliverer> logger) : IContentDeliverer
+public class HttpContentDeliverer(IDownloadService downloadService, IContentManifestBuilder manifestBuilder, ILogger<HttpContentDeliverer> logger) : IContentDeliverer
 {
+    private readonly IDownloadService _downloadService = downloadService;
+    private readonly IContentManifestBuilder _manifestBuilder = manifestBuilder;
+    private readonly ILogger<HttpContentDeliverer> _logger = logger;
+
     /// <inheritdoc />
     public string SourceName => ContentSourceNames.HttpDeliverer;
 
@@ -56,39 +56,116 @@ public class HttpContentDeliverer(
     {
         try
         {
-            var deliveredManifest = InitializeManifestBuilder(packageManifest);
+            // Extract publisher from the manifest ID (3rd segment)
+            var idSegments = packageManifest.Id.Value.Split('.');
+            var publisherId = idSegments.Length >= 3 ? idSegments[2] : "unknown";
 
-            var filesToDownload = packageManifest.Files.Where(f => !string.IsNullOrEmpty(f.DownloadUrl)).ToList();
-            var downloadResult = await DownloadDeliveredFilesAsync(
-                deliveredManifest,
-                filesToDownload,
-                targetDirectory,
-                progress,
-                cancellationToken);
+            var manifestVersionInt = int.TryParse(packageManifest.Version, out var parsedVersion) ? parsedVersion : 0;
+            var deliveredManifest = _manifestBuilder
+                .WithBasicInfo(publisherId, packageManifest.Name, manifestVersionInt)
+                .WithContentType(packageManifest.ContentType, packageManifest.TargetGame)
+                .WithPublisher(
+                    packageManifest.Publisher?.Name ?? string.Empty,
+                    packageManifest.Publisher?.Website ?? string.Empty,
+                    packageManifest.Publisher?.SupportUrl ?? string.Empty,
+                    packageManifest.Publisher?.ContactEmail ?? string.Empty)
+                .WithMetadata(
+                    packageManifest.Metadata?.Description ?? string.Empty,
+                    packageManifest.Metadata?.Tags,
+                    packageManifest.Metadata?.IconUrl ?? string.Empty,
+                    packageManifest.Metadata?.ScreenshotUrls,
+                    packageManifest.Metadata?.ChangelogUrl ?? string.Empty);
 
-            if (!downloadResult.Success)
+            // Add dependencies
+            foreach (var dep in packageManifest.Dependencies)
             {
-                return OperationResult<ContentManifest>.CreateFailure(downloadResult.Errors);
+                deliveredManifest.AddDependency(
+                    dep.Id,
+                    dep.Name,
+                    dep.DependencyType,
+                    dep.InstallBehavior,
+                    dep.MinVersion ?? string.Empty,
+                    dep.MaxVersion ?? string.Empty,
+                    dep.CompatibleVersions,
+                    dep.IsExclusive,
+                    dep.ConflictsWith);
             }
 
-            AddNonDownloadFiles(deliveredManifest, packageManifest.Files.Where(f => string.IsNullOrEmpty(f.DownloadUrl)));
+            var filesToDownload = packageManifest.Files.Where(f => !string.IsNullOrEmpty(f.DownloadUrl)).ToList();
+            var totalFiles = filesToDownload.Count;
+            var processedFiles = 0;
 
+            // Download and add files
+            foreach (var file in filesToDownload)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var localPath = Path.Combine(targetDirectory, file.RelativePath);
+
+                // Ensure directory exists
+                var directory = Path.GetDirectoryName(localPath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                // Report progress
+                progress?.Report(new ContentAcquisitionProgress
+                {
+                    Phase = ContentAcquisitionPhase.Downloading,
+                    ProgressPercentage = (double)processedFiles / totalFiles * 100,
+                    CurrentOperation = $"Downloading {file.RelativePath}",
+                    CurrentFile = file.RelativePath,
+                    FilesProcessed = processedFiles,
+                    TotalFiles = totalFiles,
+                });
+
+                // Download the file
+                var downloadResult = await _downloadService.DownloadFileAsync(
+                    new Uri(file.DownloadUrl!), localPath, file.Hash, null, cancellationToken);
+
+                if (!downloadResult.Success)
+                {
+                    return OperationResult<ContentManifest>.CreateFailure(
+                        $"Failed to download {file.RelativePath}: {downloadResult.FirstError}");
+                }
+
+                // Add the delivered file using the builder
+                await deliveredManifest.AddRemoteFileAsync(
+                    file.RelativePath,
+                    file.DownloadUrl ?? string.Empty,
+                    ContentSourceType.ContentAddressable,
+                    isExecutable: file.IsExecutable,
+                    permissions: file.Permissions);
+
+                processedFiles++;
+            }
+
+            // Add any other files (without DownloadUrl) as-is
+            foreach (var file in packageManifest.Files.Where(f => string.IsNullOrEmpty(f.DownloadUrl)))
+            {
+                await deliveredManifest.AddLocalFileAsync(
+                    file.RelativePath,
+                    file.SourcePath ?? string.Empty,
+                    ContentSourceType.ContentAddressable,
+                    isExecutable: file.IsExecutable,
+                    permissions: file.Permissions);
+            }
+
+            // Add required directories
             deliveredManifest.AddRequiredDirectories([.. packageManifest.RequiredDirectories]);
 
+            // Add installation instructions if present
             if (packageManifest.InstallationInstructions != null)
             {
-                deliveredManifest.WithInstallationInstructions(packageManifest.InstallationInstructions);
+                deliveredManifest.WithInstallationInstructions(packageManifest.InstallationInstructions.WorkspaceStrategy);
             }
 
             return OperationResult<ContentManifest>.CreateSuccess(deliveredManifest.Build());
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to deliver HTTP content for manifest {ManifestId}", packageManifest.Id);
+            _logger.LogError(ex, "Failed to deliver HTTP content for manifest {ManifestId}", packageManifest.Id);
             return OperationResult<ContentManifest>.CreateFailure($"Content delivery failed: {ex.Message}");
         }
     }
@@ -113,152 +190,8 @@ public class HttpContentDeliverer(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Validation failed for HTTP content manifest {ManifestId}", manifest.Id);
+            _logger.LogError(ex, "Validation failed for HTTP content manifest {ManifestId}", manifest.Id);
             return Task.FromResult(OperationResult<bool>.CreateFailure($"Validation failed: {ex.Message}"));
         }
-    }
-
-    private static void AddDeliveredFile(
-        IContentManifestBuilder deliveredManifest,
-        ManifestFile file,
-        string localPath)
-    {
-        var fileInfo = new FileInfo(localPath);
-        var deliveredFile = new ManifestFile
-        {
-            RelativePath = file.RelativePath,
-            SourceType = ContentSourceType.ContentAddressable,
-            InstallTarget = file.InstallTarget,
-            IsExecutable = file.IsExecutable,
-            IsRequired = file.IsRequired,
-            PackageInfo = file.PackageInfo,
-            PatchSourceFile = file.PatchSourceFile,
-            Hash = !string.IsNullOrEmpty(file.Hash) ? file.Hash : string.Empty,
-            DownloadUrl = file.DownloadUrl,
-            Size = fileInfo.Exists ? fileInfo.Length : file.Size,
-            Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
-        };
-        deliveredManifest.AddFile(deliveredFile);
-    }
-
-    private static void AddNonDownloadFiles(
-        IContentManifestBuilder deliveredManifest,
-        IEnumerable<ManifestFile> files)
-    {
-        foreach (var file in files)
-        {
-            var otherFile = new ManifestFile
-            {
-                RelativePath = file.RelativePath,
-                SourcePath = file.SourcePath ?? string.Empty,
-                SourceType = ContentSourceType.ContentAddressable,
-                InstallTarget = file.InstallTarget,
-                IsExecutable = file.IsExecutable,
-                IsRequired = file.IsRequired,
-                PackageInfo = file.PackageInfo,
-                PatchSourceFile = file.PatchSourceFile,
-                Hash = file.Hash,
-                DownloadUrl = file.DownloadUrl,
-                Size = file.Size,
-                Permissions = file.Permissions ?? new FilePermissions { UnixPermissions = file.IsExecutable ? "755" : "644" },
-            };
-            deliveredManifest.AddFile(otherFile);
-        }
-    }
-
-    private IContentManifestBuilder InitializeManifestBuilder(ContentManifest packageManifest)
-    {
-        var idSegments = packageManifest.Id.Value.Split('.');
-        var publisherId = idSegments.Length >= 3 ? idSegments[2] : "unknown";
-        var manifestVersionInt = int.TryParse(packageManifest.Version, out var parsedVersion) ? parsedVersion : 0;
-
-        var builder = manifestBuilder
-            .WithBasicInfo(publisherId, packageManifest.Name, manifestVersionInt)
-            .WithContentType(packageManifest.ContentType, packageManifest.TargetGame);
-
-        if (packageManifest.Publisher != null)
-        {
-            builder.WithPublisher(packageManifest.Publisher);
-        }
-
-        builder.WithMetadata(
-            packageManifest.Metadata?.Description ?? string.Empty,
-            packageManifest.Metadata?.Tags,
-            packageManifest.Metadata?.IconUrl ?? string.Empty,
-            packageManifest.Metadata?.ScreenshotUrls,
-            packageManifest.Metadata?.ChangelogUrl ?? string.Empty);
-
-        if (packageManifest.ContentReferences is { Count: > 0 })
-        {
-            builder.WithContentReferences(packageManifest.ContentReferences);
-        }
-
-        if (packageManifest.InstallationInstructions != null)
-        {
-            builder.WithInstallationInstructions(packageManifest.InstallationInstructions);
-        }
-
-        foreach (var dep in packageManifest.Dependencies)
-        {
-            builder.AddDependency(
-                dep.Id,
-                dep.Name,
-                dep.DependencyType,
-                dep.InstallBehavior,
-                dep.MinVersion ?? string.Empty,
-                dep.MaxVersion ?? string.Empty,
-                dep.CompatibleVersions,
-                dep.IsExclusive,
-                dep.ConflictsWith);
-        }
-
-        return builder;
-    }
-
-    private async Task<OperationResult<bool>> DownloadDeliveredFilesAsync(
-        IContentManifestBuilder deliveredManifest,
-        IReadOnlyList<ManifestFile> filesToDownload,
-        string targetDirectory,
-        IProgress<ContentAcquisitionProgress>? progress,
-        CancellationToken cancellationToken)
-    {
-        var totalFiles = filesToDownload.Count;
-        var processedFiles = 0;
-
-        foreach (var file in filesToDownload)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var localPath = Path.Combine(targetDirectory, file.RelativePath);
-            var directory = Path.GetDirectoryName(localPath);
-            if (!string.IsNullOrEmpty(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
-
-            progress?.Report(new ContentAcquisitionProgress
-            {
-                Phase = ContentAcquisitionPhase.Downloading,
-                ProgressPercentage = totalFiles > 0 ? (double)processedFiles / totalFiles * 100 : 100,
-                CurrentOperation = $"Downloading {file.RelativePath}",
-                CurrentFile = file.RelativePath,
-                FilesProcessed = processedFiles,
-                TotalFiles = totalFiles,
-            });
-
-            var downloadResult = await downloadService.DownloadFileAsync(
-                new Uri(file.DownloadUrl!), localPath, file.Hash, null, cancellationToken);
-
-            if (!downloadResult.Success)
-            {
-                return OperationResult<bool>.CreateFailure(
-                    $"Failed to download {file.RelativePath}: {downloadResult.FirstError}");
-            }
-
-            AddDeliveredFile(deliveredManifest, file, localPath);
-            processedFiles++;
-        }
-
-        return OperationResult<bool>.CreateSuccess(true);
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/AODMapsContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/AODMapsContentProvider.cs
@@ -21,7 +21,9 @@ public class AODMapsContentProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     ILogger<AODMapsContentProvider> logger,
-    IContentValidator contentValidator) : BaseContentProvider(contentValidator, logger)
+    IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private readonly IContentDiscoverer _aodMapsDiscoverer = discoverers.FirstOrDefault(d =>
         string.Equals(d.SourceName, AODMapsConstants.DiscovererSourceName, StringComparison.OrdinalIgnoreCase))

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -158,17 +158,34 @@ public abstract class BaseContentProvider(
             {
                 if (installationInstructionsService != null)
                 {
-                    // Execute post-installation steps if declared on the delivered manifest
-                    var stepExecutionResult = await installationInstructionsService.ExecutePostInstallStepsAsync(
-                        result.Data,
-                        workingDirectory,
-                        progress: progress,
-                        cancellationToken: cancellationToken);
-
-                    if (!stepExecutionResult.Success)
+                    try
                     {
-                        Logger.LogError("Post-installation steps failed for manifest {ManifestId}: {Error}", manifest.Id, stepExecutionResult.FirstError);
-                        return OperationResult<ContentManifest>.CreateFailure(stepExecutionResult.Errors);
+                        // Execute post-installation steps if declared on the delivered manifest
+                        var stepExecutionResult = await installationInstructionsService.ExecutePostInstallStepsAsync(
+                            result.Data,
+                            workingDirectory,
+                            providerSource: SourceName,
+                            progress: progress,
+                            cancellationToken: cancellationToken);
+
+                        if (!stepExecutionResult.Success)
+                        {
+                            Logger.LogError("Post-installation steps failed for manifest {ManifestId}: {Error}", manifest.Id, stepExecutionResult.FirstError);
+                            await RollbackPreparedContentAsync(manifest, result.Data, workingDirectory, CancellationToken.None);
+                            return OperationResult<ContentManifest>.CreateFailure(stepExecutionResult.Errors);
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        Logger.LogInformation("Post-installation execution was canceled for manifest {ManifestId}; rolling back prepared content", manifest.Id);
+                        await RollbackPreparedContentAsync(manifest, result.Data, workingDirectory, CancellationToken.None);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(ex, "Unexpected error executing post-installation steps for manifest {ManifestId}; rolling back prepared content", manifest.Id);
+                        await RollbackPreparedContentAsync(manifest, result.Data, workingDirectory, CancellationToken.None);
+                        return OperationResult<ContentManifest>.CreateFailure($"Post-installation execution failed: {ex.Message}");
                     }
                 }
 
@@ -221,6 +238,23 @@ public abstract class BaseContentProvider(
             Logger.LogError(ex, "Failed to prepare content for manifest {ManifestId}", manifest.Id);
             return OperationResult<ContentManifest>.CreateFailure($"Content preparation failed: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Rolls back prepared content and registered manifests when post-preparation steps fail.
+    /// </summary>
+    /// <param name="originalManifest">The original requested manifest.</param>
+    /// <param name="preparedManifest">The prepared manifest returned by PrepareContentInternalAsync.</param>
+    /// <param name="workingDirectory">The working directory where content was prepared.</param>
+    /// <param name="cancellationToken">A token to cancel rollback operations.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    protected virtual Task RollbackPreparedContentAsync(
+        ContentManifest originalManifest,
+        ContentManifest preparedManifest,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -18,12 +18,28 @@ namespace GenHub.Features.Content.Services.ContentProviders;
 /// <summary>
 /// Base class for content providers with common pipeline orchestration logic.
 /// </summary>
-public abstract class BaseContentProvider(
-    IContentValidator contentValidator,
-    IInstallationInstructionsService? installationInstructionsService,
-    ILogger logger
-) : IContentProvider
+public abstract class BaseContentProvider : IContentProvider
 {
+    private readonly IContentValidator _contentValidator;
+    private readonly IInstallationInstructionsService? _installationInstructionsService;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseContentProvider"/> class.
+    /// </summary>
+    /// <param name="contentValidator">The content validator.</param>
+    /// <param name="installationInstructionsService">The optional installation instructions service.</param>
+    /// <param name="logger">The logger.</param>
+    protected BaseContentProvider(
+        IContentValidator contentValidator,
+        IInstallationInstructionsService? installationInstructionsService,
+        ILogger logger)
+    {
+        _contentValidator = contentValidator;
+        _installationInstructionsService = installationInstructionsService;
+        _logger = logger;
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BaseContentProvider"/> class without an installation instructions service.
     /// </summary>
@@ -156,12 +172,12 @@ public abstract class BaseContentProvider(
 
             if (result.Success && result.Data != null)
             {
-                if (installationInstructionsService != null)
+                if (_installationInstructionsService != null)
                 {
                     try
                     {
                         // Execute post-installation steps if declared on the delivered manifest
-                        var stepExecutionResult = await installationInstructionsService.ExecutePostInstallStepsAsync(
+                        var stepExecutionResult = await _installationInstructionsService.ExecutePostInstallStepsAsync(
                             result.Data,
                             workingDirectory,
                             providerSource: SourceName,
@@ -260,17 +276,17 @@ public abstract class BaseContentProvider(
     /// <summary>
     /// Gets the logger for this provider.
     /// </summary>
-    protected ILogger Logger => logger;
+    protected ILogger Logger => _logger;
 
     /// <summary>
     /// Gets the content validator for manifest validation.
     /// </summary>
-    protected IContentValidator ContentValidator => contentValidator;
+    protected IContentValidator ContentValidator => _contentValidator;
 
     /// <summary>
     /// Gets the installation instructions service for post-install execution.
     /// </summary>
-    protected IInstallationInstructionsService? InstallationInstructionsService => installationInstructionsService;
+    protected IInstallationInstructionsService? InstallationInstructionsService => _installationInstructionsService;
 
     /// <summary>
     /// Gets the discoverer for this provider.

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -20,12 +20,10 @@ namespace GenHub.Features.Content.Services.ContentProviders;
 /// </summary>
 public abstract class BaseContentProvider(
     IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService,
     ILogger logger
 ) : IContentProvider
 {
-    private readonly ILogger logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    private readonly IContentValidator _contentValidator = contentValidator ?? throw new ArgumentNullException(nameof(contentValidator));
-
     /// <inheritdoc />
     public abstract string SourceName { get; }
 
@@ -58,86 +56,86 @@ public abstract class BaseContentProvider(
                 $"Discovery failed: {discoveryResult.FirstError}");
         }
 
-        var resolvedResults = new List<ContentSearchResult>();
-
-        // Step 2: Resolution & Validation
-        foreach (var discovered in discoveryResult.Data.Items)
+        // Step 2: Resolution for each discovered item
+        var results = new List<ContentSearchResult>();
+        foreach (var manifest in discoveryResult.Data)
         {
-            if (discovered.RequiresResolution)
-            {
-                var resolutionResult = await Resolver.ResolveAsync(providerDefinition, discovered, cancellationToken);
-                if (resolutionResult.Success && resolutionResult.Data != null)
-                {
-                    var validationResult = await ContentValidator.ValidateManifestAsync(
-                        resolutionResult.Data, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
-                    if (validationResult.IsValid)
-                    {
-                        var resolvedSearchResult = CreateResolvedSearchResult(discovered, resolutionResult.Data);
-                        resolvedResults.Add(resolvedSearchResult);
-                    }
-                    else
-                    {
-                        Logger.LogWarning(
-                            "Manifest validation failed for {ContentName}: {Errors}",
-                            discovered.Name,
-                            string.Join(", ", validationResult.Issues.Select(i => i.Message)));
-                    }
-                }
-                else
+            var resolveResult = await Resolver.ResolveAsync(manifest, cancellationToken);
+            if (resolveResult.Success && resolveResult.Data != null)
+            {
+                results.Add(new ContentSearchResult
                 {
-                    Logger.LogWarning(
-                        "Resolution failed for {ContentName}: {Error}",
-                        discovered.Name,
-                        resolutionResult.FirstError ?? "Unknown error");
-                }
+                    Manifest = resolveResult.Data,
+                    SourceName = SourceName,
+                    Score = CalculateRelevanceScore(query.SearchTerm, resolveResult.Data),
+                });
             }
             else
             {
-                resolvedResults.Add(discovered);
+                Logger.LogWarning("Failed to resolve manifest {ManifestId}: {Error}", manifest.Id, resolveResult.FirstError);
             }
         }
 
-        return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(resolvedResults);
+        Logger.LogInformation("Found {Count} items matching '{SearchTerm}' from {ProviderName}", results.Count, query.SearchTerm, SourceName);
+        return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(results);
     }
 
-    /// <summary>
-    /// Gets the manifest for the specified content ID.
-    /// </summary>
-    /// <param name="contentId">The content identifier.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A result containing the game manifest.</returns>
-    public abstract Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
+    /// <inheritdoc />
+    public virtual async Task<OperationResult<ContentManifest>> GetByIdAsync(
         string contentId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default)
+    {
+        Logger.LogDebug("Fetching content by ID: {ContentId} from {ProviderName}", contentId, SourceName);
 
-    /// <inheritdoc/>
+        var query = new ContentSearchQuery { SearchTerm = contentId };
+        var searchResult = await SearchAsync(query, cancellationToken);
+
+        if (!searchResult.Success || searchResult.Data == null)
+        {
+            return OperationResult<ContentManifest>.CreateFailure(
+                $"Failed to fetch content: {searchResult.FirstError}");
+        }
+
+        var match = searchResult.Data.FirstOrDefault(r => r.Manifest.Id.Value == contentId);
+        if (match?.Manifest == null)
+        {
+            return OperationResult<ContentManifest>.CreateFailure(
+                $"Content with ID '{contentId}' not found in {SourceName}");
+        }
+
+        return OperationResult<ContentManifest>.CreateSuccess(match.Manifest);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<OperationResult<ContentManifest>> PrepareContentAsync(
         ContentManifest manifest,
         string workingDirectory,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+
+        Logger.LogInformation("Starting content preparation for manifest: {ManifestId} in {Directory}", manifest.Id, workingDirectory);
+
         try
         {
-            Logger.LogDebug("Preparing content for manifest {ManifestId}", manifest.Id);
-
-            // Validate manifest before preparation
+            // Initial manifest structure validation
             progress?.Report(new ContentAcquisitionProgress
             {
-                Phase = ContentAcquisitionPhase.ValidatingManifest,
+                Phase = ContentAcquisitionPhase.ValidatingFiles,
                 CurrentOperation = "Validating manifest structure...",
             });
 
-            var validationResult = await ContentValidator.ValidateManifestAsync(manifest, cancellationToken);
-            if (!validationResult.IsValid)
+            var manifestValidationResult = await ContentValidator.ValidateManifestAsync(manifest, cancellationToken);
+            if (manifestValidationResult.HasErrors)
             {
-                var errors = validationResult.Issues.Where(i => i.Severity == ValidationSeverity.Error).ToList();
-                if (errors.Count > 0)
-                {
-                    return OperationResult<ContentManifest>.CreateFailure(
-                        errors.Select(e => $"Manifest validation failed: {e.Message}"));
-                }
+                var errors = string.Join("; ", manifestValidationResult.Issues.Where(i => i.Severity == ValidationSeverity.Error).Select(i => i.Message));
+                Logger.LogError("Manifest validation failed for {ManifestId}: {Errors}", manifest.Id, errors);
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Manifest validation failed: {errors}");
             }
 
             progress?.Report(new ContentAcquisitionProgress
@@ -149,8 +147,21 @@ public abstract class BaseContentProvider(
             // Delegate to implementation-specific preparation
             var result = await PrepareContentInternalAsync(manifest, workingDirectory, progress, cancellationToken);
 
-            if (result.Success)
+            if (result.Success && result.Data != null)
             {
+                // Execute post-installation steps if declared on the delivered manifest
+                var stepExecutionResult = await installationInstructionsService.ExecutePostInstallStepsAsync(
+                    result.Data,
+                    workingDirectory,
+                    progress,
+                    cancellationToken);
+
+                if (!stepExecutionResult.Success)
+                {
+                    Logger.LogError("Post-installation steps failed for manifest {ManifestId}: {Error}", manifest.Id, stepExecutionResult.FirstError);
+                    return OperationResult<ContentManifest>.CreateFailure(stepExecutionResult.Errors);
+                }
+
                 // Final validation of prepared content
                 progress?.Report(new ContentAcquisitionProgress
                 {
@@ -178,7 +189,7 @@ public abstract class BaseContentProvider(
 
                 var fullResult = await ContentValidator.ValidateAllAsync(
                     workingDirectory,
-                    result.Data!,
+                    result.Data,
                     validationProgress,
                     cancellationToken: cancellationToken);
 
@@ -216,7 +227,12 @@ public abstract class BaseContentProvider(
     /// <summary>
     /// Gets the content validator for manifest validation.
     /// </summary>
-    protected IContentValidator ContentValidator => _contentValidator;
+    protected IContentValidator ContentValidator => contentValidator;
+
+    /// <summary>
+    /// Gets the installation instructions service.
+    /// </summary>
+    protected IInstallationInstructionsService InstallationInstructionsService => installationInstructionsService;
 
     /// <summary>
     /// Gets the discoverer for this provider.
@@ -234,85 +250,59 @@ public abstract class BaseContentProvider(
     protected abstract IContentDeliverer Deliverer { get; }
 
     /// <summary>
-    /// Gets the provider definition for data-driven configuration.
-    /// Override this method to provide a ProviderDefinition loaded from JSON configuration.
-    /// </summary>
-    /// <returns>The provider definition, or null if the provider uses hardcoded configuration.</returns>
-    protected virtual ProviderDefinition? GetProviderDefinition() => null;
-
-    /// <summary>
     /// Implementation-specific content preparation logic.
+    /// Override this method to provide custom delivery orchestration.
+    /// Default implementation uses the Deliverer component.
     /// </summary>
-    /// <param name="manifest">The manifest to prepare.</param>
-    /// <param name="workingDirectory">Working directory for content preparation.</param>
-    /// <param name="progress">Progress reporter.</param>
+    /// <param name="manifest">The content manifest to prepare.</param>
+    /// <param name="workingDirectory">The working directory for preparation.</param>
+    /// <param name="progress">Progress reporter for tracking progress.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The prepared manifest.</returns>
-    protected abstract Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
+    /// <returns>A result containing the prepared manifest with updated file details.</returns>
+    protected virtual async Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
         ContentManifest manifest,
         string workingDirectory,
         IProgress<ContentAcquisitionProgress>? progress,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken)
+    {
+        return await Deliverer.DeliverContentAsync(manifest, workingDirectory, progress, cancellationToken);
+    }
 
     /// <summary>
-    /// Creates a resolved <see cref="ContentSearchResult"/> from a discovered item and manifest.
+    /// Gets the provider definition for data-driven configuration.
+    /// Override in derived classes to provide provider definition from loader.
     /// </summary>
-    /// <param name="discovered">The discovered search result.</param>
-    /// <param name="manifest">The resolved manifest.</param>
-    /// <returns>A resolved <see cref="ContentSearchResult"/>.</returns>
-    private ContentSearchResult CreateResolvedSearchResult(ContentSearchResult discovered, ContentManifest manifest)
+    /// <returns>The provider definition, or null if not available.</returns>
+    protected virtual ProviderDefinition? GetProviderDefinition() => null;
+
+    /// <summary>
+    /// Calculates a simple relevance score for search results.
+    /// </summary>
+    private static double CalculateRelevanceScore(string searchTerm, ContentManifest manifest)
     {
-        var resolved = new ContentSearchResult
+        if (string.IsNullOrWhiteSpace(searchTerm))
         {
-            Id = discovered.Id,
-            Name = manifest.Name,
-            Description = manifest.Metadata?.Description ?? discovered.Description,
-            Version = manifest.Version,
-            ContentType = manifest.ContentType,
-            TargetGame = manifest.TargetGame,
-            ProviderName = SourceName,
-            AuthorName = manifest.Publisher?.Name ?? discovered.AuthorName,
-            IconUrl = manifest.Metadata?.IconUrl ?? discovered.IconUrl,
-            LastUpdated = manifest.Metadata?.ReleaseDate ?? discovered.LastUpdated,
-            DownloadSize = manifest.Files?.Sum(f => f.Size) ?? discovered.DownloadSize,
-            RequiresResolution = false,
-            SourceUrl = discovered.SourceUrl,
-        };
-
-        // Copy screenshots and tags
-        resolved.ScreenshotUrls.Clear();
-        if (manifest.Metadata?.ScreenshotUrls != null && manifest.Metadata.ScreenshotUrls.Count > 0)
-        {
-            foreach (var s in manifest.Metadata.ScreenshotUrls)
-            {
-                resolved.ScreenshotUrls.Add(s);
-            }
-        }
-        else
-        {
-            foreach (var s in discovered.ScreenshotUrls)
-            {
-                resolved.ScreenshotUrls.Add(s);
-            }
+            return 1.0;
         }
 
-        resolved.Tags.Clear();
-        if (manifest.Metadata?.Tags != null && manifest.Metadata.Tags.Count > 0)
+        var score = 0.0;
+        var term = searchTerm.ToLowerInvariant();
+
+        if (manifest.Name.Contains(term, StringComparison.OrdinalIgnoreCase))
         {
-            foreach (var t in manifest.Metadata.Tags)
-            {
-                resolved.Tags.Add(t);
-            }
-        }
-        else
-        {
-            foreach (var t in discovered.Tags)
-            {
-                resolved.Tags.Add(t);
-            }
+            score += 10.0;
         }
 
-        resolved.SetData(manifest);
-        return resolved;
+        if (manifest.Metadata?.Description?.Contains(term, StringComparison.OrdinalIgnoreCase) == true)
+        {
+            score += 5.0;
+        }
+
+        if (manifest.Metadata?.Tags?.Any(t => t.Contains(term, StringComparison.OrdinalIgnoreCase)) == true)
+        {
+            score += 3.0;
+        }
+
+        return score;
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -56,86 +56,81 @@ public abstract class BaseContentProvider(
                 $"Discovery failed: {discoveryResult.FirstError}");
         }
 
-        // Step 2: Resolution for each discovered item
-        var results = new List<ContentSearchResult>();
-        foreach (var manifest in discoveryResult.Data)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+        var resolvedResults = new List<ContentSearchResult>();
 
-            var resolveResult = await Resolver.ResolveAsync(manifest, cancellationToken);
-            if (resolveResult.Success && resolveResult.Data != null)
+        // Step 2: Resolution & Validation
+        foreach (var discovered in discoveryResult.Data.Items)
+        {
+            if (discovered.RequiresResolution)
             {
-                results.Add(new ContentSearchResult
+                var resolutionResult = await Resolver.ResolveAsync(providerDefinition, discovered, cancellationToken);
+                if (resolutionResult.Success && resolutionResult.Data != null)
                 {
-                    Manifest = resolveResult.Data,
-                    SourceName = SourceName,
-                    Score = CalculateRelevanceScore(query.SearchTerm, resolveResult.Data),
-                });
+                    var validationResult = await ContentValidator.ValidateManifestAsync(
+                        resolutionResult.Data, cancellationToken);
+
+                    if (validationResult.IsValid)
+                    {
+                        var resolvedSearchResult = CreateResolvedSearchResult(discovered, resolutionResult.Data);
+                        resolvedResults.Add(resolvedSearchResult);
+                    }
+                    else
+                    {
+                        Logger.LogWarning(
+                            "Manifest validation failed for {ContentName}: {Errors}",
+                            discovered.Name,
+                            string.Join(", ", validationResult.Issues.Select(i => i.Message)));
+                    }
+                }
+                else
+                {
+                    Logger.LogWarning(
+                        "Resolution failed for {ContentName}: {Error}",
+                        discovered.Name,
+                        resolutionResult.FirstError);
+                }
             }
             else
             {
-                Logger.LogWarning("Failed to resolve manifest {ManifestId}: {Error}", manifest.Id, resolveResult.FirstError);
+                resolvedResults.Add(discovered);
             }
         }
 
-        Logger.LogInformation("Found {Count} items matching '{SearchTerm}' from {ProviderName}", results.Count, query.SearchTerm, SourceName);
-        return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(results);
+        return OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(resolvedResults);
     }
 
-    /// <inheritdoc />
-    public virtual async Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
+    /// <inheritdoc/>
+    public abstract Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
         string contentId,
-        CancellationToken cancellationToken = default)
-    {
-        Logger.LogDebug("Fetching content by ID: {ContentId} from {ProviderName}", contentId, SourceName);
+        CancellationToken cancellationToken = default);
 
-        var query = new ContentSearchQuery { SearchTerm = contentId };
-        var searchResult = await SearchAsync(query, cancellationToken);
-
-        if (!searchResult.Success || searchResult.Data == null)
-        {
-            return OperationResult<ContentManifest>.CreateFailure(
-                $"Failed to fetch content: {searchResult.FirstError}");
-        }
-
-        var match = searchResult.Data.FirstOrDefault(r => r.Manifest.Id.Value == contentId);
-        if (match?.Manifest == null)
-        {
-            return OperationResult<ContentManifest>.CreateFailure(
-                $"Content with ID '{contentId}' not found in {SourceName}");
-        }
-
-        return OperationResult<ContentManifest>.CreateSuccess(match.Manifest);
-    }
-
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public virtual async Task<OperationResult<ContentManifest>> PrepareContentAsync(
         ContentManifest manifest,
         string workingDirectory,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(manifest);
-        ArgumentNullException.ThrowIfNull(workingDirectory);
-
-        Logger.LogInformation("Starting content preparation for manifest: {ManifestId} in {Directory}", manifest.Id, workingDirectory);
-
         try
         {
-            // Initial manifest structure validation
+            Logger.LogDebug("Preparing content for manifest {ManifestId}", manifest.Id);
+
+            // Validate manifest before preparation
             progress?.Report(new ContentAcquisitionProgress
             {
-                Phase = ContentAcquisitionPhase.ValidatingFiles,
+                Phase = ContentAcquisitionPhase.ValidatingManifest,
                 CurrentOperation = "Validating manifest structure...",
             });
 
-            var manifestValidationResult = await ContentValidator.ValidateManifestAsync(manifest, cancellationToken);
-            if (manifestValidationResult.HasErrors)
+            var validationResult = await ContentValidator.ValidateManifestAsync(manifest, cancellationToken);
+            if (!validationResult.IsValid)
             {
-                var errors = string.Join("; ", manifestValidationResult.Issues.Where(i => i.Severity == ValidationSeverity.Error).Select(i => i.Message));
-                Logger.LogError("Manifest validation failed for {ManifestId}: {Errors}", manifest.Id, errors);
-                return OperationResult<ContentManifest>.CreateFailure(
-                    $"Manifest validation failed: {errors}");
+                var errors = validationResult.Issues.Where(i => i.Severity == ValidationSeverity.Error).ToList();
+                if (errors.Count > 0)
+                {
+                    return OperationResult<ContentManifest>.CreateFailure(
+                        errors.Select(e => $"Manifest validation failed: {e.Message}"));
+                }
             }
 
             progress?.Report(new ContentAcquisitionProgress
@@ -153,8 +148,8 @@ public abstract class BaseContentProvider(
                 var stepExecutionResult = await installationInstructionsService.ExecutePostInstallStepsAsync(
                     result.Data,
                     workingDirectory,
-                    progress,
-                    cancellationToken);
+                    progress: progress,
+                    cancellationToken: cancellationToken);
 
                 if (!stepExecutionResult.Success)
                 {
@@ -195,13 +190,7 @@ public abstract class BaseContentProvider(
 
                 if (!fullResult.IsValid)
                 {
-                    // Log as warning only - content may have been moved to CAS already
-                    // CAS storage validates content hash on store, so this is informational
                     Logger.LogWarning("Content validation found {IssueCount} issues for {ManifestId}", fullResult.Issues.Count, manifest.Id);
-                    foreach (var issue in fullResult.Issues.Take(5))
-                    {
-                        Logger.LogDebug("Validation issue: {Message}", issue.Message);
-                    }
                 }
             }
 
@@ -230,7 +219,7 @@ public abstract class BaseContentProvider(
     protected IContentValidator ContentValidator => contentValidator;
 
     /// <summary>
-    /// Gets the installation instructions service.
+    /// Gets the installation instructions service for post-install execution.
     /// </summary>
     protected IInstallationInstructionsService InstallationInstructionsService => installationInstructionsService;
 
@@ -250,59 +239,85 @@ public abstract class BaseContentProvider(
     protected abstract IContentDeliverer Deliverer { get; }
 
     /// <summary>
-    /// Implementation-specific content preparation logic.
-    /// Override this method to provide custom delivery orchestration.
-    /// Default implementation uses the Deliverer component.
-    /// </summary>
-    /// <param name="manifest">The content manifest to prepare.</param>
-    /// <param name="workingDirectory">The working directory for preparation.</param>
-    /// <param name="progress">Progress reporter for tracking progress.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A result containing the prepared manifest with updated file details.</returns>
-    protected virtual async Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
-        ContentManifest manifest,
-        string workingDirectory,
-        IProgress<ContentAcquisitionProgress>? progress,
-        CancellationToken cancellationToken)
-    {
-        return await Deliverer.DeliverContentAsync(manifest, workingDirectory, progress, cancellationToken);
-    }
-
-    /// <summary>
     /// Gets the provider definition for data-driven configuration.
-    /// Override in derived classes to provide provider definition from loader.
+    /// Override this method to provide a ProviderDefinition loaded from JSON configuration.
     /// </summary>
-    /// <returns>The provider definition, or null if not available.</returns>
+    /// <returns>The provider definition, or null if the provider uses hardcoded configuration.</returns>
     protected virtual ProviderDefinition? GetProviderDefinition() => null;
 
     /// <summary>
-    /// Calculates a simple relevance score for search results.
+    /// Implementation-specific content preparation logic.
     /// </summary>
-    private static double CalculateRelevanceScore(string searchTerm, ContentManifest manifest)
+    /// <param name="manifest">The manifest to prepare.</param>
+    /// <param name="workingDirectory">Working directory for content preparation.</param>
+    /// <param name="progress">Progress reporter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The prepared manifest.</returns>
+    protected abstract Task<OperationResult<ContentManifest>> PrepareContentInternalAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a resolved <see cref="ContentSearchResult"/> from a discovered item and manifest.
+    /// </summary>
+    /// <param name="discovered">The discovered search result.</param>
+    /// <param name="manifest">The resolved manifest.</param>
+    /// <returns>A resolved <see cref="ContentSearchResult"/>.</returns>
+    private ContentSearchResult CreateResolvedSearchResult(ContentSearchResult discovered, ContentManifest manifest)
     {
-        if (string.IsNullOrWhiteSpace(searchTerm))
+        var resolved = new ContentSearchResult
         {
-            return 1.0;
+            Id = discovered.Id,
+            Name = manifest.Name,
+            Description = manifest.Metadata?.Description ?? discovered.Description,
+            Version = manifest.Version,
+            ContentType = manifest.ContentType,
+            TargetGame = manifest.TargetGame,
+            ProviderName = SourceName,
+            AuthorName = manifest.Publisher?.Name ?? discovered.AuthorName,
+            IconUrl = manifest.Metadata?.IconUrl ?? discovered.IconUrl,
+            LastUpdated = manifest.Metadata?.ReleaseDate ?? discovered.LastUpdated,
+            DownloadSize = manifest.Files?.Sum(f => f.Size) ?? discovered.DownloadSize,
+            RequiresResolution = false,
+            SourceUrl = discovered.SourceUrl,
+        };
+
+        // Copy screenshots and tags
+        resolved.ScreenshotUrls.Clear();
+        if (manifest.Metadata?.ScreenshotUrls != null && manifest.Metadata.ScreenshotUrls.Count > 0)
+        {
+            foreach (var s in manifest.Metadata.ScreenshotUrls)
+            {
+                resolved.ScreenshotUrls.Add(s);
+            }
+        }
+        else
+        {
+            foreach (var s in discovered.ScreenshotUrls)
+            {
+                resolved.ScreenshotUrls.Add(s);
+            }
         }
 
-        var score = 0.0;
-        var term = searchTerm.ToLowerInvariant();
-
-        if (manifest.Name.Contains(term, StringComparison.OrdinalIgnoreCase))
+        resolved.Tags.Clear();
+        if (manifest.Metadata?.Tags != null && manifest.Metadata.Tags.Count > 0)
         {
-            score += 10.0;
+            foreach (var t in manifest.Metadata.Tags)
+            {
+                resolved.Tags.Add(t);
+            }
+        }
+        else
+        {
+            foreach (var t in discovered.Tags)
+            {
+                resolved.Tags.Add(t);
+            }
         }
 
-        if (manifest.Metadata?.Description?.Contains(term, StringComparison.OrdinalIgnoreCase) == true)
-        {
-            score += 5.0;
-        }
-
-        if (manifest.Metadata?.Tags?.Any(t => t.Contains(term, StringComparison.OrdinalIgnoreCase)) == true)
-        {
-            score += 3.0;
-        }
-
-        return score;
+        resolved.SetData(manifest);
+        return resolved;
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -20,10 +20,22 @@ namespace GenHub.Features.Content.Services.ContentProviders;
 /// </summary>
 public abstract class BaseContentProvider(
     IContentValidator contentValidator,
-    IInstallationInstructionsService installationInstructionsService,
+    IInstallationInstructionsService? installationInstructionsService,
     ILogger logger
 ) : IContentProvider
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseContentProvider"/> class without an installation instructions service.
+    /// </summary>
+    /// <param name="contentValidator">The content validator.</param>
+    /// <param name="logger">The logger.</param>
+    public BaseContentProvider(
+        IContentValidator contentValidator,
+        ILogger logger)
+        : this(contentValidator, null, logger)
+    {
+    }
+
     /// <inheritdoc />
     public abstract string SourceName { get; }
 
@@ -144,17 +156,20 @@ public abstract class BaseContentProvider(
 
             if (result.Success && result.Data != null)
             {
-                // Execute post-installation steps if declared on the delivered manifest
-                var stepExecutionResult = await installationInstructionsService.ExecutePostInstallStepsAsync(
-                    result.Data,
-                    workingDirectory,
-                    progress: progress,
-                    cancellationToken: cancellationToken);
-
-                if (!stepExecutionResult.Success)
+                if (installationInstructionsService != null)
                 {
-                    Logger.LogError("Post-installation steps failed for manifest {ManifestId}: {Error}", manifest.Id, stepExecutionResult.FirstError);
-                    return OperationResult<ContentManifest>.CreateFailure(stepExecutionResult.Errors);
+                    // Execute post-installation steps if declared on the delivered manifest
+                    var stepExecutionResult = await installationInstructionsService.ExecutePostInstallStepsAsync(
+                        result.Data,
+                        workingDirectory,
+                        progress: progress,
+                        cancellationToken: cancellationToken);
+
+                    if (!stepExecutionResult.Success)
+                    {
+                        Logger.LogError("Post-installation steps failed for manifest {ManifestId}: {Error}", manifest.Id, stepExecutionResult.FirstError);
+                        return OperationResult<ContentManifest>.CreateFailure(stepExecutionResult.Errors);
+                    }
                 }
 
                 // Final validation of prepared content
@@ -221,7 +236,7 @@ public abstract class BaseContentProvider(
     /// <summary>
     /// Gets the installation instructions service for post-install execution.
     /// </summary>
-    protected IInstallationInstructionsService InstallationInstructionsService => installationInstructionsService;
+    protected IInstallationInstructionsService? InstallationInstructionsService => installationInstructionsService;
 
     /// <summary>
     /// Gets the discoverer for this provider.

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -172,7 +172,18 @@ public abstract class BaseContentProvider : IContentProvider
 
             if (result.Success && result.Data != null)
             {
-                if (_installationInstructionsService != null)
+                if (_installationInstructionsService == null)
+                {
+                    if (result.Data.InstallationInstructions?.PostInstallSteps?.Count > 0)
+                    {
+                        Logger.LogWarning(
+                            "Manifest {ManifestId} declares {Count} post-installation step(s), but {ProviderName} has no installation instructions service; the steps were not executed",
+                            manifest.Id,
+                            result.Data.InstallationInstructions.PostInstallSteps.Count,
+                            SourceName);
+                    }
+                }
+                else
                 {
                     try
                     {
@@ -240,6 +251,8 @@ public abstract class BaseContentProvider : IContentProvider
                 {
                     Logger.LogWarning("Content validation found {IssueCount} issues for {ManifestId}", fullResult.Issues.Count, manifest.Id);
                 }
+
+                await OnContentPreparationCompletedAsync(manifest, result.Data, workingDirectory, cancellationToken);
             }
 
             return result;
@@ -265,6 +278,23 @@ public abstract class BaseContentProvider : IContentProvider
     /// <param name="cancellationToken">A token to cancel rollback operations.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     protected virtual Task RollbackPreparedContentAsync(
+        ContentManifest originalManifest,
+        ContentManifest preparedManifest,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Executes cleanup or finalization when content preparation and validation succeed.
+    /// </summary>
+    /// <param name="originalManifest">The original requested manifest.</param>
+    /// <param name="preparedManifest">The prepared manifest returned by PrepareContentInternalAsync.</param>
+    /// <param name="workingDirectory">The working directory where content was prepared.</param>
+    /// <param name="cancellationToken">A token to cancel finalization operations.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    protected virtual Task OnContentPreparationCompletedAsync(
         ContentManifest originalManifest,
         ContentManifest preparedManifest,
         string workingDirectory,

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -21,35 +21,23 @@ namespace GenHub.Features.Content.Services.ContentProviders;
 public abstract class BaseContentProvider : IContentProvider
 {
     private readonly IContentValidator _contentValidator;
-    private readonly IInstallationInstructionsService? _installationInstructionsService;
+    private readonly IInstallationInstructionsService _installationInstructionsService;
     private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BaseContentProvider"/> class.
     /// </summary>
     /// <param name="contentValidator">The content validator.</param>
-    /// <param name="installationInstructionsService">The optional installation instructions service.</param>
+    /// <param name="installationInstructionsService">The installation instructions service.</param>
     /// <param name="logger">The logger.</param>
     protected BaseContentProvider(
         IContentValidator contentValidator,
-        IInstallationInstructionsService? installationInstructionsService,
+        IInstallationInstructionsService installationInstructionsService,
         ILogger logger)
     {
         _contentValidator = contentValidator;
         _installationInstructionsService = installationInstructionsService;
         _logger = logger;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BaseContentProvider"/> class without an installation instructions service.
-    /// </summary>
-    /// <param name="contentValidator">The content validator.</param>
-    /// <param name="logger">The logger.</param>
-    protected BaseContentProvider(
-        IContentValidator contentValidator,
-        ILogger logger)
-        : this(contentValidator, null, logger)
-    {
     }
 
     /// <inheritdoc />
@@ -170,89 +158,98 @@ public abstract class BaseContentProvider : IContentProvider
             // Delegate to implementation-specific preparation
             var result = await PrepareContentInternalAsync(manifest, workingDirectory, progress, cancellationToken);
 
-            if (result.Success && result.Data != null)
+            if (!result.Success)
             {
-                if (_installationInstructionsService == null)
-                {
-                    if (result.Data.InstallationInstructions?.PostInstallSteps?.Count > 0)
-                    {
-                        Logger.LogWarning(
-                            "Manifest {ManifestId} declares {Count} post-installation step(s), but {ProviderName} has no installation instructions service; the steps were not executed",
-                            manifest.Id,
-                            result.Data.InstallationInstructions.PostInstallSteps.Count,
-                            SourceName);
-                    }
-                }
-                else
-                {
-                    try
-                    {
-                        // Execute post-installation steps if declared on the delivered manifest
-                        var stepExecutionResult = await _installationInstructionsService.ExecutePostInstallStepsAsync(
-                            result.Data,
-                            workingDirectory,
-                            providerSource: SourceName,
-                            progress: progress,
-                            cancellationToken: cancellationToken);
+                return result;
+            }
 
-                        if (!stepExecutionResult.Success)
-                        {
-                            Logger.LogError("Post-installation steps failed for manifest {ManifestId}: {Error}", manifest.Id, stepExecutionResult.FirstError);
-                            await RollbackPreparedContentAsync(manifest, result.Data, workingDirectory, CancellationToken.None);
-                            return OperationResult<ContentManifest>.CreateFailure(stepExecutionResult.Errors);
-                        }
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        Logger.LogInformation("Post-installation execution was canceled for manifest {ManifestId}; rolling back prepared content", manifest.Id);
-                        await RollbackPreparedContentAsync(manifest, result.Data, workingDirectory, CancellationToken.None);
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogError(ex, "Unexpected error executing post-installation steps for manifest {ManifestId}; rolling back prepared content", manifest.Id);
-                        await RollbackPreparedContentAsync(manifest, result.Data, workingDirectory, CancellationToken.None);
-                        return OperationResult<ContentManifest>.CreateFailure($"Post-installation execution failed: {ex.Message}");
-                    }
-                }
+            if (result.Data == null)
+            {
+                Logger.LogError("Content preparation returned success without manifest data for {ManifestId}", manifest.Id);
+                return OperationResult<ContentManifest>.CreateFailure($"Content preparation returned no manifest data for {manifest.Id}.");
+            }
 
-                // Final validation of prepared content
-                progress?.Report(new ContentAcquisitionProgress
-                {
-                    Phase = ContentAcquisitionPhase.ValidatingFiles,
-                    CurrentOperation = "Validating prepared content...",
-                });
-
-                // Forward provider progress into validation by adapting ValidationProgress -> ContentAcquisitionProgress
-                IProgress<ValidationProgress>? validationProgress = null;
-                if (progress != null)
-                {
-                    validationProgress = new Progress<ValidationProgress>(vp =>
-                    {
-                        // Map validation progress to content acquisition progress for UI display
-                        progress.Report(new ContentAcquisitionProgress
-                        {
-                            Phase = ContentAcquisitionPhase.ValidatingFiles,
-                            ProgressPercentage = vp.PercentComplete,
-                            CurrentOperation = vp.CurrentFile ?? "Validating files",
-                            FilesProcessed = vp.Processed,
-                            TotalFiles = vp.Total,
-                        });
-                    });
-                }
-
-                var fullResult = await ContentValidator.ValidateAllAsync(
-                    workingDirectory,
+            try
+            {
+                // Execute post-installation steps if declared on the delivered manifest
+                var stepExecutionResult = await _installationInstructionsService.ExecutePostInstallStepsAsync(
                     result.Data,
-                    validationProgress,
+                    workingDirectory,
+                    providerSource: SourceName,
+                    progress: progress,
                     cancellationToken: cancellationToken);
 
-                if (!fullResult.IsValid)
+                if (!stepExecutionResult.Success)
                 {
-                    Logger.LogWarning("Content validation found {IssueCount} issues for {ManifestId}", fullResult.Issues.Count, manifest.Id);
+                    Logger.LogError("Post-installation steps failed for manifest {ManifestId}: {Error}", manifest.Id, stepExecutionResult.FirstError);
+                    await SafeRollbackPreparedContentAsync(manifest, result.Data, workingDirectory);
+                    return OperationResult<ContentManifest>.CreateFailure(stepExecutionResult.Errors);
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                Logger.LogInformation("Post-installation execution was canceled for manifest {ManifestId}; rolling back prepared content", manifest.Id);
+                await SafeRollbackPreparedContentAsync(manifest, result.Data, workingDirectory);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Unexpected error executing post-installation steps for manifest {ManifestId}; rolling back prepared content", manifest.Id);
+                await SafeRollbackPreparedContentAsync(manifest, result.Data, workingDirectory);
+                return OperationResult<ContentManifest>.CreateFailure($"Post-installation execution failed: {ex.Message}");
+            }
 
+            // Final validation of prepared content
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.ValidatingFiles,
+                CurrentOperation = "Validating prepared content...",
+            });
+
+            // Forward provider progress into validation by adapting ValidationProgress -> ContentAcquisitionProgress
+            IProgress<ValidationProgress>? validationProgress = null;
+            if (progress != null)
+            {
+                validationProgress = new Progress<ValidationProgress>(vp =>
+                {
+                    // Map validation progress to content acquisition progress for UI display
+                    progress.Report(new ContentAcquisitionProgress
+                    {
+                        Phase = ContentAcquisitionPhase.ValidatingFiles,
+                        ProgressPercentage = vp.PercentComplete,
+                        CurrentOperation = vp.CurrentFile ?? "Validating files",
+                        FilesProcessed = vp.Processed,
+                        TotalFiles = vp.Total,
+                    });
+                });
+            }
+
+            var fullResult = await ContentValidator.ValidateAllAsync(
+                workingDirectory,
+                result.Data,
+                validationProgress,
+                cancellationToken: cancellationToken);
+
+            if (!fullResult.IsValid)
+            {
+                Logger.LogWarning("Content validation found {IssueCount} issues for {ManifestId}", fullResult.Issues.Count, manifest.Id);
+            }
+
+            try
+            {
                 await OnContentPreparationCompletedAsync(manifest, result.Data, workingDirectory, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                Logger.LogInformation("Content preparation completion hook was canceled for manifest {ManifestId}; rolling back", manifest.Id);
+                await SafeRollbackPreparedContentAsync(manifest, result.Data, workingDirectory);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Content preparation completion hook failed for manifest {ManifestId}; rolling back", manifest.Id);
+                await SafeRollbackPreparedContentAsync(manifest, result.Data, workingDirectory);
+                return OperationResult<ContentManifest>.CreateFailure($"Content preparation completion hook failed: {ex.Message}");
             }
 
             return result;
@@ -414,5 +411,20 @@ public abstract class BaseContentProvider : IContentProvider
 
         resolved.SetData(manifest);
         return resolved;
+    }
+
+    private async Task SafeRollbackPreparedContentAsync(
+        ContentManifest originalManifest,
+        ContentManifest preparedManifest,
+        string workingDirectory)
+    {
+        try
+        {
+            await RollbackPreparedContentAsync(originalManifest, preparedManifest, workingDirectory, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Rollback failed during error recovery for manifest {ManifestId}", originalManifest.Id);
+        }
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -83,7 +83,7 @@ public abstract class BaseContentProvider(
     }
 
     /// <inheritdoc />
-    public virtual async Task<OperationResult<ContentManifest>> GetByIdAsync(
+    public virtual async Task<OperationResult<ContentManifest>> GetValidatedContentAsync(
         string contentId,
         CancellationToken cancellationToken = default)
     {

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/BaseContentProvider.cs
@@ -29,7 +29,7 @@ public abstract class BaseContentProvider(
     /// </summary>
     /// <param name="contentValidator">The content validator.</param>
     /// <param name="logger">The logger.</param>
-    public BaseContentProvider(
+    protected BaseContentProvider(
         IContentValidator contentValidator,
         ILogger logger)
         : this(contentValidator, null, logger)

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/CNCLabsContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/CNCLabsContentProvider.cs
@@ -21,8 +21,9 @@ public class CNCLabsContentProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     ILogger<CNCLabsContentProvider> logger,
-    IContentValidator contentValidator)
-    : BaseContentProvider(contentValidator, logger)
+    IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private readonly IContentDiscoverer _cncLabsDiscoverer = discoverers.FirstOrDefault(d => d.SourceName?.Equals(ContentSourceNames.CNCLabsDiscoverer, StringComparison.OrdinalIgnoreCase) == true)
         ?? throw new ArgumentException("CNC Labs discoverer not found", nameof(discoverers));

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/LocalFileSystemContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/LocalFileSystemContentProvider.cs
@@ -24,8 +24,9 @@ public class LocalFileSystemContentProvider(
     IEnumerable<IContentDeliverer> deliverers,
     ILogger<LocalFileSystemContentProvider> logger,
     IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService,
     IConfigurationProviderService configurationProvider)
-    : BaseContentProvider(contentValidator, logger)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private readonly IContentDiscoverer _fileSystemDiscoverer = discoverers.FirstOrDefault(d => d.SourceName?.Equals(ContentSourceNames.FileSystemDiscoverer, StringComparison.OrdinalIgnoreCase) == true)
         ?? throw new InvalidOperationException("No FileSystem discoverer found");

--- a/GenHub/GenHub/Features/Content/Services/ContentProviders/ModDBContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentProviders/ModDBContentProvider.cs
@@ -21,8 +21,9 @@ public class ModDBContentProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     ILogger<ModDBContentProvider> logger,
-    IContentValidator contentValidator)
-    : BaseContentProvider(contentValidator, logger)
+    IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private readonly IContentDiscoverer _moddbDiscoverer = discoverers.FirstOrDefault(d => d.SourceName?.Equals(ContentSourceNames.ModDBDiscoverer, StringComparison.OrdinalIgnoreCase) == true)
         ?? throw new ArgumentException("ModDB discoverer not found", nameof(discoverers));

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
@@ -57,7 +57,7 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
     {
         try
         {
-            var productId = (step.Arguments != null && step.Arguments.Count > 1 && !string.IsNullOrWhiteSpace(step.Arguments[1]))
+            var productId = (step.Arguments is { Count: > 1 } && !string.IsNullOrWhiteSpace(step.Arguments[1]))
                 ? step.Arguments[1]
                 : GeneralsOnlineConstants.EacProductId;
 
@@ -68,22 +68,18 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
 
             var subKeyPath = $@"SOFTWARE\EasyAntiCheat_EOS\{productId}";
 
-            using (var baseKey32 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
-            using (var key32 = baseKey32.OpenSubKey(subKeyPath))
+            using var baseKey32 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+            using var key32 = baseKey32.OpenSubKey(subKeyPath);
+            if (key32 != null)
             {
-                if (key32 != null)
-                {
-                    return true;
-                }
+                return true;
             }
 
-            using (var baseKey64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64))
-            using (var key64 = baseKey64.OpenSubKey(subKeyPath))
+            using var baseKey64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+            using var key64 = baseKey64.OpenSubKey(subKeyPath);
+            if (key64 != null)
             {
-                if (key64 != null)
-                {
-                    return true;
-                }
+                return true;
             }
         }
         catch

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
@@ -1,14 +1,16 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
+using Microsoft.Win32;
 
 namespace GenHub.Features.Content.Services.GeneralsOnline;
 
 /// <summary>
-/// Precondition that checks whether Easy Anti-Cheat EOS service is already installed on Windows.
+/// Precondition that checks whether Easy Anti-Cheat EOS product ID is already registered in the Windows registry.
 /// </summary>
 public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
 {
@@ -37,26 +39,33 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
             return false;
         }
 
+        return IsProductRegisteredOnWindows(step);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool IsProductRegisteredOnWindows(InstallationStep step)
+    {
         try
         {
-            var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-            if (!string.IsNullOrEmpty(programFilesX86))
+            var productId = step.Arguments is { Count: > 1 }
+                ? step.Arguments[1]
+                : GeneralsOnlineConstants.EacProductId;
+
+            if (string.IsNullOrWhiteSpace(productId))
             {
-                var serviceExe = Path.Combine(programFilesX86, "EasyAntiCheat_EOS", "EasyAntiCheat_EOS.exe");
-                if (File.Exists(serviceExe))
-                {
-                    return true;
-                }
+                return false;
             }
 
-            var commonProgramFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFilesX86);
-            if (!string.IsNullOrEmpty(commonProgramFilesX86))
+            using var key32 = Registry.LocalMachine.OpenSubKey($@"SOFTWARE\WOW6432Node\EasyAntiCheat_EOS\{productId}");
+            if (key32 != null)
             {
-                var commonExe = Path.Combine(commonProgramFilesX86, "EasyAntiCheat", "EasyAntiCheat_EOS.exe");
-                if (File.Exists(commonExe))
-                {
-                    return true;
-                }
+                return true;
+            }
+
+            using var key64 = Registry.LocalMachine.OpenSubKey($@"SOFTWARE\EasyAntiCheat_EOS\{productId}");
+            if (key64 != null)
+            {
+                return true;
             }
         }
         catch

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
@@ -57,10 +57,7 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
     {
         try
         {
-            var productId = step.Arguments is { Count: > 1 }
-                ? step.Arguments[1]
-                : GeneralsOnlineConstants.EacProductId;
-
+            var productId = GeneralsOnlineConstants.EacProductId;
             if (string.IsNullOrWhiteSpace(productId))
             {
                 return false;

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
@@ -17,12 +17,22 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
     /// <inheritdoc />
     public bool CanHandle(InstallationStep step, ContentManifest manifest)
     {
-        if (!OperatingSystem.IsWindows() || step == null)
+        if (!OperatingSystem.IsWindows() || step == null || manifest == null)
         {
             return false;
         }
 
         if (step.Kind != InstallationStepKind.RunVerifiedInstaller)
+        {
+            return false;
+        }
+
+        var isGeneralsOnline = string.Equals(
+            manifest.Publisher?.PublisherType,
+            PublisherTypeConstants.GeneralsOnline,
+            StringComparison.OrdinalIgnoreCase);
+
+        if (!isGeneralsOnline)
         {
             return false;
         }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
@@ -57,22 +57,33 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
     {
         try
         {
-            var productId = GeneralsOnlineConstants.EacProductId;
+            var productId = (step.Arguments != null && step.Arguments.Count > 1 && !string.IsNullOrWhiteSpace(step.Arguments[1]))
+                ? step.Arguments[1]
+                : GeneralsOnlineConstants.EacProductId;
+
             if (string.IsNullOrWhiteSpace(productId))
             {
                 return false;
             }
 
-            using var key32 = Registry.LocalMachine.OpenSubKey($@"SOFTWARE\WOW6432Node\EasyAntiCheat_EOS\{productId}");
-            if (key32 != null)
+            var subKeyPath = $@"SOFTWARE\EasyAntiCheat_EOS\{productId}";
+
+            using (var baseKey32 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+            using (var key32 = baseKey32.OpenSubKey(subKeyPath))
             {
-                return true;
+                if (key32 != null)
+                {
+                    return true;
+                }
             }
 
-            using var key64 = Registry.LocalMachine.OpenSubKey($@"SOFTWARE\EasyAntiCheat_EOS\{productId}");
-            if (key64 != null)
+            using (var baseKey64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64))
+            using (var key64 = baseKey64.OpenSubKey(subKeyPath))
             {
-                return true;
+                if (key64 != null)
+                {
+                    return true;
+                }
             }
         }
         catch

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+
+namespace GenHub.Features.Content.Services.GeneralsOnline;
+
+/// <summary>
+/// Precondition that checks whether Easy Anti-Cheat EOS service is already installed on Windows.
+/// </summary>
+public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
+{
+    /// <inheritdoc />
+    public bool CanHandle(InstallationStep step, ContentManifest manifest)
+    {
+        if (!OperatingSystem.IsWindows() || step == null)
+        {
+            return false;
+        }
+
+        if (step.Kind != InstallationStepKind.RunVerifiedInstaller)
+        {
+            return false;
+        }
+
+        var fileName = Path.GetFileName(step.TargetRelativePath ?? string.Empty);
+        return string.Equals(fileName, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public bool IsAlreadyFulfilled(InstallationStep step, ContentManifest manifest)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        try
+        {
+            var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            if (!string.IsNullOrEmpty(programFilesX86))
+            {
+                var serviceExe = Path.Combine(programFilesX86, "EasyAntiCheat_EOS", "EasyAntiCheat_EOS.exe");
+                if (File.Exists(serviceExe))
+                {
+                    return true;
+                }
+            }
+
+            var commonProgramFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFilesX86);
+            if (!string.IsNullOrEmpty(commonProgramFilesX86))
+            {
+                var commonExe = Path.Combine(commonProgramFilesX86, "EasyAntiCheat", "EasyAntiCheat_EOS.exe");
+                if (File.Exists(commonExe))
+                {
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/EasyAntiCheatPrecondition.cs
@@ -1,10 +1,12 @@
 using System;
 using System.IO;
 using System.Runtime.Versioning;
+using System.Security;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
+using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 
 namespace GenHub.Features.Content.Services.GeneralsOnline;
@@ -12,7 +14,8 @@ namespace GenHub.Features.Content.Services.GeneralsOnline;
 /// <summary>
 /// Precondition that checks whether Easy Anti-Cheat EOS product ID is already registered in the Windows registry.
 /// </summary>
-public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
+/// <param name="logger">Optional logger instance for diagnostics.</param>
+public class EasyAntiCheatPrecondition(ILogger<EasyAntiCheatPrecondition>? logger = null) : IInstallationStepPrecondition
 {
     /// <inheritdoc />
     public bool CanHandle(InstallationStep step, ContentManifest manifest)
@@ -53,7 +56,7 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
     }
 
     [SupportedOSPlatform("windows")]
-    private static bool IsProductRegisteredOnWindows(InstallationStep step)
+    private bool IsProductRegisteredOnWindows(InstallationStep step)
     {
         try
         {
@@ -82,8 +85,19 @@ public class EasyAntiCheatPrecondition : IInstallationStepPrecondition
                 return true;
             }
         }
-        catch
+        catch (SecurityException ex)
         {
+            logger?.LogWarning(ex, "Insufficient permissions to inspect Easy Anti-Cheat registry keys for step '{StepName}'", step.Name);
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger?.LogWarning(ex, "Access denied when inspecting Easy Anti-Cheat registry keys for step '{StepName}'", step.Name);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Error while checking Easy Anti-Cheat registry registration for step '{StepName}'", step.Name);
             return false;
         }
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineDeliverer.cs
@@ -272,11 +272,20 @@ public class GeneralsOnlineDeliverer(
             CurrentFile = zipFile.RelativePath,
         });
 
-        logger.LogDebug("Downloading ZIP from {Url} to {Path}", zipFile.DownloadUrl, zipPath);
+        var expectedHash = !string.IsNullOrWhiteSpace(zipFile.Hash)
+            ? zipFile.Hash
+            : packageManifest.InstallationInstructions?.DownloadHash;
+
+        if (string.IsNullOrWhiteSpace(expectedHash))
+        {
+            expectedHash = null;
+        }
+
+        logger.LogDebug("Downloading ZIP from {Url} to {Path} (expected hash: {Hash})", zipFile.DownloadUrl, zipPath, expectedHash);
         var downloadResult = await downloadService.DownloadFileAsync(
             new Uri(zipFile.DownloadUrl!),
             zipPath,
-            expectedHash: null,
+            expectedHash: expectedHash,
             progress: null,
             cancellationToken);
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
@@ -148,6 +148,7 @@ public class GeneralsOnlineJsonCatalogParser(
             ReleaseDate = versionDate,
             PortableUrl = apiResponse.DownloadUrl,
             PortableSize = apiResponse.Size,
+            Sha256 = apiResponse.Sha256,
             Changelog = apiResponse.ReleaseNotes ?? $"Generals Online {apiResponse.Version}",
         };
     }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -730,7 +730,6 @@ public class GeneralsOnlineManifestFactory(
         {
             WorkspaceStrategy = manifest.InstallationInstructions?.WorkspaceStrategy ?? WorkspaceConstants.DefaultWorkspaceStrategy,
             DownloadHash = manifest.InstallationInstructions?.DownloadHash,
-            PreInstallSteps = [.. manifest.InstallationInstructions?.PreInstallSteps ?? []],
             PostInstallSteps = [.. inheritedPostSteps],
         };
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -25,6 +25,21 @@ public class GeneralsOnlineManifestFactory(
     ILogger<GeneralsOnlineManifestFactory> logger,
     IProviderDefinitionLoader providerLoader) : IPublisherManifestFactory
 {
+    /// <summary>
+    /// File info extracted from archive for manifest generation.
+    /// </summary>
+    /// <param name="RelativePath">The relative path within archive.</param>
+    /// <param name="FileInfo">The file info.</param>
+    /// <param name="Hash">The SHA-256 hash.</param>
+    /// <param name="IsMap">Whether this is a map file.</param>
+    /// <param name="IsGameData">Whether this is a game data file.</param>
+    private readonly record struct ExtractedFileInfo(
+        string RelativePath,
+        FileInfo FileInfo,
+        string Hash,
+        bool IsMap,
+        bool IsGameData);
+
     /// <inheritdoc />
     public string PublisherId => PublisherTypeConstants.GeneralsOnline;
 
@@ -527,21 +542,6 @@ public class GeneralsOnlineManifestFactory(
     }
 
     /// <summary>
-    /// File info extracted from archive for manifest generation.
-    /// </summary>
-    /// <param name="RelativePath">The relative path within archive.</param>
-    /// <param name="FileInfo">The file info.</param>
-    /// <param name="Hash">The SHA-256 hash.</param>
-    /// <param name="IsMap">Whether this is a map file.</param>
-    /// <param name="IsGameData">Whether this is a game data file.</param>
-    private readonly record struct ExtractedFileInfo(
-        string RelativePath,
-        FileInfo FileInfo,
-        string Hash,
-        bool IsMap,
-        bool IsGameData);
-
-    /// <summary>
     /// Updates manifests (60Hz, QuickMatch MapPack, and GeneralsOnlineGameData data patch) with extracted file information.
     /// Computes SHA-256 hashes for all files for CAS integration.
     /// Each variant gets only the files it needs plus shared files.
@@ -735,7 +735,7 @@ public class GeneralsOnlineManifestFactory(
 
         if (manifest.ContentType == ContentType.GameClient &&
             hasEacSetup &&
-            instructions.PostInstallSteps.All(s => s == null || !string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
+            instructions.PostInstallSteps.All(s => s == null || (!string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase) && !string.Equals(s.StepKey, GeneralsOnlineConstants.EacStepKey, StringComparison.OrdinalIgnoreCase))))
         {
             instructions.PostInstallSteps.Add(new InstallationStep
             {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -716,16 +716,26 @@ public class GeneralsOnlineManifestFactory(
         ContentManifest manifest,
         List<ExtractedFileInfo> filesWithHashes)
     {
+        var hasEacSetup = filesWithHashes.Any(file =>
+            !file.IsMap && !file.IsGameData &&
+            IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable));
+
+        var inheritedPostSteps = (manifest.InstallationInstructions?.PostInstallSteps ?? [])
+            .Where(s => hasEacSetup || !string.Equals(
+                s.TargetRelativePath,
+                GameClientConstants.GeneralsOnlineEacSetupExecutable,
+                StringComparison.OrdinalIgnoreCase));
+
         var instructions = new InstallationInstructions
         {
             WorkspaceStrategy = manifest.InstallationInstructions?.WorkspaceStrategy ?? WorkspaceConstants.DefaultWorkspaceStrategy,
             DownloadHash = manifest.InstallationInstructions?.DownloadHash,
             PreInstallSteps = [.. manifest.InstallationInstructions?.PreInstallSteps ?? []],
-            PostInstallSteps = [.. manifest.InstallationInstructions?.PostInstallSteps ?? []],
+            PostInstallSteps = [.. inheritedPostSteps],
         };
 
         if (manifest.ContentType == ContentType.GameClient &&
-            filesWithHashes.Any(file => !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable)) &&
+            hasEacSetup &&
             instructions.PostInstallSteps.All(s => !string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
         {
             instructions.PostInstallSteps.Add(new InstallationStep

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -632,7 +632,7 @@ public class GeneralsOnlineManifestFactory(
             var isGameData = relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
                              relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
 
-            string hash;
+            var hash = string.Empty;
             using (var stream = File.OpenRead(filePath))
             {
                 var hashBytes = await SHA256.HashDataAsync(stream, cancellationToken);

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -111,13 +111,14 @@ public class GeneralsOnlineManifestFactory(
                     DownloadUrl = release.PortableUrl,
                     Size = release.PortableSize ?? 0, // Use 0 when size is unknown
                     SourceType = ContentSourceType.RemoteDownload,
-                    Hash = string.Empty,
+                    Hash = release.Sha256 ?? string.Empty,
                 },
             ],
             Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesFor60Hz(userVersion),
             InstallationInstructions = new InstallationInstructions
             {
                 WorkspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy,
+                DownloadHash = release.Sha256,
                 PostInstallSteps =
                 [
                     new InstallationStep

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -721,10 +721,10 @@ public class GeneralsOnlineManifestFactory(
             IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable));
 
         var inheritedPostSteps = (manifest.InstallationInstructions?.PostInstallSteps ?? [])
-            .Where(s => hasEacSetup || !string.Equals(
+            .Where(s => s != null && (hasEacSetup || !string.Equals(
                 s.TargetRelativePath,
                 GameClientConstants.GeneralsOnlineEacSetupExecutable,
-                StringComparison.OrdinalIgnoreCase));
+                StringComparison.OrdinalIgnoreCase)));
 
         var instructions = new InstallationInstructions
         {
@@ -735,7 +735,7 @@ public class GeneralsOnlineManifestFactory(
 
         if (manifest.ContentType == ContentType.GameClient &&
             hasEacSetup &&
-            instructions.PostInstallSteps.All(s => !string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
+            instructions.PostInstallSteps.All(s => s == null || !string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
         {
             instructions.PostInstallSteps.Add(new InstallationStep
             {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -537,6 +537,13 @@ public class GeneralsOnlineManifestFactory(
     /// <param name="extractPath">The path to the directory containing extracted files.</param>
     /// <param name="cancellationToken">Token to cancel the operation if needed.</param>
     /// <returns>Updated content manifests with file hashes and details.</returns>
+    private readonly record struct ExtractedFileInfo(
+        string RelativePath,
+        FileInfo FileInfo,
+        string Hash,
+        bool IsMap,
+        bool IsGameData);
+
     private async Task<List<ContentManifest>> UpdateManifestsWithExtractedFiles(
         List<ContentManifest> manifests,
         string extractPath,
@@ -546,137 +553,22 @@ public class GeneralsOnlineManifestFactory(
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
-        logger.LogInformation("Processing {Count} files", allFiles.Length);
-
-        List<(string RelativePath, FileInfo FileInfo, string Hash, bool IsMap, bool IsGameData)> filesWithHashes = [];
-
-        foreach (var filePath in allFiles)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var relativePath = Path.GetRelativePath(extractPath, filePath);
-            var fileInfo = new FileInfo(filePath);
-
-            // Determine if this file is inside the Maps directory
-            var isMap = relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
-                        relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
-
-            // Determine if this file is inside the GeneralsOnlineGameData directory
-            var isGameData = relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
-                             relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
-
-            var hash = string.Empty;
-            using (var stream = File.OpenRead(filePath))
-            {
-                var hashBytes = await SHA256.HashDataAsync(stream, cancellationToken);
-                hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
-            }
-
-            filesWithHashes.Add((relativePath, fileInfo, hash, isMap, isGameData));
-            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap}, isGameData: {IsGameData})", relativePath, fileInfo.Length, hash[..8], isMap, isGameData);
-        }
-
-        List<ContentManifest> updatedManifests = [];
+        var filesWithHashes = await ScanExtractedFilesAsync(extractPath, cancellationToken);
+        var updatedManifests = new List<ContentManifest>();
 
         foreach (var manifest in manifests)
         {
-            List<ManifestFile> manifestFiles = [];
-            var isMapPackManifest = manifest.ContentType == ContentType.MapPack;
-            var isPatchManifest = manifest.ContentType == ContentType.Patch;
-
-            if (isMapPackManifest)
-            {
-                // MapPack manifest: only include map files with UserMapsDirectory install target
-                foreach (var (relativePath, fileInfo, hash, isMap, isGameData) in filesWithHashes)
-                {
-                    if (!isMap)
-                    {
-                        continue;
-                    }
-
-                    manifestFiles.Add(CreateMapManifestFile(relativePath, fileInfo, hash));
-                }
-
-                logger.LogInformation("MapPack manifest '{Name}' updated with {Count} map files", manifest.Name, manifestFiles.Count);
-            }
-            else if (isPatchManifest)
-            {
-                // Data patch manifest: only include GeneralsOnlineGameData files with UserDataDirectory install target
-                foreach (var (relativePath, fileInfo, hash, isMap, isGameData) in filesWithHashes)
-                {
-                    if (!isGameData)
-                    {
-                        continue;
-                    }
-
-                    manifestFiles.Add(CreateGameDataManifestFile(relativePath, fileInfo, hash));
-                }
-
-                logger.LogInformation("GameData patch manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
-            }
-            else
-            {
-                // Game client manifest: include executables and shared files (skipping maps and game data files)
-                // Since 060526_QFE1 the portable ships an Easy Anti-Cheat bootstrapper that starts the
-                // binary named by EasyAntiCheat/Settings.json. When present it is the only launch target;
-                // the wrapped binary stays in the workspace as ordinary content for EAC to start.
-                var hasEacLauncher = filesWithHashes.Any(file =>
-                    !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacLauncherExecutable));
-
-                var targetExecutable = hasEacLauncher
-                    ? GameClientConstants.GeneralsOnlineEacLauncherExecutable
-                    : GameClientConstants.GeneralsOnline60HzExecutable;
-
-                foreach (var (relativePath, fileInfo, hash, isMap, isGameData) in filesWithHashes)
-                {
-                    var isExecutable = false;
-
-                    // Skip map files and game data files in GameClient manifests
-                    if (isMap || isGameData)
-                    {
-                        continue;
-                    }
-
-                    if (IsArchiveRootFile(relativePath, targetExecutable))
-                    {
-                        isExecutable = true;
-                    }
-
-                    manifestFiles.Add(new ManifestFile
-                    {
-                        RelativePath = relativePath,
-                        Size = fileInfo.Length,
-                        Hash = hash,
-                        SourceType = ContentSourceType.ContentAddressable,
-                        SourcePath = fileInfo.FullName,
-                        InstallTarget = ContentInstallTarget.Workspace,
-                        IsExecutable = isExecutable,
-                    });
-                }
-
-                logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
-            }
+            var manifestFiles = BuildManifestFilesForManifest(manifest, filesWithHashes);
 
             if (manifestFiles.Count == 0)
             {
-                if (isMapPackManifest || isPatchManifest)
+                if (manifest.ContentType is ContentType.MapPack or ContentType.Patch)
                 {
                     logger.LogInformation(
                         "Skipping empty {Type} manifest '{Name}' because no matching files were found in extract path",
                         manifest.ContentType,
                         manifest.Name);
                     continue;
-                }
-
-                if (manifest.ContentType == ContentType.GameClient)
-                {
-                    logger.LogError(
-                        "GameClient manifest '{Name}' has zero files in extract path '{ExtractPath}'",
-                        manifest.Name,
-                        extractPath);
-                    throw new InvalidDataException(
-                        $"GameClient manifest '{manifest.Name}' has no files in extract path '{extractPath}'.");
                 }
 
                 logger.LogError(
@@ -688,30 +580,7 @@ public class GeneralsOnlineManifestFactory(
                     $"Manifest '{manifest.Name}' of type {manifest.ContentType} has no files in extract path '{extractPath}'.");
             }
 
-            var instructions = new InstallationInstructions
-            {
-                WorkspaceStrategy = manifest.InstallationInstructions?.WorkspaceStrategy ?? WorkspaceConstants.DefaultWorkspaceStrategy,
-                DownloadHash = manifest.InstallationInstructions?.DownloadHash,
-                PreInstallSteps = [.. manifest.InstallationInstructions?.PreInstallSteps ?? []],
-                PostInstallSteps = [.. manifest.InstallationInstructions?.PostInstallSteps ?? []],
-            };
-
-            if (manifest.ContentType == ContentType.GameClient &&
-                filesWithHashes.Any(file => !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable)) &&
-                instructions.PostInstallSteps.All(s => !string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
-            {
-                instructions.PostInstallSteps.Add(new InstallationStep
-                {
-                    Name = GeneralsOnlineConstants.EacStepName,
-                    Kind = InstallationStepKind.RunVerifiedInstaller,
-                    TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
-                    Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
-                    RequiresElevation = true,
-                    StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
-                    StepKey = GeneralsOnlineConstants.EacStepKey,
-                    RunOnce = true,
-                });
-            }
+            var instructions = BuildInstallationInstructions(manifest, filesWithHashes);
 
             updatedManifests.Add(new ContentManifest
             {
@@ -728,22 +597,162 @@ public class GeneralsOnlineManifestFactory(
             });
         }
 
-        // If MapPack was not created from archive, remove MapPack dependency so dependency resolution does not fail
-        var hasMapPack = updatedManifests.Any(m => m.ContentType == ContentType.MapPack);
-        if (!hasMapPack)
-        {
-            foreach (var m in updatedManifests)
-            {
-                if (m.Dependencies.Any(d => d.DependencyType == ContentType.MapPack))
-                {
-                    logger.LogWarning(
-                        "Removing MapPack dependency from manifest '{Name}' because MapPack was not found in archive",
-                        m.Name);
-                    m.Dependencies = m.Dependencies.Where(d => d.DependencyType != ContentType.MapPack).ToList();
-                }
-            }
-        }
+        ReconcileMissingMapPackDependencies(updatedManifests);
 
         return updatedManifests;
+    }
+
+    private async Task<List<ExtractedFileInfo>> ScanExtractedFilesAsync(
+        string extractPath,
+        CancellationToken cancellationToken)
+    {
+        var allFiles = Directory.GetFiles(extractPath, "*", SearchOption.AllDirectories);
+        logger.LogInformation("Processing {Count} files", allFiles.Length);
+
+        var filesWithHashes = new List<ExtractedFileInfo>(allFiles.Length);
+
+        foreach (var filePath in allFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var relativePath = Path.GetRelativePath(extractPath, filePath);
+            var fileInfo = new FileInfo(filePath);
+
+            var isMap = relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+                        relativePath.StartsWith(GeneralsOnlineConstants.MapsSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
+
+            var isGameData = relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+                             relativePath.StartsWith(GeneralsOnlineConstants.GameDataSubdirectory + "/", StringComparison.OrdinalIgnoreCase);
+
+            string hash;
+            using (var stream = File.OpenRead(filePath))
+            {
+                var hashBytes = await SHA256.HashDataAsync(stream, cancellationToken);
+                hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+            }
+
+            filesWithHashes.Add(new ExtractedFileInfo(relativePath, fileInfo, hash, isMap, isGameData));
+            logger.LogDebug("Processed file: {File} ({Size} bytes, hash: {Hash}, isMap: {IsMap}, isGameData: {IsGameData})", relativePath, fileInfo.Length, hash[..8], isMap, isGameData);
+        }
+
+        return filesWithHashes;
+    }
+
+    private List<ManifestFile> BuildManifestFilesForManifest(
+        ContentManifest manifest,
+        List<ExtractedFileInfo> filesWithHashes)
+    {
+        var manifestFiles = new List<ManifestFile>();
+
+        if (manifest.ContentType == ContentType.MapPack)
+        {
+            foreach (var file in filesWithHashes)
+            {
+                if (file.IsMap)
+                {
+                    manifestFiles.Add(CreateMapManifestFile(file.RelativePath, file.FileInfo, file.Hash));
+                }
+            }
+
+            logger.LogInformation("MapPack manifest '{Name}' updated with {Count} map files", manifest.Name, manifestFiles.Count);
+        }
+        else if (manifest.ContentType == ContentType.Patch)
+        {
+            foreach (var file in filesWithHashes)
+            {
+                if (file.IsGameData)
+                {
+                    manifestFiles.Add(CreateGameDataManifestFile(file.RelativePath, file.FileInfo, file.Hash));
+                }
+            }
+
+            logger.LogInformation("GameData patch manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
+        }
+        else
+        {
+            var hasEacLauncher = filesWithHashes.Any(file =>
+                !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacLauncherExecutable));
+
+            var targetExecutable = hasEacLauncher
+                ? GameClientConstants.GeneralsOnlineEacLauncherExecutable
+                : GameClientConstants.GeneralsOnline60HzExecutable;
+
+            foreach (var file in filesWithHashes)
+            {
+                if (file.IsMap || file.IsGameData)
+                {
+                    continue;
+                }
+
+                var isExecutable = IsArchiveRootFile(file.RelativePath, targetExecutable);
+
+                manifestFiles.Add(new ManifestFile
+                {
+                    RelativePath = file.RelativePath,
+                    Size = file.FileInfo.Length,
+                    Hash = file.Hash,
+                    SourceType = ContentSourceType.ContentAddressable,
+                    SourcePath = file.FileInfo.FullName,
+                    InstallTarget = ContentInstallTarget.Workspace,
+                    IsExecutable = isExecutable,
+                });
+            }
+
+            logger.LogInformation("GameClient manifest '{Name}' updated with {Count} files", manifest.Name, manifestFiles.Count);
+        }
+
+        return manifestFiles;
+    }
+
+    private static InstallationInstructions BuildInstallationInstructions(
+        ContentManifest manifest,
+        List<ExtractedFileInfo> filesWithHashes)
+    {
+        var instructions = new InstallationInstructions
+        {
+            WorkspaceStrategy = manifest.InstallationInstructions?.WorkspaceStrategy ?? WorkspaceConstants.DefaultWorkspaceStrategy,
+            DownloadHash = manifest.InstallationInstructions?.DownloadHash,
+            PreInstallSteps = [.. manifest.InstallationInstructions?.PreInstallSteps ?? []],
+            PostInstallSteps = [.. manifest.InstallationInstructions?.PostInstallSteps ?? []],
+        };
+
+        if (manifest.ContentType == ContentType.GameClient &&
+            filesWithHashes.Any(file => !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable)) &&
+            instructions.PostInstallSteps.All(s => !string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
+        {
+            instructions.PostInstallSteps.Add(new InstallationStep
+            {
+                Name = GeneralsOnlineConstants.EacStepName,
+                Kind = InstallationStepKind.RunVerifiedInstaller,
+                TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+                Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
+                RequiresElevation = true,
+                StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                StepKey = GeneralsOnlineConstants.EacStepKey,
+                RunOnce = true,
+            });
+        }
+
+        return instructions;
+    }
+
+    private void ReconcileMissingMapPackDependencies(List<ContentManifest> manifests)
+    {
+        var hasMapPack = manifests.Any(m => m.ContentType == ContentType.MapPack);
+        if (hasMapPack)
+        {
+            return;
+        }
+
+        foreach (var m in manifests)
+        {
+            if (m.Dependencies.Any(d => d.DependencyType == ContentType.MapPack))
+            {
+                logger.LogWarning(
+                    "Removing MapPack dependency from manifest '{Name}' because MapPack was not found in archive",
+                    m.Name);
+                m.Dependencies = m.Dependencies.Where(d => d.DependencyType != ContentType.MapPack).ToList();
+            }
+        }
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -113,6 +113,8 @@ public class GeneralsOnlineManifestFactory(
                         Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
                         RequiresElevation = true,
                         StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                        StepKey = GeneralsOnlineConstants.EacStepKey,
+                        RunOnce = true,
                     },
                 ],
             },
@@ -471,6 +473,8 @@ public class GeneralsOnlineManifestFactory(
                         Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
                         RequiresElevation = true,
                         StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                        StepKey = GeneralsOnlineConstants.EacStepKey,
+                        RunOnce = true,
                     },
                 ],
             },
@@ -718,6 +722,8 @@ public class GeneralsOnlineManifestFactory(
                     Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
                     RequiresElevation = true,
                     StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                    StepKey = GeneralsOnlineConstants.EacStepKey,
+                    RunOnce = true,
                 });
             }
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -527,6 +527,21 @@ public class GeneralsOnlineManifestFactory(
     }
 
     /// <summary>
+    /// File info extracted from archive for manifest generation.
+    /// </summary>
+    /// <param name="RelativePath">The relative path within archive.</param>
+    /// <param name="FileInfo">The file info.</param>
+    /// <param name="Hash">The SHA-256 hash.</param>
+    /// <param name="IsMap">Whether this is a map file.</param>
+    /// <param name="IsGameData">Whether this is a game data file.</param>
+    private readonly record struct ExtractedFileInfo(
+        string RelativePath,
+        FileInfo FileInfo,
+        string Hash,
+        bool IsMap,
+        bool IsGameData);
+
+    /// <summary>
     /// Updates manifests (60Hz, QuickMatch MapPack, and GeneralsOnlineGameData data patch) with extracted file information.
     /// Computes SHA-256 hashes for all files for CAS integration.
     /// Each variant gets only the files it needs plus shared files.
@@ -537,13 +552,6 @@ public class GeneralsOnlineManifestFactory(
     /// <param name="extractPath">The path to the directory containing extracted files.</param>
     /// <param name="cancellationToken">Token to cancel the operation if needed.</param>
     /// <returns>Updated content manifests with file hashes and details.</returns>
-    private readonly record struct ExtractedFileInfo(
-        string RelativePath,
-        FileInfo FileInfo,
-        string Hash,
-        bool IsMap,
-        bool IsGameData);
-
     private async Task<List<ContentManifest>> UpdateManifestsWithExtractedFiles(
         List<ContentManifest> manifests,
         string extractPath,
@@ -704,7 +712,7 @@ public class GeneralsOnlineManifestFactory(
         return manifestFiles;
     }
 
-    private static InstallationInstructions BuildInstallationInstructions(
+    private InstallationInstructions BuildInstallationInstructions(
         ContentManifest manifest,
         List<ExtractedFileInfo> filesWithHashes)
     {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -463,20 +463,6 @@ public class GeneralsOnlineManifestFactory(
             InstallationInstructions = originalManifest.InstallationInstructions ?? new InstallationInstructions
             {
                 WorkspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy,
-                PostInstallSteps =
-                [
-                    new InstallationStep
-                    {
-                        Name = GeneralsOnlineConstants.EacStepName,
-                        Kind = InstallationStepKind.RunVerifiedInstaller,
-                        TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
-                        Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
-                        RequiresElevation = true,
-                        StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
-                        StepKey = GeneralsOnlineConstants.EacStepKey,
-                        RunOnce = true,
-                    },
-                ],
             },
         });
 
@@ -712,7 +698,7 @@ public class GeneralsOnlineManifestFactory(
 
             if (manifest.ContentType == ContentType.GameClient &&
                 filesWithHashes.Any(file => !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable)) &&
-                !instructions.PostInstallSteps.Any(s => string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
+                instructions.PostInstallSteps.All(s => !string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
             {
                 instructions.PostInstallSteps.Add(new InstallationStep
                 {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -100,6 +100,22 @@ public class GeneralsOnlineManifestFactory(
                 },
             ],
             Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesFor60Hz(userVersion),
+            InstallationInstructions = new InstallationInstructions
+            {
+                WorkspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy,
+                PostInstallSteps =
+                [
+                    new InstallationStep
+                    {
+                        Name = GeneralsOnlineConstants.EacStepName,
+                        Kind = InstallationStepKind.RunVerifiedInstaller,
+                        TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+                        Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
+                        RequiresElevation = true,
+                        StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                    },
+                ],
+            },
         };
     }
 
@@ -323,6 +339,7 @@ public class GeneralsOnlineManifestFactory(
             // Files will be populated during extraction
             Files = [],
             Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesForGameData(userVersion),
+            InstallationInstructions = new InstallationInstructions(),
         };
     }
 
@@ -378,18 +395,19 @@ public class GeneralsOnlineManifestFactory(
                 // MapPack requires Zero Hour installation
                 GeneralsOnlineDependencyBuilder.CreateZeroHourDependencyForGeneralsOnline(),
             ],
+            InstallationInstructions = new InstallationInstructions(),
         };
     }
 
     /// <summary>
-    /// Creates all variant manifests (60Hz, MapPack, and GameData Patch) from the original manifest.
-    /// This is called AFTER extraction - we use the original manifest's metadata to create variants.
+    /// Creates variant manifests (60Hz, QuickMatch MapPack, and GeneralsOnlineGameData data patch) from an original manifest.
+    /// This is used after downloading and extracting the portable ZIP.
     /// </summary>
-    /// <param name="originalManifest">The manifest from the Resolver (contains version, publisher info, etc.).</param>
-    /// <returns>List of variant manifests ready for file hash population.</returns>
+    /// <param name="originalManifest">The original manifest (can be 60Hz or generic).</param>
+    /// <returns>List of variant manifests with basic information populated.</returns>
     private List<ContentManifest> CreateVariantManifestsFromOriginal(ContentManifest originalManifest)
     {
-        var manifests = new List<ContentManifest>();
+        List<ContentManifest> manifests = [];
         var version = originalManifest.Version ?? GeneralsOnlineConstants.UnknownVersion;
         var userVersion = ParseVersionForManifestId(version);
 
@@ -440,6 +458,22 @@ public class GeneralsOnlineManifestFactory(
             },
             Files = [],
             Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesFor60Hz(userVersion),
+            InstallationInstructions = originalManifest.InstallationInstructions ?? new InstallationInstructions
+            {
+                WorkspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy,
+                PostInstallSteps =
+                [
+                    new InstallationStep
+                    {
+                        Name = GeneralsOnlineConstants.EacStepName,
+                        Kind = InstallationStepKind.RunVerifiedInstaller,
+                        TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+                        Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
+                        RequiresElevation = true,
+                        StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                    },
+                ],
+            },
         });
 
         // Create QuickMatch MapPack
@@ -469,6 +503,7 @@ public class GeneralsOnlineManifestFactory(
             [
                 GeneralsOnlineDependencyBuilder.CreateZeroHourDependencyForGeneralsOnline(),
             ],
+            InstallationInstructions = new InstallationInstructions(),
         });
 
         // Create GeneralsOnlineGameData data patch
@@ -495,6 +530,7 @@ public class GeneralsOnlineManifestFactory(
             },
             Files = [],
             Dependencies = GeneralsOnlineDependencyBuilder.GetDependenciesForGameData(userVersion),
+            InstallationInstructions = new InstallationInstructions(),
         });
 
         return manifests;
@@ -662,6 +698,29 @@ public class GeneralsOnlineManifestFactory(
                     $"Manifest '{manifest.Name}' of type {manifest.ContentType} has no files in extract path '{extractPath}'.");
             }
 
+            var instructions = new InstallationInstructions
+            {
+                WorkspaceStrategy = manifest.InstallationInstructions?.WorkspaceStrategy ?? WorkspaceConstants.DefaultWorkspaceStrategy,
+                DownloadHash = manifest.InstallationInstructions?.DownloadHash,
+                PreInstallSteps = [.. manifest.InstallationInstructions?.PreInstallSteps ?? []],
+                PostInstallSteps = [.. manifest.InstallationInstructions?.PostInstallSteps ?? []],
+            };
+
+            if (manifest.ContentType == ContentType.GameClient &&
+                filesWithHashes.Any(file => !file.IsMap && !file.IsGameData && IsArchiveRootFile(file.RelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable)) &&
+                !instructions.PostInstallSteps.Any(s => string.Equals(s.TargetRelativePath, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase)))
+            {
+                instructions.PostInstallSteps.Add(new InstallationStep
+                {
+                    Name = GeneralsOnlineConstants.EacStepName,
+                    Kind = InstallationStepKind.RunVerifiedInstaller,
+                    TargetRelativePath = GameClientConstants.GeneralsOnlineEacSetupExecutable,
+                    Arguments = [GeneralsOnlineConstants.EacInstallCommand, GeneralsOnlineConstants.EacProductId],
+                    RequiresElevation = true,
+                    StatusMessage = GeneralsOnlineConstants.EacStatusMessage,
+                });
+            }
+
             updatedManifests.Add(new ContentManifest
             {
                 Id = manifest.Id,
@@ -673,6 +732,7 @@ public class GeneralsOnlineManifestFactory(
                 Metadata = manifest.Metadata,
                 Files = manifestFiles,
                 Dependencies = manifest.Dependencies,
+                InstallationInstructions = instructions,
             });
         }
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -204,6 +204,12 @@ public class GeneralsOnlineProvider(
         IProgress<ContentAcquisitionProgress>? progress,
         CancellationToken cancellationToken)
     {
+        if (!OperatingSystem.IsWindows())
+        {
+            return OperationResult<ContentManifest>.CreateFailure(
+                "GeneralsOnline is currently supported only on Windows. Easy Anti-Cheat was not designed for Wine/Proton environments.");
+        }
+
         Logger.LogInformation("Preparing Generals Online content: {Version}", manifest.Version);
 
         try
@@ -268,7 +274,13 @@ public class GeneralsOnlineProvider(
 
         try
         {
-            _preExistingManifestIdsByManifest.TryRemove(originalManifest.Id, out var preExistingIds);
+            if (!_preExistingManifestIdsByManifest.TryRemove(originalManifest.Id, out var preExistingIds) || preExistingIds == null)
+            {
+                Logger.LogWarning(
+                    "No pre-delivery manifest snapshot found for {ManifestId}; skipping rollback manifest unregistration to avoid removing existing content",
+                    originalManifest.Id);
+                return;
+            }
 
             var allManifestsResult = await manifestPool.GetAllManifestsAsync(cancellationToken);
             if (allManifestsResult.Success && allManifestsResult.Data != null)
@@ -276,7 +288,7 @@ public class GeneralsOnlineProvider(
                 var matchingManifests = allManifestsResult.Data
                     .Where(m => string.Equals(m.Version, preparedManifest.Version, StringComparison.OrdinalIgnoreCase) &&
                                 string.Equals(m.Publisher?.PublisherType, GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase) &&
-                                (preExistingIds == null || !preExistingIds.Contains(m.Id)))
+                                !preExistingIds.Contains(m.Id))
                     .ToList();
 
                 foreach (var manifest in matchingManifests)

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -310,4 +310,15 @@ public class GeneralsOnlineProvider(
             Logger.LogError(ex, "Error occurred during Generals Online manifest registration rollback");
         }
     }
+
+    /// <inheritdoc />
+    protected override Task OnContentPreparationCompletedAsync(
+        ContentManifest originalManifest,
+        ContentManifest preparedManifest,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        _preExistingManifestIdsByManifest.TryRemove(originalManifest.Id, out _);
+        return Task.CompletedTask;
+    }
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -242,4 +242,43 @@ public class GeneralsOnlineProvider(
                 $"Content preparation failed: {ex.Message}");
         }
     }
+
+    /// <inheritdoc />
+    protected override async Task RollbackPreparedContentAsync(
+        ContentManifest originalManifest,
+        ContentManifest preparedManifest,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        Logger.LogWarning("Rolling back Generals Online manifest registration for version {Version}", preparedManifest.Version);
+
+        try
+        {
+            var allManifestsResult = await manifestPool.GetAllManifestsAsync(cancellationToken);
+            if (allManifestsResult.Success && allManifestsResult.Data != null)
+            {
+                var matchingManifests = allManifestsResult.Data
+                    .Where(m => string.Equals(m.Version, preparedManifest.Version, StringComparison.OrdinalIgnoreCase) &&
+                                string.Equals(m.Publisher?.PublisherType, GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                foreach (var manifest in matchingManifests)
+                {
+                    var removeResult = await manifestPool.RemoveManifestAsync(manifest.Id, cancellationToken: cancellationToken);
+                    if (!removeResult.Success)
+                    {
+                        Logger.LogWarning("Failed to remove manifest {ManifestId} during rollback: {Error}", manifest.Id, removeResult.FirstError);
+                    }
+                    else
+                    {
+                        Logger.LogInformation("Unregistered manifest {ManifestId} during rollback", manifest.Id);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Exception occurred during Generals Online manifest rollback for version {Version}", preparedManifest.Version);
+        }
+    }
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -222,13 +222,16 @@ public class GeneralsOnlineProvider(
             }
 
             var existingPool = await manifestPool.GetAllManifestsAsync(cancellationToken);
-            var preExisting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (existingPool.Success && existingPool.Data != null)
+            if (!existingPool.Success || existingPool.Data == null)
             {
-                foreach (var m in existingPool.Data)
-                {
-                    preExisting.Add(m.Id);
-                }
+                return OperationResult<ContentManifest>.CreateFailure(
+                    $"Failed to query existing manifests before delivery: {existingPool.FirstError}");
+            }
+
+            var preExisting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var m in existingPool.Data)
+            {
+                preExisting.Add(m.Id);
             }
 
             _preExistingManifestIdsByManifest[manifest.Id] = preExisting;

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -28,9 +28,10 @@ public class GeneralsOnlineProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService,
     IContentManifestPool manifestPool,
     ILogger<GeneralsOnlineProvider> logger)
-    : BaseContentProvider(contentValidator, logger)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private ProviderDefinition? _cachedProviderDefinition;
 

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.Manifest;
@@ -10,11 +16,6 @@ using GenHub.Core.Models.Results;
 using GenHub.Core.Models.Results.Content;
 using GenHub.Features.Content.Services.ContentProviders;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace GenHub.Features.Content.Services.GeneralsOnline;
 
@@ -33,6 +34,7 @@ public class GeneralsOnlineProvider(
     ILogger<GeneralsOnlineProvider> logger)
     : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
+    private readonly ConcurrentDictionary<string, HashSet<string>> _preExistingManifestIdsByManifest = new(StringComparer.OrdinalIgnoreCase);
     private ProviderDefinition? _cachedProviderDefinition;
 
     /// <inheritdoc />
@@ -213,6 +215,18 @@ public class GeneralsOnlineProvider(
                     $"Cannot deliver content for manifest {manifest.Id}");
             }
 
+            var existingPool = await manifestPool.GetAllManifestsAsync(cancellationToken);
+            var preExisting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (existingPool.Success && existingPool.Data != null)
+            {
+                foreach (var m in existingPool.Data)
+                {
+                    preExisting.Add(m.Id);
+                }
+            }
+
+            _preExistingManifestIdsByManifest[manifest.Id] = preExisting;
+
             var deliveryResult = await Deliverer.DeliverContentAsync(
                 manifest,
                 workingDirectory,
@@ -254,12 +268,15 @@ public class GeneralsOnlineProvider(
 
         try
         {
+            _preExistingManifestIdsByManifest.TryRemove(originalManifest.Id, out var preExistingIds);
+
             var allManifestsResult = await manifestPool.GetAllManifestsAsync(cancellationToken);
             if (allManifestsResult.Success && allManifestsResult.Data != null)
             {
                 var matchingManifests = allManifestsResult.Data
                     .Where(m => string.Equals(m.Version, preparedManifest.Version, StringComparison.OrdinalIgnoreCase) &&
-                                string.Equals(m.Publisher?.PublisherType, GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase))
+                                string.Equals(m.Publisher?.PublisherType, GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase) &&
+                                (preExistingIds == null || !preExistingIds.Contains(m.Id)))
                     .ToList();
 
                 foreach (var manifest in matchingManifests)
@@ -278,7 +295,7 @@ public class GeneralsOnlineProvider(
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, "Exception occurred during Generals Online manifest rollback for version {Version}", preparedManifest.Version);
+            Logger.LogError(ex, "Error occurred during Generals Online manifest registration rollback");
         }
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GitHub/GitHubContentProvider.cs
@@ -24,8 +24,9 @@ public class GitHubContentProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     ILogger<GitHubContentProvider> logger,
-    IContentValidator contentValidator)
-    : BaseContentProvider(contentValidator, logger)
+    IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     /// <inheritdoc />
     public override string SourceName => "GitHub";

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -372,7 +372,7 @@ public class InstallationInstructionsService(
                 $"Installer '{step.TargetRelativePath}' has no declared hash and cannot be verified.");
         }
 
-        string computedHash;
+        var computedHash = string.Empty;
         try
         {
             computedHash = await hashProvider.ComputeFileHashAsync(targetFullPath, cancellationToken);

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -1,0 +1,429 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
+using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using Microsoft.Extensions.Logging;
+
+namespace GenHub.Features.Content.Services;
+
+/// <summary>
+/// Service for validating and executing manifest-declared installation steps.
+/// Enforces trust boundaries, path containment, and hash verification before execution.
+/// </summary>
+/// <param name="hashProvider">The file hash provider for integrity verification.</param>
+/// <param name="notificationService">The notification service for user awareness.</param>
+/// <param name="logger">The logger instance.</param>
+public class InstallationInstructionsService(
+    IFileHashProvider hashProvider,
+    INotificationService notificationService,
+    ILogger<InstallationInstructionsService> logger) : IInstallationInstructionsService
+{
+    /// <inheritdoc />
+    public async Task<OperationResult> ExecutePreInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        if (manifest.InstallationInstructions?.PreInstallSteps == null ||
+            manifest.InstallationInstructions.PreInstallSteps.Count == 0)
+        {
+            return OperationResult.CreateSuccess();
+        }
+
+        logger.LogInformation(
+            "Executing {Count} pre-install step(s) for manifest {ManifestId}",
+            manifest.InstallationInstructions.PreInstallSteps.Count,
+            manifest.Id);
+
+        return await ExecuteStepsAsync(
+            manifest.InstallationInstructions.PreInstallSteps,
+            manifest,
+            workingDirectory,
+            progress,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> ExecutePostInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        if (manifest.InstallationInstructions?.PostInstallSteps == null ||
+            manifest.InstallationInstructions.PostInstallSteps.Count == 0)
+        {
+            return OperationResult.CreateSuccess();
+        }
+
+        logger.LogInformation(
+            "Executing {Count} post-install step(s) for manifest {ManifestId}",
+            manifest.InstallationInstructions.PostInstallSteps.Count,
+            manifest.Id);
+
+        return await ExecuteStepsAsync(
+            manifest.InstallationInstructions.PostInstallSteps,
+            manifest,
+            workingDirectory,
+            progress,
+            cancellationToken);
+    }
+
+    private async Task<OperationResult> ExecuteStepsAsync(
+        IReadOnlyList<InstallationStep> steps,
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(workingDirectory) || !Directory.Exists(workingDirectory))
+        {
+            return OperationResult.CreateFailure($"Working directory does not exist: '{workingDirectory}'");
+        }
+
+        for (var i = 0; i < steps.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var step = steps[i];
+
+            if (step == null)
+            {
+                continue;
+            }
+
+            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, progress, cancellationToken);
+            if (!stepResult.Success)
+            {
+                return stepResult;
+            }
+        }
+
+        return OperationResult.CreateSuccess();
+    }
+
+    private async Task<OperationResult> ExecuteSingleStepAsync(
+        InstallationStep step,
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        switch (step.Kind)
+        {
+            case InstallationStepKind.RunVerifiedInstaller:
+                return await ExecuteRunVerifiedInstallerAsync(step, manifest, workingDirectory, progress, cancellationToken);
+
+            case InstallationStepKind.RemoveFile:
+                return ExecuteRemoveFile(step, workingDirectory);
+
+            case InstallationStepKind.RenameFile:
+                return ExecuteRenameFile(step, workingDirectory);
+
+            case InstallationStepKind.Unknown:
+            default:
+                logger.LogError("Unsupported installation step kind '{Kind}' in step '{StepName}'", step.Kind, step.Name);
+                return OperationResult.CreateFailure($"Unsupported installation step kind '{step.Kind}' for step '{step.Name}'.");
+        }
+    }
+
+    private async Task<OperationResult> ExecuteRunVerifiedInstallerAsync(
+        InstallationStep step,
+        ContentManifest manifest,
+        string workingDirectory,
+        IProgress<ContentAcquisitionProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        // 1. Publisher authorization check
+        var publisherType = manifest.Publisher?.PublisherType ?? string.Empty;
+        var publisherName = manifest.Publisher?.Name ?? string.Empty;
+
+        var isTrusted = PublisherTypeConstants.TrustedExecutablePublishers.Contains(publisherType) ||
+                        PublisherTypeConstants.TrustedExecutablePublishers.Contains(publisherName);
+
+        if (!isTrusted)
+        {
+            logger.LogError(
+                "Untrusted publisher '{PublisherType}' ({PublisherName}) attempted to execute installer step '{StepName}' for manifest {ManifestId}",
+                publisherType,
+                publisherName,
+                step.Name,
+                manifest.Id);
+
+            return OperationResult.CreateFailure(
+                $"Publisher '{(!string.IsNullOrEmpty(publisherType) ? publisherType : publisherName)}' is not authorized to execute installation steps.");
+        }
+
+        // 2. Target path validation
+        if (string.IsNullOrWhiteSpace(step.TargetRelativePath))
+        {
+            return OperationResult.CreateFailure($"Target relative path is required for executable step '{step.Name}'.");
+        }
+
+        var normalizedRelativePath = PathHelper.NormalizeRelativePath(step.TargetRelativePath);
+        var targetFullPath = Path.Combine(workingDirectory, normalizedRelativePath);
+
+        if (!PathHelper.IsPathContainedIn(targetFullPath, workingDirectory))
+        {
+            logger.LogError("Target installer path '{Target}' escapes working directory '{Dir}'", step.TargetRelativePath, workingDirectory);
+            return OperationResult.CreateFailure($"Installer path '{step.TargetRelativePath}' escapes the working directory.");
+        }
+
+        if (!File.Exists(targetFullPath))
+        {
+            logger.LogError("Installer executable not found at '{Path}'", targetFullPath);
+            return OperationResult.CreateFailure($"Installer executable '{step.TargetRelativePath}' was not found in delivered content.");
+        }
+
+        // 3. Manifest file declaration and integrity verification
+        var manifestFile = manifest.Files?.FirstOrDefault(f =>
+            string.Equals(
+                PathHelper.NormalizeRelativePath(f.RelativePath),
+                normalizedRelativePath,
+                PathHelper.PathComparison));
+
+        if (manifestFile == null)
+        {
+            logger.LogError("Executable '{Target}' is not declared in manifest files for {ManifestId}", step.TargetRelativePath, manifest.Id);
+            return OperationResult.CreateFailure($"Installer executable '{step.TargetRelativePath}' is not declared in manifest files.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(manifestFile.Hash))
+        {
+            var computedHash = await hashProvider.ComputeFileHashAsync(targetFullPath, cancellationToken);
+            if (!string.Equals(computedHash, manifestFile.Hash, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogError(
+                    "Integrity verification failed for installer '{Target}'. Expected: {Expected}, Computed: {Computed}",
+                    step.TargetRelativePath,
+                    manifestFile.Hash,
+                    computedHash);
+
+                return OperationResult.CreateFailure(
+                    $"Integrity verification failed for installer '{step.TargetRelativePath}'.");
+            }
+
+            logger.LogDebug("Integrity verified for installer '{Target}'", step.TargetRelativePath);
+        }
+
+        // 4. User notification
+        var displayTitle = !string.IsNullOrWhiteSpace(step.Name) ? step.Name : "Running Installation Step";
+        var displayMessage = !string.IsNullOrWhiteSpace(step.StatusMessage)
+            ? step.StatusMessage
+            : $"Executing verified installer '{step.TargetRelativePath}'";
+
+        notificationService.ShowInfo(
+            displayTitle,
+            displayMessage,
+            NotificationConstants.DefaultAutoDismissMs);
+
+        progress?.Report(new ContentAcquisitionProgress
+        {
+            Phase = ContentAcquisitionPhase.Extracting,
+            CurrentOperation = displayMessage,
+            CurrentFile = step.TargetRelativePath,
+        });
+
+        // 5. Process execution
+        logger.LogInformation(
+            "Executing verified installer '{Target}' (Elevation: {RequiresElevation}) for manifest {ManifestId}",
+            step.TargetRelativePath,
+            step.RequiresElevation,
+            manifest.Id);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = targetFullPath,
+            WorkingDirectory = workingDirectory,
+        };
+
+        if (step.Arguments is { Count: > 0 })
+        {
+            foreach (var arg in step.Arguments)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+        }
+
+        if (step.RequiresElevation && OperatingSystem.IsWindows())
+        {
+            startInfo.UseShellExecute = true;
+            startInfo.Verb = "runas";
+        }
+        else
+        {
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+        }
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                logger.LogError("Failed to start process for installer '{Target}'", step.TargetRelativePath);
+                notificationService.ShowError("Installation Step Failed", $"Failed to start installer '{step.Name}'.");
+                return OperationResult.CreateFailure($"Failed to start installer '{step.TargetRelativePath}'.");
+            }
+
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0)
+            {
+                logger.LogError(
+                    "Installer step '{StepName}' exited with error code {ExitCode}",
+                    step.Name,
+                    process.ExitCode);
+
+                notificationService.ShowError(
+                    "Installation Step Failed",
+                    $"Step '{step.Name}' failed with exit code {process.ExitCode}.");
+
+                return OperationResult.CreateFailure(
+                    $"Installation step '{step.Name}' failed with exit code {process.ExitCode}.");
+            }
+
+            logger.LogInformation("Successfully completed installer step '{StepName}'", step.Name);
+            notificationService.ShowSuccess(
+                "Installation Step Completed",
+                $"Successfully completed '{step.Name}'.");
+
+            return OperationResult.CreateSuccess();
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("Installation step '{StepName}' was canceled", step.Name);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to execute installer step '{StepName}'", step.Name);
+            notificationService.ShowError(
+                "Installation Step Error",
+                $"Error executing '{step.Name}': {ex.Message}");
+
+            return OperationResult.CreateFailure($"Execution of step '{step.Name}' failed: {ex.Message}");
+        }
+    }
+
+    private OperationResult ExecuteRemoveFile(InstallationStep step, string workingDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(step.TargetRelativePath))
+        {
+            return OperationResult.CreateFailure($"Target relative path is required for remove file step '{step.Name}'.");
+        }
+
+        var normalizedRelativePath = PathHelper.NormalizeRelativePath(step.TargetRelativePath);
+        var targetFullPath = Path.Combine(workingDirectory, normalizedRelativePath);
+
+        if (!PathHelper.IsPathContainedIn(targetFullPath, workingDirectory))
+        {
+            logger.LogError("Target remove path '{Target}' escapes working directory '{Dir}'", step.TargetRelativePath, workingDirectory);
+            return OperationResult.CreateFailure($"Target file '{step.TargetRelativePath}' escapes the working directory.");
+        }
+
+        try
+        {
+            if (File.Exists(targetFullPath))
+            {
+                File.Delete(targetFullPath);
+                logger.LogInformation("Deleted file '{Target}' as part of step '{StepName}'", step.TargetRelativePath, step.Name);
+            }
+            else
+            {
+                logger.LogDebug("File '{Target}' already absent during remove step '{StepName}'", step.TargetRelativePath, step.Name);
+            }
+
+            return OperationResult.CreateSuccess();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete file '{Target}' in step '{StepName}'", step.TargetRelativePath, step.Name);
+            return OperationResult.CreateFailure($"Failed to delete file '{step.TargetRelativePath}': {ex.Message}");
+        }
+    }
+
+    private OperationResult ExecuteRenameFile(InstallationStep step, string workingDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(step.TargetRelativePath))
+        {
+            return OperationResult.CreateFailure($"Target relative path is required for rename step '{step.Name}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(step.DestinationRelativePath))
+        {
+            return OperationResult.CreateFailure($"Destination relative path is required for rename step '{step.Name}'.");
+        }
+
+        var normalizedSourcePath = PathHelper.NormalizeRelativePath(step.TargetRelativePath);
+        var normalizedDestPath = PathHelper.NormalizeRelativePath(step.DestinationRelativePath);
+
+        var sourceFullPath = Path.Combine(workingDirectory, normalizedSourcePath);
+        var destFullPath = Path.Combine(workingDirectory, normalizedDestPath);
+
+        if (!PathHelper.IsPathContainedIn(sourceFullPath, workingDirectory))
+        {
+            logger.LogError("Source path '{Source}' escapes working directory '{Dir}'", step.TargetRelativePath, workingDirectory);
+            return OperationResult.CreateFailure($"Source path '{step.TargetRelativePath}' escapes the working directory.");
+        }
+
+        if (!PathHelper.IsPathContainedIn(destFullPath, workingDirectory))
+        {
+            logger.LogError("Destination path '{Dest}' escapes working directory '{Dir}'", step.DestinationRelativePath, workingDirectory);
+            return OperationResult.CreateFailure($"Destination path '{step.DestinationRelativePath}' escapes the working directory.");
+        }
+
+        try
+        {
+            if (File.Exists(sourceFullPath))
+            {
+                var destDir = Path.GetDirectoryName(destFullPath);
+                if (!string.IsNullOrEmpty(destDir))
+                {
+                    Directory.CreateDirectory(destDir);
+                }
+
+                File.Move(sourceFullPath, destFullPath, overwrite: true);
+                logger.LogInformation(
+                    "Renamed '{Source}' to '{Dest}' in step '{StepName}'",
+                    step.TargetRelativePath,
+                    step.DestinationRelativePath,
+                    step.Name);
+            }
+            else
+            {
+                logger.LogWarning("Source file '{Source}' does not exist for rename step '{StepName}'", step.TargetRelativePath, step.Name);
+            }
+
+            return OperationResult.CreateSuccess();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to rename '{Source}' to '{Dest}' in step '{StepName}'",
+                step.TargetRelativePath,
+                step.DestinationRelativePath,
+                step.Name);
+
+            return OperationResult.CreateFailure(
+                $"Failed to rename '{step.TargetRelativePath}' to '{step.DestinationRelativePath}': {ex.Message}");
+        }
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -437,6 +437,18 @@ public class InstallationInstructionsService(
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 logger.LogError("Installer step '{StepName}' timed out", step.Name);
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                }
+                catch (Exception killEx)
+                {
+                    logger.LogWarning(killEx, "Failed to terminate timed-out installer step '{StepName}'", step.Name);
+                }
+
                 notificationService.ShowError("Installation Step Failed", $"Step '{step.Name}' timed out.");
                 return OperationResult.CreateFailure($"Installation step '{step.Name}' timed out.");
             }

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -53,60 +53,21 @@ public class InstallationInstructionsService(
     }
 
     /// <inheritdoc />
-    public Task<OperationResult> ExecutePreInstallStepsAsync(
-        ContentManifest manifest,
-        string workingDirectory,
-        IProgress<ContentAcquisitionProgress>? progress = null,
-        CancellationToken cancellationToken = default)
-    {
-        return ExecutePreInstallStepsAsync(manifest, workingDirectory, force: false, progress, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public async Task<OperationResult> ExecutePreInstallStepsAsync(
-        ContentManifest manifest,
-        string workingDirectory,
-        bool force,
-        IProgress<ContentAcquisitionProgress>? progress = null,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(manifest);
-
-        if (manifest.InstallationInstructions?.PreInstallSteps == null ||
-            manifest.InstallationInstructions.PreInstallSteps.Count == 0)
-        {
-            return OperationResult.CreateSuccess();
-        }
-
-        logger.LogInformation(
-            "Executing {Count} pre-install step(s) for manifest {ManifestId} (force: {Force})",
-            manifest.InstallationInstructions.PreInstallSteps.Count,
-            manifest.Id,
-            force);
-
-        return await ExecuteStepsAsync(
-            manifest.InstallationInstructions.PreInstallSteps,
-            manifest,
-            workingDirectory,
-            force,
-            progress,
-            cancellationToken);
-    }
-
-    /// <inheritdoc />
     public Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        string? providerSource = null,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        return ExecutePostInstallStepsAsync(manifest, workingDirectory, force: false, progress, cancellationToken);
+        return ExecutePostInstallStepsAsync(manifest, workingDirectory, providerSource, force: false, progress, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        string? providerSource,
         bool force,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
@@ -120,15 +81,17 @@ public class InstallationInstructionsService(
         }
 
         logger.LogInformation(
-            "Executing {Count} post-install step(s) for manifest {ManifestId} (force: {Force})",
+            "Executing {Count} post-install step(s) for manifest {ManifestId} from provider {Provider} (force: {Force})",
             manifest.InstallationInstructions.PostInstallSteps.Count,
             manifest.Id,
+            providerSource ?? "unspecified",
             force);
 
         return await ExecuteStepsAsync(
             manifest.InstallationInstructions.PostInstallSteps,
             manifest,
             workingDirectory,
+            providerSource,
             force,
             progress,
             cancellationToken);
@@ -138,6 +101,7 @@ public class InstallationInstructionsService(
         IReadOnlyList<InstallationStep> steps,
         ContentManifest manifest,
         string workingDirectory,
+        string? providerSource,
         bool force,
         IProgress<ContentAcquisitionProgress>? progress,
         CancellationToken cancellationToken)
@@ -157,7 +121,7 @@ public class InstallationInstructionsService(
                 continue;
             }
 
-            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, force, progress, cancellationToken);
+            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, providerSource, force, progress, cancellationToken);
             if (!stepResult.Success)
             {
                 return stepResult;
@@ -171,10 +135,17 @@ public class InstallationInstructionsService(
         InstallationStep step,
         ContentManifest manifest,
         string workingDirectory,
+        string? providerSource,
         bool force,
         IProgress<ContentAcquisitionProgress>? progress,
         CancellationToken cancellationToken)
     {
+        var authResult = ValidateProviderAuthorization(providerSource, manifest, step);
+        if (!authResult.Success)
+        {
+            return authResult;
+        }
+
         var stepKey = GetStepKey(step, manifest);
 
         if (!force && step.RunOnce && await ShouldSkipStepAsync(step, stepKey, manifest, cancellationToken))
@@ -291,12 +262,6 @@ public class InstallationInstructionsService(
         IProgress<ContentAcquisitionProgress>? progress,
         CancellationToken cancellationToken)
     {
-        var authResult = ValidatePublisherAuthorization(manifest, step);
-        if (!authResult.Success)
-        {
-            return authResult;
-        }
-
         var pathResult = ValidateInstallerTargetPath(step, workingDirectory, out var targetFullPath);
         if (!pathResult.Success)
         {
@@ -320,25 +285,25 @@ public class InstallationInstructionsService(
         return await RunInstallerProcessAsync(step, targetFullPath, workingDirectory, cancellationToken);
     }
 
-    private OperationResult ValidatePublisherAuthorization(ContentManifest manifest, InstallationStep step)
+    private OperationResult ValidateProviderAuthorization(string? providerSource, ContentManifest manifest, InstallationStep step)
     {
-        var publisherType = manifest.Publisher?.PublisherType ?? string.Empty;
-        var publisherName = manifest.Publisher?.Name ?? string.Empty;
+        var effectiveSource = !string.IsNullOrWhiteSpace(providerSource)
+            ? providerSource
+            : string.Empty;
 
-        var isTrusted = PublisherTypeConstants.TrustedExecutablePublishers.Contains(publisherType) ||
-                        PublisherTypeConstants.TrustedExecutablePublishers.Contains(publisherName);
+        var isTrusted = PublisherTypeConstants.TrustedExecutablePublishers.Contains(effectiveSource);
 
         if (!isTrusted)
         {
             logger.LogError(
-                "Untrusted publisher '{PublisherType}' ({PublisherName}) attempted to execute installer step '{StepName}' for manifest {ManifestId}",
-                publisherType,
-                publisherName,
+                "Untrusted provider '{ProviderSource}' attempted to execute step '{StepName}' (Kind: {Kind}) for manifest {ManifestId}",
+                effectiveSource,
                 step.Name,
+                step.Kind,
                 manifest.Id);
 
             return OperationResult.CreateFailure(
-                $"Publisher '{(!string.IsNullOrEmpty(publisherType) ? publisherType : publisherName)}' is not authorized to execute installation steps.");
+                $"Provider '{(!string.IsNullOrEmpty(effectiveSource) ? effectiveSource : "unknown")}' is not authorized to execute installation steps.");
         }
 
         return OperationResult.CreateSuccess();
@@ -356,7 +321,7 @@ public class InstallationInstructionsService(
         var normalizedRelativePath = PathHelper.NormalizeRelativePath(step.TargetRelativePath);
         targetFullPath = Path.Combine(workingDirectory, normalizedRelativePath);
 
-        if (!PathHelper.IsPathContainedIn(targetFullPath, workingDirectory))
+        if (!PathHelper.IsPathWithinDirectory(workingDirectory, targetFullPath))
         {
             logger.LogError("Target installer path '{Target}' escapes working directory '{Dir}'", step.TargetRelativePath, workingDirectory);
             return OperationResult.CreateFailure($"Installer path '{step.TargetRelativePath}' escapes the working directory.");
@@ -454,8 +419,15 @@ public class InstallationInstructionsService(
             }
         }
 
-        if (step.RequiresElevation && OperatingSystem.IsWindows())
+        if (step.RequiresElevation)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                logger.LogError("Installation step '{StepName}' requires administrator elevation, which is only supported on Windows", step.Name);
+                return OperationResult.CreateFailure(
+                    $"Installation step '{step.Name}' requires administrator elevation, which is only supported on Windows.");
+            }
+
             startInfo.UseShellExecute = true;
             startInfo.Verb = "runas";
         }
@@ -499,6 +471,23 @@ public class InstallationInstructionsService(
 
                 notificationService.ShowError("Installation Step Failed", $"Step '{step.Name}' timed out.");
                 return OperationResult.CreateFailure($"Installation step '{step.Name}' timed out.");
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                logger.LogInformation("Installation step '{StepName}' was canceled by caller, killing process tree", step.Name);
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                }
+                catch (Exception killEx)
+                {
+                    logger.LogWarning(killEx, "Failed to terminate canceled installer step '{StepName}'", step.Name);
+                }
+
+                throw;
             }
 
             if (process.ExitCode != 0)
@@ -549,7 +538,7 @@ public class InstallationInstructionsService(
         var normalizedRelativePath = PathHelper.NormalizeRelativePath(step.TargetRelativePath);
         var targetFullPath = Path.Combine(workingDirectory, normalizedRelativePath);
 
-        if (!PathHelper.IsPathContainedIn(targetFullPath, workingDirectory))
+        if (!PathHelper.IsPathWithinDirectory(workingDirectory, targetFullPath))
         {
             logger.LogError("Target remove path '{Target}' escapes working directory '{Dir}'", step.TargetRelativePath, workingDirectory);
             return OperationResult.CreateFailure($"Target file '{step.TargetRelativePath}' escapes the working directory.");
@@ -594,13 +583,13 @@ public class InstallationInstructionsService(
         var sourceFullPath = Path.Combine(workingDirectory, normalizedSourcePath);
         var destFullPath = Path.Combine(workingDirectory, normalizedDestPath);
 
-        if (!PathHelper.IsPathContainedIn(sourceFullPath, workingDirectory))
+        if (!PathHelper.IsPathWithinDirectory(workingDirectory, sourceFullPath))
         {
             logger.LogError("Source path '{Source}' escapes working directory '{Dir}'", step.TargetRelativePath, workingDirectory);
             return OperationResult.CreateFailure($"Source path '{step.TargetRelativePath}' escapes the working directory.");
         }
 
-        if (!PathHelper.IsPathContainedIn(destFullPath, workingDirectory))
+        if (!PathHelper.IsPathWithinDirectory(workingDirectory, destFullPath))
         {
             logger.LogError("Destination path '{Dest}' escapes working directory '{Dir}'", step.DestinationRelativePath, workingDirectory);
             return OperationResult.CreateFailure($"Destination path '{step.DestinationRelativePath}' escapes the working directory.");

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -53,11 +53,21 @@ public class InstallationInstructionsService(
     }
 
     /// <inheritdoc />
-    public async Task<OperationResult> ExecutePreInstallStepsAsync(
+    public Task<OperationResult> ExecutePreInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
         IProgress<ContentAcquisitionProgress>? progress = null,
-        bool force = false,
+        CancellationToken cancellationToken = default)
+    {
+        return ExecutePreInstallStepsAsync(manifest, workingDirectory, force: false, progress, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> ExecutePreInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        bool force,
+        IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(manifest);
@@ -84,11 +94,21 @@ public class InstallationInstructionsService(
     }
 
     /// <inheritdoc />
-    public async Task<OperationResult> ExecutePostInstallStepsAsync(
+    public Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
         IProgress<ContentAcquisitionProgress>? progress = null,
-        bool force = false,
+        CancellationToken cancellationToken = default)
+    {
+        return ExecutePostInstallStepsAsync(manifest, workingDirectory, force: false, progress, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationResult> ExecutePostInstallStepsAsync(
+        ContentManifest manifest,
+        string workingDirectory,
+        bool force,
+        IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(manifest);

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -24,16 +24,19 @@ namespace GenHub.Features.Content.Services;
 /// </summary>
 /// <param name="hashProvider">The file hash provider for integrity verification.</param>
 /// <param name="notificationService">The notification service for user awareness.</param>
+/// <param name="userSettingsService">The user settings service for tracking executed installation steps across updates.</param>
 /// <param name="logger">The logger instance.</param>
 public class InstallationInstructionsService(
     IFileHashProvider hashProvider,
     INotificationService notificationService,
+    IUserSettingsService? userSettingsService,
     ILogger<InstallationInstructionsService> logger) : IInstallationInstructionsService
 {
     /// <inheritdoc />
     public async Task<OperationResult> ExecutePreInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
@@ -46,14 +49,16 @@ public class InstallationInstructionsService(
         }
 
         logger.LogInformation(
-            "Executing {Count} pre-install step(s) for manifest {ManifestId}",
+            "Executing {Count} pre-install step(s) for manifest {ManifestId} (force: {Force})",
             manifest.InstallationInstructions.PreInstallSteps.Count,
-            manifest.Id);
+            manifest.Id,
+            force);
 
         return await ExecuteStepsAsync(
             manifest.InstallationInstructions.PreInstallSteps,
             manifest,
             workingDirectory,
+            force,
             progress,
             cancellationToken);
     }
@@ -62,6 +67,7 @@ public class InstallationInstructionsService(
     public async Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
+        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
@@ -74,14 +80,16 @@ public class InstallationInstructionsService(
         }
 
         logger.LogInformation(
-            "Executing {Count} post-install step(s) for manifest {ManifestId}",
+            "Executing {Count} post-install step(s) for manifest {ManifestId} (force: {Force})",
             manifest.InstallationInstructions.PostInstallSteps.Count,
-            manifest.Id);
+            manifest.Id,
+            force);
 
         return await ExecuteStepsAsync(
             manifest.InstallationInstructions.PostInstallSteps,
             manifest,
             workingDirectory,
+            force,
             progress,
             cancellationToken);
     }
@@ -90,6 +98,7 @@ public class InstallationInstructionsService(
         IReadOnlyList<InstallationStep> steps,
         ContentManifest manifest,
         string workingDirectory,
+        bool force,
         IProgress<ContentAcquisitionProgress>? progress,
         CancellationToken cancellationToken)
     {
@@ -108,7 +117,7 @@ public class InstallationInstructionsService(
                 continue;
             }
 
-            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, progress, cancellationToken);
+            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, force, progress, cancellationToken);
             if (!stepResult.Success)
             {
                 return stepResult;
@@ -122,25 +131,144 @@ public class InstallationInstructionsService(
         InstallationStep step,
         ContentManifest manifest,
         string workingDirectory,
+        bool force,
         IProgress<ContentAcquisitionProgress>? progress,
         CancellationToken cancellationToken)
     {
+        var stepKey = GetStepKey(step, manifest);
+
+        if (!force && step.RunOnce && ShouldSkipStep(step, stepKey))
+        {
+            logger.LogInformation(
+                "Skipping installation step '{StepName}' for manifest {ManifestId} because it has already been executed (key: {StepKey})",
+                step.Name,
+                manifest.Id,
+                stepKey);
+
+            progress?.Report(new ContentAcquisitionProgress
+            {
+                Phase = ContentAcquisitionPhase.Extracting,
+                CurrentOperation = $"Skipping {step.Name} (already installed)",
+                CurrentFile = step.TargetRelativePath,
+            });
+
+            return OperationResult.CreateSuccess();
+        }
+
+        OperationResult result;
         switch (step.Kind)
         {
             case InstallationStepKind.RunVerifiedInstaller:
-                return await ExecuteRunVerifiedInstallerAsync(step, manifest, workingDirectory, progress, cancellationToken);
+                result = await ExecuteRunVerifiedInstallerAsync(step, manifest, workingDirectory, progress, cancellationToken);
+                break;
 
             case InstallationStepKind.RemoveFile:
-                return ExecuteRemoveFile(step, workingDirectory);
+                result = ExecuteRemoveFile(step, workingDirectory);
+                break;
 
             case InstallationStepKind.RenameFile:
-                return ExecuteRenameFile(step, workingDirectory);
+                result = ExecuteRenameFile(step, workingDirectory);
+                break;
 
             case InstallationStepKind.Unknown:
             default:
                 logger.LogError("Unsupported installation step kind '{Kind}' in step '{StepName}'", step.Kind, step.Name);
                 return OperationResult.CreateFailure($"Unsupported installation step kind '{step.Kind}' for step '{step.Name}'.");
         }
+
+        if (result.Success && userSettingsService != null && !string.IsNullOrWhiteSpace(stepKey))
+        {
+            userSettingsService.Update(s => s.RecordInstallationStepExecuted(stepKey));
+            try
+            {
+                await userSettingsService.SaveAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to persist executed installation step key '{StepKey}'", stepKey);
+            }
+        }
+
+        return result;
+    }
+
+    private bool ShouldSkipStep(InstallationStep step, string stepKey)
+    {
+        if (userSettingsService?.Get().IsInstallationStepExecuted(stepKey) == true)
+        {
+            return true;
+        }
+
+        if (OperatingSystem.IsWindows() && IsEacAlreadyInstalled(step))
+        {
+            userSettingsService?.Update(s => s.RecordInstallationStepExecuted(stepKey));
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsEacAlreadyInstalled(InstallationStep step)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        if (step.Kind != InstallationStepKind.RunVerifiedInstaller)
+        {
+            return false;
+        }
+
+        var fileName = Path.GetFileName(step.TargetRelativePath ?? string.Empty);
+        if (!string.Equals(fileName, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        try
+        {
+            var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            if (!string.IsNullOrEmpty(programFilesX86))
+            {
+                var serviceExe = Path.Combine(programFilesX86, "EasyAntiCheat_EOS", "EasyAntiCheat_EOS.exe");
+                if (File.Exists(serviceExe))
+                {
+                    return true;
+                }
+            }
+
+            var commonProgramFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFilesX86);
+            if (!string.IsNullOrEmpty(commonProgramFilesX86))
+            {
+                var commonExe = Path.Combine(commonProgramFilesX86, "EasyAntiCheat", "EasyAntiCheat_EOS.exe");
+                if (File.Exists(commonExe))
+                {
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static string GetStepKey(InstallationStep step, ContentManifest manifest)
+    {
+        if (!string.IsNullOrWhiteSpace(step.StepKey))
+        {
+            return step.StepKey;
+        }
+
+        var publisher = manifest.Publisher?.PublisherType ?? "generic";
+        var name = step.Name;
+        var target = step.TargetRelativePath ?? string.Empty;
+        var args = step.Arguments is { Count: > 0 } ? string.Join(" ", step.Arguments) : string.Empty;
+
+        return $"{publisher}:{name}:{target}:{args}".TrimEnd(':');
     }
 
     private async Task<OperationResult> ExecuteRunVerifiedInstallerAsync(

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -170,7 +170,6 @@ public class InstallationInstructionsService(
                 result = ExecuteRenameFile(step, workingDirectory);
                 break;
 
-            case InstallationStepKind.Unknown:
             default:
                 logger.LogError("Unsupported installation step kind '{Kind}' in step '{StepName}'", step.Kind, step.Name);
                 return OperationResult.CreateFailure($"Unsupported installation step kind '{step.Kind}' for step '{step.Name}'.");

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -111,6 +111,8 @@ public class InstallationInstructionsService(
             return OperationResult.CreateFailure($"Working directory does not exist: '{workingDirectory}'");
         }
 
+        var keysToRecord = new List<string>();
+
         for (var i = 0; i < steps.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -121,10 +123,30 @@ public class InstallationInstructionsService(
                 continue;
             }
 
-            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, providerSource, force, progress, cancellationToken);
+            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, providerSource, force, progress, keysToRecord, cancellationToken);
             if (!stepResult.Success)
             {
                 return stepResult;
+            }
+        }
+
+        if (userSettingsService != null && keysToRecord.Count > 0)
+        {
+            userSettingsService.Update(s =>
+            {
+                foreach (var key in keysToRecord)
+                {
+                    s.RecordInstallationStepExecuted(key);
+                }
+            });
+
+            try
+            {
+                await userSettingsService.SaveAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to persist executed installation step keys");
             }
         }
 
@@ -138,6 +160,7 @@ public class InstallationInstructionsService(
         string? providerSource,
         bool force,
         IProgress<ContentAcquisitionProgress>? progress,
+        List<string> keysToRecord,
         CancellationToken cancellationToken)
     {
         var authResult = ValidateProviderAuthorization(providerSource, manifest, step);
@@ -148,7 +171,7 @@ public class InstallationInstructionsService(
 
         var stepKey = GetStepKey(step, manifest);
 
-        if (!force && step.RunOnce && await ShouldSkipStepAsync(step, stepKey, manifest, cancellationToken))
+        if (!force && step.RunOnce && ShouldSkipStep(step, stepKey, manifest, keysToRecord))
         {
             logger.LogInformation(
                 "Skipping installation step '{StepName}' for manifest {ManifestId} because it has already been executed (key: {StepKey})",
@@ -186,27 +209,19 @@ public class InstallationInstructionsService(
                 return OperationResult.CreateFailure($"Unsupported installation step kind '{step.Kind}' for step '{step.Name}'.");
         }
 
-        if (result.Success && step.RunOnce && userSettingsService != null && !string.IsNullOrWhiteSpace(stepKey))
+        if (result.Success && step.RunOnce && !string.IsNullOrWhiteSpace(stepKey) && !keysToRecord.Contains(stepKey))
         {
-            userSettingsService.Update(s => s.RecordInstallationStepExecuted(stepKey));
-            try
-            {
-                await userSettingsService.SaveAsync(cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to persist executed installation step key '{StepKey}'", stepKey);
-            }
+            keysToRecord.Add(stepKey);
         }
 
         return result;
     }
 
-    private async Task<bool> ShouldSkipStepAsync(
+    private bool ShouldSkipStep(
         InstallationStep step,
         string stepKey,
         ContentManifest manifest,
-        CancellationToken cancellationToken)
+        List<string> keysToRecord)
     {
         if (userSettingsService?.Get().IsInstallationStepExecuted(stepKey) == true)
         {
@@ -219,17 +234,9 @@ public class InstallationInstructionsService(
             {
                 if (precondition.CanHandle(step, manifest) && precondition.IsAlreadyFulfilled(step, manifest))
                 {
-                    if (userSettingsService != null && !string.IsNullOrWhiteSpace(stepKey))
+                    if (!string.IsNullOrWhiteSpace(stepKey) && !keysToRecord.Contains(stepKey))
                     {
-                        userSettingsService.Update(s => s.RecordInstallationStepExecuted(stepKey));
-                        try
-                        {
-                            await userSettingsService.SaveAsync(cancellationToken);
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogWarning(ex, "Failed to persist detected installation step key '{StepKey}'", stepKey);
-                        }
+                        keysToRecord.Add(stepKey);
                     }
 
                     return true;

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -53,22 +53,11 @@ public class InstallationInstructionsService(
     }
 
     /// <inheritdoc />
-    public Task<OperationResult> ExecutePostInstallStepsAsync(
-        ContentManifest manifest,
-        string workingDirectory,
-        string? providerSource = null,
-        IProgress<ContentAcquisitionProgress>? progress = null,
-        CancellationToken cancellationToken = default)
-    {
-        return ExecutePostInstallStepsAsync(manifest, workingDirectory, providerSource, force: false, progress, cancellationToken);
-    }
-
-    /// <inheritdoc />
     public async Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
-        string? providerSource,
-        bool force,
+        string? providerSource = null,
+        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -291,7 +291,37 @@ public class InstallationInstructionsService(
         IProgress<ContentAcquisitionProgress>? progress,
         CancellationToken cancellationToken)
     {
-        // 1. Publisher authorization check
+        var authResult = ValidatePublisherAuthorization(manifest, step);
+        if (!authResult.Success)
+        {
+            return authResult;
+        }
+
+        var pathResult = ValidateInstallerTargetPath(step, workingDirectory, out var targetFullPath);
+        if (!pathResult.Success)
+        {
+            return pathResult;
+        }
+
+        var integrityResult = await VerifyInstallerIntegrityAsync(step, manifest, targetFullPath, cancellationToken);
+        if (!integrityResult.Success)
+        {
+            return integrityResult;
+        }
+
+        NotifyStepStarting(step, progress);
+
+        logger.LogInformation(
+            "Executing verified installer '{Target}' (Elevation: {RequiresElevation}) for manifest {ManifestId}",
+            step.TargetRelativePath,
+            step.RequiresElevation,
+            manifest.Id);
+
+        return await RunInstallerProcessAsync(step, targetFullPath, workingDirectory, cancellationToken);
+    }
+
+    private OperationResult ValidatePublisherAuthorization(ContentManifest manifest, InstallationStep step)
+    {
         var publisherType = manifest.Publisher?.PublisherType ?? string.Empty;
         var publisherName = manifest.Publisher?.Name ?? string.Empty;
 
@@ -311,14 +341,20 @@ public class InstallationInstructionsService(
                 $"Publisher '{(!string.IsNullOrEmpty(publisherType) ? publisherType : publisherName)}' is not authorized to execute installation steps.");
         }
 
-        // 2. Target path validation
+        return OperationResult.CreateSuccess();
+    }
+
+    private OperationResult ValidateInstallerTargetPath(InstallationStep step, string workingDirectory, out string targetFullPath)
+    {
+        targetFullPath = string.Empty;
+
         if (string.IsNullOrWhiteSpace(step.TargetRelativePath))
         {
             return OperationResult.CreateFailure($"Target relative path is required for executable step '{step.Name}'.");
         }
 
         var normalizedRelativePath = PathHelper.NormalizeRelativePath(step.TargetRelativePath);
-        var targetFullPath = Path.Combine(workingDirectory, normalizedRelativePath);
+        targetFullPath = Path.Combine(workingDirectory, normalizedRelativePath);
 
         if (!PathHelper.IsPathContainedIn(targetFullPath, workingDirectory))
         {
@@ -332,7 +368,16 @@ public class InstallationInstructionsService(
             return OperationResult.CreateFailure($"Installer executable '{step.TargetRelativePath}' was not found in delivered content.");
         }
 
-        // 3. Manifest file declaration and integrity verification
+        return OperationResult.CreateSuccess();
+    }
+
+    private async Task<OperationResult> VerifyInstallerIntegrityAsync(
+        InstallationStep step,
+        ContentManifest manifest,
+        string targetFullPath,
+        CancellationToken cancellationToken)
+    {
+        var normalizedRelativePath = PathHelper.NormalizeRelativePath(step.TargetRelativePath ?? string.Empty);
         var manifestFile = manifest.Files?.FirstOrDefault(f =>
             string.Equals(
                 PathHelper.NormalizeRelativePath(f.RelativePath),
@@ -366,8 +411,11 @@ public class InstallationInstructionsService(
         }
 
         logger.LogDebug("Integrity verified for installer '{Target}'", step.TargetRelativePath);
+        return OperationResult.CreateSuccess();
+    }
 
-        // 4. User notification
+    private void NotifyStepStarting(InstallationStep step, IProgress<ContentAcquisitionProgress>? progress)
+    {
         var displayTitle = !string.IsNullOrWhiteSpace(step.Name) ? step.Name : "Running Installation Step";
         var displayMessage = !string.IsNullOrWhiteSpace(step.StatusMessage)
             ? step.StatusMessage
@@ -384,14 +432,14 @@ public class InstallationInstructionsService(
             CurrentOperation = displayMessage,
             CurrentFile = step.TargetRelativePath ?? string.Empty,
         });
+    }
 
-        // 5. Process execution
-        logger.LogInformation(
-            "Executing verified installer '{Target}' (Elevation: {RequiresElevation}) for manifest {ManifestId}",
-            step.TargetRelativePath,
-            step.RequiresElevation,
-            manifest.Id);
-
+    private async Task<OperationResult> RunInstallerProcessAsync(
+        InstallationStep step,
+        string targetFullPath,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
         var startInfo = new ProcessStartInfo
         {
             FileName = targetFullPath,

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -104,8 +104,6 @@ public class InstallationInstructionsService(
         await _executionGate.WaitAsync(cancellationToken);
         try
         {
-            var keysToRecord = new List<string>();
-
             for (var i = 0; i < steps.Count; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -116,34 +114,10 @@ public class InstallationInstructionsService(
                     continue;
                 }
 
-                var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, providerSource, force, progress, keysToRecord, cancellationToken);
+                var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, providerSource, force, progress, cancellationToken);
                 if (!stepResult.Success)
                 {
                     return stepResult;
-                }
-            }
-
-            if (userSettingsService != null && keysToRecord.Count > 0)
-            {
-                userSettingsService.Update(s =>
-                {
-                    foreach (var key in keysToRecord)
-                    {
-                        s.RecordInstallationStepExecuted(key);
-                    }
-                });
-
-                try
-                {
-                    await userSettingsService.SaveAsync(cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "Failed to persist executed installation step keys");
                 }
             }
 
@@ -162,18 +136,11 @@ public class InstallationInstructionsService(
         string? providerSource,
         bool force,
         IProgress<ContentAcquisitionProgress>? progress,
-        List<string> keysToRecord,
         CancellationToken cancellationToken)
     {
-        var authResult = ValidateProviderAuthorization(providerSource, manifest, step);
-        if (!authResult.Success)
-        {
-            return authResult;
-        }
-
         var stepKey = GetStepKey(step, manifest);
 
-        if (!force && step.RunOnce && ShouldSkipStep(step, stepKey, manifest, keysToRecord))
+        if (!force && step.RunOnce && await ShouldSkipStepAsync(step, stepKey, manifest, cancellationToken))
         {
             logger.LogInformation(
                 "Skipping installation step '{StepName}' for manifest {ManifestId} because it has already been executed (key: {StepKey})",
@@ -189,6 +156,12 @@ public class InstallationInstructionsService(
             });
 
             return OperationResult.CreateSuccess();
+        }
+
+        var authResult = ValidateProviderAuthorization(providerSource, manifest, step);
+        if (!authResult.Success)
+        {
+            return authResult;
         }
 
         var result = OperationResult.CreateFailure("Uninitialized step result");
@@ -211,19 +184,19 @@ public class InstallationInstructionsService(
                 return OperationResult.CreateFailure($"Unsupported installation step kind '{step.Kind}' for step '{step.Name}'.");
         }
 
-        if (result.Success && step.RunOnce && !string.IsNullOrWhiteSpace(stepKey) && !keysToRecord.Contains(stepKey))
+        if (result.Success && step.RunOnce && !string.IsNullOrWhiteSpace(stepKey))
         {
-            keysToRecord.Add(stepKey);
+            await RecordStepExecutedAsync(stepKey, cancellationToken);
         }
 
         return result;
     }
 
-    private bool ShouldSkipStep(
+    private async Task<bool> ShouldSkipStepAsync(
         InstallationStep step,
         string stepKey,
         ContentManifest manifest,
-        List<string> keysToRecord)
+        CancellationToken cancellationToken)
     {
         if (userSettingsService?.Get().IsInstallationStepExecuted(stepKey) == true)
         {
@@ -236,9 +209,9 @@ public class InstallationInstructionsService(
             {
                 if (precondition.CanHandle(step, manifest) && precondition.IsAlreadyFulfilled(step, manifest))
                 {
-                    if (!string.IsNullOrWhiteSpace(stepKey) && !keysToRecord.Contains(stepKey))
+                    if (!string.IsNullOrWhiteSpace(stepKey))
                     {
-                        keysToRecord.Add(stepKey);
+                        await RecordStepExecutedAsync(stepKey, cancellationToken);
                     }
 
                     return true;
@@ -247,6 +220,29 @@ public class InstallationInstructionsService(
         }
 
         return false;
+    }
+
+    private async Task RecordStepExecutedAsync(string stepKey, CancellationToken cancellationToken)
+    {
+        if (userSettingsService == null || string.IsNullOrWhiteSpace(stepKey))
+        {
+            return;
+        }
+
+        userSettingsService.Update(s => s.RecordInstallationStepExecuted(stepKey));
+
+        try
+        {
+            await userSettingsService.SaveAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to persist executed installation step key '{StepKey}'", stepKey);
+        }
     }
 
     private string GetStepKey(InstallationStep step, ContentManifest manifest)

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -35,6 +35,7 @@ public class InstallationInstructionsService(
     ILogger<InstallationInstructionsService> logger) : IInstallationInstructionsService
 {
     private static readonly TimeSpan InstallerStepTimeout = TimeSpan.FromMinutes(10);
+    private readonly SemaphoreSlim _executionGate = new(1, 1);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InstallationInstructionsService"/> class.
@@ -100,46 +101,58 @@ public class InstallationInstructionsService(
             return OperationResult.CreateFailure($"Working directory does not exist: '{workingDirectory}'");
         }
 
-        var keysToRecord = new List<string>();
-
-        for (var i = 0; i < steps.Count; i++)
+        await _executionGate.WaitAsync(cancellationToken);
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var step = steps[i];
+            var keysToRecord = new List<string>();
 
-            if (step == null)
+            for (var i = 0; i < steps.Count; i++)
             {
-                continue;
-            }
+                cancellationToken.ThrowIfCancellationRequested();
+                var step = steps[i];
 
-            var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, providerSource, force, progress, keysToRecord, cancellationToken);
-            if (!stepResult.Success)
-            {
-                return stepResult;
-            }
-        }
-
-        if (userSettingsService != null && keysToRecord.Count > 0)
-        {
-            userSettingsService.Update(s =>
-            {
-                foreach (var key in keysToRecord)
+                if (step == null)
                 {
-                    s.RecordInstallationStepExecuted(key);
+                    continue;
                 }
-            });
 
-            try
-            {
-                await userSettingsService.SaveAsync(cancellationToken);
+                var stepResult = await ExecuteSingleStepAsync(step, manifest, workingDirectory, providerSource, force, progress, keysToRecord, cancellationToken);
+                if (!stepResult.Success)
+                {
+                    return stepResult;
+                }
             }
-            catch (Exception ex)
+
+            if (userSettingsService != null && keysToRecord.Count > 0)
             {
-                logger.LogWarning(ex, "Failed to persist executed installation step keys");
+                userSettingsService.Update(s =>
+                {
+                    foreach (var key in keysToRecord)
+                    {
+                        s.RecordInstallationStepExecuted(key);
+                    }
+                });
+
+                try
+                {
+                    await userSettingsService.SaveAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to persist executed installation step keys");
+                }
             }
+
+            return OperationResult.CreateSuccess();
         }
-
-        return OperationResult.CreateSuccess();
+        finally
+        {
+            _executionGate.Release();
+        }
     }
 
     private async Task<OperationResult> ExecuteSingleStepAsync(
@@ -170,7 +183,7 @@ public class InstallationInstructionsService(
 
             progress?.Report(new ContentAcquisitionProgress
             {
-                Phase = ContentAcquisitionPhase.Extracting,
+                Phase = ContentAcquisitionPhase.Delivering,
                 CurrentOperation = $"Skipping {step.Name} (already installed)",
                 CurrentFile = step.TargetRelativePath ?? string.Empty,
             });
@@ -244,11 +257,12 @@ public class InstallationInstructionsService(
         }
 
         var publisher = manifest.Publisher?.PublisherType ?? "generic";
+        var manifestId = manifest.Id.Value ?? string.Empty;
         var name = step.Name;
         var target = step.TargetRelativePath ?? string.Empty;
         var args = step.Arguments is { Count: > 0 } ? string.Join(" ", step.Arguments) : string.Empty;
 
-        return $"{publisher}:{name}:{target}:{args}".TrimEnd(':');
+        return $"{publisher}:{manifestId}:{name}:{target}:{args}".TrimEnd(':');
     }
 
     private async Task<OperationResult> ExecuteRunVerifiedInstallerAsync(
@@ -358,7 +372,21 @@ public class InstallationInstructionsService(
                 $"Installer '{step.TargetRelativePath}' has no declared hash and cannot be verified.");
         }
 
-        var computedHash = await hashProvider.ComputeFileHashAsync(targetFullPath, cancellationToken);
+        string computedHash;
+        try
+        {
+            computedHash = await hashProvider.ComputeFileHashAsync(targetFullPath, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to compute hash for installer '{Target}' in manifest {ManifestId}", step.TargetRelativePath, manifest.Id);
+            return OperationResult.CreateFailure($"Failed to compute hash for installer '{step.TargetRelativePath}': {ex.Message}");
+        }
+
         if (!string.Equals(computedHash, manifestFile.Hash, StringComparison.OrdinalIgnoreCase))
         {
             logger.LogError(
@@ -389,7 +417,7 @@ public class InstallationInstructionsService(
 
         progress?.Report(new ContentAcquisitionProgress
         {
-            Phase = ContentAcquisitionPhase.Extracting,
+            Phase = ContentAcquisitionPhase.Delivering,
             CurrentOperation = displayMessage,
             CurrentFile = step.TargetRelativePath ?? string.Empty,
         });
@@ -458,6 +486,7 @@ public class InstallationInstructionsService(
                     if (!process.HasExited)
                     {
                         process.Kill(entireProcessTree: true);
+                        await process.WaitForExitAsync(CancellationToken.None);
                     }
                 }
                 catch (Exception killEx)
@@ -476,6 +505,7 @@ public class InstallationInstructionsService(
                     if (!process.HasExited)
                     {
                         process.Kill(entireProcessTree: true);
+                        await process.WaitForExitAsync(CancellationToken.None);
                     }
                 }
                 catch (Exception killEx)

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -25,13 +25,33 @@ namespace GenHub.Features.Content.Services;
 /// <param name="hashProvider">The file hash provider for integrity verification.</param>
 /// <param name="notificationService">The notification service for user awareness.</param>
 /// <param name="userSettingsService">The user settings service for tracking executed installation steps across updates.</param>
+/// <param name="preconditions">Optional installation step preconditions for environment detection.</param>
 /// <param name="logger">The logger instance.</param>
 public class InstallationInstructionsService(
     IFileHashProvider hashProvider,
     INotificationService notificationService,
     IUserSettingsService? userSettingsService,
+    IEnumerable<IInstallationStepPrecondition>? preconditions,
     ILogger<InstallationInstructionsService> logger) : IInstallationInstructionsService
 {
+    private static readonly TimeSpan InstallerStepTimeout = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InstallationInstructionsService"/> class.
+    /// </summary>
+    /// <param name="hashProvider">The file hash provider for integrity verification.</param>
+    /// <param name="notificationService">The notification service for user awareness.</param>
+    /// <param name="userSettingsService">The user settings service for tracking executed installation steps across updates.</param>
+    /// <param name="logger">The logger instance.</param>
+    public InstallationInstructionsService(
+        IFileHashProvider hashProvider,
+        INotificationService notificationService,
+        IUserSettingsService? userSettingsService,
+        ILogger<InstallationInstructionsService> logger)
+        : this(hashProvider, notificationService, userSettingsService, null, logger)
+    {
+    }
+
     /// <inheritdoc />
     public async Task<OperationResult> ExecutePreInstallStepsAsync(
         ContentManifest manifest,
@@ -137,7 +157,7 @@ public class InstallationInstructionsService(
     {
         var stepKey = GetStepKey(step, manifest);
 
-        if (!force && step.RunOnce && ShouldSkipStep(step, stepKey))
+        if (!force && step.RunOnce && await ShouldSkipStepAsync(step, stepKey, manifest, cancellationToken))
         {
             logger.LogInformation(
                 "Skipping installation step '{StepName}' for manifest {ManifestId} because it has already been executed (key: {StepKey})",
@@ -155,7 +175,7 @@ public class InstallationInstructionsService(
             return OperationResult.CreateSuccess();
         }
 
-        OperationResult result;
+        var result = OperationResult.CreateFailure("Uninitialized step result");
         switch (step.Kind)
         {
             case InstallationStepKind.RunVerifiedInstaller:
@@ -175,7 +195,7 @@ public class InstallationInstructionsService(
                 return OperationResult.CreateFailure($"Unsupported installation step kind '{step.Kind}' for step '{step.Name}'.");
         }
 
-        if (result.Success && userSettingsService != null && !string.IsNullOrWhiteSpace(stepKey))
+        if (result.Success && step.RunOnce && userSettingsService != null && !string.IsNullOrWhiteSpace(stepKey))
         {
             userSettingsService.Update(s => s.RecordInstallationStepExecuted(stepKey));
             try
@@ -191,65 +211,39 @@ public class InstallationInstructionsService(
         return result;
     }
 
-    private bool ShouldSkipStep(InstallationStep step, string stepKey)
+    private async Task<bool> ShouldSkipStepAsync(
+        InstallationStep step,
+        string stepKey,
+        ContentManifest manifest,
+        CancellationToken cancellationToken)
     {
         if (userSettingsService?.Get().IsInstallationStepExecuted(stepKey) == true)
         {
             return true;
         }
 
-        if (OperatingSystem.IsWindows() && IsEacAlreadyInstalled(step))
+        if (preconditions != null)
         {
-            userSettingsService?.Update(s => s.RecordInstallationStepExecuted(stepKey));
-            return true;
-        }
-
-        return false;
-    }
-
-    private bool IsEacAlreadyInstalled(InstallationStep step)
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            return false;
-        }
-
-        if (step.Kind != InstallationStepKind.RunVerifiedInstaller)
-        {
-            return false;
-        }
-
-        var fileName = Path.GetFileName(step.TargetRelativePath ?? string.Empty);
-        if (!string.Equals(fileName, GameClientConstants.GeneralsOnlineEacSetupExecutable, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        try
-        {
-            var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-            if (!string.IsNullOrEmpty(programFilesX86))
+            foreach (var precondition in preconditions)
             {
-                var serviceExe = Path.Combine(programFilesX86, "EasyAntiCheat_EOS", "EasyAntiCheat_EOS.exe");
-                if (File.Exists(serviceExe))
+                if (precondition.CanHandle(step, manifest) && precondition.IsAlreadyFulfilled(step, manifest))
                 {
+                    if (userSettingsService != null && !string.IsNullOrWhiteSpace(stepKey))
+                    {
+                        userSettingsService.Update(s => s.RecordInstallationStepExecuted(stepKey));
+                        try
+                        {
+                            await userSettingsService.SaveAsync(cancellationToken);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex, "Failed to persist detected installation step key '{StepKey}'", stepKey);
+                        }
+                    }
+
                     return true;
                 }
             }
-
-            var commonProgramFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFilesX86);
-            if (!string.IsNullOrEmpty(commonProgramFilesX86))
-            {
-                var commonExe = Path.Combine(commonProgramFilesX86, "EasyAntiCheat", "EasyAntiCheat_EOS.exe");
-                if (File.Exists(commonExe))
-                {
-                    return true;
-                }
-            }
-        }
-        catch
-        {
-            return false;
         }
 
         return false;
@@ -331,23 +325,27 @@ public class InstallationInstructionsService(
             return OperationResult.CreateFailure($"Installer executable '{step.TargetRelativePath}' is not declared in manifest files.");
         }
 
-        if (!string.IsNullOrWhiteSpace(manifestFile.Hash))
+        if (string.IsNullOrWhiteSpace(manifestFile.Hash))
         {
-            var computedHash = await hashProvider.ComputeFileHashAsync(targetFullPath, cancellationToken);
-            if (!string.Equals(computedHash, manifestFile.Hash, StringComparison.OrdinalIgnoreCase))
-            {
-                logger.LogError(
-                    "Integrity verification failed for installer '{Target}'. Expected: {Expected}, Computed: {Computed}",
-                    step.TargetRelativePath,
-                    manifestFile.Hash,
-                    computedHash);
-
-                return OperationResult.CreateFailure(
-                    $"Integrity verification failed for installer '{step.TargetRelativePath}'.");
-            }
-
-            logger.LogDebug("Integrity verified for installer '{Target}'", step.TargetRelativePath);
+            logger.LogError("Installer '{Target}' has no declared hash in manifest {ManifestId}", step.TargetRelativePath, manifest.Id);
+            return OperationResult.CreateFailure(
+                $"Installer '{step.TargetRelativePath}' has no declared hash and cannot be verified.");
         }
+
+        var computedHash = await hashProvider.ComputeFileHashAsync(targetFullPath, cancellationToken);
+        if (!string.Equals(computedHash, manifestFile.Hash, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogError(
+                "Integrity verification failed for installer '{Target}'. Expected: {Expected}, Computed: {Computed}",
+                step.TargetRelativePath,
+                manifestFile.Hash,
+                computedHash);
+
+            return OperationResult.CreateFailure(
+                $"Integrity verification failed for installer '{step.TargetRelativePath}'.");
+        }
+
+        logger.LogDebug("Integrity verified for installer '{Target}'", step.TargetRelativePath);
 
         // 4. User notification
         var displayTitle = !string.IsNullOrWhiteSpace(step.Name) ? step.Name : "Running Installation Step";
@@ -409,7 +407,19 @@ public class InstallationInstructionsService(
                 return OperationResult.CreateFailure($"Failed to start installer '{step.TargetRelativePath}'.");
             }
 
-            await process.WaitForExitAsync(cancellationToken);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(InstallerStepTimeout);
+
+            try
+            {
+                await process.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                logger.LogError("Installer step '{StepName}' timed out", step.Name);
+                notificationService.ShowError("Installation Step Failed", $"Step '{step.Name}' timed out.");
+                return OperationResult.CreateFailure($"Installation step '{step.Name}' timed out.");
+            }
 
             if (process.ExitCode != 0)
             {

--- a/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
+++ b/GenHub/GenHub/Features/Content/Services/InstallationInstructionsService.cs
@@ -36,8 +36,8 @@ public class InstallationInstructionsService(
     public async Task<OperationResult> ExecutePreInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
-        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
+        bool force = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(manifest);
@@ -67,8 +67,8 @@ public class InstallationInstructionsService(
     public async Task<OperationResult> ExecutePostInstallStepsAsync(
         ContentManifest manifest,
         string workingDirectory,
-        bool force = false,
         IProgress<ContentAcquisitionProgress>? progress = null,
+        bool force = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(manifest);
@@ -149,7 +149,7 @@ public class InstallationInstructionsService(
             {
                 Phase = ContentAcquisitionPhase.Extracting,
                 CurrentOperation = $"Skipping {step.Name} (already installed)",
-                CurrentFile = step.TargetRelativePath,
+                CurrentFile = step.TargetRelativePath ?? string.Empty,
             });
 
             return OperationResult.CreateSuccess();
@@ -207,7 +207,7 @@ public class InstallationInstructionsService(
         return false;
     }
 
-    private static bool IsEacAlreadyInstalled(InstallationStep step)
+    private bool IsEacAlreadyInstalled(InstallationStep step)
     {
         if (!OperatingSystem.IsWindows())
         {
@@ -255,7 +255,7 @@ public class InstallationInstructionsService(
         return false;
     }
 
-    private static string GetStepKey(InstallationStep step, ContentManifest manifest)
+    private string GetStepKey(InstallationStep step, ContentManifest manifest)
     {
         if (!string.IsNullOrWhiteSpace(step.StepKey))
         {
@@ -364,7 +364,7 @@ public class InstallationInstructionsService(
         {
             Phase = ContentAcquisitionPhase.Extracting,
             CurrentOperation = displayMessage,
-            CurrentFile = step.TargetRelativePath,
+            CurrentFile = step.TargetRelativePath ?? string.Empty,
         });
 
         // 5. Process execution

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -28,8 +28,9 @@ public class SuperHackersProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     IContentValidator contentValidator,
+    IInstallationInstructionsService installationInstructionsService,
     ILogger<SuperHackersProvider> logger)
-    : BaseContentProvider(contentValidator, logger)
+    : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private readonly IContentResolver _resolver = resolvers.FirstOrDefault(r =>
             r.ResolverId?.Equals(SuperHackersConstants.ResolverId, StringComparison.OrdinalIgnoreCase) == true)

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -28,30 +28,10 @@ public class SuperHackersProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     IContentValidator contentValidator,
-    IInstallationInstructionsService? installationInstructionsService,
-    ILogger<SuperHackersProvider> logger)
+    ILogger<SuperHackersProvider> logger,
+    IInstallationInstructionsService? installationInstructionsService = null)
     : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SuperHackersProvider"/> class without an installation instructions service.
-    /// </summary>
-    /// <param name="providerDefinitionLoader">The provider definition loader.</param>
-    /// <param name="gitHubApiClient">The GitHub API client.</param>
-    /// <param name="resolvers">The content resolvers.</param>
-    /// <param name="deliverers">The content deliverers.</param>
-    /// <param name="contentValidator">The content validator.</param>
-    /// <param name="logger">The logger.</param>
-    public SuperHackersProvider(
-        IProviderDefinitionLoader providerDefinitionLoader,
-        IGitHubApiClient gitHubApiClient,
-        IEnumerable<IContentResolver> resolvers,
-        IEnumerable<IContentDeliverer> deliverers,
-        IContentValidator contentValidator,
-        ILogger<SuperHackersProvider> logger)
-        : this(providerDefinitionLoader, gitHubApiClient, resolvers, deliverers, contentValidator, null, logger)
-    {
-    }
-
     private readonly IContentResolver _resolver = resolvers.FirstOrDefault(r =>
             r.ResolverId?.Equals(SuperHackersConstants.ResolverId, StringComparison.OrdinalIgnoreCase) == true)
         ?? throw new InvalidOperationException("No GitHub resolver found for SuperHackers");

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -28,10 +28,30 @@ public class SuperHackersProvider(
     IEnumerable<IContentResolver> resolvers,
     IEnumerable<IContentDeliverer> deliverers,
     IContentValidator contentValidator,
-    IInstallationInstructionsService installationInstructionsService,
+    IInstallationInstructionsService? installationInstructionsService,
     ILogger<SuperHackersProvider> logger)
     : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SuperHackersProvider"/> class without an installation instructions service.
+    /// </summary>
+    /// <param name="providerDefinitionLoader">The provider definition loader.</param>
+    /// <param name="gitHubApiClient">The GitHub API client.</param>
+    /// <param name="resolvers">The content resolvers.</param>
+    /// <param name="deliverers">The content deliverers.</param>
+    /// <param name="contentValidator">The content validator.</param>
+    /// <param name="logger">The logger.</param>
+    public SuperHackersProvider(
+        IProviderDefinitionLoader providerDefinitionLoader,
+        IGitHubApiClient gitHubApiClient,
+        IEnumerable<IContentResolver> resolvers,
+        IEnumerable<IContentDeliverer> deliverers,
+        IContentValidator contentValidator,
+        ILogger<SuperHackersProvider> logger)
+        : this(providerDefinitionLoader, gitHubApiClient, resolvers, deliverers, contentValidator, null, logger)
+    {
+    }
+
     private readonly IContentResolver _resolver = resolvers.FirstOrDefault(r =>
             r.ResolverId?.Equals(SuperHackersConstants.ResolverId, StringComparison.OrdinalIgnoreCase) == true)
         ?? throw new InvalidOperationException("No GitHub resolver found for SuperHackers");

--- a/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/Publishers/SuperHackersProvider.cs
@@ -29,7 +29,7 @@ public class SuperHackersProvider(
     IEnumerable<IContentDeliverer> deliverers,
     IContentValidator contentValidator,
     ILogger<SuperHackersProvider> logger,
-    IInstallationInstructionsService? installationInstructionsService = null)
+    IInstallationInstructionsService installationInstructionsService)
     : BaseContentProvider(contentValidator, installationInstructionsService, logger)
 {
     private readonly IContentResolver _resolver = resolvers.FirstOrDefault(r =>

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -956,7 +956,7 @@ public class GameProcessManager(
                 // Terminated first, so the launcher has exited and its stderr drains in full.
                 return OperationResult<GameProcessInfo>.CreateFailure(
                     AppendLauncherErrors(
-                        $"Cannot adopt {expectedName}: the launcher's start time could not be read.",
+                        $"Launcher exited without starting {expectedName}: the launcher's start time could not be read.",
                         launcher,
                         capturedErrors));
             }

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -615,19 +615,14 @@ public partial class ContentManifestBuilder(
     public IContentManifestBuilder WithInstallationInstructions(
         WorkspaceStrategy workspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy)
     {
-        if (_manifest.InstallationInstructions == null)
-        {
-            _manifest.InstallationInstructions = new InstallationInstructions { WorkspaceStrategy = workspaceStrategy };
-        }
-        else
-        {
-            _manifest.InstallationInstructions = new InstallationInstructions
+        _manifest.InstallationInstructions = _manifest.InstallationInstructions == null
+            ? new InstallationInstructions { WorkspaceStrategy = workspaceStrategy }
+            : new InstallationInstructions
             {
                 WorkspaceStrategy = workspaceStrategy,
                 DownloadHash = _manifest.InstallationInstructions.DownloadHash,
                 PostInstallSteps = [.. _manifest.InstallationInstructions.PostInstallSteps],
             };
-        }
 
         logger.LogDebug("Set workspace strategy: {Strategy}", workspaceStrategy);
         return this;
@@ -636,19 +631,14 @@ public partial class ContentManifestBuilder(
     /// <inheritdoc />
     public IContentManifestBuilder WithInstallationInstructions(InstallationInstructions installationInstructions)
     {
-        if (installationInstructions == null)
-        {
-            _manifest.InstallationInstructions = new InstallationInstructions();
-        }
-        else
-        {
-            _manifest.InstallationInstructions = new InstallationInstructions
+        _manifest.InstallationInstructions = installationInstructions == null
+            ? new InstallationInstructions()
+            : new InstallationInstructions
             {
                 WorkspaceStrategy = installationInstructions.WorkspaceStrategy,
                 DownloadHash = installationInstructions.DownloadHash,
                 PostInstallSteps = [.. installationInstructions.PostInstallSteps],
             };
-        }
 
         logger.LogDebug(
             "Set installation instructions with strategy {Strategy}, {PostCount} post-install steps",

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -621,7 +621,9 @@ public partial class ContentManifestBuilder(
             {
                 WorkspaceStrategy = workspaceStrategy,
                 DownloadHash = _manifest.InstallationInstructions.DownloadHash,
-                PostInstallSteps = [.. _manifest.InstallationInstructions.PostInstallSteps],
+                PostInstallSteps = _manifest.InstallationInstructions.PostInstallSteps == null
+                    ? []
+                    : [.. _manifest.InstallationInstructions.PostInstallSteps],
             };
 
         logger.LogDebug("Set workspace strategy: {Strategy}", workspaceStrategy);
@@ -631,14 +633,16 @@ public partial class ContentManifestBuilder(
     /// <inheritdoc />
     public IContentManifestBuilder WithInstallationInstructions(InstallationInstructions installationInstructions)
     {
-        _manifest.InstallationInstructions = installationInstructions == null
-            ? new InstallationInstructions()
-            : new InstallationInstructions
-            {
-                WorkspaceStrategy = installationInstructions.WorkspaceStrategy,
-                DownloadHash = installationInstructions.DownloadHash,
-                PostInstallSteps = [.. installationInstructions.PostInstallSteps],
-            };
+        ArgumentNullException.ThrowIfNull(installationInstructions);
+
+        _manifest.InstallationInstructions = new InstallationInstructions
+        {
+            WorkspaceStrategy = installationInstructions.WorkspaceStrategy,
+            DownloadHash = installationInstructions.DownloadHash,
+            PostInstallSteps = installationInstructions.PostInstallSteps == null
+                ? []
+                : [.. installationInstructions.PostInstallSteps],
+        };
 
         logger.LogDebug(
             "Set installation instructions with strategy {Strategy}, {PostCount} post-install steps",

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -625,47 +625,9 @@ public partial class ContentManifestBuilder(
     {
         _manifest.InstallationInstructions = installationInstructions ?? new InstallationInstructions();
         logger.LogDebug(
-            "Set installation instructions with strategy {Strategy}, {PreCount} pre-install steps, {PostCount} post-install steps",
+            "Set installation instructions with strategy {Strategy}, {PostCount} post-install steps",
             _manifest.InstallationInstructions.WorkspaceStrategy,
-            _manifest.InstallationInstructions.PreInstallSteps.Count,
             _manifest.InstallationInstructions.PostInstallSteps.Count);
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IContentManifestBuilder AddPreInstallStep(
-        string name,
-        InstallationStepKind kind,
-        string? targetRelativePath = null,
-        List<string>? arguments = null,
-        string? destinationRelativePath = null,
-        bool requiresElevation = false,
-        string? statusMessage = null,
-        bool runOnce = false,
-        string? stepKey = null)
-    {
-        var step = new InstallationStep
-        {
-            Name = name,
-            Kind = kind,
-            TargetRelativePath = targetRelativePath,
-            Arguments = arguments,
-            DestinationRelativePath = destinationRelativePath,
-            RequiresElevation = requiresElevation,
-            StatusMessage = statusMessage,
-            RunOnce = runOnce,
-            StepKey = stepKey,
-        };
-        return AddPreInstallStep(step);
-    }
-
-    /// <inheritdoc />
-    public IContentManifestBuilder AddPreInstallStep(InstallationStep step)
-    {
-        ArgumentNullException.ThrowIfNull(step);
-        _manifest.InstallationInstructions ??= new InstallationInstructions();
-        _manifest.InstallationInstructions.PreInstallSteps.Add(step);
-        logger.LogDebug("Added pre-install step: {StepName} (Kind: {Kind}, RunOnce: {RunOnce})", step.Name, step.Kind, step.RunOnce);
         return this;
     }
 

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -614,69 +614,87 @@ public partial class ContentManifestBuilder(
     public IContentManifestBuilder WithInstallationInstructions(
         WorkspaceStrategy workspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy)
     {
-        _manifest.InstallationInstructions = new InstallationInstructions
-        {
-            WorkspaceStrategy = workspaceStrategy,
-        };
+        _manifest.InstallationInstructions ??= new InstallationInstructions();
+        _manifest.InstallationInstructions.WorkspaceStrategy = workspaceStrategy;
         logger.LogDebug("Set workspace strategy: {Strategy}", workspaceStrategy);
         return this;
     }
 
-    /// <summary>
-    /// Adds a pre-installation step to the manifest.
-    /// </summary>
-    /// <param name="name">Step name.</param>
-    /// <param name="command">Command.</param>
-    /// <param name="arguments">Arguments.</param>
-    /// <param name="workingDirectory">Working directory.</param>
-    /// <param name="requiresElevation">Requires elevation.</param>
-    /// <returns>The builder instance.</returns>
-    public IContentManifestBuilder AddPreInstallStep(
-        string name,
-        string command,
-        List<string>? arguments = null,
-        string workingDirectory = "",
-        bool requiresElevation = false)
+    /// <inheritdoc />
+    public IContentManifestBuilder WithInstallationInstructions(InstallationInstructions installationInstructions)
     {
-        var step = new InstallationStep
-        {
-            Name = name,
-            Command = command,
-            Arguments = arguments ?? [],
-            WorkingDirectory = workingDirectory,
-            RequiresElevation = requiresElevation,
-        };
-        _manifest.InstallationInstructions.PreInstallSteps.Add(step);
-        logger.LogDebug("Added pre-install step: {StepName}", name);
+        _manifest.InstallationInstructions = installationInstructions ?? new InstallationInstructions();
+        logger.LogDebug(
+            "Set installation instructions with strategy {Strategy}, {PreCount} pre-install steps, {PostCount} post-install steps",
+            _manifest.InstallationInstructions.WorkspaceStrategy,
+            _manifest.InstallationInstructions.PreInstallSteps.Count,
+            _manifest.InstallationInstructions.PostInstallSteps.Count);
         return this;
     }
 
-    /// <summary>
-    /// Adds a post-installation step to the manifest.
-    /// </summary>
-    /// <param name="name">Step name.</param>
-    /// <param name="command">Command.</param>
-    /// <param name="arguments">Arguments.</param>
-    /// <param name="workingDirectory">Working directory.</param>
-    /// <param name="requiresElevation">Requires elevation.</param>
-    /// <returns>The builder instance.</returns>
-    public IContentManifestBuilder AddPostInstallStep(
+    /// <inheritdoc />
+    public IContentManifestBuilder AddPreInstallStep(
         string name,
-        string command,
+        InstallationStepKind kind,
+        string? targetRelativePath = null,
         List<string>? arguments = null,
-        string workingDirectory = "",
-        bool requiresElevation = false)
+        string? destinationRelativePath = null,
+        bool requiresElevation = false,
+        string? statusMessage = null)
     {
         var step = new InstallationStep
         {
             Name = name,
-            Command = command,
-            Arguments = arguments ?? [],
-            WorkingDirectory = workingDirectory,
+            Kind = kind,
+            TargetRelativePath = targetRelativePath,
+            Arguments = arguments,
+            DestinationRelativePath = destinationRelativePath,
             RequiresElevation = requiresElevation,
+            StatusMessage = statusMessage,
         };
+        return AddPreInstallStep(step);
+    }
+
+    /// <inheritdoc />
+    public IContentManifestBuilder AddPreInstallStep(InstallationStep step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        _manifest.InstallationInstructions ??= new InstallationInstructions();
+        _manifest.InstallationInstructions.PreInstallSteps.Add(step);
+        logger.LogDebug("Added pre-install step: {StepName} (Kind: {Kind})", step.Name, step.Kind);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IContentManifestBuilder AddPostInstallStep(
+        string name,
+        InstallationStepKind kind,
+        string? targetRelativePath = null,
+        List<string>? arguments = null,
+        string? destinationRelativePath = null,
+        bool requiresElevation = false,
+        string? statusMessage = null)
+    {
+        var step = new InstallationStep
+        {
+            Name = name,
+            Kind = kind,
+            TargetRelativePath = targetRelativePath,
+            Arguments = arguments,
+            DestinationRelativePath = destinationRelativePath,
+            RequiresElevation = requiresElevation,
+            StatusMessage = statusMessage,
+        };
+        return AddPostInstallStep(step);
+    }
+
+    /// <inheritdoc />
+    public IContentManifestBuilder AddPostInstallStep(InstallationStep step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        _manifest.InstallationInstructions ??= new InstallationInstructions();
         _manifest.InstallationInstructions.PostInstallSteps.Add(step);
-        logger.LogDebug("Added post-install step: {StepName}", name);
+        logger.LogDebug("Added post-install step: {StepName} (Kind: {Kind})", step.Name, step.Kind);
         return this;
     }
 

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -640,7 +640,9 @@ public partial class ContentManifestBuilder(
         List<string>? arguments = null,
         string? destinationRelativePath = null,
         bool requiresElevation = false,
-        string? statusMessage = null)
+        string? statusMessage = null,
+        bool runOnce = false,
+        string? stepKey = null)
     {
         var step = new InstallationStep
         {
@@ -651,6 +653,8 @@ public partial class ContentManifestBuilder(
             DestinationRelativePath = destinationRelativePath,
             RequiresElevation = requiresElevation,
             StatusMessage = statusMessage,
+            RunOnce = runOnce,
+            StepKey = stepKey,
         };
         return AddPreInstallStep(step);
     }
@@ -661,7 +665,7 @@ public partial class ContentManifestBuilder(
         ArgumentNullException.ThrowIfNull(step);
         _manifest.InstallationInstructions ??= new InstallationInstructions();
         _manifest.InstallationInstructions.PreInstallSteps.Add(step);
-        logger.LogDebug("Added pre-install step: {StepName} (Kind: {Kind})", step.Name, step.Kind);
+        logger.LogDebug("Added pre-install step: {StepName} (Kind: {Kind}, RunOnce: {RunOnce})", step.Name, step.Kind, step.RunOnce);
         return this;
     }
 
@@ -673,7 +677,9 @@ public partial class ContentManifestBuilder(
         List<string>? arguments = null,
         string? destinationRelativePath = null,
         bool requiresElevation = false,
-        string? statusMessage = null)
+        string? statusMessage = null,
+        bool runOnce = false,
+        string? stepKey = null)
     {
         var step = new InstallationStep
         {
@@ -684,6 +690,8 @@ public partial class ContentManifestBuilder(
             DestinationRelativePath = destinationRelativePath,
             RequiresElevation = requiresElevation,
             StatusMessage = statusMessage,
+            RunOnce = runOnce,
+            StepKey = stepKey,
         };
         return AddPostInstallStep(step);
     }
@@ -694,7 +702,7 @@ public partial class ContentManifestBuilder(
         ArgumentNullException.ThrowIfNull(step);
         _manifest.InstallationInstructions ??= new InstallationInstructions();
         _manifest.InstallationInstructions.PostInstallSteps.Add(step);
-        logger.LogDebug("Added post-install step: {StepName} (Kind: {Kind})", step.Name, step.Kind);
+        logger.LogDebug("Added post-install step: {StepName} (Kind: {Kind}, RunOnce: {RunOnce})", step.Name, step.Kind, step.RunOnce);
         return this;
     }
 

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -255,6 +255,28 @@ public partial class ContentManifestBuilder(
         return this;
     }
 
+    /// <inheritdoc />
+    public IContentManifestBuilder WithPublisher(PublisherInfo publisher)
+    {
+        ArgumentNullException.ThrowIfNull(publisher);
+
+        _manifest.Publisher = new PublisherInfo
+        {
+            Name = publisher.Name,
+            PublisherType = publisher.PublisherType,
+            Website = publisher.Website,
+            SupportUrl = publisher.SupportUrl,
+            ContactEmail = publisher.ContactEmail,
+            UpdateApiEndpoint = publisher.UpdateApiEndpoint,
+            ContentIndexUrl = publisher.ContentIndexUrl,
+            UpdateCheckIntervalHours = publisher.UpdateCheckIntervalHours,
+            SupportsIncrementalUpdates = publisher.SupportsIncrementalUpdates,
+            AuthenticationMethod = publisher.AuthenticationMethod,
+        };
+        logger.LogDebug("Set publisher: {PublisherName} (Type: {PublisherType})", publisher.Name, publisher.PublisherType);
+        return this;
+    }
+
     /// <summary>
     /// Sets the metadata for the manifest.
     /// </summary>
@@ -355,6 +377,16 @@ public partial class ContentManifestBuilder(
             "Added content reference: {ContentId} from publisher {PublisherId}",
             contentId,
             publisherId);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IContentManifestBuilder WithContentReferences(IEnumerable<ContentReference> contentReferences)
+    {
+        ArgumentNullException.ThrowIfNull(contentReferences);
+
+        _manifest.ContentReferences = [.. contentReferences];
+        logger.LogDebug("Set {Count} content references", _manifest.ContentReferences.Count);
         return this;
     }
 
@@ -682,6 +714,16 @@ public partial class ContentManifestBuilder(
     public IContentManifestBuilder AddPostInstallStep(InstallationStep step)
     {
         ArgumentNullException.ThrowIfNull(step);
+        if (step.Kind == InstallationStepKind.Unknown)
+        {
+            throw new ArgumentException("Installation step kind cannot be Unknown.", nameof(step));
+        }
+
+        if (string.IsNullOrWhiteSpace(step.Name))
+        {
+            throw new ArgumentException("Installation step name cannot be empty or whitespace.", nameof(step));
+        }
+
         _manifest.InstallationInstructions ??= new InstallationInstructions();
         _manifest.InstallationInstructions.PostInstallSteps.Add(step);
         logger.LogDebug("Added post-install step: {StepName} (Kind: {Kind}, RunOnce: {RunOnce})", step.Name, step.Kind, step.RunOnce);

--- a/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
+++ b/GenHub/GenHub/Features/Manifest/ContentManifestBuilder.cs
@@ -512,6 +512,7 @@ public partial class ContentManifestBuilder(
         {
             RelativePath = relativePath,
             SourceType = ContentSourceType.ContentAddressable,
+            InstallTarget = DetermineInstallTarget(relativePath),
             IsExecutable = isExecutable,
             Hash = hash,
             Size = size,
@@ -614,8 +615,20 @@ public partial class ContentManifestBuilder(
     public IContentManifestBuilder WithInstallationInstructions(
         WorkspaceStrategy workspaceStrategy = WorkspaceConstants.DefaultWorkspaceStrategy)
     {
-        _manifest.InstallationInstructions ??= new InstallationInstructions();
-        _manifest.InstallationInstructions.WorkspaceStrategy = workspaceStrategy;
+        if (_manifest.InstallationInstructions == null)
+        {
+            _manifest.InstallationInstructions = new InstallationInstructions { WorkspaceStrategy = workspaceStrategy };
+        }
+        else
+        {
+            _manifest.InstallationInstructions = new InstallationInstructions
+            {
+                WorkspaceStrategy = workspaceStrategy,
+                DownloadHash = _manifest.InstallationInstructions.DownloadHash,
+                PostInstallSteps = [.. _manifest.InstallationInstructions.PostInstallSteps],
+            };
+        }
+
         logger.LogDebug("Set workspace strategy: {Strategy}", workspaceStrategy);
         return this;
     }
@@ -623,7 +636,20 @@ public partial class ContentManifestBuilder(
     /// <inheritdoc />
     public IContentManifestBuilder WithInstallationInstructions(InstallationInstructions installationInstructions)
     {
-        _manifest.InstallationInstructions = installationInstructions ?? new InstallationInstructions();
+        if (installationInstructions == null)
+        {
+            _manifest.InstallationInstructions = new InstallationInstructions();
+        }
+        else
+        {
+            _manifest.InstallationInstructions = new InstallationInstructions
+            {
+                WorkspaceStrategy = installationInstructions.WorkspaceStrategy,
+                DownloadHash = installationInstructions.DownloadHash,
+                PostInstallSteps = [.. installationInstructions.PostInstallSteps],
+            };
+        }
+
         logger.LogDebug(
             "Set installation instructions with strategy {Strategy}, {PostCount} post-install steps",
             _manifest.InstallationInstructions.WorkspaceStrategy,

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -361,5 +361,8 @@ public static class ContentPipelineModule
 
         // Register content orchestrator and validator
         services.AddSingleton<IContentValidator, ContentValidator>();
+
+        // Register installation instructions execution service
+        services.AddSingleton<IInstallationInstructionsService, InstallationInstructionsService>();
     }
 }

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -240,6 +240,9 @@ public static class ContentPipelineModule
         services.AddScoped<GeneralsOnlineProfileReconciler>();
         services.AddScoped<IGeneralsOnlineProfileReconciler>(sp => sp.GetRequiredService<GeneralsOnlineProfileReconciler>());
         services.AddScoped<IPublisherReconciler>(sp => sp.GetRequiredService<GeneralsOnlineProfileReconciler>());
+
+        // Register Easy Anti-Cheat installation step precondition
+        services.AddSingleton<IInstallationStepPrecondition, EasyAntiCheatPrecondition>();
     }
 
     /// <summary>

--- a/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
+++ b/GenHub/GenHub/Infrastructure/DependencyInjection/ContentPipelineModule.cs
@@ -240,9 +240,6 @@ public static class ContentPipelineModule
         services.AddScoped<GeneralsOnlineProfileReconciler>();
         services.AddScoped<IGeneralsOnlineProfileReconciler>(sp => sp.GetRequiredService<GeneralsOnlineProfileReconciler>());
         services.AddScoped<IPublisherReconciler>(sp => sp.GetRequiredService<GeneralsOnlineProfileReconciler>());
-
-        // Register Easy Anti-Cheat installation step precondition
-        services.AddSingleton<IInstallationStepPrecondition, EasyAntiCheatPrecondition>();
     }
 
     /// <summary>
@@ -364,6 +361,9 @@ public static class ContentPipelineModule
 
         // Register content orchestrator and validator
         services.AddSingleton<IContentValidator, ContentValidator>();
+
+        // Register installation step preconditions
+        services.AddSingleton<IInstallationStepPrecondition, EasyAntiCheatPrecondition>();
 
         // Register installation instructions execution service
         services.AddSingleton<IInstallationInstructionsService, InstallationInstructionsService>();


### PR DESCRIPTION
## Summary
Implements the manifest installation instructions execution engine and configures Easy Anti-Cheat (EAC) product registration as a post-acquisition installation step on GeneralsOnline game client manifests, resolving issue #342.

## Motivation & Solution
GeneralsOnline requires registration of the EAC product ID (`fc1cc0d936424212b645105f084d08b0`) via `EasyAntiCheat_EOS_Setup.exe` post-acquisition. To futureproof against arbitrary/malicious execution while ensuring clear UX and update idempotency:
1. Replaced free-form commands with a typed, closed-kind installation step model (`RunVerifiedInstaller`, `RemoveFile`, `RenameFile`).
2. Implemented `IInstallationInstructionsService` enforcing publisher trust boundaries, workspace path containment via `PathHelper.IsPathContainedIn`, and manifest file declaration + SHA-256 hash verification before execution.
3. Added user notifications via `INotificationService` clearly communicating step execution.
4. Added `RunOnce` / `StepKey` state persistence in `UserSettings` and detection logic so users cleanly skip the installation step on updates if already executed.

## Changes
- **Core Models & Interfaces**:
  - Added `InstallationStepKind` enum.
  - Refactored `InstallationStep` to typed model with `Kind`, `TargetRelativePath`, `DestinationRelativePath`, `Arguments`, `RequiresElevation`, `StatusMessage`, `StepKey`, and `RunOnce`.
  - Added typed methods to `IContentManifestBuilder` and `ContentManifestBuilder`.
  - Added `IsPathContainedIn` and `NormalizeRelativePath` to `PathHelper`.
  - Added `ExecutedInstallationSteps` collection and helper methods to `UserSettings`.
  - Added `IInstallationInstructionsService` contract.
- **Content Pipeline & Delivery**:
  - Implemented `InstallationInstructionsService` with publisher allowlisting (`TrustedExecutablePublishers`), path containment verification, file integrity checks, user notifications, async execution, and `RunOnce` update skipping.
  - Wired `IInstallationInstructionsService` into `BaseContentProvider.PrepareContentAsync` and all 8 derived content providers.
  - Updated `FileSystemDeliverer` and `HttpContentDeliverer` to preserve `InstallationInstructions`.
  - Configured `GeneralsOnlineManifestFactory` to declare the EAC post-install step on 60Hz GameClient manifests when `EasyAntiCheat_EOS_Setup.exe` is present.
- **Tests**:
  - Created `InstallationInstructionsServiceTests` covering security checks, hash verification, notifications, step execution, `RunOnce` skipping, and force bypass.
  - Updated `GeneralsOnlineManifestFactoryEacTests`, `BaseContentProviderTests`, `GitHubContentProviderTests`, `ContentManifestBuilderTests`, and `PathHelperTests`.

## Verification
- [x] All unit tests written and verified
- [x] Strictly adheres to repository rules and coding standards
- [x] Cross-platform path containment and Windows elevation handling implemented

Closes #342