### PR TITLE
fix(ci): support fork PRs via pull_request_target and isolate review concurrency

### DIFF
--- a/.github/workflows/qodo-review.yml
+++ b/.github/workflows/qodo-review.yml
@@ -4,19 +4,29 @@ on:
   pull_request_target:
     branches: [main, development]
     types: [opened, reopened, ready_for_review, synchronize]
+  pull_request:
+    branches: [main, development]
+    types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
 
 jobs:
   qodo_review:
+    # Fork PRs: run under pull_request_target to access secrets safely
+    # Internal PRs: run under pull_request
+    # Bot comments: ignored to prevent unnecessary runs and cancellations
     if: >-
       ${{
         github.event.sender.type != 'Bot' &&
-        (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
+        (
+          (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+          github.event.issue.pull_request
+        )
       }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/qodo-review.yml
+++ b/.github/workflows/qodo-review.yml
@@ -50,11 +50,13 @@ jobs:
           OPENAI_API_BASE: "https://api.z.ai/api/coding/paas/v4"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # --- Single Model (No Fallbacks) & Token Limits ---
+          # --- Single Model (No Fallbacks), Token Limits & Extended Timeouts ---
           CONFIG.MODEL: "openai/glm-5.3-flash"
           PR_AGENT__CONFIG__MODEL: "openai/glm-5.3-flash"
           CONFIG.FALLBACK_MODELS: "[]"
           PR_AGENT__CONFIG__FALLBACK_MODELS: "[]"
+          CONFIG.AI_TIMEOUT: 900
+          PR_AGENT__CONFIG__AI_TIMEOUT: 900
           CONFIG.MAX_MODEL_TOKENS: 128000
           PR_AGENT__CONFIG__MAX_MODEL_TOKENS: 128000
           CONFIG.CUSTOM_MODEL_MAX_TOKENS: 128000

--- a/.github/workflows/qodo-review.yml
+++ b/.github/workflows/qodo-review.yml
@@ -1,23 +1,22 @@
 name: Qodo PR Review (Z.AI Coding Plan)
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main, development]
     types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
 
 jobs:
   qodo_review:
     if: >-
       ${{
         github.event.sender.type != 'Bot' &&
-        (github.event_name == 'pull_request' || github.event.issue.pull_request)
+        (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
       }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,6 +27,10 @@ jobs:
       - name: Run Qodo PR-Agent
         uses: qodo-ai/pr-agent@97169bcab8943d457b99256d357b856c68e0c61e # main
         env:
+          # --- Configuration Branch (Safely loads .pr_agent.toml from PR's target base branch) ---
+          PR_AGENT_CONFIG_BRANCH: ${{ github.base_ref || 'development' }}
+          CONFIG.CONFIG_BRANCH: ${{ github.base_ref || 'development' }}
+
           # --- Z.AI Coding Plan Credentials & Base URL ---
           OPENAI_KEY: ${{ secrets.ZAI_API_KEY }}
           PR_AGENT__OPENAI__KEY: ${{ secrets.ZAI_API_KEY }}
@@ -37,11 +40,13 @@ jobs:
           OPENAI_API_BASE: "https://api.z.ai/api/coding/paas/v4"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # --- Single Model (No Fallbacks) ---
+          # --- Single Model (No Fallbacks) & Token Limits ---
           CONFIG.MODEL: "openai/glm-5.3-flash"
           PR_AGENT__CONFIG__MODEL: "openai/glm-5.3-flash"
           CONFIG.FALLBACK_MODELS: "[]"
           PR_AGENT__CONFIG__FALLBACK_MODELS: "[]"
+          CONFIG.MAX_MODEL_TOKENS: 128000
+          PR_AGENT__CONFIG__MAX_MODEL_TOKENS: 128000
           CONFIG.CUSTOM_MODEL_MAX_TOKENS: 128000
           PR_AGENT__CONFIG__CUSTOM_MODEL_MAX_TOKENS: 128000
 

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,7 @@
 [config]
 model = "openai/glm-5.3-flash"
 fallback_models = []
+max_model_tokens = 128000
 custom_model_max_tokens = 128000
 
 [openai]

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,7 @@
 [config]
 model = "openai/glm-5.3-flash"
 fallback_models = []
+ai_timeout = 900
 max_model_tokens = 128000
 custom_model_max_tokens = 128000
 


### PR DESCRIPTION
## Description
Fixes an issue where Qodo reviews fail or get prematurely cancelled on PRs:
1. **Fork PR support**: PRs originating from forks (e.g. #375) have secrets stripped under \pull_request\, causing PR-Agent to run without \ZAI_API_KEY\ and with read-only token permissions. Uses \pull_request_target\ (as recommended by Qodo documentation) to safely access secrets without checking out untrusted fork code.
2. **Job-level isolated concurrency**: Moves \concurrency\ into the job and includes the event name. Prevents automated bot comments (\pura-app[bot]\, \sonarqubecloud[bot]\, \coderabbitai[bot]\) from cancelling active review jobs via workflow-level \cancel-in-progress\.
3. **128k token ceiling**: Sets \max_model_tokens\ to \128000\ so large diffs are not clamped by PR-Agent's default 32k limit.
4. **Base-branch config resolution**: Pins \CONFIG.CONFIG_BRANCH\ to the PR base branch (\development\) to safely load \.pr_agent.toml\ repository standards.