### PR TITLE
fix(installations,workspace): resolve standalone Zero Hour detection, manifest reconstruction, and eliminate copy fallback

### DIFF
--- a/GenHub/GenHub.Core/Constants/GameClientConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameClientConstants.cs
@@ -21,6 +21,9 @@ public static class GameClientConstants
     /// <summary>Steam game.dat executable (primary for Steam installations, avoids launcher stubs).</summary>
     public const string SteamGameDatExecutable = "game.dat";
 
+    /// <summary>Contra modded client executable filename.</summary>
+    public const string ContraExecutable = "generals.ctr";
+
     // ===== SuperHackers Client Detection =====
 
     /// <summary>SuperHackers Generals executable filename.</summary>
@@ -60,6 +63,20 @@ public static class GameClientConstants
 
     /// <summary>Standard retail Zero Hour directory name.</summary>
     public const string ZeroHourRetailDirectoryName = "Command & Conquer Generals Zero Hour";
+
+    // ===== Core Game Archives =====
+
+    /// <summary>Primary Zero Hour INI archive filename.</summary>
+    public const string ZeroHourIniBig = "INIZH.big";
+
+    /// <summary>Primary Zero Hour Patch archive filename.</summary>
+    public const string ZeroHourPatchBig = "PatchZH.big";
+
+    /// <summary>Primary Generals Vanilla INI archive filename.</summary>
+    public const string GeneralsIniBig = "INI.big";
+
+    /// <summary>Primary Generals Vanilla Patch archive filename.</summary>
+    public const string GeneralsPatchBig = "Patch.big";
 
     // ===== GeneralsOnline Client Detection =====
 

--- a/GenHub/GenHub.Core/Constants/WorkspaceConstants.cs
+++ b/GenHub/GenHub.Core/Constants/WorkspaceConstants.cs
@@ -12,4 +12,10 @@ public static class WorkspaceConstants
     /// Default is HardLink as it provides space-efficient file management with good compatibility.
     /// </summary>
     public const WorkspaceStrategy DefaultWorkspaceStrategy = WorkspaceStrategy.HardLink;
+
+    /// <summary>
+    /// Guidance message appended to errors when zero-copy hard links or symlinks cannot be created.
+    /// </summary>
+    public const string ZeroCopyElevationGuidance =
+        "To use zero-copy workspaces without copying game files, ensure GenHub has permission to create links (on Windows, enable Developer Mode or run as Administrator).";
 }

--- a/GenHub/GenHub.Core/Extensions/GameInstallations/InstallationExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/GameInstallations/InstallationExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Models.Enums;
@@ -51,11 +52,74 @@ public static class InstallationExtensions
             var files = directoryInfo.GetFiles();
             return files.Any(f => string.Equals(f.Name, fileName, StringComparison.OrdinalIgnoreCase));
         }
-        catch
+        catch (IOException)
         {
             // If directory enumeration fails, fall back to false
             return false;
         }
+        catch (UnauthorizedAccessException)
+        {
+            // If directory enumeration fails due to permissions, fall back to false
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            // If path contains invalid characters, fall back to false
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a subdirectory exists under a parent path in a case-insensitive manner, returning the matched directory path.
+    /// </summary>
+    /// <param name="parentDirectory">The parent directory to search within.</param>
+    /// <param name="subDirectoryName">The subdirectory name to look for.</param>
+    /// <param name="matchedPath">The actual matched full path if found.</param>
+    /// <returns>True if the subdirectory exists; otherwise false.</returns>
+    public static bool TryGetDirectoryCaseInsensitive(this string parentDirectory, string subDirectoryName, [NotNullWhen(true)] out string? matchedPath)
+    {
+        matchedPath = null;
+        if (string.IsNullOrEmpty(parentDirectory) || string.IsNullOrEmpty(subDirectoryName))
+        {
+            return false;
+        }
+
+        try
+        {
+            var candidate = Path.Combine(parentDirectory, subDirectoryName);
+            if (Directory.Exists(candidate))
+            {
+                matchedPath = candidate;
+                return true;
+            }
+
+            var directoryInfo = new DirectoryInfo(parentDirectory);
+            if (!directoryInfo.Exists)
+            {
+                return false;
+            }
+
+            var matchingDir = directoryInfo.GetDirectories().FirstOrDefault(d => string.Equals(d.Name, subDirectoryName, StringComparison.OrdinalIgnoreCase));
+            if (matchingDir is not null)
+            {
+                matchedPath = matchingDir.FullName;
+                return true;
+            }
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
+++ b/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
@@ -309,18 +309,21 @@ public class GameInstallation : IGameInstallation
             GameClientConstants.GeneralsRetailDirectoryName,
         ];
 
-        foreach (var subDir in generalsSubdirs)
+        if (!foundGenerals)
         {
-            if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var generalsPath))
+            foreach (var subDir in generalsSubdirs)
             {
-                var generalsExe = Path.Combine(generalsPath, GameClientConstants.GeneralsExecutable);
-                if (generalsExe.FileExistsCaseInsensitive())
+                if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var generalsPath))
                 {
-                    HasGenerals = true;
-                    GeneralsPath = generalsPath;
-                    foundGenerals = true;
-                    _logger?.LogDebug("Found Generals installation at {GeneralsPath}", GeneralsPath);
-                    break;
+                    var generalsExe = Path.Combine(generalsPath, GameClientConstants.GeneralsExecutable);
+                    if (generalsExe.FileExistsCaseInsensitive())
+                    {
+                        HasGenerals = true;
+                        GeneralsPath = generalsPath;
+                        foundGenerals = true;
+                        _logger?.LogDebug("Found Generals installation at {GeneralsPath}", GeneralsPath);
+                        break;
+                    }
                 }
             }
         }
@@ -334,18 +337,21 @@ public class GameInstallation : IGameInstallation
             GameClientConstants.ZeroHourDirectoryNameColonVariant,
         ];
 
-        foreach (var subDir in zhSubdirs)
+        if (!foundZeroHour)
         {
-            if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var zeroHourPath))
+            foreach (var subDir in zhSubdirs)
             {
-                var zeroHourExe = Path.Combine(zeroHourPath, GameClientConstants.ZeroHourExecutable);
-                if (zeroHourExe.FileExistsCaseInsensitive())
+                if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var zeroHourPath))
                 {
-                    HasZeroHour = true;
-                    ZeroHourPath = zeroHourPath;
-                    foundZeroHour = true;
-                    _logger?.LogDebug("Found Zero Hour installation at {ZeroHourPath}", ZeroHourPath);
-                    break;
+                    var zeroHourExe = Path.Combine(zeroHourPath, GameClientConstants.ZeroHourExecutable);
+                    if (zeroHourExe.FileExistsCaseInsensitive())
+                    {
+                        HasZeroHour = true;
+                        ZeroHourPath = zeroHourPath;
+                        foundZeroHour = true;
+                        _logger?.LogDebug("Found Zero Hour installation at {ZeroHourPath}", ZeroHourPath);
+                        break;
+                    }
                 }
             }
         }

--- a/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
+++ b/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
@@ -262,7 +262,7 @@ public class GameInstallation : IGameInstallation
             if (Directory.Exists(path))
             {
                 var directoryInfo = new DirectoryInfo(path);
-                if (directoryInfo.GetFiles("*.big").Any(f => f.Name.EndsWith("ZH.big", StringComparison.OrdinalIgnoreCase)))
+                if (directoryInfo.EnumerateFiles().Any(f => f.Name.EndsWith("ZH.big", StringComparison.OrdinalIgnoreCase)))
                 {
                     return true;
                 }
@@ -382,7 +382,8 @@ public class GameInstallation : IGameInstallation
                 Path.Combine(InstallationPath, "gensec.big").FileExistsCaseInsensitive() ||
                 Path.Combine(InstallationPath, GameClientConstants.SuperHackersGeneralsExecutable).FileExistsCaseInsensitive();
 
-            if (!isZhNamed || isStrictGeneralsOnlySignature)
+            var isZeroHour = isZhNamed || hasZhSignature;
+            if (!isZeroHour || isStrictGeneralsOnlySignature)
             {
                 HasGenerals = true;
                 GeneralsPath = InstallationPath;

--- a/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
+++ b/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using GenHub.Core.Constants;
@@ -303,58 +304,64 @@ public class GameInstallation : IGameInstallation
 
     private void FetchSubdirectoryInstallations(ref bool foundGenerals, ref bool foundZeroHour)
     {
-        ReadOnlySpan<string> generalsSubdirs =
-        [
-            GameClientConstants.GeneralsDirectoryName,
-            GameClientConstants.GeneralsRetailDirectoryName,
-        ];
-
         if (!foundGenerals)
         {
-            foreach (var subDir in generalsSubdirs)
+            ReadOnlySpan<string> generalsSubdirs =
+            [
+                GameClientConstants.GeneralsDirectoryName,
+                GameClientConstants.GeneralsRetailDirectoryName,
+            ];
+
+            if (TryFindSubdirectoryInstallation(generalsSubdirs, GameClientConstants.GeneralsExecutable, out var generalsPath))
             {
-                if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var generalsPath))
-                {
-                    var generalsExe = Path.Combine(generalsPath, GameClientConstants.GeneralsExecutable);
-                    if (generalsExe.FileExistsCaseInsensitive())
-                    {
-                        HasGenerals = true;
-                        GeneralsPath = generalsPath;
-                        foundGenerals = true;
-                        _logger?.LogDebug("Found Generals installation at {GeneralsPath}", GeneralsPath);
-                        break;
-                    }
-                }
+                HasGenerals = true;
+                GeneralsPath = generalsPath;
+                foundGenerals = true;
+                _logger?.LogDebug("Found Generals installation at {GeneralsPath}", GeneralsPath);
             }
         }
-
-        ReadOnlySpan<string> zhSubdirs =
-        [
-            GameClientConstants.ZeroHourDirectoryName,
-            GameClientConstants.ZeroHourDirectoryNameAmpersandHyphen,
-            GameClientConstants.ZeroHourRetailDirectoryName,
-            GameClientConstants.ZeroHourDirectoryNameAbbreviated,
-            GameClientConstants.ZeroHourDirectoryNameColonVariant,
-        ];
 
         if (!foundZeroHour)
         {
-            foreach (var subDir in zhSubdirs)
+            ReadOnlySpan<string> zhSubdirs =
+            [
+                GameClientConstants.ZeroHourDirectoryName,
+                GameClientConstants.ZeroHourDirectoryNameAmpersandHyphen,
+                GameClientConstants.ZeroHourRetailDirectoryName,
+                GameClientConstants.ZeroHourDirectoryNameAbbreviated,
+                GameClientConstants.ZeroHourDirectoryNameColonVariant,
+            ];
+
+            if (TryFindSubdirectoryInstallation(zhSubdirs, GameClientConstants.ZeroHourExecutable, out var zeroHourPath))
             {
-                if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var zeroHourPath))
+                HasZeroHour = true;
+                ZeroHourPath = zeroHourPath;
+                foundZeroHour = true;
+                _logger?.LogDebug("Found Zero Hour installation at {ZeroHourPath}", ZeroHourPath);
+            }
+        }
+    }
+
+    private bool TryFindSubdirectoryInstallation(
+        ReadOnlySpan<string> candidateSubdirectories,
+        string executableName,
+        [NotNullWhen(true)] out string? foundPath)
+    {
+        foreach (var subDir in candidateSubdirectories)
+        {
+            if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var subDirPath))
+            {
+                var exePath = Path.Combine(subDirPath, executableName);
+                if (exePath.FileExistsCaseInsensitive())
                 {
-                    var zeroHourExe = Path.Combine(zeroHourPath, GameClientConstants.ZeroHourExecutable);
-                    if (zeroHourExe.FileExistsCaseInsensitive())
-                    {
-                        HasZeroHour = true;
-                        ZeroHourPath = zeroHourPath;
-                        foundZeroHour = true;
-                        _logger?.LogDebug("Found Zero Hour installation at {ZeroHourPath}", ZeroHourPath);
-                        break;
-                    }
+                    foundPath = subDirPath;
+                    return true;
                 }
             }
         }
