### PR TITLE
feat(info): explain workspace strategies, file linking differences, and permissions

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/DefaultInfoContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/DefaultInfoContentProviderTests.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GenHub.Core.Interfaces.Info;
+using GenHub.Features.Info.Services;
+using Moq;
+using Xunit;
+
+namespace GenHub.Tests.Core.Features.Info;
+
+/// <summary>
+/// Unit tests for <see cref="DefaultInfoContentProvider"/>.
+/// </summary>
+public class DefaultInfoContentProviderTests
+{
+    private readonly Mock<IGeneralsOnlinePatchNotesService> _patchNotesServiceMock = new();
+    private readonly DefaultInfoContentProvider _provider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultInfoContentProviderTests"/> class.
+    /// </summary>
+    public DefaultInfoContentProviderTests()
+    {
+        _provider = new DefaultInfoContentProvider(_patchNotesServiceMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that GetAllSectionsAsync returns all expected info sections.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task GetAllSectionsAsync_ReturnsOrderedSections()
+    {
+        var sections = (await _provider.GetAllSectionsAsync()).ToList();
+
+        sections.Should().NotBeEmpty();
+        sections.Should().Contain(s => s.Id == "workspaces");
+        sections.Should().Contain(s => s.Id == "quickstart");
+    }
+
+    /// <summary>
+    /// Verifies that GetSectionAsync returns the workspace section with comprehensive strategy explanations.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task GetSectionAsync_WorkspaceSection_ContainsComprehensiveStrategyExplanations()
+    {
+        var section = await _provider.GetSectionAsync("workspaces");
+
+        section.Should().NotBeNull();
+        section!.Title.Should().Be("Virtual Workspaces");
+        section.Cards.Should().NotBeEmpty();
+
+        var titles = section.Cards.Select(c => c.Title).ToList();
+        titles.Should().Contain("The Magic Mirror");
+        titles.Should().Contain("Workspace Strategies Compared");
+        titles.Should().Contain("Hardlinks vs Symlinks vs Copies: Deep Dive");
+        titles.Should().Contain("Troubleshooting & Permissions");
+        titles.Should().Contain("Performance Specs");
+
+        var comparisonCard = section.Cards.First(c => c.Title == "Workspace Strategies Compared");
+        comparisonCard.DetailedContent.Should().Contain("HardLink");
+        comparisonCard.DetailedContent.Should().Contain("SymlinkOnly");
+        comparisonCard.DetailedContent.Should().Contain("HybridCopySymlink");
+        comparisonCard.DetailedContent.Should().Contain("FullCopy");
+
+        var deepDiveCard = section.Cards.First(c => c.Title == "Hardlinks vs Symlinks vs Copies: Deep Dive");
+        deepDiveCard.DetailedContent.Should().Contain("Hardlink");
+        deepDiveCard.DetailedContent.Should().Contain("Symlink");
+        deepDiveCard.DetailedContent.Should().Contain("Full Copy");
+        deepDiveCard.DetailedContent.Should().Contain("Automatic Fallback");
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/DefaultInfoContentProviderTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/DefaultInfoContentProviderTests.cs
@@ -29,7 +29,7 @@ public class DefaultInfoContentProviderTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task GetAllSectionsAsync_ReturnsOrderedSections()
+    public async Task GetAllSectionsAsync_ReturnsOrderedSectionsAsync()
     {
         var sections = (await _provider.GetAllSectionsAsync()).ToList();
 
@@ -43,7 +43,7 @@ public class DefaultInfoContentProviderTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task GetSectionAsync_WorkspaceSection_ContainsComprehensiveStrategyExplanations()
+    public async Task GetSectionAsync_WorkspaceSection_ContainsComprehensiveStrategyExplanationsAsync()
     {
         var section = await _provider.GetSectionAsync("workspaces");
 

--- a/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
+++ b/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
@@ -800,11 +800,11 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                     IsExpandable = true,
                     DetailedContent = """
                     **The "Magic Mirror":**
-                    When you hit Play, GenHub creates an isolated, disposable "Virtual Copy" of your game installation in milliseconds.
+                    When you hit Play, GenHub creates an isolated virtual workspace for your profile (taking milliseconds in linked modes).
 
                     **Why is this cool?**
-                    1.  **Zero Space:** In linked modes, it acts like a full multi-gigabyte game folder while consuming virtually 0 MB of extra disk space.
-                    2.  **Total Safety:** Mods, configuration tweaks, and runtime files live only in this isolated mirror. Your original game installation remains clean and untouched.
+                    1.  **Zero Space:** In linked modes (HardLink and SymlinkOnly), it acts like a full multi-gigabyte game folder while consuming virtually 0 MB of extra disk space.
+                    2.  **Profile Isolation:** Mods and configurations live in dedicated profile workspaces without manually shuffling files in your main game directory. (Note: In direct linked modes, file data is shared with the underlying source; choose Hybrid or Full Copy if mods modify game binaries in-place).
                     3.  **Instant Mod Switching:** Switch between massive total conversions like *Rise of the Reds* and *ShockWave* without reinstalling or moving files.
                     """,
                 },
@@ -898,7 +898,7 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                     *   **HardLink:**
                         *   *Creation Time:* < 50ms (Metadata only)
                         *   *Disk Overhead:* 0 MB
-                        *   *Integrity:* Read-only source safety; workspace writes do not corrupt base game installation.
+                        *   *Integrity:* Shared data clusters (CAS objects remain immutable in CAS pool; direct writes affect linked file).
                     *   **SymlinkOnly:**
                         *   *Creation Time:* < 50ms (Pointer creation)
                         *   *Disk Overhead:* < 1 MB
@@ -906,7 +906,7 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                     *   **Hybrid:**
                         *   *Creation Time:* 1-2 seconds
                         *   *Disk Overhead:* ~50-100 MB
-                        *   *Integrity:* Isolated configs with linked large assets.
+                        *   *Integrity:* Physical copies for mutable configs, shared links for immutable large assets.
                     *   **Full Copy:**
                         *   *Creation Time:* 10-30 seconds
                         *   *Disk Overhead:* Full size (2,000 - 5,000+ MB)

--- a/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
+++ b/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
@@ -819,24 +819,24 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                     GenHub supports four file deployment strategies under **Settings -> Game Configuration**:
 
                     *   **HardLink (Default & Recommended):**
-                        *   *How it works:* Creates direct filesystem pointers (hard links) to the underlying game and mod files.
-                        *   *Disk Space:* **0 bytes** extra storage used.
-                        *   *Speed:* Instant (< 50ms).
+                        *   *How it works:* Creates direct filesystem pointers (hard links) on the same drive. If the workspace is on a different drive than the game installation, it automatically falls back to copying files.
+                        *   *Disk Space:* **0 bytes** extra storage when on the same drive (full file size if copying across drives).
+                        *   *Speed:* Instant (< 50ms) on the same volume.
                         *   *Privileges:* No administrator privileges or developer mode needed.
-                        *   *Limitation:* Workspace and game files must be on the **same drive/volume** (e.g. both on `C:` or both on `D:`).
+                        *   *Recommendation:* Place workspaces and game files on the **same drive/volume** (e.g. both on `C:` or both on `D:`) for optimal zero-space operation.
 
                     *   **SymlinkOnly:**
                         *   *How it works:* Creates symbolic link pointers referencing target files and directories.
                         *   *Disk Space:* **Negligible** (~few KB of pointer metadata).
                         *   *Speed:* Instant (< 50ms).
-                        *   *Advantage:* Can link across **different drives and partitions**.
+                        *   *Advantage:* Links seamlessly across **different drives and partitions**.
                         *   *Limitation:* On Windows, requires **Administrator rights** or **Developer Mode** enabled in Windows Settings.
 
                     *   **HybridCopySymlink (Balanced Compatibility):**
-                        *   *How it works:* Copies essential mutable files (like `.exe`, `.ini`, and configuration scripts) while symlinking or hardlinking massive immutable asset archives (`.big` files).
-                        *   *Disk Space:* Minimal (~50 MB copied, gigabytes linked).
+                        *   *How it works:* Copies essential engine files, scripts, and mod configurations into the workspace while symlinking non-essential media assets (such as textures, audio, and video).
+                        *   *Disk Space:* Balanced (copies essential assets, links media assets).
                         *   *Speed:* Fast (1-2 seconds).
-                        *   *Advantage:* Prevents engine quirks if a legacy mod tries to modify its executable or config directly in the workspace.
+                        *   *Advantage:* Protects essential configs from cross-profile conflicts while reducing overall workspace footprint.
 
                     *   **FullCopy (Universal Fallback):**
                         *   *How it works:* Physically duplicates every game and mod file into the workspace directory.
@@ -879,9 +879,9 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                     *   **"Access Denied" / Privilege Errors:**
                         *   If using Symlink strategy on Windows, enable **Developer Mode** in *Windows Settings -> System -> For developers*, or run GenHub as Administrator.
                         *   Alternatively, switch your Default Workspace Strategy to **HardLink** in GenHub Settings.
-                    *   **Cross-Drive Linking Errors:**
-                        *   Hardlinks cannot span across different drives (e.g., CAS pool on `C:` and game on `D:`).
-                        *   Set your CAS pool location or workspace directory on the same drive as your game installation in **Settings -> Data Directories**, or enable Symlink mode with Developer Mode turned on.
+                    *   **Cross-Drive Linking & Storage:**
+                        *   Hardlinks require the same drive/volume to achieve zero-space linking; across different drives, HardLink strategy falls back to copying files.
+                        *   To maintain instant, zero-space workspaces, keep your CAS pool and workspace directories on the same drive as your game installation in **Settings -> Data Directories**, or enable Symlink mode with Developer Mode turned on.
                     *   **"File In Use" / Locked Files:**
                         *   Ensure all instances of `generals.exe` or `game.dat` are completely closed before switching profiles or rebuilding workspaces.
                     """,
@@ -896,8 +896,8 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                     **Strategy Metrics:**
 
                     *   **HardLink:**
-                        *   *Creation Time:* < 50ms (Metadata only)
-                        *   *Disk Overhead:* 0 MB
+                        *   *Creation Time:* < 50ms on same volume (Metadata only)
+                        *   *Disk Overhead:* 0 MB on same volume (copies on cross-volume)
                         *   *Integrity:* Shared data clusters (CAS objects remain immutable in CAS pool; direct writes affect linked file).
                     *   **SymlinkOnly:**
                         *   *Creation Time:* < 50ms (Pointer creation)
@@ -905,8 +905,8 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                         *   *Integrity:* Transparent pointer redirection across volumes.
                     *   **Hybrid:**
                         *   *Creation Time:* 1-2 seconds
-                        *   *Disk Overhead:* ~50-100 MB
-                        *   *Integrity:* Physical copies for mutable configs, shared links for immutable large assets.
+                        *   *Disk Overhead:* Copies essential configs, links media assets
+                        *   *Integrity:* Physical copies for essential configs, shared links for media assets.
                     *   **Full Copy:**
                         *   *Creation Time:* 10-30 seconds
                         *   *Disk Overhead:* Full size (2,000 - 5,000+ MB)

--- a/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
+++ b/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
@@ -788,7 +788,7 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
         {
             Id = "workspaces",
             Title = "Virtual Workspaces",
-            Description = "Technical details of NTFS Hardlink isolation.",
+            Description = "Workspace strategies, file linking techniques, and isolation mechanics.",
             Order = 8,
             Cards =
             [
@@ -800,36 +800,117 @@ public class DefaultInfoContentProvider(IGeneralsOnlinePatchNotesService patchNo
                     IsExpandable = true,
                     DetailedContent = """
                     **The "Magic Mirror":**
-                    When you hit Play, GenHub creates a "Virtual Copy" of your game installation instantly.
+                    When you hit Play, GenHub creates an isolated, disposable "Virtual Copy" of your game installation in milliseconds.
 
                     **Why is this cool?**
-                    1.  **Zero Space:** It looks like a full 5GB game, but it takes up 0MB of disk space on your drive.
-                    2.  **Safety:** Any changes made by mods happen in this "Mirror". If a mod breaks the game, your actual installation is perfectly safe.
+                    1.  **Zero Space:** In linked modes, it acts like a full multi-gigabyte game folder while consuming virtually 0 MB of extra disk space.
+                    2.  **Total Safety:** Mods, configuration tweaks, and runtime files live only in this isolated mirror. Your original game installation remains clean and untouched.
+                    3.  **Instant Mod Switching:** Switch between massive total conversions like *Rise of the Reds* and *ShockWave* without reinstalling or moving files.
                     """,
                 },
                 new InfoCard
                 {
-                    Title = "Troubleshooting",
-                    Content = "Resolving common build errors.",
+                    Title = "Workspace Strategies Compared",
+                    Content = "Comparing Hardlink, Symlink, Hybrid, and Full Copy strategies.",
+                    Type = InfoCardType.Concept,
+                    IsExpandable = true,
+                    DetailedContent = """
+                    **Choosing the Right Strategy:**
+                    GenHub supports four file deployment strategies under **Settings -> Game Configuration**:
+
+                    *   **HardLink (Default & Recommended):**
+                        *   *How it works:* Creates direct filesystem pointers (hard links) to the underlying game and mod files.
+                        *   *Disk Space:* **0 bytes** extra storage used.
+                        *   *Speed:* Instant (< 50ms).
+                        *   *Privileges:* No administrator privileges or developer mode needed.
+                        *   *Limitation:* Workspace and game files must be on the **same drive/volume** (e.g. both on `C:` or both on `D:`).
+
+                    *   **SymlinkOnly:**
+                        *   *How it works:* Creates symbolic link pointers referencing target files and directories.
+                        *   *Disk Space:* **Negligible** (~few KB of pointer metadata).
+                        *   *Speed:* Instant (< 50ms).
+                        *   *Advantage:* Can link across **different drives and partitions**.
+                        *   *Limitation:* On Windows, requires **Administrator rights** or **Developer Mode** enabled in Windows Settings.
+
+                    *   **HybridCopySymlink (Balanced Compatibility):**
+                        *   *How it works:* Copies essential mutable files (like `.exe`, `.ini`, and configuration scripts) while symlinking or hardlinking massive immutable asset archives (`.big` files).
+                        *   *Disk Space:* Minimal (~50 MB copied, gigabytes linked).
+                        *   *Speed:* Fast (1-2 seconds).
+                        *   *Advantage:* Prevents engine quirks if a legacy mod tries to modify its executable or config directly in the workspace.
+
+                    *   **FullCopy (Universal Fallback):**
+                        *   *How it works:* Physically duplicates every game and mod file into the workspace directory.
+                        *   *Disk Space:* Uses full game size (**2-5+ GB** per profile).
+                        *   *Speed:* Slower (10-30+ seconds depending on drive speed).
+                        *   *Advantage:* Unconditional compatibility across external drives, network drives, and restricted environments.
+                    """,
+                },
+                new InfoCard
+                {
+                    Title = "Hardlinks vs Symlinks vs Copies: Deep Dive",
+                    Content = "How file linking differs under the hood.",
+                    Type = InfoCardType.Feature,
+                    IsExpandable = true,
+                    DetailedContent = """
+                    **Under the Hood:**
+
+                    *   **Hardlink:**
+                        A hardlink is a directory entry that points directly to an existing file's data cluster on disk (the NTFS file record / inode). The file data is shared, so creating a hardlink takes zero disk space. Because it points directly to physical drive sectors, hardlinks cannot cross drive partitions.
+
+                    *   **Symlink (Symbolic Link):**
+                        A symlink is a special small file that contains a text path pointing to another file or folder (like a transparent shortcut at the operating system level). Because it stores a path, it can point across different drives, but Windows security policies require elevated privileges or Developer Mode to create symlinks.
+
+                    *   **Full Copy:**
+                        A physical byte-for-byte duplicate of the source file. It allocates new disk clusters and writes the entire file contents again.
+
+                    **Automatic Fallback:**
+                    If you configure Symlink mode but run GenHub without administrator rights or Developer Mode, GenHub automatically falls back to hardlinks when files reside on the same drive, ensuring your game launches seamlessly without interruptions.
+                    """,
+                },
+                new InfoCard
+                {
+                    Title = "Troubleshooting & Permissions",
+                    Content = "Resolving common permissions and workspace build errors.",
                     Type = InfoCardType.HowTo,
                     IsExpandable = true,
                     DetailedContent = """
-                    **Common Issues:**
-                    -   **"Access Denied":** GenHub requires Write permissions to `AppData`. Run as Admin if issues persist.
-                    -   **"File In Use":** Ensure the game process is fully terminated before rebuilding.
+                    **Common Issues & Solutions:**
+
+                    *   **"Access Denied" / Privilege Errors:**
+                        *   If using Symlink strategy on Windows, enable **Developer Mode** in *Windows Settings -> System -> For developers*, or run GenHub as Administrator.
+                        *   Alternatively, switch your Default Workspace Strategy to **HardLink** in GenHub Settings.
+                    *   **Cross-Drive Linking Errors:**
+                        *   Hardlinks cannot span across different drives (e.g., CAS pool on `C:` and game on `D:`).
+                        *   Set your CAS pool location or workspace directory on the same drive as your game installation in **Settings -> Data Directories**, or enable Symlink mode with Developer Mode turned on.
+                    *   **"File In Use" / Locked Files:**
+                        *   Ensure all instances of `generals.exe` or `game.dat` are completely closed before switching profiles or rebuilding workspaces.
                     """,
                 },
                 new InfoCard
                 {
                     Title = "Performance Specs",
-                    Content = "Efficiency and integrity metrics.",
+                    Content = "Efficiency, speed, and integrity metrics across strategies.",
                     Type = InfoCardType.Feature,
                     IsExpandable = true,
                     DetailedContent = """
-                    **Hardlinks:**
-                    -   **Speed:** < 50ms creation time (Metadata only).
-                    -   **Space:** 0 bytes additional disk usage (Pointers).
-                    -   **Integrity:** Read-only source files. Modifications in workspace do not corrupt the installation.
+                    **Strategy Metrics:**
+
+                    *   **HardLink:**
+                        *   *Creation Time:* < 50ms (Metadata only)
+                        *   *Disk Overhead:* 0 MB
+                        *   *Integrity:* Read-only source safety; workspace writes do not corrupt base game installation.
+                    *   **SymlinkOnly:**
+                        *   *Creation Time:* < 50ms (Pointer creation)
+                        *   *Disk Overhead:* < 1 MB
+                        *   *Integrity:* Transparent pointer redirection across volumes.
+                    *   **Hybrid:**
+                        *   *Creation Time:* 1-2 seconds
+                        *   *Disk Overhead:* ~50-100 MB
+                        *   *Integrity:* Isolated configs with linked large assets.
+                    *   **Full Copy:**
+                        *   *Creation Time:* 10-30 seconds
+                        *   *Disk Overhead:* Full size (2,000 - 5,000+ MB)
+                        *   *Integrity:* Total physical file isolation.
                     """,
                 },
             ],

--- a/GenHub/GenHub/Features/Info/Views/GenHubInfoSectionView.axaml
+++ b/GenHub/GenHub/Features/Info/Views/GenHubInfoSectionView.axaml
@@ -733,7 +733,7 @@
           <StackPanel>
             <StackPanel HorizontalAlignment="Left">
                 <TextBlock Text="Workspace Simulator" Classes="demo-title"/>
-                <TextBlock Text="Visualizes virtual file system construction via symlinks." Classes="demo-subtitle"/>
+                <TextBlock Text="Visualizes virtual file system construction using hardlinks, symlinks, and copies." Classes="demo-subtitle"/>
             </StackPanel>
 
             <Border Classes="demo-container">


### PR DESCRIPTION
## Summary
Expands the **Virtual Workspaces** section of the Info tab to thoroughly explain GenHub's file deployment mechanisms, comparing **Hardlinks**, **Symlinks**, **Hybrid (Copy + Symlink)**, and **Full Copies**. It provides end-users with clear insights into performance characteristics, disk usage, cross-drive support, and OS permission requirements.

### Motivation
Users encounter options such as "Default Workspace Strategy" in Settings and observe link types in the Workspace Simulator demo, but previous Info tab documentation only briefly mentioned hardlinks without explaining how the four deployment strategies differ, how symlink permissions work on Windows, or when automatic fallback occurs.

### Changes
- **UI / Info Content Provider**: Updated `DefaultInfoContentProvider` with comprehensive cards:
  - *The Magic Mirror*: Expanded concept explanation of zero-space isolation and instant mod switching.
  - *Workspace Strategies Compared*: Side-by-side comparison of `HardLink`, `SymlinkOnly`, `HybridCopySymlink`, and `FullCopy`.
  - *Hardlinks vs Symlinks vs Copies: Deep Dive*: Detailed breakdown of physical cluster pointers vs path redirection vs byte duplication, including automatic fallback from symlink to hardlink when running without elevation on the same volume.
  - *Troubleshooting & Permissions*: Practical guide for resolving Access Denied errors, Windows Developer Mode configuration, and cross-drive limitations.
  - *Performance Specs*: Strategy metrics for speed, disk overhead, and data integrity.
- **UI / Views**: Updated workspace demo subtitle in `GenHubInfoSectionView.axaml` to accurately reference hardlinks, symlinks, and copies.
- **Tests**: Added unit test suite `DefaultInfoContentProviderTests` covering section retrieval, card presence, and strategy comparison content.

### Verification
- [x] Unit tests added in `DefaultInfoContentProviderTests` verifying all cards, strategy identifiers, and fallback explanations
- [x] Follows coding style guidelines (clean sentence-cased docstrings, file-scoped namespaces, zero warnings)

---
*Created with Gemini 3.7 Flash via Antigravity*
