### PR TITLE
fix(security): require every download validation criterion

### DIFF
--- a/GenHub/GenHub.Core/Helpers/DownloadSecurityValidator.cs
+++ b/GenHub/GenHub.Core/Helpers/DownloadSecurityValidator.cs
@@ -180,12 +180,11 @@ public static class DownloadSecurityValidator
         }
 
         // Check SHA-256 hash if specified
-        bool hashMatched = false;
         if (allowedSha256Hashes is { Count: > 0 })
         {
             var actualHash = await ComputeSha256Async(filePath, ct);
-            hashMatched = allowedSha256Hashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase));
-            if (!hashMatched && !hasPublisherCheck)
+            bool hashMatched = allowedSha256Hashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase));
+            if (!hashMatched)
             {
                 return OperationResult<bool>.CreateFailure(
                     $"SHA-256 hash mismatch for '{Path.GetFileName(filePath)}'. Computed hash: '{actualHash}'. Expected one of: [{string.Join(", ", allowedSha256Hashes)}].");
@@ -198,12 +197,6 @@ public static class DownloadSecurityValidator
             var authResult = ValidateAuthenticodeSignature(filePath, expectedAuthenticodePublisher, allowExpiredCertificates);
             if (!authResult.Success)
             {
-                // If hash check was also specified and matched, allow fallback to known pinned hash
-                if (hasHashCheck && hashMatched)
-                {
-                    return OperationResult<bool>.CreateSuccess(true);
-                }
-
                 return authResult;
             }
         }
@@ -313,13 +306,12 @@ public static class DownloadSecurityValidator
             return OperationResult<bool>.CreateFailure("No validation criteria (hash or publisher) specified.");
         }
 
-        bool hashMatched = false;
         if (allowedSha256Hashes is { Count: > 0 })
         {
             var actualHash = await ComputeSha256Async(stream, ct);
             stream.Position = 0;
-            hashMatched = allowedSha256Hashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase));
-            if (!hashMatched && !hasPublisherCheck)
+            bool hashMatched = allowedSha256Hashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase));
+            if (!hashMatched)
             {
                 return OperationResult<bool>.CreateFailure(
                     $"SHA-256 hash mismatch for '{Path.GetFileName(filePath)}'. Computed hash: '{actualHash}'. Expected one of: [{string.Join(", ", allowedSha256Hashes)}].");
@@ -331,11 +323,6 @@ public static class DownloadSecurityValidator
             var authResult = ValidateAuthenticodeSignature(filePath, expectedAuthenticodePublisher, allowExpiredCertificates);
             if (!authResult.Success)
             {
-                if (hasHashCheck && hashMatched)
-                {
-                    return OperationResult<bool>.CreateSuccess(true);
-                }
-
                 return authResult;
             }
         }

--- a/GenHub/GenHub.Core/Helpers/DownloadSecurityValidator.cs
+++ b/GenHub/GenHub.Core/Helpers/DownloadSecurityValidator.cs
@@ -171,37 +171,18 @@ public static class DownloadSecurityValidator
             return OperationResult<bool>.CreateFailure($"File '{filePath}' does not exist for validation.");
         }
 
-        bool hasHashCheck = allowedSha256Hashes is { Count: > 0 };
-        bool hasPublisherCheck = !string.IsNullOrWhiteSpace(expectedAuthenticodePublisher);
-
-        if (!hasHashCheck && !hasPublisherCheck)
-        {
-            return OperationResult<bool>.CreateFailure("No validation criteria (hash or publisher) specified.");
-        }
-
-        // Check SHA-256 hash if specified
+        string? actualHash = null;
         if (allowedSha256Hashes is { Count: > 0 })
         {
-            var actualHash = await ComputeSha256Async(filePath, ct);
-            bool hashMatched = allowedSha256Hashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase));
-            if (!hashMatched)
-            {
-                return OperationResult<bool>.CreateFailure(
-                    $"SHA-256 hash mismatch for '{Path.GetFileName(filePath)}'. Computed hash: '{actualHash}'. Expected one of: [{string.Join(", ", allowedSha256Hashes)}].");
-            }
+            actualHash = await ComputeSha256Async(filePath, ct);
         }
 