+
+        foundPath = null;
+        return false;
     }
 
     private void FetchRootInstallation(ref bool foundGenerals, ref bool foundZeroHour)

--- a/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
+++ b/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using GenHub.Core.Constants;
 using GenHub.Core.Extensions.GameInstallations;
 using GenHub.Core.Interfaces.GameInstallations;
@@ -157,93 +161,21 @@ public class GameInstallation : IGameInstallation
             bool foundGenerals = false;
             bool foundZeroHour = false;
 
-            // 1. Check strict subdirectories first (standard structure)
-            var generalsPath = Path.Combine(InstallationPath, "Command and Conquer Generals");
-            if (Directory.Exists(generalsPath))
+            // Preserve explicitly configured and valid paths (e.g. from platform detectors or manifests)
+            if (!string.IsNullOrEmpty(GeneralsPath) && Directory.Exists(GeneralsPath) && HasValidExecutable(GeneralsPath))
             {
-                var generalsExe = Path.Combine(generalsPath, GameClientConstants.GeneralsExecutable);
-                if (generalsExe.FileExistsCaseInsensitive())
-                {
-                    HasGenerals = true;
-                    GeneralsPath = generalsPath;
-                    foundGenerals = true;
-                    _logger?.LogDebug("Found Generals installation at {GeneralsPath}", GeneralsPath);
-                }
+                HasGenerals = true;
+                foundGenerals = true;
             }
 
-            var zeroHourPath = Path.Combine(InstallationPath, GameClientConstants.ZeroHourDirectoryName);
-            if (Directory.Exists(zeroHourPath))
+            if (!string.IsNullOrEmpty(ZeroHourPath) && Directory.Exists(ZeroHourPath) && HasValidExecutable(ZeroHourPath))
             {
-                var zeroHourExe = Path.Combine(zeroHourPath, GameClientConstants.ZeroHourExecutable);
-                if (zeroHourExe.FileExistsCaseInsensitive())
-                {
-                    HasZeroHour = true;
-                    ZeroHourPath = zeroHourPath;
-                    foundZeroHour = true;
-                    _logger?.LogDebug("Found Zero Hour installation at {ZeroHourPath}", ZeroHourPath);
-                }
+                HasZeroHour = true;
+                foundZeroHour = true;
             }
 
-            // 2. If not found in subdirectories, check the root path (common for manual installs/repacks)
-            if (!foundGenerals)
-            {
-                var rootGeneralsExe = Path.Combine(InstallationPath, GameClientConstants.GeneralsExecutable);
-
-                // Note: Zero Hour also has a generals.exe, so we need to be careful.
-                // If checking for valid installation, presence of generals.exe usually implies Generals capability.
-                if (rootGeneralsExe.FileExistsCaseInsensitive())
-                {
-                    HasGenerals = true;
-                    GeneralsPath = InstallationPath;
-                    foundGenerals = true;
-                    _logger?.LogDebug("Found Generals installation at root {GeneralsPath}", GeneralsPath);
-                }
-            }
-
-            if (!foundZeroHour && string.IsNullOrEmpty(ZeroHourPath))
-            {
-                // Zero Hour usually has generals.exe AND specific files like "generals.zh.exe" (sometimes) or just "generals.exe" with different hash/version.
-                // Detection primarily relies on folder name or presence of expansion files.
-                // Checking for generals.exe in root can map to both if the user selected a merged directory.
-                var rootGeneralsExe = Path.Combine(InstallationPath, GameClientConstants.GeneralsExecutable);
-
-                if (rootGeneralsExe.FileExistsCaseInsensitive())
-                {
-                    // Check if Generals is already set to this path to avoid duplicate detection
-                    // This prevents setting both GeneralsPath and ZeroHourPath to the same directory
-                    // when platform-specific detectors (Steam/EA/etc) have already identified Generals here
-                    bool isGeneralsAlreadySetToRoot =
-                        !string.IsNullOrEmpty(GeneralsPath) &&
-                        Path.GetFullPath(GeneralsPath).Equals(
-                            Path.GetFullPath(InstallationPath),
-                            StringComparison.OrdinalIgnoreCase);
-
-                    if (!isGeneralsAlreadySetToRoot)
-                    {
-                        // If we are in root and found generals.exe, it could be ZH.
-                        // Check for something specific to ZH if possible, or just assume if user pointed here it might be combined.
-                        // For safety, let's treat root install as potentially containing both if we can't distinguish.
-
-                        // Ideally we check for a ZH specific file, but standard detection often just looks for exe.
-                        // Let's assume if the user pointed us here and it has the exe, it's valid.
-                        // Standard Retail ZH has "generals.exe" but also usually lives in its own folder.
-                        // If user pointed to "C:\Games\ZH", it has generals.exe.
-                        HasZeroHour = true;
-                        ZeroHourPath = InstallationPath;
-                        foundZeroHour = true;
-                        _logger?.LogDebug("Found Zero Hour installation at root {ZeroHourPath}", ZeroHourPath);
-                    }
-                    else
-                    {
-                        _logger?.LogDebug(
-                            "Skipping Zero Hour detection at root {InstallationPath} - Generals already detected here",
-                            InstallationPath);
-                    }
-                }
-            }
-
-            // Logic improvement: If we found generals.exe in root, we might have set BOTH to true/root.
-            // This is acceptable for some "All in One" repacks or if the user manually merged them.
+            FetchSubdirectoryInstallations(ref foundGenerals, ref foundZeroHour);
+            FetchRootInstallation(ref foundGenerals, ref foundZeroHour);
 
             // Log warnings only if absolutely nothing found
             if (!foundGenerals && !foundZeroHour)
@@ -259,7 +191,7 @@ public class GameInstallation : IGameInstallation
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Failed to fetch installations for {InstallationPath}", InstallationPath);
+            _logger?.LogError(ex, "Failed to fetch installation at {InstallationPath}", InstallationPath);
         }
     }
 
