### PR TITLE
fix(appupdate): fall back from main artifacts to releases

### DIFF
--- a/GenHub/GenHub.Core/Constants/AppUpdateConstants.cs
+++ b/GenHub/GenHub.Core/Constants/AppUpdateConstants.cs
@@ -244,6 +244,11 @@ public static class AppUpdateConstants
     public const string MainBranch = "main";
 
     /// <summary>
+    /// Log message used when a main-branch artifact check falls back to standard releases.
+    /// </summary>
+    public const string MainBranchReleaseFallbackLogMessage = "Main branch has no artifact update; checking standard releases instead";
+
+    /// <summary>
     /// Update available notification title when a subscribed PR has been merged or closed.
     /// </summary>
     public const string PrMergedUpdateAvailableNotificationTitle = "PR Merged — Update Available";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
@@ -276,10 +276,19 @@ public class BackgroundUpdateCoordinatorTests
         mockVelopack.SetupProperty(x => x.SubscribedBranch, AppUpdateConstants.MainBranch);
         mockVelopack.Setup(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync((ArtifactUpdateInfo?)null);
+        var stableRelease = new Velopack.VelopackAsset
+        {
+            PackageId = "GenHub",
+            Version = NuGet.Versioning.NuGetVersion.Parse("1.5.0"),
+            Type = Velopack.VelopackAssetType.Full,
+            FileName = "GenHub-1.5.0-full.nupkg",
+            SHA1 = "0000000000000000000000000000000000000000",
+            Size = 1024,
+        };
+        var stableUpdate = new Velopack.UpdateInfo(stableRelease, false, null, []);
         mockVelopack.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Velopack.UpdateInfo?)null);
-        mockVelopack.SetupGet(x => x.HasUpdateAvailableFromGitHub).Returns(true);
-        mockVelopack.SetupGet(x => x.LatestVersionFromGitHub).Returns("1.5.0");
+            .ReturnsAsync(stableUpdate);
+        mockVelopack.SetupGet(x => x.HasUpdateAvailableFromGitHub).Returns(false);
 
         var mockTokenStorage = new Mock<IGitHubTokenStorage>();
         mockTokenStorage.Setup(x => x.HasToken()).Returns(true);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
+using GenHub.Core.Interfaces.GitHub;
 using GenHub.Core.Interfaces.Notifications;
 using GenHub.Core.Messages;
 using GenHub.Core.Models.AppUpdate;
@@ -256,6 +257,41 @@ public class BackgroundUpdateCoordinatorTests
         Assert.NotNull(updateNotification);
         Assert.Equal(AppUpdateConstants.BranchStaleUpdateAvailableNotificationTitle, updateNotification.Title);
         Assert.Contains("1.5.0", updateNotification.Message);