-        // Check Authenticode publisher if specified
-        if (hasPublisherCheck)
-        {
-            var authResult = ValidateAuthenticodeSignature(filePath, expectedAuthenticodePublisher, allowExpiredCertificates);
-            if (!authResult.Success)
-            {
-                return authResult;
-            }
-        }
-
-        return OperationResult<bool>.CreateSuccess(true);
+        return ValidateComputedHashAndSignature(
+            filePath,
+            actualHash,
+            allowedSha256Hashes,
+            expectedAuthenticodePublisher,
+            allowExpiredCertificates);
     }
 
     /// <summary>
@@ -298,6 +279,28 @@ public static class DownloadSecurityValidator
         bool allowExpiredCertificates,
         CancellationToken ct)
     {
+        string? actualHash = null;
+        if (allowedSha256Hashes is { Count: > 0 })
+        {
+            actualHash = await ComputeSha256Async(stream, ct);
+            stream.Position = 0;
+        }
+
+        return ValidateComputedHashAndSignature(
+            filePath,
+            actualHash,
+            allowedSha256Hashes,
+            expectedAuthenticodePublisher,
+            allowExpiredCertificates);
+    }
+
+    private static OperationResult<bool> ValidateComputedHashAndSignature(
+        string filePath,
+        string? actualHash,
+        IReadOnlyList<string>? allowedSha256Hashes,
+        string? expectedAuthenticodePublisher,
+        bool allowExpiredCertificates)
+    {
         bool hasHashCheck = allowedSha256Hashes is { Count: > 0 };
         bool hasPublisherCheck = !string.IsNullOrWhiteSpace(expectedAuthenticodePublisher);
 
@@ -306,15 +309,13 @@ public static class DownloadSecurityValidator
             return OperationResult<bool>.CreateFailure("No validation criteria (hash or publisher) specified.");
         }
 
-        if (allowedSha256Hashes is { Count: > 0 })
+        if (hasHashCheck)
         {
-            var actualHash = await ComputeSha256Async(stream, ct);
-            stream.Position = 0;
-            bool hashMatched = allowedSha256Hashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase));
-            if (!hashMatched)
+            var allowedHashes = allowedSha256Hashes!;
+            if (!allowedHashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase)))
             {
                 return OperationResult<bool>.CreateFailure(
-                    $"SHA-256 hash mismatch for '{Path.GetFileName(filePath)}'. Computed hash: '{actualHash}'. Expected one of: [{string.Join(", ", allowedSha256Hashes)}].");
+                    $"SHA-256 hash mismatch for '{Path.GetFileName(filePath)}'. Computed hash: '{actualHash}'. Expected one of: [{string.Join(", ", allowedHashes)}].");
             }
         }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/DownloadSecurityValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/DownloadSecurityValidatorTests.cs
@@ -77,56 +77,42 @@ public class DownloadSecurityValidatorTests
     }
 
     /// <summary>