@@ -287,5 +219,195 @@ public class GameInstallation : IGameInstallation
     {
         var possibleExes = new[] { GameClientConstants.SteamGameDatExecutable, GameClientConstants.GeneralsExecutable, GameClientConstants.ZeroHourExecutable };
         return possibleExes.Any(exe => Path.Combine(path, exe).FileExistsCaseInsensitive());
+    }
+
+    private static bool HasRootExecutable(string path)
+    {
+        var possibleExes = new[]
+        {
+            GameClientConstants.GeneralsExecutable,
+            GameClientConstants.SuperHackersZeroHourExecutable,
+            GameClientConstants.SuperHackersGeneralsExecutable,
+            GameClientConstants.GeneralsOnlineDefaultExecutable,
+            GameClientConstants.GeneralsOnline60HzExecutable,
+            GameClientConstants.GeneralsOnlineEacLauncherExecutable,
+            GameClientConstants.ContraExecutable,
+            GameClientConstants.SteamGameDatExecutable,
+            GameClientConstants.GameExecutable,
+        };
+
+        return possibleExes.Any(exe => Path.Combine(path, exe).FileExistsCaseInsensitive());
+    }
+
+    private static bool HasZeroHourArchiveOrExecutableSignature(string path)
+    {
+        if (Path.Combine(path, GameClientConstants.ZeroHourIniBig).FileExistsCaseInsensitive() ||
+            Path.Combine(path, GameClientConstants.ZeroHourPatchBig).FileExistsCaseInsensitive())
+        {
+            return true;
+        }
+
+        if (Path.Combine(path, GameClientConstants.SuperHackersZeroHourExecutable).FileExistsCaseInsensitive() ||
+            Path.Combine(path, GameClientConstants.GeneralsOnlineDefaultExecutable).FileExistsCaseInsensitive() ||
+            Path.Combine(path, GameClientConstants.GeneralsOnline60HzExecutable).FileExistsCaseInsensitive() ||
+            Path.Combine(path, GameClientConstants.GeneralsOnlineEacLauncherExecutable).FileExistsCaseInsensitive() ||
+            Path.Combine(path, GameClientConstants.ContraExecutable).FileExistsCaseInsensitive())
+        {
+            return true;
+        }
+
+        // Check for any localized or mod big archive ending with ZH.big (e.g. SpeechEnglishZH.big, RussianZH.big, GermanZH.big, MapsZH.big)
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                var directoryInfo = new DirectoryInfo(path);
+                if (directoryInfo.GetFiles("*.big").Any(f => f.Name.EndsWith("ZH.big", StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (IOException)
+        {
+            // Directory probe failure fallback
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Directory access denied fallback
+        }
+
+        return false;
+    }
+
+    private static bool HasGeneralsArchiveSignature(string path)
+    {
+        return Path.Combine(path, "gensec.big").FileExistsCaseInsensitive() ||
+               Path.Combine(path, GameClientConstants.GeneralsIniBig).FileExistsCaseInsensitive() ||
+               Path.Combine(path, GameClientConstants.GeneralsPatchBig).FileExistsCaseInsensitive() ||
+               Path.Combine(path, GameClientConstants.SuperHackersGeneralsExecutable).FileExistsCaseInsensitive();
+    }
+
+    private static bool IsZeroHourNamedDirectory(string path)
+    {
+        var folderName = Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+        return folderName.Contains("Zero Hour", StringComparison.OrdinalIgnoreCase) ||
+               folderName.Contains("ZeroHour", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(folderName, "ZH", StringComparison.OrdinalIgnoreCase) ||
+               folderName.StartsWith("ZH_", StringComparison.OrdinalIgnoreCase) ||
+               folderName.EndsWith("_ZH", StringComparison.OrdinalIgnoreCase) ||
+               folderName.StartsWith("ZH-", StringComparison.OrdinalIgnoreCase) ||
+               folderName.EndsWith("-ZH", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void FetchSubdirectoryInstallations(ref bool foundGenerals, ref bool foundZeroHour)
+    {
+        ReadOnlySpan<string> generalsSubdirs =
+        [
+            GameClientConstants.GeneralsDirectoryName,
+            GameClientConstants.GeneralsRetailDirectoryName,
+        ];
+
+        foreach (var subDir in generalsSubdirs)
+        {
+            if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var generalsPath))
+            {
+                var generalsExe = Path.Combine(generalsPath, GameClientConstants.GeneralsExecutable);
+                if (generalsExe.FileExistsCaseInsensitive())
+                {
+                    HasGenerals = true;
+                    GeneralsPath = generalsPath;
+                    foundGenerals = true;
+                    _logger?.LogDebug("Found Generals installation at {GeneralsPath}", GeneralsPath);
+                    break;
+                }
+            }
+        }
+
+        ReadOnlySpan<string> zhSubdirs =
+        [
+            GameClientConstants.ZeroHourDirectoryName,
+            GameClientConstants.ZeroHourDirectoryNameAmpersandHyphen,
+            GameClientConstants.ZeroHourRetailDirectoryName,
+            GameClientConstants.ZeroHourDirectoryNameAbbreviated,
+            GameClientConstants.ZeroHourDirectoryNameColonVariant,
+        ];
+
+        foreach (var subDir in zhSubdirs)
+        {
+            if (InstallationPath.TryGetDirectoryCaseInsensitive(subDir, out var zeroHourPath))
+            {
+                var zeroHourExe = Path.Combine(zeroHourPath, GameClientConstants.ZeroHourExecutable);
+                if (zeroHourExe.FileExistsCaseInsensitive())
+                {
+                    HasZeroHour = true;
+                    ZeroHourPath = zeroHourPath;
+                    foundZeroHour = true;
+                    _logger?.LogDebug("Found Zero Hour installation at {ZeroHourPath}", ZeroHourPath);
+                    break;
+                }
+            }
+        }
+    }
+
+    private void FetchRootInstallation(ref bool foundGenerals, ref bool foundZeroHour)
+    {
+        if ((foundGenerals && foundZeroHour) || !HasRootExecutable(InstallationPath))
+        {
+            return;
+        }
+
+        var isZhNamed = IsZeroHourNamedDirectory(InstallationPath);
+        var hasZhSignature = HasZeroHourArchiveOrExecutableSignature(InstallationPath);
+        var hasGenSignature = HasGeneralsArchiveSignature(InstallationPath);
+
+        if (!foundZeroHour && (isZhNamed || hasZhSignature))
+        {
+            HasZeroHour = true;
+            ZeroHourPath = InstallationPath;
+            foundZeroHour = true;
+            _logger?.LogDebug("Found Zero Hour installation at root {ZeroHourPath}", ZeroHourPath);
+        }
+
+        if (!foundGenerals && hasGenSignature)
+        {
+            var isStrictGeneralsOnlySignature =
+                Path.Combine(InstallationPath, "gensec.big").FileExistsCaseInsensitive() ||
+                Path.Combine(InstallationPath, GameClientConstants.SuperHackersGeneralsExecutable).FileExistsCaseInsensitive();
+
+            if (!isZhNamed || isStrictGeneralsOnlySignature)
+            {
+                HasGenerals = true;
+                GeneralsPath = InstallationPath;
+                foundGenerals = true;
+                _logger?.LogDebug("Found Generals installation at root {GeneralsPath}", GeneralsPath);
+            }
+        }
+
+        if (foundGenerals || foundZeroHour)
+        {
+            return;
+        }
+
+        AssignRootFallback(ref foundGenerals, ref foundZeroHour);
+    }
+
+    private void AssignRootFallback(ref bool foundGenerals, ref bool foundZeroHour)
+    {
+        if (IsZeroHourNamedDirectory(InstallationPath))
+        {
+            HasZeroHour = true;
+            ZeroHourPath = InstallationPath;
+            foundZeroHour = true;
+            _logger?.LogDebug("Found Zero Hour installation at root based on directory name {ZeroHourPath}", ZeroHourPath);
+        }
+        else
+        {
+            HasGenerals = true;
+            GeneralsPath = InstallationPath;
+            foundGenerals = true;
+            _logger?.LogDebug("Found Generals installation at root {GeneralsPath}", GeneralsPath);
+        }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
@@ -395,8 +395,55 @@ public class GameInstallationServiceTests : IDisposable
             Assert.True(result.Success);
             Assert.NotNull(result.Data);
             var install = Assert.Single(result.Data);
+            Assert.True(install.HasGenerals);
+            Assert.Equal(tempDir, install.GeneralsPath);
             Assert.True(install.HasZeroHour);
             Assert.Equal(tempDir, install.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that when TargetGame defaults to Generals (0) because it was omitted in JSON, a Zero Hour manifest ID only sets the Zero Hour path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetAllInstallationsAsync_ReconstructsZeroHourInstallation_WhenTargetGameOmittedAsync()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenHubZHManifestReconstruct_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INIZH.big"), string.Empty);
+
+            _orchestratorMock.Setup(x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(DetectionResult<GameInstallation>.CreateSuccess([], TimeSpan.Zero));
+
+            // TargetGame is omitted / default(GameType) which equals GameType.Generals (0)
+            var zeroHourManifest = new ContentManifest
+            {
+                Id = "1.104.retail.gameinstallation.zerohour",
+                ContentType = GenHub.Core.Models.Enums.ContentType.GameInstallation,
+                Version = "1.04",
+                Metadata = new ContentMetadata { SourcePath = tempDir },
+            };
+
+            _manifestPoolMock
+                .Setup(x => x.SearchManifestsAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([zeroHourManifest]));
+
+            var result = await _service.GetAllInstallationsAsync();
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            var install = Assert.Single(result.Data);
+            Assert.True(install.HasZeroHour);
+            Assert.Equal(tempDir, install.ZeroHourPath);
+            Assert.False(install.HasGenerals);
         }
         finally
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
@@ -450,4 +450,60 @@ public class GameInstallationServiceTests : IDisposable
             Directory.Delete(tempDir, true);
         }
     }
+
+    /// <summary>
+    /// Verifies that manifests with distinct source paths reconstruct into distinct installations.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetAllInstallationsAsync_ReconstructsInstallations_RespectingPathComparerAsync()
+    {
+        var tempDir1 = Path.Combine(Path.GetTempPath(), "GenHubPathTest_A_" + Guid.NewGuid().ToString("N"));
+        var tempDir2 = Path.Combine(Path.GetTempPath(), "GenHubPathTest_B_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir1);
+        Directory.CreateDirectory(tempDir2);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir1, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir1, "INIZH.big"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir2, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir2, "INIZH.big"), string.Empty);
+
+            _orchestratorMock.Setup(x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(DetectionResult<GameInstallation>.CreateSuccess([], TimeSpan.Zero));
+
+            var manifest1 = new ContentManifest
+            {
+                Id = "1.104.retail.gameinstallation.zerohour",
+                ContentType = GenHub.Core.Models.Enums.ContentType.GameInstallation,
+                TargetGame = GameType.ZeroHour,
+                Version = "1.04",
+                Metadata = new ContentMetadata { SourcePath = tempDir1 },
+            };
+
+            var manifest2 = new ContentManifest
+            {
+                Id = "1.104.retail.gameinstallation.zerohour",
+                ContentType = GenHub.Core.Models.Enums.ContentType.GameInstallation,
+                TargetGame = GameType.ZeroHour,
+                Version = "1.04",
+                Metadata = new ContentMetadata { SourcePath = tempDir2 },
+            };
+
+            _manifestPoolMock
+                .Setup(x => x.SearchManifestsAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([manifest1, manifest2]));
+
+            var result = await _service.GetAllInstallationsAsync();
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.Equal(2, result.Data.Count);
+        }
+        finally
+        {
+            Directory.Delete(tempDir1, true);
+            Directory.Delete(tempDir2, true);
+        }
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
@@ -350,4 +350,57 @@ public class GameInstallationServiceTests : IDisposable
             x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    /// <summary>
+    /// Verifies that persisted manifests reconstruct an installation with both Generals and Zero Hour capabilities.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetAllInstallationsAsync_ReconstructsInstallationWithGeneralsAndZeroHour_FromPersistedManifestsAsync()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenHubManifestReconstruct_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INIZH.big"), string.Empty);
+
+            _orchestratorMock.Setup(x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(DetectionResult<GameInstallation>.CreateSuccess([], TimeSpan.Zero));
+
+            var generalsManifest = new ContentManifest
+            {
+                Id = "1.108.retail.gameinstallation.generals",
+                ContentType = GenHub.Core.Models.Enums.ContentType.GameInstallation,
+                TargetGame = GameType.Generals,
+                Version = "1.08",
+                Metadata = new ContentMetadata { SourcePath = tempDir },
+            };
+
+            var zeroHourManifest = new ContentManifest
+            {
+                Id = "1.104.retail.gameinstallation.zerohour",
+                ContentType = GenHub.Core.Models.Enums.ContentType.GameInstallation,
+                TargetGame = GameType.ZeroHour,
+                Version = "1.04",
+                Metadata = new ContentMetadata { SourcePath = tempDir },
+            };
+
+            _manifestPoolMock
+                .Setup(x => x.SearchManifestsAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([generalsManifest, zeroHourManifest]));
+
+            var result = await _service.GetAllInstallationsAsync();
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            var install = Assert.Single(result.Data);
+            Assert.True(install.HasZeroHour);
+            Assert.Equal(tempDir, install.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameInstallations/GameInstallationServiceTests.cs
@@ -506,4 +506,41 @@ public class GameInstallationServiceTests : IDisposable
             Directory.Delete(tempDir2, true);
         }
     }
+
+    /// <summary>
+    /// Verifies that installations with paths differing only by case are handled according to platform path comparison semantics.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AddInstallationToCacheAsync_HandlesCaseDistinctPaths_AccordingToPlatformPathComparisonAsync()
+    {
+        var basePath = Path.Combine(Path.GetTempPath(), "GenHubCaseTest_" + Guid.NewGuid().ToString("N"));
+        var path1 = Path.Combine(basePath, "zh");
+        var path2 = Path.Combine(basePath, "ZH");
+
+        var install1 = new GameInstallation(path1, GameInstallationType.Steam);
+        var install2 = new GameInstallation(path2, GameInstallationType.Retail);
+
+        _orchestratorMock.Setup(x => x.DetectAllInstallationsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DetectionResult<GameInstallation>.CreateSuccess([], TimeSpan.Zero));
+
+        var addResult1 = await _service.AddInstallationToCacheAsync(install1);
+        var addResult2 = await _service.AddInstallationToCacheAsync(install2);
+
+        Assert.True(addResult1.Success);
+        Assert.True(addResult2.Success);
+
+        var allResult = await _service.GetAllInstallationsAsync();
+        Assert.True(allResult.Success);
+        Assert.NotNull(allResult.Data);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Single(allResult.Data);
+        }
+        else
+        {
+            Assert.Equal(2, allResult.Data.Count);
+        }
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
@@ -389,6 +389,14 @@ public class StrategyTests : IDisposable
         Assert.False(result.IsPrepared);
         Assert.NotEmpty(result.ValidationIssues);
         _fileOps.Verify(
+            service => service.LinkFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                false,
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _fileOps.Verify(
             service => service.CopyFromCasAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Workspace/StrategyTests.cs
@@ -201,7 +201,7 @@ public class StrategyTests : IDisposable
     [InlineData(WorkspaceStrategy.FullCopy, false, false)]
     [InlineData(WorkspaceStrategy.SymlinkOnly, true, false)]
     [InlineData(WorkspaceStrategy.HybridCopySymlink, true, false)]
-    [InlineData(WorkspaceStrategy.HardLink, false, true)]
+    [InlineData(WorkspaceStrategy.HardLink, false, false)]
     public void AllStrategies_Requirements_MatchExpected(WorkspaceStrategy strategyType, bool expectedAdminRights, bool expectedSameVolume)
     {
         // Arrange
@@ -253,11 +253,11 @@ public class StrategyTests : IDisposable
     }
 
     /// <summary>
-    /// Verifies that hard-link preparation copies CAS content instead of rejecting a cross-volume workspace.
+    /// Verifies that hard-link preparation falls back to symlinks instead of copying when hard linking fails.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task HardLinkStrategy_WhenVolumesDiffer_FallsBackToCopyAsync()
+    public async Task HardLinkStrategy_WhenHardLinkFails_FallsBackToSymlinkAsync()
     {
         const string Hash = "test-hash";
         var strategy = new HardLinkStrategy(_fileOps.Object, new Mock<ILogger<HardLinkStrategy>>().Object);
@@ -296,9 +296,10 @@ public class StrategyTests : IDisposable
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         _fileOps
-            .Setup(service => service.CopyFromCasAsync(
+            .Setup(service => service.LinkFromCasAsync(
                 Hash,
                 It.IsAny<string>(),
+                false,
                 ManifestContentType.GameClient,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -307,12 +308,93 @@ public class StrategyTests : IDisposable
 
         Assert.True(result.IsPrepared);
         _fileOps.Verify(
-            service => service.CopyFromCasAsync(
+            service => service.LinkFromCasAsync(
                 Hash,
                 It.IsAny<string>(),
+                true,
                 ManifestContentType.GameClient,
                 It.IsAny<CancellationToken>()),
             Times.Once);
+        _fileOps.Verify(
+            service => service.LinkFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                false,
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _fileOps.Verify(
+            service => service.CopyFromCasAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ManifestContentType?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that HardLinkStrategy records preparation failure when both hard link and symlink CAS operations fail.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task HardLinkStrategy_PrepareAsync_HandlesCasLinkDoubleFailure_FailsPreparation()
+    {
+        const string Hash = "test-hash";
+        var strategy = new HardLinkStrategy(_fileOps.Object, new Mock<ILogger<HardLinkStrategy>>().Object);
+        var configuration = new WorkspaceConfiguration
+        {
+            Id = "test-ws-double-failure",
+            Strategy = WorkspaceStrategy.HardLink,
+            WorkspaceRootPath = _tempDir,
+            BaseInstallationPath = "relative-installation-path",
+            GameClient = new GameClient { Id = "test" },
+            Manifests =
+            [
+                new ContentManifest
+                {
+                    ContentType = ManifestContentType.GameClient,
+                    Files =
+                    [
+                        new ManifestFile
+                        {
+                            RelativePath = "game.exe",
+                            Hash = Hash,
+                            Size = 1024,
+                            InstallTarget = ContentInstallTarget.Workspace,
+                            SourceType = ContentSourceType.ContentAddressable,
+                        },
+                    ],
+                },
+            ],
+        };
+        _fileOps
+            .Setup(service => service.LinkFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                true,
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _fileOps
+            .Setup(service => service.LinkFromCasAsync(
+                Hash,
+                It.IsAny<string>(),
+                false,
+                ManifestContentType.GameClient,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await strategy.PrepareAsync(configuration, null, CancellationToken.None);
+
+        Assert.False(result.IsPrepared);
+        Assert.NotEmpty(result.ValidationIssues);
+        _fileOps.Verify(
+            service => service.CopyFromCasAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ManifestContentType?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameInstallations/GameInstallationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameInstallations/GameInstallationTests.cs
@@ -1,3 +1,4 @@
+using GenHub.Core.Constants;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameInstallations;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -73,6 +74,359 @@ public class GameInstallationTests
         finally
         {
             Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch correctly identifies a standalone Zero Hour installation by its INIZH.big archive.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsStandaloneZeroHour_WhenZeroHourBigsPresent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenHubZHTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INIZH.big"), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+            Assert.False(installation.HasGenerals);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch correctly identifies a standalone Generals installation by its INI.big archive.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsStandaloneGenerals_WhenGeneralsBigsPresent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenHubGenTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INI.big"), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasGenerals);
+            Assert.Equal(tempDir, installation.GeneralsPath);
+            Assert.False(installation.HasZeroHour);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch correctly identifies a merged installation containing both Generals and Zero Hour archives.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsMergedInstall_WhenBothBigsPresent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenHubMergedTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INI.big"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INIZH.big"), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasGenerals);
+            Assert.Equal(tempDir, installation.GeneralsPath);
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch correctly identifies Zero Hour based on folder name when specific archives are absent.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsZeroHour_WhenDirectoryNamedZeroHour()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "Command and Conquer Generals Zero Hour_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch does not misclassify a vanilla Generals installation when parent path contains ZH text.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DoesNotMisclassifyGenerals_WhenParentPathContainsZh()
+    {
+        var parentDir = Path.Combine(Path.GetTempPath(), "ZH_Tools_" + Guid.NewGuid().ToString("N"));
+        var generalsDir = Path.Combine(parentDir, "Generals");
+        Directory.CreateDirectory(generalsDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(generalsDir, "generals.exe"), string.Empty);
+
+            var installation = new GameInstallation(generalsDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasGenerals);
+            Assert.Equal(generalsDir, installation.GeneralsPath);
+            Assert.False(installation.HasZeroHour);
+        }
+        finally
+        {
+            Directory.Delete(parentDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch identifies Zero Hour for leaf directories matching anchored ZH tokens.
+    /// </summary>
+    /// <param name="dirName">The directory name matching the anchored Zero Hour token.</param>
+    [Theory]
+    [InlineData("ZH")]
+    [InlineData("ZH_Mod")]
+    [InlineData("Mod_ZH")]
+    [InlineData("ZH-Mod")]
+    [InlineData("Mod-ZH")]
+    public void GameInstallation_Fetch_DetectsZeroHour_WhenDirectoryMatchesAnchoredZhToken(string dirName)
+    {
+        var parentDir = Path.Combine(Path.GetTempPath(), "ZhTestParent_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(parentDir, dirName);
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(parentDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch detects Zero Hour from supported subdirectories under a parent installation path.
+    /// </summary>
+    /// <param name="subDirName">The subdirectory name under the installation root.</param>
+    [Theory]
+    [InlineData(GameClientConstants.ZeroHourDirectoryName)]
+    [InlineData(GameClientConstants.ZeroHourDirectoryNameAmpersandHyphen)]
+    [InlineData(GameClientConstants.ZeroHourRetailDirectoryName)]
+    [InlineData(GameClientConstants.ZeroHourDirectoryNameAbbreviated)]
+    public void GameInstallation_Fetch_DetectsZeroHour_FromSupportedSubdirectory(string subDirName)
+    {
+        var parentDir = Path.Combine(Path.GetTempPath(), "GamesParent_" + Guid.NewGuid().ToString("N"));
+        var zhDir = Path.Combine(parentDir, subDirName);
+        Directory.CreateDirectory(zhDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(zhDir, "generals.exe"), string.Empty);
+
+            var installation = new GameInstallation(parentDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(zhDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(parentDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch detects Zero Hour based on archive signatures like PatchZH.big.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsZeroHour_WhenPatchZhArchivePresent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenericRoot_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, GameClientConstants.ZeroHourPatchBig), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch detects Generals Vanilla based on Patch.big archive signature.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsGenerals_WhenPatchArchivePresent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenericRoot_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, GameClientConstants.GeneralsPatchBig), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasGenerals);
+            Assert.Equal(tempDir, installation.GeneralsPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch detects Zero Hour when client-specific executables like generalszh.exe or generalsonlinezh_60.exe are present.
+    /// </summary>
+    /// <param name="exeName">The client executable name.</param>
+    [Theory]
+    [InlineData(GameClientConstants.SuperHackersZeroHourExecutable)]
+    [InlineData(GameClientConstants.GeneralsOnlineDefaultExecutable)]
+    [InlineData(GameClientConstants.GeneralsOnline60HzExecutable)]
+    [InlineData(GameClientConstants.GeneralsOnlineEacLauncherExecutable)]
+    [InlineData(GameClientConstants.ContraExecutable)]
+    public void GameInstallation_Fetch_DetectsZeroHour_WhenClientExecutablePresent(string exeName)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenericRoot_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, exeName), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch identifies a directory named Zero Hour as Zero Hour even if generic INI.big is present (repack scenario).
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsZeroHour_WhenNamedZeroHourAndIniBigPresent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "Command and Conquer Generals Zero Hour_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INI.big"), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+            Assert.False(installation.HasGenerals);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch detects Zero Hour when non-English localized archives like RussianZH.big or GermanZH.big are present.
+    /// </summary>
+    /// <param name="archiveName">The localized Zero Hour archive filename.</param>
+    [Theory]
+    [InlineData("RussianZH.big")]
+    [InlineData("GermanZH.big")]
+    [InlineData("FrenchZH.big")]
+    [InlineData("AudioZH.big")]
+    public void GameInstallation_Fetch_DetectsZeroHour_WhenLocalizedZhBigArchivePresent(string archiveName)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenericRoot_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, archiveName), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch preserves explicitly configured paths when those paths exist on disk.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_PreservesExplicitlyConfiguredPaths()
+    {
+        var tempParent = Path.Combine(Path.GetTempPath(), "ExplicitTest_" + Guid.NewGuid().ToString("N"));
+        var zhDir = Path.Combine(tempParent, "ZH_Custom");
+        Directory.CreateDirectory(zhDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(zhDir, "generals.exe"), string.Empty);
+
+            var installation = new GameInstallation(tempParent, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.SetPaths(null, zhDir);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(zhDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempParent, true);
         }
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameInstallations/GameInstallationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameInstallations/GameInstallationTests.cs
@@ -140,7 +140,7 @@ public class GameInstallationTests
         try
         {
             File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
-            File.WriteAllText(Path.Combine(tempDir, "INI.big"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "gensec.big"), string.Empty);
             File.WriteAllText(Path.Combine(tempDir, "INIZH.big"), string.Empty);
 
             var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
@@ -380,9 +380,12 @@ public class GameInstallationTests
     /// <param name="archiveName">The localized Zero Hour archive filename.</param>
     [Theory]
     [InlineData("RussianZH.big")]
+    [InlineData("RussianZH.BIG")]
     [InlineData("GermanZH.big")]
+    [InlineData("GermanZH.Big")]
     [InlineData("FrenchZH.big")]
     [InlineData("AudioZH.big")]
+    [InlineData("MapsZH.BIG")]
     public void GameInstallation_Fetch_DetectsZeroHour_WhenLocalizedZhBigArchivePresent(string archiveName)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "GenericRoot_" + Guid.NewGuid().ToString("N"));
@@ -397,6 +400,34 @@ public class GameInstallationTests
 
             Assert.True(installation.HasZeroHour);
             Assert.Equal(tempDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch identifies a generic directory containing both generic INI.big and a Zero Hour archive signature as Zero Hour only.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_DetectsOnlyZeroHour_WhenGenericRootContainsIniBigAndZhArchive()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GenericRoot_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "INI.big"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDir, "RussianZH.BIG"), string.Empty);
+
+            var installation = new GameInstallation(tempDir, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(tempDir, installation.ZeroHourPath);
+            Assert.False(installation.HasGenerals);
+            Assert.True(string.IsNullOrEmpty(installation.GeneralsPath));
         }
         finally
         {
@@ -452,6 +483,35 @@ public class GameInstallationTests
 
             Assert.True(installation.HasZeroHour);
             Assert.Equal(customZhDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempParent, true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Fetch preserves explicitly configured Generals paths even when a standard supported subdirectory also exists.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_PreservesExplicitlyConfiguredGeneralsPath_EvenWhenStandardSubdirectoriesExist()
+    {
+        var tempParent = Path.Combine(Path.GetTempPath(), "ExplicitGenSubdirTest_" + Guid.NewGuid().ToString("N"));
+        var customGenDir = Path.Combine(tempParent, "Generals_Custom");
+        var standardGenDir = Path.Combine(tempParent, GameClientConstants.GeneralsDirectoryName);
+        Directory.CreateDirectory(customGenDir);
+        Directory.CreateDirectory(standardGenDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(customGenDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(standardGenDir, "generals.exe"), string.Empty);
+
+            var installation = new GameInstallation(tempParent, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.SetPaths(customGenDir, null);
+            installation.Fetch();
+
+            Assert.True(installation.HasGenerals);
+            Assert.Equal(customGenDir, installation.GeneralsPath);
         }
         finally
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameInstallations/GameInstallationTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Models/GameInstallations/GameInstallationTests.cs
@@ -429,4 +429,33 @@ public class GameInstallationTests
             Directory.Delete(tempParent, true);
         }
     }
+
+    /// <summary>
+    /// Verifies that Fetch preserves explicitly configured paths even when a standard supported subdirectory also exists.
+    /// </summary>
+    [Fact]
+    public void GameInstallation_Fetch_PreservesExplicitlyConfiguredPaths_EvenWhenStandardSubdirectoriesExist()
+    {
+        var tempParent = Path.Combine(Path.GetTempPath(), "ExplicitSubdirTest_" + Guid.NewGuid().ToString("N"));
+        var customZhDir = Path.Combine(tempParent, "ZH_Custom");
+        var standardZhDir = Path.Combine(tempParent, GameClientConstants.ZeroHourDirectoryName);
+        Directory.CreateDirectory(customZhDir);
+        Directory.CreateDirectory(standardZhDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(customZhDir, "generals.exe"), string.Empty);
+            File.WriteAllText(Path.Combine(standardZhDir, "generals.exe"), string.Empty);
+
+            var installation = new GameInstallation(tempParent, GameInstallationType.Retail, NullLogger<GameInstallation>.Instance);
+            installation.SetPaths(null, customZhDir);
+            installation.Fetch();
+
+            Assert.True(installation.HasZeroHour);
+            Assert.Equal(customZhDir, installation.ZeroHourPath);
+        }
+        finally
+        {
+            Directory.Delete(tempParent, true);
+        }
+    }
 }

--- a/GenHub/GenHub.Windows/Features/Workspace/WindowsFileOperationsService.cs
+++ b/GenHub/GenHub.Windows/Features/Workspace/WindowsFileOperationsService.cs
@@ -150,7 +150,7 @@ public partial class WindowsFileOperationsService(
             }
             else
             {
-                await CreateSymlinkAsync(destinationPath, casSourcePath, allowFallback: true, cancellationToken).ConfigureAwait(false);
+                await CreateSymlinkAsync(destinationPath, casSourcePath, allowFallback: false, cancellationToken).ConfigureAwait(false);
             }
 
             logger.LogDebug("Created {LinkType} from CAS hash {Hash} to {DestinationPath}", useHardLink ? "hard link" : "symlink", hash, destinationPath);

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -688,7 +688,7 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
 
                     return hasPath;
                 })
-                .GroupBy(m => m.Metadata.SourcePath!, StringComparer.OrdinalIgnoreCase);
+                .GroupBy(m => m.Metadata.SourcePath!, PathHelper.PathComparer);
 
             foreach (var group in manifestsByPath)
             {

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -391,6 +391,14 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
                 }
             }
 
+            if (clients.Count == 0 && Directory.Exists(installation.InstallationPath))
+            {
+                needsDetection = true;
+                logger.LogDebug(
+                    "No clients loaded from manifests for installation {Id} - will trigger detection",
+                    installation.Id);
+            }
+
             if (clients.Count > 0)
             {
                 installation.PopulateGameClients(clients);
@@ -696,6 +704,14 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
                     Id = Guid.NewGuid().ToString(), // Generate new ID
                     DetectedAt = DateTime.UtcNow,
                 };
+
+                // Seed game capabilities from existing manifests
+                var hasGeneralsManifest = group.Any(m => m.TargetGame == GameType.Generals || m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase));
+                var hasZeroHourManifest = group.Any(m => m.TargetGame == GameType.ZeroHour || m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase));
+
+                installation.SetPaths(
+                    hasGeneralsManifest ? sourcePath : null,
+                    hasZeroHourManifest ? sourcePath : null);
 
                 // Populate Generals/ZeroHour paths
                 installation.Fetch();

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -705,9 +705,13 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
                     DetectedAt = DateTime.UtcNow,
                 };
 
-                // Seed game capabilities from existing manifests
-                var hasGeneralsManifest = group.Any(m => m.TargetGame == GameType.Generals || m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase));
-                var hasZeroHourManifest = group.Any(m => m.TargetGame == GameType.ZeroHour || m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase));
+                // Seed game capabilities from existing manifests (canonical manifest ID takes precedence over enum default)
+                var hasGeneralsManifest = group.Any(m =>
+                    m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase) ||
+                    (!m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase) && m.TargetGame == GameType.Generals));
+                var hasZeroHourManifest = group.Any(m =>
+                    m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase) ||
+                    (!m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase) && m.TargetGame == GameType.ZeroHour));
 
                 installation.SetPaths(
                     hasGeneralsManifest ? sourcePath : null,

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -324,6 +324,40 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
         return GameInstallationType.Unknown;
     }
 
+    private static bool ContainsGeneralsManifest(IEnumerable<ContentManifest> manifests) =>
+        manifests.Any(m =>
+            m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase) ||
+            (!m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase) && m.TargetGame == GameType.Generals));
+
+    private static bool ContainsZeroHourManifest(IEnumerable<ContentManifest> manifests) =>
+        manifests.Any(m =>
+            m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase) ||
+            (!m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase) && m.TargetGame == GameType.ZeroHour));
+
+    private static GameInstallation ReconstructInstallationFromManifests(
+        string sourcePath,
+        IReadOnlyList<ContentManifest> manifests)
+    {
+        var firstManifest = manifests[0];
+        var installationType = ExtractInstallationTypeFromManifestId(firstManifest.Id);
+
+        var installation = new GameInstallation(sourcePath, installationType)
+        {
+            Id = Guid.NewGuid().ToString(),
+            DetectedAt = DateTime.UtcNow,
+        };
+
+        var hasGeneralsManifest = ContainsGeneralsManifest(manifests);
+        var hasZeroHourManifest = ContainsZeroHourManifest(manifests);
+
+        installation.SetPaths(
+            hasGeneralsManifest ? sourcePath : null,
+            hasZeroHourManifest ? sourcePath : null);
+
+        installation.Fetch();
+        return installation;
+    }
+
     /// <summary>
     /// Attempts to load game clients from existing manifests in the pool.
     /// </summary>
@@ -698,37 +732,18 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
                     continue;
                 }
 
-                // Determine installation type from the first manifest ID
-                var firstManifest = group.First();
-                var installationType = ExtractInstallationTypeFromManifestId(firstManifest.Id);
-
-                // Create GameInstallation object
-                var installation = new GameInstallation(sourcePath, installationType)
+                var groupManifests = group.ToList();
+                if (groupManifests.Count == 0)
                 {
-                    Id = Guid.NewGuid().ToString(), // Generate new ID
-                    DetectedAt = DateTime.UtcNow,
-                };
+                    continue;
+                }
 
-                // Seed game capabilities from existing manifests (canonical manifest ID takes precedence over enum default)
-                var hasGeneralsManifest = group.Any(m =>
-                    m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase) ||
-                    (!m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase) && m.TargetGame == GameType.Generals));
-                var hasZeroHourManifest = group.Any(m =>
-                    m.Id.Value.Contains(".gameinstallation.zerohour", StringComparison.OrdinalIgnoreCase) ||
-                    (!m.Id.Value.Contains(".gameinstallation.generals", StringComparison.OrdinalIgnoreCase) && m.TargetGame == GameType.ZeroHour));
-
-                installation.SetPaths(
-                    hasGeneralsManifest ? sourcePath : null,
-                    hasZeroHourManifest ? sourcePath : null);
-
-                // Populate Generals/ZeroHour paths
-                installation.Fetch();
-
+                var installation = ReconstructInstallationFromManifests(sourcePath, groupManifests);
                 installations.Add(installation);
 
                 logger.LogInformation(
                     "Reconstructed {InstallationType} installation from manifests: {Path}",
-                    installationType,
+                    installation.InstallationType,
                     sourcePath);
             }
 

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -688,11 +688,15 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
 
                     return hasPath;
                 })