+    }
+
+    /// <summary>
+    /// Verifies that a token-authenticated main subscription falls back to standard releases when no branch artifact exists.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckForUpdatesAsync_WhenMainBranchHasNoArtifact_FallsBackToStandardReleaseAsync()
+    {
+        var settings = new UserSettings { SubscribedBranch = AppUpdateConstants.MainBranch };
+        var mockUserSettings = new Mock<IUserSettingsService>();
+        mockUserSettings.Setup(x => x.Get()).Returns(settings);
+
+        var mockVelopack = new Mock<IVelopackUpdateManager>();
+        mockVelopack.SetupProperty(x => x.SubscribedPrNumber, null);
+        mockVelopack.SetupProperty(x => x.SubscribedBranch, AppUpdateConstants.MainBranch);
+        mockVelopack.Setup(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ArtifactUpdateInfo?)null);
+        mockVelopack.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Velopack.UpdateInfo?)null);
+
+        var mockTokenStorage = new Mock<IGitHubTokenStorage>();
+        mockTokenStorage.Setup(x => x.HasToken()).Returns(true);
+
+        using var coordinator = new BackgroundUpdateCoordinator(
+            mockVelopack.Object,
+            mockUserSettings.Object,
+            CreateNotificationServiceMock().Object,
+            new Mock<ILogger<BackgroundUpdateCoordinator>>().Object,
+            mockTokenStorage.Object);
+
+        await coordinator.CheckForUpdatesAsync();
+
+        mockVelopack.Verify(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        mockVelopack.Verify(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs
@@ -260,12 +260,13 @@ public class BackgroundUpdateCoordinatorTests
     }
 
     /// <summary>
-    /// Verifies that a token-authenticated main subscription falls back to standard releases when no branch artifact exists.
+    /// Verifies that a token-authenticated main subscription notifies from the release fallback when no branch artifact exists.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task CheckForUpdatesAsync_WhenMainBranchHasNoArtifact_FallsBackToStandardReleaseAsync()
+    public async Task CheckForUpdatesAsync_WhenMainBranchHasNoArtifact_NotifiesFromStandardReleaseFallbackAsync()
     {
+        var notificationShown = new TaskCompletionSource<NotificationMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         var settings = new UserSettings { SubscribedBranch = AppUpdateConstants.MainBranch };
         var mockUserSettings = new Mock<IUserSettingsService>();
         mockUserSettings.Setup(x => x.Get()).Returns(settings);
@@ -277,21 +278,32 @@ public class BackgroundUpdateCoordinatorTests
             .ReturnsAsync((ArtifactUpdateInfo?)null);
         mockVelopack.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync((Velopack.UpdateInfo?)null);
+        mockVelopack.SetupGet(x => x.HasUpdateAvailableFromGitHub).Returns(true);
+        mockVelopack.SetupGet(x => x.LatestVersionFromGitHub).Returns("1.5.0");
 
         var mockTokenStorage = new Mock<IGitHubTokenStorage>();
         mockTokenStorage.Setup(x => x.HasToken()).Returns(true);
+        var mockNotificationService = CreateNotificationServiceMock();
+        mockNotificationService.Setup(x => x.Show(It.IsAny<NotificationMessage>()))
+            .Callback<NotificationMessage>(message => notificationShown.TrySetResult(message));
 
         using var coordinator = new BackgroundUpdateCoordinator(
             mockVelopack.Object,
             mockUserSettings.Object,
-            CreateNotificationServiceMock().Object,
+            mockNotificationService.Object,
             new Mock<ILogger<BackgroundUpdateCoordinator>>().Object,
             mockTokenStorage.Object);
 
         await coordinator.CheckForUpdatesAsync();
+        var notification = await notificationShown.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         mockVelopack.Verify(x => x.CheckForArtifactUpdatesAsync(It.IsAny<CancellationToken>()), Times.Once);
         mockVelopack.Verify(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal(AppUpdateConstants.UpdateAvailableNotificationTitle, notification.Title);
+        Assert.Contains("1.5.0", notification.Message);
+        Assert.Single(notification.Actions);
+        Assert.True(notification.IsPersistent);
+        Assert.True(notification.ShowInBadge);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
@@ -439,6 +439,13 @@ public class BackgroundUpdateCoordinator(
             !string.Equals(branch, AppUpdateConstants.MainBranch, StringComparison.OrdinalIgnoreCase))
         {
             await CheckStaleBranchFallbackUpdateAsync(branch, settings, cancellationToken);
+            return;
+        }
+
+        if (string.Equals(branch, AppUpdateConstants.MainBranch, StringComparison.OrdinalIgnoreCase))
+        {
+            logger?.LogDebug("Main branch has no artifact update; checking standard releases instead");
+            await CheckStandardReleaseUpdateAsync(settings, cancellationToken);
         }
     }
 

--- a/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
@@ -444,7 +444,7 @@ public class BackgroundUpdateCoordinator(
 
         if (string.Equals(branch, AppUpdateConstants.MainBranch, StringComparison.OrdinalIgnoreCase))
         {
-            logger?.LogDebug("Main branch has no artifact update; checking standard releases instead");
+            logger?.LogDebug(AppUpdateConstants.MainBranchReleaseFallbackLogMessage);
             await CheckStandardReleaseUpdateAsync(settings, cancellationToken);
         }
     }


### PR DESCRIPTION
## Problem

Token-authenticated users subscribed to `main` receive no stable-release notification when no branch artifact exists.

## Fix

Fall back to the standard release check when the `main` artifact check returns nothing, matching the existing no-token behavior. Includes regression coverage.

## Testing

`BackgroundUpdateCoordinatorTests`: 12 passed using .NET SDK 8.0.424.

Addresses https://github.com/community-outpost/GenHub/pull/378#discussion_r3859171670

Model/harness: GPT-5 / Codex desktop.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ensures token-authenticated users subscribed to `main` fall back to the standard stable-release check when no branch artifact is available.
- Adds the standard-release fallback after an empty `main` artifact result.
- Moves the fallback log message into the dedicated application-update constants class.
- Strengthens regression coverage by verifying the resulting stable-release notification and its user-visible properties.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the fallback behavior is narrowly implemented and the strengthened regression test covers the targeted notification path.

No new actionable issues remain. Both previous findings are resolved: the diagnostic message now resides in `AppUpdateConstants`, and the regression test now exercises a concrete stable update and verifies notification delivery.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs | Adds the intended standard-release fallback for `main` subscriptions after an empty artifact result without altering the non-main fallback path. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/BackgroundUpdateCoordinatorTests.cs | Extends the regression test to return a stable update and verify that the expected user-visible notification is delivered. |
| GenHub/GenHub.Core/Constants/AppUpdateConstants.cs | Defines the fallback diagnostic message in the repository’s dedicated constants class. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Background update check] --> B{Authenticated branch subscription?}
    B -->|main| C[Check main artifact]
    C -->|Artifact available| D[Handle artifact update]
    C -->|No artifact| E[Check standard stable release]
    E -->|Release available| F[Show persistent update notification]
    E -->|No release| G[No notification]
    B -->|non-main branch| H[Existing stale-branch fallback]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(appupdate): exercise stable release..."](https://github.com/community-outpost/genhub/commit/4c1f6e6b1f778a8f65cafc4b0411800807cd66a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60605133)</sub>

<!-- /greptile_comment -->