### PR TITLE
chore(build): exclude large cover images from archive tarballs via export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude large backdrop cover images from source archives (PURA bot 25MB cap / GitHub release tarballs)
+GenHub/GenHub/Assets/Covers/china-cover.png export-ignore
+GenHub/GenHub/Assets/Covers/gla-cover.png export-ignore
+GenHub/GenHub/Assets/Covers/usa-cover.png export-ignore
+.gitattributes export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .*
 !.github/
 !.gitignore
+!.gitattributes
 !.agents/
 !.claude/
 


### PR DESCRIPTION
﻿## Summary
Adds `.gitattributes` configured with `export-ignore` to omit large game cover assets from git-generated source tarballs and archives. Also unignores `.gitattributes` in `.gitignore` so Git and GitHub track and enforce export attributes.

### Root Cause
PURA code review bot downloads the full repository archive (`.tar.gz`) to index project context and enforces a strict 25 MB cap. Three high-resolution cover backdrop PNGs in `GenHub/GenHub/Assets/Covers/` weighed ~29.5 MB combined, pushing the total repository tarball to ~33.66 MB (32.10 MiB) and causing the bot to bail out on every PR push.

### Changes
- **Git Attributes**: Created `.gitattributes` marking `china-cover.png`, `gla-cover.png`, `usa-cover.png`, and `.gitattributes` with `export-ignore`.
- **Git Ignore**: Added `!.gitattributes` to `.gitignore` under `# User-specific files` to ensure `.gitattributes` is tracked and pushed to GitHub.

### Verification
- [x] Verified `git archive --format=tar.gz HEAD` size drops from **33.66 MB (32.10 MiB)** down to **3.95 MB** (~88% reduction, well within the 25 MB cap).
- [x] Full solution `dotnet build GenHub/GenHub.sln` completed successfully with 0 errors.
- [x] Verified working tree and clone operations remain unaffected.

---
*Created with gemini-3.8-flash-high via Antigravity*