-    /// Verifies that a publisher criterion cannot override a pinned SHA-256 mismatch in either validation path.
+    /// Verifies that both SHA-256 and publisher criteria are required in either validation path.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the test.</returns>
+    /// <param name="hashMatches">Whether the supplied SHA-256 hash matches the file.</param>
     /// <param name="lockFile">Whether to validate through the locked-file path.</param>
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task ValidateCombinedCriteriaAsync_WhenSha256Mismatches_ReturnsHashFailureAsync(bool lockFile)
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ValidateCombinedCriteriaAsync_RequiresEveryCriterionAsync(bool hashMatches, bool lockFile)
     {
-        var (tempFile, _) = await CreateTempFileWithHashAsync("Hash mismatch must fail before publisher validation.");
+        var (tempFile, expectedHash) = await CreateTempFileWithHashAsync("Every validation criterion must pass.");
         try
         {
+            var hashToValidate = hashMatches
+                ? expectedHash
+                : "0000000000000000000000000000000000000000000000000000000000000000";
             var result = await ValidateWithCombinedCriteriaAsync(
                 tempFile,
-                "0000000000000000000000000000000000000000000000000000000000000000",
+                hashToValidate,
                 lockFile);
 
             Assert.False(result.Success);
-            Assert.Contains(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
-        }
-        finally
-        {
-            File.Delete(tempFile);
-        }
-    }
-
-    /// <summary>
-    /// Verifies that a matching SHA-256 hash cannot override a failed publisher check in either validation path.
-    /// </summary>
-    /// <returns>A <see cref="Task"/> representing the test.</returns>
-    /// <param name="lockFile">Whether to validate through the locked-file path.</param>
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task ValidateCombinedCriteriaAsync_WhenSha256MatchesAndPublisherFails_ReturnsPublisherFailureAsync(bool lockFile)
-    {
-        var (tempFile, expectedHash) = await CreateTempFileWithHashAsync("A matching hash must not bypass publisher validation.");
-        try
-        {
-            var result = await ValidateWithCombinedCriteriaAsync(
-                tempFile,
-                expectedHash,
-                lockFile);
-
-            Assert.False(result.Success);
-            Assert.DoesNotContain(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
-            Assert.Contains(
-                result.Errors,
-                e => e.Contains("Authenticode", StringComparison.OrdinalIgnoreCase) ||
-                     e.Contains("publisher", StringComparison.OrdinalIgnoreCase));
+            if (hashMatches)
+            {
+                Assert.DoesNotContain(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
+                Assert.Contains(
+                    result.Errors,
+                    e => e.Contains("Authenticode", StringComparison.OrdinalIgnoreCase) ||
+                         e.Contains("publisher", StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                Assert.Contains(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
+            }
         }
         finally
         {

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/DownloadSecurityValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/DownloadSecurityValidatorTests.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using GenHub.Core.Helpers;
+using GenHub.Core.Models.Results;
 using Xunit;
 
 /// <summary>
@@ -76,21 +77,22 @@ public class DownloadSecurityValidatorTests
     }
 
     /// <summary>
-    /// Verifies that a publisher criterion cannot override a pinned SHA-256 mismatch.
+    /// Verifies that a publisher criterion cannot override a pinned SHA-256 mismatch in either validation path.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the test.</returns>
-    [Fact]
-    public async Task ValidateFileAsync_WhenSha256MismatchesAndPublisherSpecified_ReturnsHashFailureAsync()
+    /// <param name="lockFile">Whether to validate through the locked-file path.</param>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ValidateCombinedCriteriaAsync_WhenSha256Mismatches_ReturnsHashFailureAsync(bool lockFile)
     {
-        var tempFile = Path.GetTempFileName();
+        var (tempFile, _) = await CreateTempFileWithHashAsync("Hash mismatch must fail before publisher validation.");
         try
         {
-            await File.WriteAllTextAsync(tempFile, "Hash mismatch must fail before publisher validation.");
-
-            var result = await DownloadSecurityValidator.ValidateFileAsync(
+            var result = await ValidateWithCombinedCriteriaAsync(
                 tempFile,
-                allowedSha256Hashes: ["0000000000000000000000000000000000000000000000000000000000000000"],
-                expectedAuthenticodePublisher: "Test Publisher");
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                lockFile);
 
             Assert.False(result.Success);
             Assert.Contains(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
@@ -102,26 +104,29 @@ public class DownloadSecurityValidatorTests
     }
 
     /// <summary>
-    /// Verifies that a matching SHA-256 hash cannot override a failed publisher check.
+    /// Verifies that a matching SHA-256 hash cannot override a failed publisher check in either validation path.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the test.</returns>
-    [Fact]
-    public async Task ValidateFileAsync_WhenSha256MatchesAndPublisherFails_ReturnsPublisherFailureAsync()
+    /// <param name="lockFile">Whether to validate through the locked-file path.</param>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ValidateCombinedCriteriaAsync_WhenSha256MatchesAndPublisherFails_ReturnsPublisherFailureAsync(bool lockFile)
     {
-        var tempFile = Path.GetTempFileName();
+        var (tempFile, expectedHash) = await CreateTempFileWithHashAsync("A matching hash must not bypass publisher validation.");
         try
         {
-            var content = Encoding.UTF8.GetBytes("A matching hash must not bypass publisher validation.");
-            await File.WriteAllBytesAsync(tempFile, content);
-            var expectedHash = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
-
-            var result = await DownloadSecurityValidator.ValidateFileAsync(
+            var result = await ValidateWithCombinedCriteriaAsync(
                 tempFile,
-                allowedSha256Hashes: [expectedHash],
-                expectedAuthenticodePublisher: "Publisher That Does Not Match");
+                expectedHash,
+                lockFile);
 
             Assert.False(result.Success);
             Assert.DoesNotContain(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
+            Assert.Contains(
+                result.Errors,
+                e => e.Contains("Authenticode", StringComparison.OrdinalIgnoreCase) ||
+                     e.Contains("publisher", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -218,62 +223,6 @@ public class DownloadSecurityValidatorTests
     }
 
     /// <summary>
-    /// Verifies that locked-file validation also fails before publisher validation when the pinned hash mismatches.
-    /// </summary>
-    /// <returns>A <see cref="Task"/> representing the test.</returns>
-    [Fact]
-    public async Task ValidateAndLockFileAsync_WhenSha256MismatchesAndPublisherSpecified_ReturnsHashFailureAsync()
-    {
-        var tempFile = Path.GetTempFileName();
-        try
-        {
-            await File.WriteAllTextAsync(tempFile, "Locked hash mismatch must fail before publisher validation.");
-
-            var result = await DownloadSecurityValidator.ValidateAndLockFileAsync(
-                tempFile,
-                allowedSha256Hashes: ["ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
-                expectedAuthenticodePublisher: "Test Publisher");
-
-            Assert.False(result.Success);
-            Assert.Null(result.Data);
-            Assert.Contains(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
-        }
-        finally
-        {
-            File.Delete(tempFile);
-        }
-    }
-
-    /// <summary>
-    /// Verifies that locked-file validation requires the publisher check after a matching SHA-256 hash.
-    /// </summary>
-    /// <returns>A <see cref="Task"/> representing the test.</returns>
-    [Fact]
-    public async Task ValidateAndLockFileAsync_WhenSha256MatchesAndPublisherFails_ReturnsPublisherFailureAsync()
-    {
-        var tempFile = Path.GetTempFileName();
-        try
-        {
-            var content = Encoding.UTF8.GetBytes("A locked matching hash must not bypass publisher validation.");
-            await File.WriteAllBytesAsync(tempFile, content);
-            var expectedHash = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
-
-            var result = await DownloadSecurityValidator.ValidateAndLockFileAsync(
-                tempFile,
-                allowedSha256Hashes: [expectedHash],
-                expectedAuthenticodePublisher: "Publisher That Does Not Match");
-
-            Assert.False(result.Success);
-            Assert.Null(result.Data);
-            Assert.DoesNotContain(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
-        }
-        finally
-        {
-            File.Delete(tempFile);
-        }
-    }
-
-    /// <summary>
     /// Verifies that ComputeSha256Async from stream returns the correct hexadecimal hash.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the test.</returns>
@@ -289,5 +238,41 @@ public class DownloadSecurityValidatorTests
         var computedHash = await DownloadSecurityValidator.ComputeSha256Async(ms);
 
         Assert.Equal(expectedHash, computedHash);
+    }
+
+    private static async Task<(string Path, string Sha256)> CreateTempFileWithHashAsync(string text)
+    {
+        var path = Path.GetTempFileName();
+        var content = Encoding.UTF8.GetBytes(text);
+        await File.WriteAllBytesAsync(path, content);
+        return (path, Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant());
+    }
+
+    private static async Task<OperationResult<bool>> ValidateWithCombinedCriteriaAsync(
+        string filePath,
+        string expectedHash,
+        bool lockFile)
+    {
+        if (!lockFile)
+        {
+            return await DownloadSecurityValidator.ValidateFileAsync(
+                filePath,
+                allowedSha256Hashes: [expectedHash],
+                expectedAuthenticodePublisher: "Publisher That Does Not Match");
+        }
+
+        var result = await DownloadSecurityValidator.ValidateAndLockFileAsync(
+            filePath,
+            allowedSha256Hashes: [expectedHash],
+            expectedAuthenticodePublisher: "Publisher That Does Not Match");
+
+        if (result.Data is not null)
+        {
+            await result.Data.DisposeAsync();
+        }
+
+        return result.Success
+            ? OperationResult<bool>.CreateSuccess(true)
+            : OperationResult<bool>.CreateFailure(result.Errors);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/DownloadSecurityValidatorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/DownloadSecurityValidatorTests.cs
@@ -76,6 +76,60 @@ public class DownloadSecurityValidatorTests
     }
 
     /// <summary>
+    /// Verifies that a publisher criterion cannot override a pinned SHA-256 mismatch.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the test.</returns>
+    [Fact]
+    public async Task ValidateFileAsync_WhenSha256MismatchesAndPublisherSpecified_ReturnsHashFailureAsync()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, "Hash mismatch must fail before publisher validation.");
+
+            var result = await DownloadSecurityValidator.ValidateFileAsync(
+                tempFile,
+                allowedSha256Hashes: ["0000000000000000000000000000000000000000000000000000000000000000"],
+                expectedAuthenticodePublisher: "Test Publisher");
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a matching SHA-256 hash cannot override a failed publisher check.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the test.</returns>
+    [Fact]
+    public async Task ValidateFileAsync_WhenSha256MatchesAndPublisherFails_ReturnsPublisherFailureAsync()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var content = Encoding.UTF8.GetBytes("A matching hash must not bypass publisher validation.");
+            await File.WriteAllBytesAsync(tempFile, content);
+            var expectedHash = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+
+            var result = await DownloadSecurityValidator.ValidateFileAsync(
+                tempFile,
+                allowedSha256Hashes: [expectedHash],
+                expectedAuthenticodePublisher: "Publisher That Does Not Match");
+
+            Assert.False(result.Success);
+            Assert.DoesNotContain(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
     /// Verifies that ValidateAndLockFileAsync succeeds, sets read-only, and locks the file when SHA-256 matches.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the test.</returns>
@@ -160,6 +214,62 @@ public class DownloadSecurityValidatorTests
                 {
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that locked-file validation also fails before publisher validation when the pinned hash mismatches.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the test.</returns>
+    [Fact]
+    public async Task ValidateAndLockFileAsync_WhenSha256MismatchesAndPublisherSpecified_ReturnsHashFailureAsync()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, "Locked hash mismatch must fail before publisher validation.");
+
+            var result = await DownloadSecurityValidator.ValidateAndLockFileAsync(
+                tempFile,
+                allowedSha256Hashes: ["ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
+                expectedAuthenticodePublisher: "Test Publisher");
+
+            Assert.False(result.Success);
+            Assert.Null(result.Data);
+            Assert.Contains(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that locked-file validation requires the publisher check after a matching SHA-256 hash.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the test.</returns>
+    [Fact]
+    public async Task ValidateAndLockFileAsync_WhenSha256MatchesAndPublisherFails_ReturnsPublisherFailureAsync()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var content = Encoding.UTF8.GetBytes("A locked matching hash must not bypass publisher validation.");
+            await File.WriteAllBytesAsync(tempFile, content);
+            var expectedHash = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+
+            var result = await DownloadSecurityValidator.ValidateAndLockFileAsync(
+                tempFile,
+                allowedSha256Hashes: [expectedHash],
+                expectedAuthenticodePublisher: "Publisher That Does Not Match");
+
+            Assert.False(result.Success);
+            Assert.Null(result.Data);
+            Assert.DoesNotContain(result.Errors, e => e.Contains("SHA-256 hash mismatch"));
+        }
+        finally
+        {
+            File.Delete(tempFile);
         }
     }
 


### PR DESCRIPTION
## Problem

The validator’s combined hash-and-publisher behavior contradicted its fail-closed contract. No current production call site enables both criteria, but a future combined configuration could accept a file when only one criterion passed.

## Fix

Require every supplied validation criterion to pass in both regular and locked-stream validation. Regression tests cover hash failure with a publisher specified and publisher failure with a matching hash.

Authenticode remains Windows-only; current production callers are in `GenHub.Windows`.

## Testing

`DownloadSecurityValidatorTests`: 9 passed using .NET SDK 8.0.424.

Addresses https://github.com/community-outpost/GenHub/pull/378#discussion_r3890594853

Model/harness: GPT-5 / Codex desktop.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes download validation fail closed by requiring every supplied criterion to pass.
- Centralizes hash and Authenticode validation shared by regular and locked-stream paths.
- Rejects a hash mismatch before publisher validation and rejects publisher failure even when the hash matches.
- Adds cross-platform regression coverage for both validation paths and criterion outcomes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule violations identified.

The shared helper preserves existing single-criterion and stream-handling behavior while enforcing failure for either supplied criterion, and the regression tests exercise both regular and locked validation paths.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| GenHub/GenHub.Core/Helpers/DownloadSecurityValidator.cs | Centralizes validation while requiring each supplied hash and publisher criterion to succeed. |
| GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/DownloadSecurityValidatorTests.cs | Covers matching and mismatching hashes across regular and locked validation when publisher validation fails. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Download validation request] --> B{SHA-256 hashes supplied?}
    B -- Yes --> C[Compute and compare SHA-256]
    C --> D{Hash matched?}
    D -- No --> E[Validation failure]
    D -- Yes --> F{Publisher supplied?}
    B -- No --> F
    F -- Yes --> G[Validate Authenticode publisher]
    G --> H{Publisher matched?}
    H -- No --> E
    H -- Yes --> I[Validation success]
    F -- No --> J{Any criterion supplied?}
    J -- No --> E
    J -- Yes --> I
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(security): centralize download ..."](https://github.com/community-outpost/genhub/commit/cdf85fa6896f7b74a23527c66fd2b4afc5541249) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60605128)</sub>

<!-- /greptile_comment -->