-                .GroupBy(m => m.Metadata.SourcePath!, PathHelper.PathComparer);
+                .GroupBy(m => m.Metadata.SourcePath, PathHelper.PathComparer);
 
             foreach (var group in manifestsByPath)
             {
                 var sourcePath = group.Key;
+                if (string.IsNullOrEmpty(sourcePath))
+                {
+                    continue;
+                }
 
                 // Determine installation type from the first manifest ID
                 var firstManifest = group.First();

--- a/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
+++ b/GenHub/GenHub/Features/GameInstallations/GameInstallationService.cs
@@ -140,7 +140,7 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
                 // Check if installation already exists (by ID or path)
                 var existing = installationsList.FirstOrDefault(i =>
                     i.Id == installation.Id ||
-                    i.InstallationPath.Equals(installation.InstallationPath, StringComparison.OrdinalIgnoreCase));
+                    PathHelper.AreSamePath(i.InstallationPath, installation.InstallationPath));
 
                 if (existing != null)
                 {
@@ -832,7 +832,7 @@ IInstallationPathResolver? pathResolver = null) : IGameInstallationService, IDis
                 foreach (var manifestInstall in manifestInstallations)
                 {
                     var existingByPath = installations.FirstOrDefault(i =>
-                        i.InstallationPath.Equals(manifestInstall.InstallationPath, StringComparison.OrdinalIgnoreCase));
+                        PathHelper.AreSamePath(i.InstallationPath, manifestInstall.InstallationPath));
 
                     if (existingByPath == null)
                     {

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -1608,8 +1608,8 @@ public class ProfileLauncherFacade(
                 // First try to match by both game type AND installation path (most specific match)
                 var exactPathMatches = allInstallationsResult.Data
                     .Where(inst =>
-                        ((profile.GameClient?.GameType == Core.Models.Enums.GameType.Generals && inst.HasGenerals && !string.IsNullOrEmpty(inst.GeneralsPath) && inst.GeneralsPath.Equals(profile.GameClient?.WorkingDirectory, StringComparison.OrdinalIgnoreCase)) ||
-                         (profile.GameClient?.GameType == Core.Models.Enums.GameType.ZeroHour && inst.HasZeroHour && !string.IsNullOrEmpty(inst.ZeroHourPath) && inst.ZeroHourPath.Equals(profile.GameClient?.WorkingDirectory, StringComparison.OrdinalIgnoreCase))))
+                        ((profile.GameClient?.GameType == Core.Models.Enums.GameType.Generals && inst.HasGenerals && !string.IsNullOrEmpty(inst.GeneralsPath) && !string.IsNullOrEmpty(profile.GameClient?.WorkingDirectory) && PathHelper.AreSamePath(inst.GeneralsPath, profile.GameClient.WorkingDirectory)) ||
+                         (profile.GameClient?.GameType == Core.Models.Enums.GameType.ZeroHour && inst.HasZeroHour && !string.IsNullOrEmpty(inst.ZeroHourPath) && !string.IsNullOrEmpty(profile.GameClient?.WorkingDirectory) && PathHelper.AreSamePath(inst.ZeroHourPath, profile.GameClient.WorkingDirectory))))
                     .ToList();
 
                 if (exactPathMatches.Count == 1)

--- a/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/FileOperationsService.cs
@@ -195,18 +195,14 @@ public class FileOperationsService(
                 try
                 {
                     FileInfo sourceInfo = new(sourcePath);
-                    FileInfo destInfo = new(destinationPath)
-                    {
-                        // Timestamps
-                        CreationTime = sourceInfo.CreationTime,
-                        LastWriteTime = sourceInfo.LastWriteTime,
+                    File.SetCreationTime(destinationPath, sourceInfo.CreationTime);
+                    File.SetLastWriteTime(destinationPath, sourceInfo.LastWriteTime);
 
-                        // Attributes - avoid reparse/read-only/system flags
-                        Attributes = sourceInfo.Attributes
+                    var targetAttributes = sourceInfo.Attributes
                         & ~FileAttributes.ReparsePoint
                         & ~FileAttributes.ReadOnly
-                        & ~FileAttributes.System,
-                    };
+                        & ~FileAttributes.System;
+                    File.SetAttributes(destinationPath, targetAttributes);
                 }
                 catch (Exception attrEx)
                 {
@@ -646,7 +642,7 @@ public class FileOperationsService(
             }
             else
             {
-                await CreateSymlinkAsync(destinationPath, pathResult.Data, !useHardLink, cancellationToken).ConfigureAwait(false);
+                await CreateSymlinkAsync(destinationPath, pathResult.Data, allowFallback: false, cancellationToken).ConfigureAwait(false);
             }
 
             logger.LogDebug("Created {LinkType} from CAS hash {Hash} to {DestinationPath}", useHardLink ? "hard link" : "symlink", hash, destinationPath);

--- a/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
@@ -119,7 +119,7 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
                 {
                     if (file.SourceType == Core.Models.Enums.ContentSourceType.ContentAddressable && !string.IsNullOrEmpty(file.Hash))
                     {
-                        var (linked, bytes) = await ProcessCasFileAsync(file, manifest, destinationPath, sameVolume, cancellationToken);
+                        var (linked, bytes) = await ProcessCasFileAsync(file, manifest, destinationPath, cancellationToken);
                         if (linked)
                         {
                             linkedFiles++;
@@ -294,7 +294,6 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         ManifestFile file,
         ContentManifest manifest,
         string destinationPath,
-        bool sameVolume,
         CancellationToken cancellationToken)
     {
         await CreateCasLinkAsync(file.Hash!, destinationPath, manifest.ContentType, cancellationToken);

--- a/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
+++ b/GenHub/GenHub/Features/Workspace/Strategies/HardLinkStrategy.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Extensions;
 using GenHub.Core.Interfaces.Workspace;
 using GenHub.Core.Models.Enums;
@@ -13,8 +14,8 @@ using Microsoft.Extensions.Logging;
 namespace GenHub.Features.Workspace.Strategies;
 
 /// <summary>
-/// Workspace strategy that creates hard links to game files where possible, falling back to copy.
-/// Space-efficient, requires same volume for optimal results.
+/// Workspace strategy that creates hard links or symbolic links to game files.
+/// Space-efficient zero-copy workspace.
 /// </summary>
 /// <remarks>
 /// Initializes a new instance of the <see cref="HardLinkStrategy"/> class.
@@ -27,13 +28,13 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
     public override string Name => "Hard Link";
 
     /// <inheritdoc/>
-    public override string Description => "Creates hard links where possible, copies otherwise. Space-efficient with good performance, works best on same volume.";
+    public override string Description => "Creates hard links or symbolic links to game files. Space-efficient zero-copy workspace.";
 
     /// <inheritdoc/>
     public override bool RequiresAdminRights => false;
 
     /// <inheritdoc/>
-    public override bool RequiresSameVolume => true;
+    public override bool RequiresSameVolume => false;
 
     /// <inheritdoc/>
     public override bool CanHandle(WorkspaceConfiguration configuration)
@@ -47,21 +48,8 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         // Deduplicate files for accurate estimation - only include workspace-targeted files
         var allFiles = configuration.GetWorkspaceUniqueFiles().ToList();
 
-        // Check if source and destination are on the same volume
-        var sourceRoot = Path.GetPathRoot(configuration.BaseInstallationPath);
-        var destRoot = Path.GetPathRoot(configuration.WorkspaceRootPath);
-
-        if (string.Equals(sourceRoot, destRoot, StringComparison.OrdinalIgnoreCase))
-        {
-            // Same volume: hard links use minimal space
-            // Even empty workspaces need some directory overhead
-            return Math.Max(LinkOverheadBytes, allFiles.Count * LinkOverheadBytes);
-        }
-        else
-        {
-            // Different volumes: will fall back to copying
-            return allFiles.Sum(f => f.Size);
-        }
+        // HardLink strategy enforces zero-copy (hard links or symlinks)
+        return Math.Max(LinkOverheadBytes, allFiles.Count * LinkOverheadBytes);
     }
 
     /// <inheritdoc/>
@@ -109,8 +97,7 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
             var totalFiles = prioritizedFiles.Count;
             var processedFiles = 0;
             long totalBytesProcessed = 0;
-            var hardLinkedFiles = 0;
-            var copiedFiles = 0;
+            var linkedFiles = 0;
 
             // Check if source and destination are on the same volume
             var sourceRoot = Path.GetPathRoot(configuration.BaseInstallationPath);
@@ -132,14 +119,10 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
                 {
                     if (file.SourceType == Core.Models.Enums.ContentSourceType.ContentAddressable && !string.IsNullOrEmpty(file.Hash))
                     {
-                        var (hardLinked, bytes) = await ProcessCasFileAsync(file, manifest, destinationPath, sameVolume, cancellationToken);
-                        if (hardLinked)
+                        var (linked, bytes) = await ProcessCasFileAsync(file, manifest, destinationPath, sameVolume, cancellationToken);
+                        if (linked)
                         {
-                            hardLinkedFiles++;
-                        }
-                        else
-                        {
-                            copiedFiles++;
+                            linkedFiles++;
                         }
 
                         totalBytesProcessed += bytes;
@@ -151,11 +134,7 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
                         {
                             if (processResult.HardLinked)
                             {
-                                hardLinkedFiles++;
-                            }
-                            else
-                            {
-                                copiedFiles++;
+                                linkedFiles++;
                             }
 
                             totalBytesProcessed += processResult.BytesProcessed;
@@ -173,7 +152,7 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
                 }
 
                 processedFiles++;
-                var operation = sameVolume ? "Hard linking" : "Copying";
+                var operation = sameVolume ? "Hard linking" : "Symlinking";
                 ReportProgress(progress, processedFiles, totalFiles, operation, file.RelativePath);
             }
 
@@ -181,10 +160,9 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
             workspaceInfo.IsPrepared = true;
 
             Logger.LogInformation(
-                "Hard link workspace prepared successfully at {WorkspacePath} with {HardLinked} hard links and {Copied} copies ({TotalSize} bytes)",
+                "Hard link workspace prepared successfully at {WorkspacePath} with {Linked} zero-copy links ({TotalSize} bytes)",
                 workspacePath,
-                hardLinkedFiles,
-                copiedFiles,
+                linkedFiles,
                 totalBytesProcessed);
 
             return workspaceInfo;
@@ -206,10 +184,10 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
     }
 
     /// <summary>
-    /// Attempts to create a hard link for the specified CAS file hash at the target path; falls back to copying if hard link creation fails.
+    /// Attempts to create a hard link for the specified CAS file hash at the target path; falls back to symlinking if hard link creation fails.
     /// </summary>
-    /// <param name="hash">The content-addressable storage (CAS) hash of the file to link or copy.</param>
-    /// <param name="targetPath">The destination path where the hard link or copy should be created.</param>
+    /// <param name="hash">The content-addressable storage (CAS) hash of the file to link.</param>
+    /// <param name="targetPath">The destination path where the link should be created.</param>
     /// <param name="contentType">The content type for pool-specific CAS lookup.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -218,11 +196,12 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         var success = await FileOperations.LinkFromCasAsync(hash, targetPath, useHardLink: true, contentType: contentType, cancellationToken: cancellationToken);
         if (!success)
         {
-            Logger.LogWarning("Hard link creation failed for hash {Hash}, attempting copy fallback", hash);
-            success = await FileOperations.CopyFromCasAsync(hash, targetPath, contentType: contentType, cancellationToken: cancellationToken);
+            Logger.LogWarning("Hard link creation failed for hash {Hash}, attempting symlink fallback", hash);
+            success = await FileOperations.LinkFromCasAsync(hash, targetPath, useHardLink: false, contentType: contentType, cancellationToken: cancellationToken);
             if (!success)
             {
-                throw new InvalidOperationException($"Failed to create hard link or copy from CAS for hash {hash} to {targetPath}");
+                throw new UnauthorizedAccessException(
+                    $"Failed to create hard link or symbolic link from CAS for hash {hash} to {targetPath}. {WorkspaceConstants.ZeroCopyElevationGuidance}");
             }
         }
     }
@@ -244,36 +223,46 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         var destRoot = Path.GetPathRoot(targetPath);
         var sameVolume = string.Equals(sourceRoot, destRoot, StringComparison.OrdinalIgnoreCase);
 
-        var verifyHash = !sameVolume;
         if (sameVolume)
         {
             try
             {
                 await FileOperations.CreateHardLinkAsync(targetPath, sourcePath, cancellationToken);
             }
-            catch (Exception hardLinkEx)
+            catch (Exception hardLinkEx) when (hardLinkEx is not OperationCanceledException)
             {
-                Logger.LogDebug(hardLinkEx, "Hard link creation failed for {RelativePath}, falling back to copy", file.RelativePath);
+                Logger.LogWarning(hardLinkEx, "Hard link creation failed for {RelativePath}, attempting symlink fallback", file.RelativePath);
 
-                // Fall back to copy
-                await FileOperations.CopyFileAsync(sourcePath, targetPath, cancellationToken);
-                verifyHash = true;
+                try
+                {
+                    await FileOperations.CreateSymlinkAsync(targetPath, sourcePath, allowFallback: false, cancellationToken);
+                }
+                catch (Exception symlinkEx) when (symlinkEx is not OperationCanceledException)
+                {
+                    Logger.LogError(
+                        symlinkEx,
+                        "Both hard link and symlink creation failed for {RelativePath}. Refusing to copy to prevent disk overhead.",
+                        file.RelativePath);
+
+                    throw WrapLinkException(file.RelativePath, symlinkEx);
+                }
             }
         }
         else
         {
-            // Different volumes, must copy
-            await FileOperations.CopyFileAsync(sourcePath, targetPath, cancellationToken);
-            verifyHash = true;
-        }
-
-        // Verify file integrity if hash is provided and file was copied
-        if (verifyHash && !string.IsNullOrEmpty(file.Hash))
-        {
-            var hashValid = await FileOperations.VerifyFileHashAsync(targetPath, file.Hash, cancellationToken);
-            if (!hashValid)
+            // Different volumes: create symlink to maintain zero-copy invariant
+            try
             {
-                Logger.LogWarning("Hash verification failed for file: {RelativePath}", file.RelativePath);
+                await FileOperations.CreateSymlinkAsync(targetPath, sourcePath, allowFallback: false, cancellationToken);
+            }
+            catch (Exception symlinkEx) when (symlinkEx is not OperationCanceledException)
+            {
+                Logger.LogError(
+                    symlinkEx,
+                    "Cross-volume symlink creation failed for {RelativePath}. Refusing to copy to prevent disk overhead.",
+                    file.RelativePath);
+
+                throw WrapLinkException(file.RelativePath, symlinkEx, isCrossVolume: true);
             }
         }
     }
@@ -287,6 +276,20 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         await ProcessLocalFileAsync(file, manifest, targetPath, configuration, cancellationToken);
     }
 
+    private static Exception WrapLinkException(string relativePath, Exception ex, bool isCrossVolume = false)
+    {
+        if (ex is OperationCanceledException or FileNotFoundException or DirectoryNotFoundException or PlatformNotSupportedException)
+        {
+            return ex;
+        }
+
+        var message = isCrossVolume
+            ? $"Failed to create symbolic link across different volumes for '{relativePath}'. {WorkspaceConstants.ZeroCopyElevationGuidance}"
+            : $"Failed to create hard link or symbolic link for '{relativePath}'. {WorkspaceConstants.ZeroCopyElevationGuidance}";
+
+        return new UnauthorizedAccessException(message, ex);
+    }
+
     private async Task<(bool HardLinked, long BytesProcessed)> ProcessCasFileAsync(
         ManifestFile file,
         ContentManifest manifest,
@@ -295,12 +298,7 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         CancellationToken cancellationToken)
     {
         await CreateCasLinkAsync(file.Hash!, destinationPath, manifest.ContentType, cancellationToken);
-        if (sameVolume)
-        {
-            return (true, LinkOverheadBytes);
-        }
-
-        return (false, file.Size);
+        return (true, LinkOverheadBytes);
     }
 
     private async Task<(bool Skipped, bool HardLinked, long BytesProcessed)> ProcessStandardFileAsync(
@@ -324,7 +322,6 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
             return (true, false, 0);
         }
 
-        bool verifyHash = false;
         bool hardLinked = false;
         long bytesProcessed = 0;
 
@@ -336,7 +333,6 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
                 return (true, false, 0);
             }
 
-            verifyHash = result.VerifyHash;
             hardLinked = result.HardLinked;
             bytesProcessed = result.BytesProcessed;
         }
