### PR TITLE
fix(tests): pass the dialog service to the settings view model constructions that development added

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/SettingsViewModelTests.cs
@@ -211,7 +211,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object);
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object);
 
         // Assert
         Assert.False(viewModel.AutoCheckForUpdatesPeriodically);
@@ -238,7 +239,8 @@ public class SettingsViewModelTests
             _mockConfigurationProvider.Object,
             _mockInstallationService.Object,
             _mockStorageLocationService.Object,
-            _mockUserDataTracker.Object)
+            _mockUserDataTracker.Object,
+            _mockDialogService.Object)
         {
             AutoCheckForUpdatesPeriodically = false,
             PeriodicUpdateCheckIntervalMinutes = 45,


### PR DESCRIPTION
## `development` does not currently compile

`GenHub.Tests.Core` fails to build at `38f655e8`:

```
SettingsViewModelTests.cs(202,29): error CS7036: There is no argument given that corresponds to
  the required parameter 'dialogService' of 'SettingsViewModel.SettingsViewModel(...)'
SettingsViewModelTests.cs(229,29): error CS7036: ...
```

## How it happened

#383 added `IDialogService` to the `SettingsViewModel` constructor (for the delete-all confirmation) and updated every call site **its branch contained**. In the meantime `development` had gained two further `new SettingsViewModel(...)` call sites that #383's branch never saw.

On merge, git combined both sides textually — #383's updated call sites plus development's two untouched ones — producing a conflict-free merge that does not build.

Neither PR's CI could have caught this: each was green in isolation, and the breakage exists only in the combination. A green check on a PR says nothing about the merge result once the base has moved.

## The fix

The `_mockDialogService` field already exists in that test file; the two stragglers simply weren't passed it. Two lines.

Verified by building `development` directly in a clean worktree to confirm the breakage was pre-existing and not an artifact of a local rebase, then rebuilding with this change.

**1939 passing.** The 3 failures are the environment-dependent real-engine tests (`NativeClientLaunchIntegrationTests`, `NativeClientManifestLaunchTests`, `RetailArchiveRootTests`), which require a native client on the machine and are unrelated to this change.

## Worth a follow-up

Any other in-flight branch that constructs `SettingsViewModel` will hit the same trap on merge — worth a quick grep across open PRs before landing them.