### PR TITLE
fix(appupdate): close update lifetime disposal races

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
@@ -355,6 +356,59 @@ public class BackgroundUpdateCoordinatorTests
     }
 
     /// <summary>
+    /// Verifies that a persistent update notification cannot start installation after the coordinator is disposed.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task UpdateNotificationAction_WhenCoordinatorDisposed_DoesNotInstallArtifactAsync()
+    {
+        var notificationShownTcs = new TaskCompletionSource<NotificationMessage>();
+        var settings = new UserSettings { SubscribedPrNumber = 100 };
+        var mockUserSettings = new Mock<IUserSettingsService>();
+        mockUserSettings.Setup(x => x.Get()).Returns(settings);
+
+        var artifactInfo = new ArtifactUpdateInfo(
+            Version: "0.0.99999-pr100",
+            GitHash: "abc1234",
+            PullRequestNumber: 100,
+            WorkflowRunId: 12345,
+            WorkflowRunUrl: "https://example.com/runs/1",
+            ArtifactId: 67890,
+            ArtifactName: "genhub-velopack-linux-0.0.99999",
+            CreatedAt: DateTime.UtcNow,
+            DownloadUrl: "https://example.com/artifact.zip",
+            Size: 1024);
+
+        var mockVelopack = new Mock<IVelopackUpdateManager>();
+        mockVelopack.SetupProperty(x => x.SubscribedPrNumber, 100);
+        mockVelopack.Setup(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifactInfo);
+
+        var mockNotificationService = CreateNotificationServiceMock();
+        mockNotificationService.Setup(x => x.Show(It.IsAny<NotificationMessage>()))
+            .Callback<NotificationMessage>(message => notificationShownTcs.TrySetResult(message));
+
+        var coordinator = new BackgroundUpdateCoordinator(
+            mockVelopack.Object,
+            mockUserSettings.Object,
+            mockNotificationService.Object,
+            new Mock<ILogger<BackgroundUpdateCoordinator>>().Object);
+
+        await coordinator.CheckForUpdatesAsync();
+        var updateNotification = await notificationShownTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        coordinator.Dispose();
+
+        updateNotification.Actions[0].Callback?.Invoke();
+
+        mockVelopack.Verify(
+            x => x.InstallArtifactAsync(It.IsAny<ArtifactUpdateInfo>(), It.IsAny<IProgress<UpdateProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        mockNotificationService.Verify(
+            x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Verifies that checking updates repeatedly with the same version deduplicates notifications.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -632,6 +686,35 @@ public class BackgroundUpdateCoordinatorTests
         });
 
         Assert.Null(exception);
+    }
+
+    /// <summary>
+    /// Verifies that a timer callback carrying a cancelled lifetime token does not start an update check.
+    /// </summary>
+    [Fact]
+    public void OnPeriodicUpdateTimerCallback_WhenLifetimeCancelled_DoesNotCheckForUpdates()
+    {
+        var mockVelopack = new Mock<IVelopackUpdateManager>();
+        var mockUserSettings = new Mock<IUserSettingsService>();
+        mockUserSettings.Setup(x => x.Get()).Returns(new UserSettings());
+
+        using var coordinator = new BackgroundUpdateCoordinator(
+            mockVelopack.Object,
+            mockUserSettings.Object,
+            CreateNotificationServiceMock().Object,
+            new Mock<ILogger<BackgroundUpdateCoordinator>>().Object);
+        using var lifetimeCts = new CancellationTokenSource();
+        lifetimeCts.Cancel();
+
+        var callback = typeof(BackgroundUpdateCoordinator).GetMethod(
+            "OnPeriodicUpdateTimerCallback",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(callback);
+        callback.Invoke(coordinator, [lifetimeCts.Token]);
+
+        mockVelopack.Verify(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        mockVelopack.Verify(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static Mock<INotificationService> CreateNotificationServiceMock()

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
@@ -409,6 +409,87 @@ public class BackgroundUpdateCoordinatorTests
     }
 
     /// <summary>
+    /// Verifies that disposing the coordinator cancels an update installation without showing an error.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task UpdateNotificationAction_WhenDisposedDuringInstall_CancelsWithoutErrorAsync()
+    {
+        var updateNotificationShown = new TaskCompletionSource<NotificationMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var installStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var installCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var progressDismissed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var settings = new UserSettings { SubscribedPrNumber = 100 };
+        var mockUserSettings = new Mock<IUserSettingsService>();
+        mockUserSettings.Setup(x => x.Get()).Returns(settings);
+
+        var artifactInfo = new ArtifactUpdateInfo(
+            Version: "0.0.99999-pr100",
+            GitHash: "abc1234",
+            PullRequestNumber: 100,
+            WorkflowRunId: 12345,
+            WorkflowRunUrl: "https://example.com/runs/1",
+            ArtifactId: 67890,
+            ArtifactName: "genhub-velopack-linux-0.0.99999",
+            CreatedAt: DateTime.UtcNow,
+            DownloadUrl: "https://example.com/artifact.zip",
+            Size: 1024);
+
+        var mockVelopack = new Mock<IVelopackUpdateManager>();
+        mockVelopack.SetupProperty(x => x.SubscribedPrNumber, 100);
+        mockVelopack.Setup(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifactInfo);
+        mockVelopack.Setup(x => x.InstallArtifactAsync(
+                artifactInfo,
+                It.IsAny<IProgress<UpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<ArtifactUpdateInfo, IProgress<UpdateProgress>?, CancellationToken>(async (_, _, token) =>
+            {
+                installStarted.TrySetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    installCancelled.TrySetResult(true);
+                    throw;
+                }
+            });
+
+        var mockNotificationService = CreateNotificationServiceMock();
+        mockNotificationService.Setup(x => x.Show(It.IsAny<NotificationMessage>()))
+            .Callback<NotificationMessage>(message =>
+            {
+                if (message.Title == AppUpdateConstants.PrUpdateAvailableNotificationTitle)
+                {
+                    updateNotificationShown.TrySetResult(message);
+                }
+            });
+        mockNotificationService.Setup(x => x.Dismiss(It.IsAny<Guid>()))
+            .Callback(() => progressDismissed.TrySetResult(true));
+
+        var coordinator = new BackgroundUpdateCoordinator(
+            mockVelopack.Object,
+            mockUserSettings.Object,
+            mockNotificationService.Object,
+            new Mock<ILogger<BackgroundUpdateCoordinator>>().Object);
+
+        await coordinator.CheckForUpdatesAsync();
+        var updateNotification = await updateNotificationShown.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        updateNotification.Actions[0].Callback?.Invoke();
+        await installStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        coordinator.Dispose();
+
+        await installCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await progressDismissed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        mockNotificationService.Verify(
+            x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Verifies that checking updates repeatedly with the same version deduplicates notifications.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -484,6 +565,51 @@ public class BackgroundUpdateCoordinatorTests
             mockLogger.Object);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => coordinator.CheckForUpdatesAsync(cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that disposing the coordinator cancels a direct update check and suppresses notifications.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckForUpdatesAsync_WhenDisposedDuringCheck_CancelsWithoutNotificationAsync()
+    {
+        var checkStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var mockVelopack = new Mock<IVelopackUpdateManager>();
+        mockVelopack.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async token =>
+            {
+                checkStarted.TrySetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    checkCancelled.TrySetResult(true);
+                    throw;
+                }
+
+                return null;
+            });
+
+        var mockUserSettings = new Mock<IUserSettingsService>();
+        mockUserSettings.Setup(x => x.Get()).Returns(new UserSettings());
+        var mockNotificationService = CreateNotificationServiceMock();
+        var coordinator = new BackgroundUpdateCoordinator(
+            mockVelopack.Object,
+            mockUserSettings.Object,
+            mockNotificationService.Object,
+            new Mock<ILogger<BackgroundUpdateCoordinator>>().Object);
+
+        var checkTask = coordinator.CheckForUpdatesAsync();
+        await checkStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        coordinator.Dispose();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => checkTask);
+        await checkCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        mockNotificationService.Verify(x => x.Show(It.IsAny<NotificationMessage>()), Times.Never);
     }
 
     /// <summary>
@@ -689,32 +815,60 @@ public class BackgroundUpdateCoordinatorTests
     }
 
     /// <summary>
-    /// Verifies that a timer callback carrying a cancelled lifetime token does not start an update check.
+    /// Verifies that disposing the coordinator cancels a check started by its periodic timer.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public void OnPeriodicUpdateTimerCallback_WhenLifetimeCancelled_DoesNotCheckForUpdates()
+    public async Task PeriodicUpdateTimer_WhenCoordinatorDisposed_CancelsInFlightCheckAsync()
     {
+        var checkStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var mockVelopack = new Mock<IVelopackUpdateManager>();
-        var mockUserSettings = new Mock<IUserSettingsService>();
-        mockUserSettings.Setup(x => x.Get()).Returns(new UserSettings());
+        mockVelopack.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async token =>
+            {
+                checkStarted.TrySetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    checkCancelled.TrySetResult(true);
+                    throw;
+                }
 
-        using var coordinator = new BackgroundUpdateCoordinator(
+                return null;
+            });
+
+        var mockUserSettings = new Mock<IUserSettingsService>();
+        mockUserSettings.Setup(x => x.Get()).Returns(new UserSettings
+        {
+            AutoCheckForUpdatesOnStartup = false,
+            AutoCheckForUpdatesPeriodically = true,
+            PeriodicUpdateCheckIntervalMinutes = 15,
+        });
+        var mockNotificationService = CreateNotificationServiceMock();
+
+        var coordinator = new BackgroundUpdateCoordinator(
             mockVelopack.Object,
             mockUserSettings.Object,
-            CreateNotificationServiceMock().Object,
+            mockNotificationService.Object,
             new Mock<ILogger<BackgroundUpdateCoordinator>>().Object);
-        using var lifetimeCts = new CancellationTokenSource();
-        lifetimeCts.Cancel();
+        await coordinator.InitializeAsync();
 
-        var callback = typeof(BackgroundUpdateCoordinator).GetMethod(
-            "OnPeriodicUpdateTimerCallback",
+        var timerField = typeof(BackgroundUpdateCoordinator).GetField(
+            "_periodicUpdateTimer",
             BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(timerField);
+        var timer = Assert.IsType<Timer>(timerField.GetValue(coordinator));
+        timer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan);
+        await checkStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.NotNull(callback);
-        callback.Invoke(coordinator, [lifetimeCts.Token]);
+        coordinator.Dispose();
 
-        mockVelopack.Verify(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()), Times.Never);
-        mockVelopack.Verify(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        await checkCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        mockNotificationService.Verify(x => x.Show(It.IsAny<NotificationMessage>()), Times.Never);
     }
 
     private static Mock<INotificationService> CreateNotificationServiceMock()

--- a/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
@@ -37,6 +37,7 @@ public class BackgroundUpdateCoordinator(
     IGitHubTokenStorage? gitHubTokenStorage = null) : IBackgroundUpdateCoordinator, IRecipient<UpdateSettingsChangedMessage>
 {
     private readonly CancellationTokenSource _cts = new();
+    private readonly object _lifecycleLock = new();
     private readonly SemaphoreSlim _checkLock = new(1, 1);
     private Timer? _periodicUpdateTimer;
     private string? _lastNotifiedUpdateIdentity;
@@ -48,9 +49,9 @@ public class BackgroundUpdateCoordinator(
         RegisterMessages();
 
         var settings = userSettingsService.Get();
-        if (settings.AutoCheckForUpdatesOnStartup)
+        if (settings.AutoCheckForUpdatesOnStartup && TryGetLifetimeToken(out var lifetimeToken))
         {
-            _ = CheckForUpdatesOnStartupAsync(cancellationToken);
+            _ = CheckForUpdatesOnStartupAsync(lifetimeToken, cancellationToken);
         }
 
         RestartPeriodicUpdateTimer(settings.AutoCheckForUpdatesPeriodically, settings.PeriodicUpdateCheckIntervalMinutes);
@@ -136,9 +137,17 @@ public class BackgroundUpdateCoordinator(
     /// <param name="disposing">True if disposing managed resources; false if finalizing.</param>
     protected virtual void Dispose(bool disposing)
     {
-        if (_disposed)
+        Timer? timerToDispose = null;
+        lock (_lifecycleLock)
         {
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            timerToDispose = _periodicUpdateTimer;
+            _periodicUpdateTimer = null;
         }
 
         if (disposing)
@@ -147,6 +156,7 @@ public class BackgroundUpdateCoordinator(
 
             try
             {
+                // Cancel first so callbacks already holding the token observe shutdown before the source is disposed.
                 _cts.Cancel();
             }
             catch (ObjectDisposedException)
@@ -154,12 +164,9 @@ public class BackgroundUpdateCoordinator(
                 // Ignore if already disposed
             }
 
-            _periodicUpdateTimer?.Dispose();
-            _periodicUpdateTimer = null;
+            timerToDispose?.Dispose();
             _cts.Dispose();
         }
-
-        _disposed = true;
     }
 
     private void RegisterMessages()
@@ -688,6 +695,12 @@ public class BackgroundUpdateCoordinator(
         int? clearedPrNumber = null,
         string? clearedBranch = null)
     {
+        if (!TryGetLifetimeToken(out var lifetimeToken))
+        {
+            logger?.LogDebug("Skipping update installation because the coordinator is disposed");
+            return;
+        }
+
         var progressNotificationId = Guid.NewGuid();
 
         try
@@ -729,8 +742,8 @@ public class BackgroundUpdateCoordinator(
             if (artifactUpdate != null)
             {
                 logger?.LogInformation("Starting one-click artifact install: {Version}", artifactUpdate.DisplayVersion);
-                await velopackUpdateManager.InstallArtifactAsync(artifactUpdate, progress, _cts.Token);
-                await ClearStaleSubscriptionAsync(clearedPrNumber, clearedBranch);
+                await velopackUpdateManager.InstallArtifactAsync(artifactUpdate, progress, lifetimeToken);
+                await ClearStaleSubscriptionAsync(clearedPrNumber, clearedBranch, lifetimeToken);
                 notificationService.Update(
                     progressNotificationId,
                     AppUpdateConstants.UpdateCompleteRestartingMessage,
@@ -739,8 +752,8 @@ public class BackgroundUpdateCoordinator(
             else if (updateInfo != null)
             {
                 logger?.LogInformation("Starting one-click release update: {Version}", updateInfo.TargetFullRelease.Version);
-                await velopackUpdateManager.DownloadUpdatesAsync(updateInfo, progress, _cts.Token);
-                await ClearStaleSubscriptionAsync(clearedPrNumber, clearedBranch);
+                await velopackUpdateManager.DownloadUpdatesAsync(updateInfo, progress, lifetimeToken);
+                await ClearStaleSubscriptionAsync(clearedPrNumber, clearedBranch, lifetimeToken);
                 notificationService.Update(
                     progressNotificationId,
                     AppUpdateConstants.UpdateDownloadedRestartingMessage,
@@ -765,7 +778,10 @@ public class BackgroundUpdateCoordinator(
         }
     }
 
-    private async Task ClearStaleSubscriptionAsync(int? clearedPrNumber, string? clearedBranch)
+    private async Task ClearStaleSubscriptionAsync(
+        int? clearedPrNumber,
+        string? clearedBranch,
+        CancellationToken cancellationToken)
     {
         if (!clearedPrNumber.HasValue && string.IsNullOrEmpty(clearedBranch))
         {
@@ -787,7 +803,7 @@ public class BackgroundUpdateCoordinator(
                     settings.SubscribedBranch = null;
                 }
             });
-            await userSettingsService.SaveAsync(_cts.Token);
+            await userSettingsService.SaveAsync(cancellationToken);
             logger?.LogInformation(
                 "Cleared stale subscription (PR: {PrNumber}, Branch: {Branch}) after applying fallback update",
                 clearedPrNumber,
@@ -816,9 +832,9 @@ public class BackgroundUpdateCoordinator(
         });
     }
 
-    private async Task CheckForUpdatesOnStartupAsync(CancellationToken cancellationToken)
+    private async Task CheckForUpdatesOnStartupAsync(CancellationToken lifetimeToken, CancellationToken cancellationToken)
     {
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(lifetimeToken, cancellationToken);
         await CheckForUpdatesInBackgroundAsync(linkedCts.Token);
     }
 
@@ -840,37 +856,61 @@ public class BackgroundUpdateCoordinator(
 
     private void RestartPeriodicUpdateTimer(bool enabled, int intervalMinutes)
     {
-        _periodicUpdateTimer?.Dispose();
-        _periodicUpdateTimer = null;
-
-        if (!enabled || intervalMinutes <= 0)
+        Timer? timerToDispose = null;
+        lock (_lifecycleLock)
         {
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+
+            timerToDispose = _periodicUpdateTimer;
+            _periodicUpdateTimer = null;
+
+            if (enabled && intervalMinutes > 0)
+            {
+                var clampedInterval = Math.Clamp(
+                    intervalMinutes,
+                    AppUpdateConstants.MinPeriodicUpdateCheckIntervalMinutes,
+                    AppUpdateConstants.MaxPeriodicUpdateCheckIntervalMinutes);
+
+                var interval = TimeSpan.FromMinutes(clampedInterval);
+                logger?.LogDebug("Starting periodic update check timer with interval: {Interval}", interval);
+
+                _periodicUpdateTimer = new Timer(
+                    OnPeriodicUpdateTimerCallback,
+                    _cts.Token,
+                    interval,
+                    interval);
+            }
         }
 
-        var clampedInterval = Math.Clamp(
-            intervalMinutes,
-            AppUpdateConstants.MinPeriodicUpdateCheckIntervalMinutes,
-            AppUpdateConstants.MaxPeriodicUpdateCheckIntervalMinutes);
-
-        var interval = TimeSpan.FromMinutes(clampedInterval);
-        logger?.LogDebug("Starting periodic update check timer with interval: {Interval}", interval);
-
-        _periodicUpdateTimer = new Timer(
-            OnPeriodicUpdateTimerCallback,
-            null,
-            interval,
-            interval);
+        timerToDispose?.Dispose();
     }
 
     private void OnPeriodicUpdateTimerCallback(object? state)
     {
-        if (_disposed || _cts.IsCancellationRequested)
+        if (state is not CancellationToken lifetimeToken || lifetimeToken.IsCancellationRequested)
         {
             return;
         }
 
         logger?.LogDebug("Periodic update check timer triggered");
-        _ = CheckForUpdatesInBackgroundAsync(_cts.Token);
+        _ = CheckForUpdatesInBackgroundAsync(lifetimeToken);
+    }
+
+    private bool TryGetLifetimeToken(out CancellationToken lifetimeToken)
+    {
+        lock (_lifecycleLock)
+        {
+            if (_disposed)
+            {
+                lifetimeToken = default;
+                return false;
+            }
+
+            lifetimeToken = _cts.Token;
+            return true;
+        }
     }
 }

--- a/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
@@ -61,11 +61,19 @@ public class BackgroundUpdateCoordinator(
     /// <inheritdoc/>
     public async Task CheckForUpdatesAsync(CancellationToken cancellationToken = default)
     {
+        if (!TryGetLifetimeToken(out var lifetimeToken))
+        {
+            return;
+        }
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(lifetimeToken, cancellationToken);
+        var effectiveToken = linkedCts.Token;
+
         logger?.LogDebug("Starting background update check");
 
         try
         {
-            await _checkLock.WaitAsync(cancellationToken);
+            await _checkLock.WaitAsync(effectiveToken);
         }
         catch (ObjectDisposedException)
         {
@@ -79,19 +87,19 @@ public class BackgroundUpdateCoordinator(
             // 1. check for subscribed pr artifacts
             if (settings.SubscribedPrNumber.HasValue)
             {
-                await CheckSubscribedPrUpdateAsync(settings.SubscribedPrNumber.Value, settings, cancellationToken);
+                await CheckSubscribedPrUpdateAsync(settings.SubscribedPrNumber.Value, settings, effectiveToken);
                 return;
             }
 
             // 2. check for subscribed branch artifacts
             if (!string.IsNullOrWhiteSpace(settings.SubscribedBranch))
             {
-                await CheckSubscribedBranchUpdateAsync(settings.SubscribedBranch, settings, cancellationToken);
+                await CheckSubscribedBranchUpdateAsync(settings.SubscribedBranch, settings, effectiveToken);
                 return;
             }
 
             // 3. check for standard github releases
-            await CheckStandardReleaseUpdateAsync(settings, cancellationToken);
+            await CheckStandardReleaseUpdateAsync(settings, effectiveToken);
         }
         catch (OperationCanceledException)
         {
@@ -137,6 +145,19 @@ public class BackgroundUpdateCoordinator(
     /// <param name="disposing">True if disposing managed resources; false if finalizing.</param>
     protected virtual void Dispose(bool disposing)
     {
+        if (disposing)
+        {
+            try
+            {
+                // Cancel before publishing the disposed state so every observer of shutdown sees a cancelled token.
+                _cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Ignore if another Dispose call already completed.
+            }
+        }
+
         Timer? timerToDispose = null;
         lock (_lifecycleLock)
         {
@@ -153,17 +174,6 @@ public class BackgroundUpdateCoordinator(
         if (disposing)
         {
             WeakReferenceMessenger.Default.UnregisterAll(this);
-
-            try
-            {
-                // Cancel first so callbacks already holding the token observe shutdown before the source is disposed.
-                _cts.Cancel();
-            }
-            catch (ObjectDisposedException)
-            {
-                // Ignore if already disposed
-            }
-
             timerToDispose?.Dispose();
             _cts.Dispose();
         }
@@ -767,6 +777,10 @@ public class BackgroundUpdateCoordinator(
                 OpenUpdateSettings();
             }
         }
+        catch (OperationCanceledException) when (lifetimeToken.IsCancellationRequested)
+        {
+            notificationService.Dismiss(progressNotificationId);
+        }
         catch (Exception ex)
         {
             logger?.LogError(ex, "Failed to install update");
@@ -808,6 +822,10 @@ public class BackgroundUpdateCoordinator(
                 "Cleared stale subscription (PR: {PrNumber}, Branch: {Branch}) after applying fallback update",
                 clearedPrNumber,
                 clearedBranch);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Problem

Update callbacks could access the coordinator’s cancellation source while it was being disposed. Persistent notification actions retained the same unsafe access path.

## Fix

- Pass captured lifetime tokens to timer callbacks.
- Serialize timer replacement and disposal.
- Cancel before disposing so in-flight callbacks observe shutdown.
- Route startup, installation, download, and settings-save operations through captured tokens.
- Ignore persistent update actions after disposal.
- Add regression coverage for timer and notification-action shutdown behavior.

## Testing

`BackgroundUpdateCoordinatorTests`: 13 passed using .NET SDK 8.0.424.

Addresses https://github.com/community-outpost/GenHub/pull/378#discussion_r3859171675

Model/harness: GPT-5 / Codex desktop.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the background update coordinator against disposal races.
- Captures and propagates coordinator lifetime tokens through update checks, installs, downloads, and settings saves.
- Serializes periodic-timer replacement and disposal.
- Prevents retained notification actions from starting updates after disposal.
- Adds regression coverage using the coordinator-created timer and in-flight update operations.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no outstanding actionable failures identified.

The previously reported timer-test weakness was addressed by exercising the coordinator-created timer across disposal, and the new cancellation and lifecycle changes are covered by focused regression tests. No confirmed repository-rule or security violations remain.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs | Coordinates lifetime-token capture, cancellation-before-disposal, serialized timer replacement, and post-disposal action guards. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs | Adds shutdown regression tests and replaces the artificial timer-token test with an in-flight check driven by the coordinator’s actual timer. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Initialize coordinator] --> B[Capture lifetime token]
    B --> C{Start operation}
    C --> D[Periodic update check]
    C --> E[Notification update action]
    C --> F[Direct update check]
    G[Dispose coordinator] --> H[Cancel lifetime token]
    H --> I[Mark disposed and detach timer]
    I --> J[Dispose timer and token source]
    H --> K[In-flight operations observe cancellation]
    K --> L[Suppress errors and dismiss progress]
    I --> M[Later actions and checks return without starting]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(appupdate): complete coordinator shu..."](https://github.com/community-outpost/genhub/commit/53d5fdaa7d2137e95fcb19dc696f7662ad70d061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60605137)</sub>

<!-- /greptile_comment -->