@@ -348,24 +344,14 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
                 return (true, false, 0);
             }
 
-            verifyHash = result.VerifyHash;
             hardLinked = result.HardLinked;
             bytesProcessed = result.BytesProcessed;
-        }
-
-        if (verifyHash && !string.IsNullOrEmpty(file.Hash))
-        {
-            var hashValid = await FileOperations.VerifyFileHashAsync(destinationPath, file.Hash, cancellationToken);
-            if (!hashValid)
-            {
-                Logger.LogWarning("Hash verification failed for file: {RelativePath}", file.RelativePath);
-            }
         }
 
         return (false, hardLinked, bytesProcessed);
     }
 
-    private async Task<(bool Skipped, bool HardLinked, long BytesProcessed, bool VerifyHash)> ProcessSameVolumeFileAsync(
+    private async Task<(bool Skipped, bool HardLinked, long BytesProcessed)> ProcessSameVolumeFileAsync(
         ManifestFile file,
         string sourcePath,
         string destinationPath,
@@ -374,7 +360,7 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
         try
         {
             await FileOperations.CreateHardLinkAsync(destinationPath, sourcePath, cancellationToken);
-            return (false, true, LinkOverheadBytes, false);
+            return (false, true, LinkOverheadBytes);
         }
         catch (IOException ioEx)
         {
@@ -382,36 +368,29 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
                 ioEx.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase))
             {
                 Logger.LogWarning("Skipping missing file: {RelativePath} (source: {SourcePath})", file.RelativePath, sourcePath);
-                return (true, false, 0, false);
+                return (true, false, 0);
             }
 
-            Logger.LogDebug(ioEx, "Hard link creation failed for {RelativePath}, falling back to copy", file.RelativePath);
-
-            if (!File.Exists(sourcePath))
-            {
-                Logger.LogWarning("Skipping missing file during fallback: {RelativePath}", file.RelativePath);
-                return (true, false, 0, false);
-            }
+            Logger.LogWarning(ioEx, "Hard link creation failed for {RelativePath}, attempting symlink fallback", file.RelativePath);
 
             try
             {
-                await FileOperations.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
-                return (false, false, file.Size, true);
+                await FileOperations.CreateSymlinkAsync(destinationPath, sourcePath, allowFallback: false, cancellationToken);
+                return (false, true, LinkOverheadBytes);
             }
-            catch (IOException copyEx)
+            catch (Exception symlinkEx) when (symlinkEx is not OperationCanceledException)
             {
-                Logger.LogWarning(copyEx, "Failed to copy file, skipping: {RelativePath}", file.RelativePath);
-                return (true, false, 0, false);
+                Logger.LogError(
+                    symlinkEx,
+                    "Both hard link and symlink creation failed for {RelativePath}. Refusing to copy to prevent disk overhead.",
+                    file.RelativePath);
+
+                throw WrapLinkException(file.RelativePath, symlinkEx);
             }
-        }
-        catch (Exception hardLinkEx)
-        {
-            Logger.LogWarning(hardLinkEx, "Unexpected error processing file, skipping: {RelativePath}", file.RelativePath);
-            return (true, false, 0, false);
         }
     }
 
-    private async Task<(bool Skipped, bool HardLinked, long BytesProcessed, bool VerifyHash)> ProcessDifferentVolumeFileAsync(
+    private async Task<(bool Skipped, bool HardLinked, long BytesProcessed)> ProcessDifferentVolumeFileAsync(
         ManifestFile file,
         string sourcePath,
         string destinationPath,
@@ -419,11 +398,23 @@ public sealed class HardLinkStrategy(IFileOperationsService fileOperations, ILog
     {
         if (!File.Exists(sourcePath))
         {
-            Logger.LogWarning("Skipping missing file for copy: {RelativePath}", file.RelativePath);
-            return (true, false, 0, false);
+            Logger.LogWarning("Skipping missing file: {RelativePath} (source: {SourcePath})", file.RelativePath, sourcePath);
+            return (true, false, 0);
         }
 
-        await FileOperations.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
-        return (false, false, file.Size, true);
+        try
+        {
+            await FileOperations.CreateSymlinkAsync(destinationPath, sourcePath, allowFallback: false, cancellationToken);
+            return (false, true, LinkOverheadBytes);
+        }
+        catch (Exception symlinkEx) when (symlinkEx is not OperationCanceledException)
+        {
+            Logger.LogError(
+                symlinkEx,
+                "Cross-volume symlink creation failed for {RelativePath}. Refusing to copy to prevent disk overhead.",
+                file.RelativePath);
+
+            throw WrapLinkException(file.RelativePath, symlinkEx, isCrossVolume: true);
+        }
     }
 }

--- a/GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs
+++ b/GenHub/GenHub/Features/Workspace/UnixFileOperationsService.cs
@@ -101,8 +101,16 @@ public class UnixFileOperationsService(
 
         if (!useHardLink)
         {
-            await baseService.CreateSymlinkAsync(destinationPath, casPath, true, cancellationToken).ConfigureAwait(false);
-            return true;
+            try
+            {
+                await baseService.CreateSymlinkAsync(destinationPath, casPath, allowFallback: false, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogError(ex, "Failed to create symlink from CAS hash {Hash} to {DestinationPath}", hash, destinationPath);
+                return false;
+            }
         }
 
         try
@@ -110,17 +118,10 @@ public class UnixFileOperationsService(
             await CreateHardLinkAsync(destinationPath, casPath, cancellationToken).ConfigureAwait(false);
             return true;
         }
-        catch (IOException ex) when (ex is not FileNotFoundException)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // Cross-device or a filesystem without link support. Copying keeps the
-            // workspace usable; the caller loses deduplication, not correctness.
-            logger.LogWarning(
-                ex,
-                "Hard link from CAS failed for {Destination}; falling back to a copy",
-                destinationPath);
-
-            await baseService.CopyFileAsync(casPath, destinationPath, cancellationToken).ConfigureAwait(false);
-            return true;
+            logger.LogError(ex, "Failed to create hard link from CAS hash {Hash} to {DestinationPath}", hash, destinationPath);
+            return false;
         }
     }
 

--- a/GenHub/GenHub/Infrastructure/Converters/WorkspaceStrategyTooltipConverter.cs
+++ b/GenHub/GenHub/Infrastructure/Converters/WorkspaceStrategyTooltipConverter.cs
@@ -32,7 +32,7 @@ public class WorkspaceStrategyTooltipConverter : IValueConverter
                 WorkspaceStrategy.SymlinkOnly => "Creates symbolic links to all files. Minimal disk usage, requires admin rights. (Legacy)",
                 WorkspaceStrategy.FullCopy => "Copies all files to workspace. Maximum compatibility and isolation, highest disk usage.",
                 WorkspaceStrategy.HybridCopySymlink => "Copies essential files, symlinks others. Balanced disk usage and compatibility. (Legacy)",
-                WorkspaceStrategy.HardLink => "Creates hard links where possible, copies otherwise. Space-efficient, requires same volume. (Default)",
+                WorkspaceStrategy.HardLink => "Creates hard links or symbolic links to game files. Space-efficient zero-copy workspace (may require elevation for cross-volume links). (Default)",
                 _ => strategy.ToString(),
             };
         }

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -207,6 +207,22 @@ Configuration key constants for `appsettings.json` and environment variables.
 Constants related to workspace management and configuration.
 
 - `DefaultWorkspaceStrategy`: The default workspace strategy to use when none is specified (`WorkspaceStrategy.HardLink`)
+- `ZeroCopyElevationGuidance`: Guidance message appended to errors when zero-copy hard links or symlinks cannot be created (`"To use zero-copy workspaces without copying game files, ensure GenHub has permission to create links (on Windows, enable Developer Mode or run as Administrator)."`)
+
+---
+
+## CommandLineConstants Class
+
+Constants for command line arguments and URI schemes.
+
+| Constant                    | Value                 | Description                                                |
+| --------------------------- | --------------------- | ---------------------------------------------------------- |
+| `LaunchProfileArg`          | `"--launch-profile"`  | Command-line argument used to request launching a profile  |
+| `LaunchProfileInlinePrefix` | `"--launch-profile="` | Prefix for inline profile launching                        |
+| `UriScheme`                 | `"genhub://"`         | URI scheme used for protocol handling                      |
+| `SubscribeCommand`          | `"subscribe"`         | Command for subscribing to a catalog via URI               |
+| `SubscribeUriPrefix`        | `"genhub://subscribe"`| Full prefix for subscription URI                           |
+| `SubscribeUrlParam`         | `"?url="`             | Query parameter name for the catalog URL                   |
 
 ---
 
@@ -669,6 +685,7 @@ Constants related to game client detection and management.
 | -------------------- | ---------------- | ----------------------------- |
 | `GeneralsExecutable` | `"generals.exe"` | Generals executable filename  |
 | `ZeroHourExecutable` | `"game.exe"`     | Zero Hour executable filename |
+| `ContraExecutable`   | `"generals.ctr"` | Contra modded client executable filename |
 
 ### SuperHackers Client Detection
 
@@ -686,6 +703,15 @@ Constants related to game client detection and management.
 | `ZeroHourDirectoryNameAmpersandHyphen` | `"Command & Conquer Generals - Zero Hour"`  | Zero Hour directory name with ampersand and hyphen (Steam standard) |
 | `ZeroHourDirectoryNameColonVariant`    | `"Command & Conquer: Generals - Zero Hour"` | Zero Hour directory name with colon variant |
 | `ZeroHourDirectoryNameAbbreviated`     | `"C&C Generals Zero Hour"`                  | Zero Hour directory name abbreviated form |
+
+### Core Game Archives
+
+| Constant            | Value          | Description                              |
+| ------------------- | -------------- | ---------------------------------------- |
+| `ZeroHourIniBig`    | `"INIZH.big"`  | Primary Zero Hour INI archive filename   |
+| `ZeroHourPatchBig`  | `"PatchZH.big"`| Primary Zero Hour Patch archive filename |
+| `GeneralsIniBig`    | `"INI.big"`    | Primary Generals Vanilla INI archive     |
+| `GeneralsPatchBig`  | `"Patch.big"`  | Primary Generals Vanilla Patch archive   |
 
 ### GeneralsOnline Client Detection
 


### PR DESCRIPTION
## Summary
Resolves the game installation detection and manifest reconstruction regression where standalone Zero Hour installations (repacks and localized releases) were misclassified as Generals vanilla or failed to rebind launch profiles. Also preserves zero-copy workspace integrity by eliminating silent copy fallbacks for cross-volume links.

### Root Cause
1. **Zero Hour Archive Probing**: Previous archive checks only matched hardcoded `INIZH.big` and `PatchZH.big`, missing localized archives (e.g. `RussianZH.big`, `GermanZH.big`, `FrenchZH.big`) and repack configurations.
2. **Root Detection Precedence**: In root directories containing generic `INI.big` alongside Zero Hour naming or archives, `FetchRootInstallation` prematurely flagged Generals vanilla and returned, skipping directory name fallback.
3. **Manifest Reconstruction**: `LoadInstallationsFromManifestsAsync` discarded known game capabilities from CAS manifests when recreating installations on startup.
4. **Client Detection Trigger**: `TryLoadGameClientsFromManifestsAsync` suppressed fallback client detection when zero clients were populated from manifests.
5. **Path Matching**: Profile rebinding relied on exact string equality rather than normalized path comparisons, causing mismatches across path formats.

### Changes
- **Core Domain (`GameInstallation`)**:
  - Broadened Zero Hour archive detection to support all `*ZH.big` localized archives and client executables (`EAC_LaunchGeneralsOnline.exe`, `generals.ctr`).
  - Evaluated folder name heuristics upfront alongside archive signatures to prevent misclassification.
  - Preserved pre-configured and valid paths during `Fetch()`.
- **Game Installation Service (`GameInstallationService`)**:
  - Seeded game capabilities from CAS manifest pool metadata during startup reconstruction.
  - Triggered automatic fallback detection if no clients are populated from existing manifests.
- **Profile Launcher (`ProfileLauncherFacade`)**:
  - Replaced strict string comparison with `PathHelper.AreSamePath` for normalized profile rebinding.
- **Workspace Linking (`HardLinkStrategy`)**:
  - Eliminated silent copy fallback for cross-volume links, enforcing zero-copy symlinking with elevation guidance.
- **Tests**:
  - Added test cases covering standalone Zero Hour detection with generic bigs, localized archives, path preservation, and manifest capability reconstruction.

### Verification
- [x] All 2,164 Core unit tests pass (`dotnet test GenHub.Tests.Core.csproj`)
- [x] All 14 Linux platform unit tests pass (`dotnet test GenHub.Tests.Linux.csproj`)
- [x] Verified zero-copy workspace hardlink and symlink strategies