### PR TITLE
fix(manifest): use development branch URLs, embedded fallback, and scan progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
       any: ${{ steps.filter.outputs.any }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Filter Changed Paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -107,15 +107,15 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -232,7 +232,7 @@ jobs:
           }
 
       - name: Upload Velopack Update Package (.nupkg)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: genhub-velopack-windows-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/*.nupkg
@@ -240,7 +240,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Velopack Setup Installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: genhub-setup-windows-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/*-Setup.exe
@@ -248,7 +248,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Velopack Metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: genhub-metadata-windows-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/RELEASES
@@ -265,15 +265,15 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -364,7 +364,7 @@ jobs:
           done
 
       - name: Upload Velopack Update Package (.nupkg)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: genhub-velopack-linux-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/*.nupkg
@@ -372,7 +372,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Velopack Metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: genhub-metadata-linux-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/releases.*.json
@@ -392,17 +392,17 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -533,7 +533,7 @@ jobs:
           done < <(find GenHub/GenHub.Tests -type f -name '*.csproj' | sort)
 
       - name: Upload macOS App Bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v6
         with:
           name: genhub-macos-app-${{ steps.buildinfo.outputs.VERSION }}
           path: macos-dist/
@@ -542,7 +542,7 @@ jobs:
 
       - name: Upload Launch Log On Failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v6
         with:
           name: genhub-macos-launch-log-${{ steps.buildinfo.outputs.VERSION }}
           path: app-launch.log
@@ -566,17 +566,17 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
       any: ${{ steps.filter.outputs.any }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Filter Changed Paths
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
           filters: |
@@ -107,15 +107,15 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -232,7 +232,7 @@ jobs:
           }
 
       - name: Upload Velopack Update Package (.nupkg)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: genhub-velopack-windows-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/*.nupkg
@@ -240,7 +240,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Velopack Setup Installer
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: genhub-setup-windows-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/*-Setup.exe
@@ -248,7 +248,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Velopack Metadata
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: genhub-metadata-windows-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/RELEASES
@@ -265,15 +265,15 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -364,7 +364,7 @@ jobs:
           done
 
       - name: Upload Velopack Update Package (.nupkg)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: genhub-velopack-linux-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/*.nupkg
@@ -372,7 +372,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Velopack Metadata
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: genhub-metadata-linux-${{ steps.buildinfo.outputs.VERSION }}
           path: velopack-release/releases.*.json
@@ -392,17 +392,17 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -533,7 +533,7 @@ jobs:
           done < <(find GenHub/GenHub.Tests -type f -name '*.csproj' | sort)
 
       - name: Upload macOS App Bundle
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: genhub-macos-app-${{ steps.buildinfo.outputs.VERSION }}
           path: macos-dist/
@@ -542,7 +542,7 @@ jobs:
 
       - name: Upload Launch Log On Failure
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: genhub-macos-launch-log-${{ steps.buildinfo.outputs.VERSION }}
           path: app-launch.log
@@ -566,17 +566,17 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet Packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - uses: actions/configure-pages@v5
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/configure-pages@v5
 

--- a/.github/workflows/gitnexus.yml
+++ b/.github/workflows/gitnexus.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload GitNexus Knowledge Graph Artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v6
         with:
           name: gitnexus-graph-${{ github.sha }}
           path: .gitnexus/

--- a/.github/workflows/gitnexus.yml
+++ b/.github/workflows/gitnexus.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload GitNexus Knowledge Graph Artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: gitnexus-graph-${{ github.sha }}
           path: .gitnexus/

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 1
       - name: Run agent

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
     steps:
       - name: Checkout promoted ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
           fetch-depth: 0
@@ -109,12 +109,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.promote.outputs.sha }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -204,7 +204,7 @@ jobs:
           }
 
       - name: Upload Windows Release Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: windows-release
           path: velopack-release-windows/*
@@ -212,7 +212,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Windows Portable Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: windows-portable
           path: "GenHub-*-win-portable.zip"
@@ -225,12 +225,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.promote.outputs.sha }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -295,7 +295,7 @@ jobs:
           fi
 
       - name: Upload Linux Release Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: linux-release
           path: velopack-release-linux/*
@@ -310,7 +310,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.promote.outputs.sha }}
           fetch-depth: 0
@@ -335,7 +335,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Download All Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
     steps:
       - name: Checkout promoted ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
           fetch-depth: 0
@@ -109,12 +109,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.promote.outputs.sha }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -204,7 +204,7 @@ jobs:
           }
 
       - name: Upload Windows Release Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-release
           path: velopack-release-windows/*
@@ -212,7 +212,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Windows Portable Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-portable
           path: "GenHub-*-win-portable.zip"
@@ -225,12 +225,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.promote.outputs.sha }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -295,7 +295,7 @@ jobs:
           fi
 
       - name: Upload Linux Release Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-release
           path: velopack-release-linux/*
@@ -310,7 +310,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.promote.outputs.sha }}
           fetch-depth: 0
@@ -335,7 +335,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 

--- a/GenHub/GenHub.Core/Assets/Registries/index.json
+++ b/GenHub/GenHub.Core/Assets/Registries/index.json
@@ -7,7 +7,7 @@
       "id": "generals-1.08",
       "gameType": "Generals",
       "version": "1.08",
-      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
+      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
       "fileCount": 164,
       "totalSizeBytes": 28977,
       "languages": [
@@ -35,7 +35,7 @@
       "id": "zerohour-1.04",
       "gameType": "ZeroHour",
       "version": "1.04",
-      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv",
+      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv",
       "fileCount": 175,
       "totalSizeBytes": 31246,
       "languages": [

--- a/GenHub/GenHub.Core/Constants/CsvConstants.cs
+++ b/GenHub/GenHub.Core/Constants/CsvConstants.cs
@@ -10,9 +10,14 @@ namespace GenHub.Core.Constants;
 public static class CsvConstants
 {
     /// <summary>
+    /// Default remote base URL for CSV registry assets.
+    /// </summary>
+    public const string DefaultRegistryBaseUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry";
+
+    /// <summary>
     /// Default remote index.json source for CSV catalog discovery.
     /// </summary>
-    public const string DefaultIndexFileUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/index.json";
+    public const string DefaultIndexFileUrl = $"{DefaultRegistryBaseUrl}/index.json";
 
     /// <summary>
     /// Source name for the CSV catalog discoverer.

--- a/GenHub/GenHub.Core/Constants/CsvConstants.cs
+++ b/GenHub/GenHub.Core/Constants/CsvConstants.cs
@@ -197,12 +197,12 @@ public static class CsvConstants
     /// <summary>
     /// Default remote URL for Generals 1.08 CSV.
     /// </summary>
-    public const string DefaultGeneralsCsvUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv";
+    public const string DefaultGeneralsCsvUrl = $"{DefaultRegistryBaseUrl}/Generals-1.08.csv";
 
     /// <summary>
     /// Default remote URL for Zero Hour 1.04 CSV.
     /// </summary>
-    public const string DefaultZeroHourCsvUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv";
+    public const string DefaultZeroHourCsvUrl = $"{DefaultRegistryBaseUrl}/ZeroHour-1.04.csv";
 
     /// <summary>
     /// Trusted SHA-256 checksum for Generals 1.08 authoritative CSV registry.

--- a/GenHub/GenHub.Core/Constants/CsvConstants.cs
+++ b/GenHub/GenHub.Core/Constants/CsvConstants.cs
@@ -12,7 +12,7 @@ public static class CsvConstants
     /// <summary>
     /// Default remote index.json source for CSV catalog discovery.
     /// </summary>
-    public const string DefaultIndexFileUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/index.json";
+    public const string DefaultIndexFileUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/index.json";
 
     /// <summary>
     /// Source name for the CSV catalog discoverer.
@@ -192,12 +192,12 @@ public static class CsvConstants
     /// <summary>
     /// Default remote URL for Generals 1.08 CSV.
     /// </summary>
-    public const string DefaultGeneralsCsvUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/Generals-1.08.csv";
+    public const string DefaultGeneralsCsvUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv";
 
     /// <summary>
     /// Default remote URL for Zero Hour 1.04 CSV.
     /// </summary>
-    public const string DefaultZeroHourCsvUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv";
+    public const string DefaultZeroHourCsvUrl = "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv";
 
     /// <summary>
     /// Trusted SHA-256 checksum for Generals 1.08 authoritative CSV registry.

--- a/GenHub/GenHub.Core/Constants/ManifestConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ManifestConstants.cs
@@ -21,6 +21,26 @@ public static class ManifestConstants
     public const string IncompleteInstallationNotificationTitle = "Incomplete Game Installation";
 
     /// <summary>
+    /// Default auto-dismiss timeout in milliseconds for standard info/success scan notifications.
+    /// </summary>
+    public const int DefaultNotificationAutoDismissMs = 4000;
+
+    /// <summary>
+    /// Auto-dismiss timeout in milliseconds for incomplete installation warning notifications.
+    /// </summary>
+    public const int WarningNotificationAutoDismissMs = 10000;
+
+    /// <summary>
+    /// Frequency interval (number of files processed) for progress log emission during manifest generation.
+    /// </summary>
+    public const int ProgressLoggingThrottleInterval = 25;
+
+    /// <summary>
+    /// Maximum number of missing required files to list in warning notifications before truncating.
+    /// </summary>
+    public const int MaxMissingFilesNotificationDisplayCount = 5;
+
+    /// <summary>
     /// Default manifest format version.
     /// </summary>
     public const int DefaultManifestFormatVersion = 1;

--- a/GenHub/GenHub.Core/Constants/ManifestConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ManifestConstants.cs
@@ -6,6 +6,21 @@ namespace GenHub.Core.Constants;
 public static class ManifestConstants
 {
     /// <summary>
+    /// Notification title when game file verification/indexing begins.
+    /// </summary>
+    public const string IndexingNotificationTitle = "Indexing Game Files";
+
+    /// <summary>
+    /// Notification title when game file verification completes successfully.
+    /// </summary>
+    public const string IndexedNotificationTitle = "Game Files Indexed";
+
+    /// <summary>
+    /// Notification title when game installation is missing required files.
+    /// </summary>
+    public const string IncompleteInstallationNotificationTitle = "Incomplete Game Installation";
+
+    /// <summary>
     /// Default manifest format version.
     /// </summary>
     public const int DefaultManifestFormatVersion = 1;

--- a/GenHub/GenHub.Core/Constants/ManifestConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ManifestConstants.cs
@@ -21,6 +21,11 @@ public static class ManifestConstants
     public const string IncompleteInstallationNotificationTitle = "Incomplete Game Installation";
 
     /// <summary>
+    /// Notification title when directory scan encounters an error.
+    /// </summary>
+    public const string DirectoryScanWarningNotificationTitle = "Directory Scan Warning";
+
+    /// <summary>
     /// Default auto-dismiss timeout in milliseconds for standard info/success scan notifications.
     /// </summary>
     public const int DefaultNotificationAutoDismissMs = 4000;

--- a/GenHub/GenHub.Core/Constants/ManifestConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ManifestConstants.cs
@@ -41,6 +41,17 @@ public static class ManifestConstants
     public const int ProgressLoggingThrottleInterval = 25;
 
     /// <summary>
+    /// File size threshold in bytes (5 MB) above which a file is considered large during verification,
+    /// triggering individual hashing progress status reports and notifications.
+    /// </summary>
+    public const long LargeFileProgressThresholdBytes = 5 * 1024 * 1024;
+
+    /// <summary>
+    /// Throttle interval in milliseconds for periodic notification updates during file verification.
+    /// </summary>
+    public const int NotificationUpdateThrottleMs = 500;
+
+    /// <summary>
     /// Maximum number of missing required files to list in warning notifications before truncating.
     /// </summary>
     public const int MaxMissingFilesNotificationDisplayCount = 5;

--- a/GenHub/GenHub.Core/Constants/ManifestConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ManifestConstants.cs
@@ -41,6 +41,11 @@ public static class ManifestConstants
     public const int ProgressLoggingThrottleInterval = 25;
 
     /// <summary>
+    /// Throttle interval in seconds for periodic progress logging during manifest generation file verification.
+    /// </summary>
+    public const int ProgressLogThrottleSeconds = 5;
+
+    /// <summary>
     /// File size threshold in bytes (5 MB) above which a file is considered large during verification,
     /// triggering individual hashing progress status reports and notifications.
     /// </summary>

--- a/GenHub/GenHub.Core/Constants/ManifestConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ManifestConstants.cs
@@ -41,7 +41,7 @@ public static class ManifestConstants
     public const int ProgressLoggingThrottleInterval = 25;
 
     /// <summary>
-    /// Throttle interval in seconds for periodic progress logging during manifest generation file verification.
+    /// Throttle interval in seconds for periodic progress logging during manifest generation.
     /// </summary>
     public const int ProgressLogThrottleSeconds = 5;
 

--- a/GenHub/GenHub.Core/Interfaces/Manifest/IManifestGenerationService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Manifest/IManifestGenerationService.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Threading;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Validation;
 
 namespace GenHub.Core.Interfaces.Manifest;
 
@@ -28,6 +30,26 @@ public interface IManifestGenerationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Creates a manifest builder for a game installation with string version normalization and progress reporting.
+    /// </summary>
+    /// <param name="gameInstallationPath">Path to the game installation.</param>
+    /// <param name="gameType">The game type (Generals, ZeroHour).</param>
+    /// <param name="installationType">The installation type (Steam, EaApp).</param>
+    /// <param name="manifestVersion">The manifest version (e.g., "1.08", "1.04", or integer like 0, 1, 2). If null, defaults to 0.</param>
+    /// <param name="language">Optional explicit language code (e.g., "EN", "DE"). If null, language is detected automatically.</param>
+    /// <param name="progress">Optional progress reporter receiving file indexing progress updates.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> that returns a configured manifest builder.</returns>
+    Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
+        string gameInstallationPath,
+        GameType gameType,
+        GameInstallationType installationType,
+        string? manifestVersion,
+        string? language,
+        IProgress<ValidationProgress>? progress,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates a manifest builder for a game installation with integer version.
     /// </summary>
     /// <param name="gameInstallationPath">Path to the game installation.</param>
@@ -43,6 +65,26 @@ public interface IManifestGenerationService
         GameInstallationType installationType,
         int manifestVersion = 0,
         string? language = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a manifest builder for a game installation with integer version and progress reporting.
+    /// </summary>
+    /// <param name="gameInstallationPath">Path to the game installation.</param>
+    /// <param name="gameType">The game type (Generals, ZeroHour).</param>
+    /// <param name="installationType">The installation type (Steam, EaApp).</param>
+    /// <param name="manifestVersion">The manifest version (e.g., 1, 2, 20). Defaults to 0 for first version.</param>
+    /// <param name="language">Optional explicit language code (e.g., "EN", "DE"). If null, language is detected automatically.</param>
+    /// <param name="progress">Optional progress reporter receiving file indexing progress updates.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> that returns a configured manifest builder.</returns>
+    Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
+        string gameInstallationPath,
+        GameType gameType,
+        GameInstallationType installationType,
+        int manifestVersion,
+        string? language,
+        IProgress<ValidationProgress>? progress,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/GenHub/GenHub.Core/Interfaces/Manifest/IManifestGenerationService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Manifest/IManifestGenerationService.cs
@@ -73,7 +73,7 @@ public interface IManifestGenerationService
     /// <param name="gameInstallationPath">Path to the game installation.</param>
     /// <param name="gameType">The game type (Generals, ZeroHour).</param>
     /// <param name="installationType">The installation type (Steam, EaApp).</param>
-    /// <param name="manifestVersion">The manifest version (e.g., 1, 2, 20). Defaults to 0 for first version.</param>
+    /// <param name="manifestVersion">The manifest version (e.g., 1, 2, 20). 0 represents the first version.</param>
     /// <param name="language">Optional explicit language code (e.g., "EN", "DE"). If null, language is detected automatically.</param>
     /// <param name="progress">Optional progress reporter receiving file indexing progress updates.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
@@ -703,13 +703,12 @@ public class CsvResolverTests
         stream!.CopyTo(memoryStream);
         var embeddedText = Encoding.UTF8.GetString(memoryStream.ToArray()).Trim();
 
-        var solutionRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        var solutionRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
         var docsIndexJsonPath = Path.Combine(solutionRoot, "docs", CsvConstants.RegistryDocsFolder, CsvConstants.RegistryIndexFileName);
-        if (File.Exists(docsIndexJsonPath))
-        {
-            var docsText = File.ReadAllText(docsIndexJsonPath).Trim();
-            embeddedText.Should().Be(docsText);
-        }
+        File.Exists(docsIndexJsonPath).Should().BeTrue(
+            $"docs/{CsvConstants.RegistryDocsFolder}/{CsvConstants.RegistryIndexFileName} must exist relative to the solution root ({solutionRoot})");
+        var docsText = File.ReadAllText(docsIndexJsonPath).Trim();
+        embeddedText.Should().Be(docsText);
     }
 
     private static CsvResolver CreateResolver(HttpMessageHandler? handler = null, string? applicationDataPath = null)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
@@ -400,6 +400,24 @@ public class CsvResolverTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="CsvResolver.ResolveAsync(ContentSearchResult, CancellationToken)"/> propagates cancellation when reading local files.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ResolveAsync_WhenLocalFileAndCancelled_ThrowsOperationCanceledExceptionAsync()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        using var tempCsv = new TempCsvFile(FullSampleCsv);
+        var resolver = CreateResolver();
+        var item = CreateDiscoveredItem(tempCsv.FilePath, GameType.Generals, CsvConstants.LanguageEn);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            resolver.ResolveAsync(item, cts.Token));
+    }
+
+    /// <summary>
     /// Verifies that <see cref="CsvResolver.ResolverId"/> returns the expected constant.
     /// </summary>
     [Fact]

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
@@ -703,11 +703,23 @@ public class CsvResolverTests
         stream!.CopyTo(memoryStream);
         var embeddedText = Encoding.UTF8.GetString(memoryStream.ToArray()).Trim();
 
-        var solutionRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
-        var docsIndexJsonPath = Path.Combine(solutionRoot, "docs", CsvConstants.RegistryDocsFolder, CsvConstants.RegistryIndexFileName);
-        File.Exists(docsIndexJsonPath).Should().BeTrue(
-            $"docs/{CsvConstants.RegistryDocsFolder}/{CsvConstants.RegistryIndexFileName} must exist relative to the solution root ({solutionRoot})");
-        var docsText = File.ReadAllText(docsIndexJsonPath).Trim();
+        var currentDir = new DirectoryInfo(AppContext.BaseDirectory);
+        string? docsIndexJsonPath = null;
+        while (currentDir != null)
+        {
+            var candidate = Path.Combine(currentDir.FullName, "docs", CsvConstants.RegistryDocsFolder, CsvConstants.RegistryIndexFileName);
+            if (File.Exists(candidate))
+            {
+                docsIndexJsonPath = candidate;
+                break;
+            }
+
+            currentDir = currentDir.Parent;
+        }
+
+        docsIndexJsonPath.Should().NotBeNull(
+            $"docs/{CsvConstants.RegistryDocsFolder}/{CsvConstants.RegistryIndexFileName} must exist in the repository tree above {AppContext.BaseDirectory}");
+        var docsText = File.ReadAllText(docsIndexJsonPath!).Trim();
         embeddedText.Should().Be(docsText);
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
@@ -670,6 +670,30 @@ public class CsvResolverTests
         actualHash.Should().Be(expectedSha256);
     }
 
+    /// <summary>
+    /// Verifies that the embedded index.json is synchronized with docs/GameInstallationFilesRegistry/index.json.
+    /// </summary>
+    [Fact]
+    public void EmbeddedIndexJson_MatchesDocsIndexJson()
+    {
+        var assembly = typeof(CsvConstants).Assembly;
+        var resourceName = $"{CsvConstants.EmbeddedResourceNamespace}.{CsvConstants.RegistryIndexFileName}";
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        stream.Should().NotBeNull($"Resource '{resourceName}' must exist in {assembly.GetName().Name}");
+
+        using var memoryStream = new MemoryStream();
+        stream!.CopyTo(memoryStream);
+        var embeddedText = Encoding.UTF8.GetString(memoryStream.ToArray()).Trim();
+
+        var solutionRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        var docsIndexJsonPath = Path.Combine(solutionRoot, "docs", CsvConstants.RegistryDocsFolder, CsvConstants.RegistryIndexFileName);
+        if (File.Exists(docsIndexJsonPath))
+        {
+            var docsText = File.ReadAllText(docsIndexJsonPath).Trim();
+            embeddedText.Should().Be(docsText);
+        }
+    }
+
     private static CsvResolver CreateResolver(HttpMessageHandler? handler = null, string? applicationDataPath = null)
     {
         var mockHttpClientFactory = new Mock<IHttpClientFactory>();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
@@ -714,6 +714,12 @@ public class CsvResolverTests
                 break;
             }
 
+            // Stop search at repo root boundary (.git file/directory) to prevent escaping outside the repository
+            if (Path.Exists(Path.Combine(currentDir.FullName, ".git")))
+            {
+                break;
+            }
+
             currentDir = currentDir.Parent;
         }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/CsvResolverTests.cs
@@ -621,6 +621,29 @@ public class CsvResolverTests
     }
 
     /// <summary>
+    /// Verifies that when a remote catalog URL returns 404 Not Found, <see cref="CsvResolver"/> gracefully falls back
+    /// to the embedded assembly asset matching the registry filename without failing.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ResolveAsync_WhenRemoteReturns404_FallsBackToEmbeddedResourceAsync()
+    {
+        var remote404Url = "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv";
+        var httpHandler = new StubHttpMessageHandler(expectedUrl: remote404Url, statusCode: HttpStatusCode.NotFound);
+        var resolver = CreateResolver(httpHandler);
+
+        var item = CreateDiscoveredItem(remote404Url, GameType.ZeroHour, CsvConstants.LanguageEn);
+        item.ResolverMetadata[CsvConstants.Sha256MetadataKey] = CsvConstants.ZeroHour104Sha256;
+
+        var result = await resolver.ResolveAsync(item);
+
+        result.Success.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Files.Should().NotBeEmpty();
+        result.Data.Files.Should().Contain(f => f.RelativePath == "generals.exe");
+    }
+
+    /// <summary>
     /// Verifies that the embedded authoritative CSV registries match their pinned SHA-256 checksum constants.
     /// </summary>
     /// <param name="fileName">The embedded CSV catalog file name.</param>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -895,7 +895,7 @@ public class ManifestGenerationServiceTests : IDisposable
         await File.WriteAllTextAsync(Path.Combine(installationPath, "AudioZH.big"), "zh audio");
 
         var progressReports = new List<ValidationProgress>();
-        var progress = new Progress<ValidationProgress>(p => progressReports.Add(p));
+        var progress = new SynchronousProgress<ValidationProgress>(progressReports.Add);
 
         // Act
         var builder = await _service.CreateGameInstallationManifestAsync(
@@ -950,10 +950,10 @@ public class ManifestGenerationServiceTests : IDisposable
         // Assert
         Assert.NotNull(manifest);
         notificationServiceMock.Verify(
-            n => n.ShowInfo(It.Is<string>(s => s.Contains("Indexing")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
         notificationServiceMock.Verify(
-            n => n.ShowSuccess(It.Is<string>(s => s.Contains("Indexed")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.ShowSuccess(ManifestConstants.IndexedNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
         notificationServiceMock.Verify(
             n => n.ShowWarning(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
@@ -994,10 +994,10 @@ public class ManifestGenerationServiceTests : IDisposable
         // Assert
         Assert.NotNull(manifest);
         notificationServiceMock.Verify(
-            n => n.ShowInfo(It.Is<string>(s => s.Contains("Indexing")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
         notificationServiceMock.Verify(
-            n => n.ShowWarning(It.Is<string>(s => s.Contains("Incomplete")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.ShowWarning(ManifestConstants.IncompleteInstallationNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
         notificationServiceMock.Verify(
             n => n.ShowSuccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
@@ -1024,5 +1024,10 @@ public class ManifestGenerationServiceTests : IDisposable
         var executablePath = Path.Combine(clientPath, "generals.exe");
         await File.WriteAllTextAsync(executablePath, "dummy exe");
         return (clientPath, executablePath);
+    }
+
+    private sealed class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
+    {
+        public void Report(T value) => handler(value);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -1166,7 +1166,7 @@ public class ManifestGenerationServiceTests : IDisposable
         notificationServiceMock.Verify(
             n => n.Update(
                 It.IsAny<Guid>(),
-                It.Is<string>(msg => msg.Contains("Calculating SHA-256") || msg.Contains("game.dat")),
+                It.Is<string>(msg => msg.Contains("Calculating SHA-256") && msg.Contains("game.dat")),
                 ManifestConstants.IndexingNotificationTitle),
             Times.AtLeastOnce);
         notificationServiceMock.Verify(

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -5,6 +5,7 @@ using GenHub.Core.Interfaces.Notifications;
 using GenHub.Core.Interfaces.Tools;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Notifications;
 using GenHub.Core.Models.Results;
 using GenHub.Core.Models.Validation;
 using GenHub.Features.Manifest;
@@ -955,7 +956,13 @@ public class ManifestGenerationServiceTests : IDisposable
         // Assert
         Assert.NotNull(manifest);
         notificationServiceMock.Verify(
-            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.Show(It.Is<NotificationMessage>(m =>
+                m.Title == ManifestConstants.IndexingNotificationTitle &&
+                m.AutoDismissMilliseconds == null &&
+                m.IsPersistent)),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.Dismiss(It.IsAny<Guid>()),
             Times.Once);
         notificationServiceMock.Verify(
             n => n.ShowSuccess(ManifestConstants.IndexedNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
@@ -999,7 +1006,13 @@ public class ManifestGenerationServiceTests : IDisposable
         // Assert
         Assert.NotNull(manifest);
         notificationServiceMock.Verify(
-            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.Show(It.Is<NotificationMessage>(m =>
+                m.Title == ManifestConstants.IndexingNotificationTitle &&
+                m.AutoDismissMilliseconds == null &&
+                m.IsPersistent)),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.Dismiss(It.IsAny<Guid>()),
             Times.Once);
         notificationServiceMock.Verify(
             n => n.ShowWarning(ManifestConstants.IncompleteInstallationNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
@@ -1042,7 +1055,13 @@ public class ManifestGenerationServiceTests : IDisposable
         // Assert
         Assert.NotNull(manifest);
         notificationServiceMock.Verify(
-            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.Show(It.Is<NotificationMessage>(m =>
+                m.Title == ManifestConstants.IndexingNotificationTitle &&
+                m.AutoDismissMilliseconds == null &&
+                m.IsPersistent)),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.Dismiss(It.IsAny<Guid>()),
             Times.Once);
         notificationServiceMock.Verify(
             n => n.ShowSuccess(ManifestConstants.IndexedNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
@@ -1084,7 +1103,13 @@ public class ManifestGenerationServiceTests : IDisposable
         // Assert
         Assert.NotNull(manifest);
         notificationServiceMock.Verify(
-            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            n => n.Show(It.Is<NotificationMessage>(m =>
+                m.Title == ManifestConstants.IndexingNotificationTitle &&
+                m.AutoDismissMilliseconds == null &&
+                m.IsPersistent)),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.Dismiss(It.IsAny<Guid>()),
             Times.Once);
         notificationServiceMock.Verify(
             n => n.ShowWarning(ManifestConstants.DirectoryScanWarningNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
@@ -1092,6 +1117,61 @@ public class ManifestGenerationServiceTests : IDisposable
         notificationServiceMock.Verify(
             n => n.ShowSuccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that CreateGameInstallationManifestAsync updates the persistent notification with file details when hashing large files.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateGameInstallationManifestAsync_WhenProcessingLargeFiles_UpdatesProgressNotificationWithDetailsAsync()
+    {
+        // Arrange
+        var notificationServiceMock = new Mock<INotificationService>();
+        var serviceWithNotifications = new ManifestGenerationService(
+            NullLogger<ManifestGenerationService>.Instance,
+            _hashProviderMock.Object,
+            _manifestIdServiceMock.Object,
+            _downloadServiceMock.Object,
+            _configProviderServiceMock.Object,
+            notificationService: notificationServiceMock.Object);
+
+        var installationPath = Path.Combine(_tempDirectory, "NotificationLargeFileInstall");
+        Directory.CreateDirectory(installationPath);
+
+        // Create game.dat with size >= LargeFileProgressThresholdBytes (5 MB)
+        var largeFilePath = Path.Combine(installationPath, "game.dat");
+        using (var fs = new FileStream(largeFilePath, System.IO.FileMode.Create, System.IO.FileAccess.Write))
+        {
+            fs.SetLength(ManifestConstants.LargeFileProgressThresholdBytes + 1024);
+        }
+
+        // Act
+        var builder = await serviceWithNotifications.CreateGameInstallationManifestAsync(
+            installationPath,
+            GameType.ZeroHour,
+            GameInstallationType.Steam,
+            "1.04",
+            "EN");
+        var manifest = builder.Build();
+
+        // Assert
+        Assert.NotNull(manifest);
+        notificationServiceMock.Verify(
+            n => n.Show(It.Is<NotificationMessage>(m =>
+                m.Title == ManifestConstants.IndexingNotificationTitle &&
+                m.AutoDismissMilliseconds == null &&
+                m.IsPersistent)),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.Update(
+                It.IsAny<Guid>(),
+                It.Is<string>(msg => msg.Contains("Calculating SHA-256") || msg.Contains("game.dat")),
+                ManifestConstants.IndexingNotificationTitle),
+            Times.AtLeastOnce);
+        notificationServiceMock.Verify(
+            n => n.Dismiss(It.IsAny<Guid>()),
+            Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -1091,7 +1091,7 @@ public class ManifestGenerationServiceTests : IDisposable
         var skippedFiles = new[] { "skip1.dat", "skip2.dat" };
 
         // Act
-        var message = _service.GetIncompleteInstallationWarningMessage(GameType.ZeroHour, missingFiles, skippedFiles);
+        var message = ManifestGenerationService.GetIncompleteInstallationWarningMessage(GameType.ZeroHour, missingFiles, skippedFiles);
 
         // Assert
         Assert.Contains("ZeroHour has 6 missing required file(s)", message);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -1023,6 +1023,64 @@ public class ManifestGenerationServiceTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that CreateGameInstallationManifestAsync shows warning notification and suppresses success when a required file is skipped due to access failure.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateGameInstallationManifestAsync_WhenRequiredFileSkippedDueToAccessFailure_DispatchesWarningNotificationAsync()
+    {
+        // Arrange
+        var notificationServiceMock = new Mock<INotificationService>();
+        var failingHashProviderMock = new Mock<IFileHashProvider>();
+        failingHashProviderMock.Setup(x => x.ComputeFileHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string path, CancellationToken ct) => $"hash_{Path.GetFileName(path)}");
+        failingHashProviderMock.Setup(x => x.ComputeFileHashAsync(It.Is<string>(p => p.Contains("game.dat")), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("Simulated I/O failure on required file"));
+
+        var serviceWithNotifications = new ManifestGenerationService(
+            NullLogger<ManifestGenerationService>.Instance,
+            failingHashProviderMock.Object,
+            _manifestIdServiceMock.Object,
+            _downloadServiceMock.Object,
+            _configProviderServiceMock.Object,
+            notificationService: notificationServiceMock.Object);
+
+        var installationPath = Path.Combine(_tempDirectory, "NotificationRequiredSkippedInstall");
+        Directory.CreateDirectory(installationPath);
+
+        // game.dat is the required file in ZeroHour catalog
+        var requiredFile = Path.Combine(installationPath, "game.dat");
+        await File.WriteAllTextAsync(requiredFile, "game dat content");
+
+        // Act
+        var builder = await serviceWithNotifications.CreateGameInstallationManifestAsync(
+            installationPath,
+            GameType.ZeroHour,
+            GameInstallationType.Steam,
+            "1.04",
+            "EN");
+        var manifest = builder.Build();
+
+        // Assert
+        Assert.NotNull(manifest);
+        notificationServiceMock.Verify(
+            n => n.Show(It.Is<NotificationMessage>(m =>
+                m.Title == ManifestConstants.IndexingNotificationTitle &&
+                m.AutoDismissMilliseconds == null &&
+                m.IsPersistent)),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.Dismiss(It.IsAny<Guid>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowWarning(ManifestConstants.IncompleteInstallationNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowSuccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Tests that fallback directory scan shows info and success notifications when completing normally.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -1053,6 +1053,48 @@ public class ManifestGenerationServiceTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that fallback directory scan shows warning notification and suppresses success when file enumeration fails.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateGameInstallationManifestAsync_DirectoryScanFallback_WhenEnumerationFails_DispatchesWarningNotificationAsync()
+    {
+        // Arrange
+        var notificationServiceMock = new Mock<INotificationService>();
+        var serviceWithNotifications = new ManifestGenerationService(
+            NullLogger<ManifestGenerationService>.Instance,
+            _hashProviderMock.Object,
+            _manifestIdServiceMock.Object,
+            _downloadServiceMock.Object,
+            _configProviderServiceMock.Object,
+            notificationService: notificationServiceMock.Object);
+
+        // A non-existent directory triggers DirectoryNotFoundException (IOException) during Directory.EnumerateFiles
+        var nonExistentPath = Path.Combine(_tempDirectory, "NonExistentDirectoryForScanFailure");
+
+        // Act - Unsupported version forces directory scan fallback on non-existent path
+        var builder = await serviceWithNotifications.CreateGameInstallationManifestAsync(
+            nonExistentPath,
+            GameType.Generals,
+            GameInstallationType.Steam,
+            "9.99",
+            "EN");
+        var manifest = builder.Build();
+
+        // Assert
+        Assert.NotNull(manifest);
+        notificationServiceMock.Verify(
+            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowWarning(ManifestConstants.DirectoryScanWarningNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowSuccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Cleans up temporary test files.
     /// </summary>
     public void Dispose()

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -1,10 +1,12 @@
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Notifications;
 using GenHub.Core.Interfaces.Tools;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
+using GenHub.Core.Models.Validation;
 using GenHub.Features.Manifest;
 using GenHub.Features.Workspace;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -876,6 +878,130 @@ public class ManifestGenerationServiceTests : IDisposable
                 File.SetUnixFileMode(inaccessibleFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
             }
         }
+    }
+
+    /// <summary>
+    /// Tests that CreateGameInstallationManifestAsync reports progress through IProgress.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateGameInstallationManifestAsync_ReportsProgressAsync()
+    {
+        // Arrange
+        var installationPath = Path.Combine(_tempDirectory, "ProgressTestInstall");
+        Directory.CreateDirectory(installationPath);
+
+        await File.WriteAllTextAsync(Path.Combine(installationPath, "generals.exe"), "zh exe");
+        await File.WriteAllTextAsync(Path.Combine(installationPath, "AudioZH.big"), "zh audio");
+
+        var progressReports = new List<ValidationProgress>();
+        var progress = new Progress<ValidationProgress>(p => progressReports.Add(p));
+
+        // Act
+        var builder = await _service.CreateGameInstallationManifestAsync(
+            installationPath,
+            GameType.ZeroHour,
+            GameInstallationType.Steam,
+            "1.04",
+            "EN",
+            progress);
+        var manifest = builder.Build();
+
+        // Assert
+        Assert.NotNull(manifest);
+        Assert.NotEmpty(progressReports);
+        var last = progressReports.Last();
+        Assert.True(last.Total > 0);
+        Assert.True(last.Processed > 0);
+    }
+
+    /// <summary>
+    /// Tests that CreateGameInstallationManifestAsync shows info on start and success when no required files are missing.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateGameInstallationManifestAsync_WhenAllRequiredFilesPresent_DispatchesSuccessNotificationAsync()
+    {
+        // Arrange
+        var notificationServiceMock = new Mock<INotificationService>();
+        var serviceWithNotifications = new ManifestGenerationService(
+            NullLogger<ManifestGenerationService>.Instance,
+            _hashProviderMock.Object,
+            _manifestIdServiceMock.Object,
+            _downloadServiceMock.Object,
+            _configProviderServiceMock.Object,
+            notificationService: notificationServiceMock.Object);
+
+        var installationPath = Path.Combine(_tempDirectory, "NotificationSuccessInstall");
+        Directory.CreateDirectory(installationPath);
+
+        // game.dat is the required file in ZeroHour catalog
+        await File.WriteAllTextAsync(Path.Combine(installationPath, "game.dat"), "game dat content");
+
+        // Act
+        var builder = await serviceWithNotifications.CreateGameInstallationManifestAsync(
+            installationPath,
+            GameType.ZeroHour,
+            GameInstallationType.Steam,
+            "1.04",
+            "EN");
+        var manifest = builder.Build();
+
+        // Assert
+        Assert.NotNull(manifest);
+        notificationServiceMock.Verify(
+            n => n.ShowInfo(It.Is<string>(s => s.Contains("Indexing")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowSuccess(It.Is<string>(s => s.Contains("Indexed")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowWarning(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that CreateGameInstallationManifestAsync shows warning notification when required files are missing.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateGameInstallationManifestAsync_WhenRequiredFilesMissing_DispatchesWarningNotificationAsync()
+    {
+        // Arrange
+        var notificationServiceMock = new Mock<INotificationService>();
+        var serviceWithNotifications = new ManifestGenerationService(
+            NullLogger<ManifestGenerationService>.Instance,
+            _hashProviderMock.Object,
+            _manifestIdServiceMock.Object,
+            _downloadServiceMock.Object,
+            _configProviderServiceMock.Object,
+            notificationService: notificationServiceMock.Object);
+
+        var installationPath = Path.Combine(_tempDirectory, "NotificationMissingInstall");
+        Directory.CreateDirectory(installationPath);
+
+        // Missing game.dat (required file)
+
+        // Act
+        var builder = await serviceWithNotifications.CreateGameInstallationManifestAsync(
+            installationPath,
+            GameType.ZeroHour,
+            GameInstallationType.Steam,
+            "1.04",
+            "EN");
+        var manifest = builder.Build();
+
+        // Assert
+        Assert.NotNull(manifest);
+        notificationServiceMock.Verify(
+            n => n.ShowInfo(It.Is<string>(s => s.Contains("Indexing")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowWarning(It.Is<string>(s => s.Contains("Incomplete")), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowSuccess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -1081,6 +1081,26 @@ public class ManifestGenerationServiceTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that GetIncompleteInstallationWarningMessage formats a combined message when files are both missing and skipped, including truncation.
+    /// </summary>
+    [Fact]
+    public void GetIncompleteInstallationWarningMessage_WhenBothMissingAndSkipped_FormatsCombinedMessageWithTruncation()
+    {
+        // Arrange
+        var missingFiles = new[] { "file1.dat", "file2.dat", "file3.dat", "file4.dat", "file5.dat", "file6.dat" };
+        var skippedFiles = new[] { "skip1.dat", "skip2.dat" };
+
+        // Act
+        var message = _service.GetIncompleteInstallationWarningMessage(GameType.ZeroHour, missingFiles, skippedFiles);
+
+        // Assert
+        Assert.Contains("ZeroHour has 6 missing required file(s)", message);
+        Assert.Contains("and 1 more", message);
+        Assert.Contains("and 2 unreadable/skipped file(s)", message);
+        Assert.Contains("skip1.dat, skip2.dat", message);
+    }
+
+    /// <summary>
     /// Tests that fallback directory scan shows info and success notifications when completing normally.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -24,6 +24,11 @@ namespace GenHub.Tests.Core.Features.Manifest;
 /// </summary>
 public class ManifestGenerationServiceTests : IDisposable
 {
+    private sealed class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
+    {
+        public void Report(T value) => handler(value);
+    }
+
     private readonly Mock<IFileHashProvider> _hashProviderMock;
     private readonly Mock<IManifestIdService> _manifestIdServiceMock;
     private readonly Mock<IDownloadService> _downloadServiceMock;
@@ -1024,10 +1029,5 @@ public class ManifestGenerationServiceTests : IDisposable
         var executablePath = Path.Combine(clientPath, "generals.exe");
         await File.WriteAllTextAsync(executablePath, "dummy exe");
         return (clientPath, executablePath);
-    }
-
-    private sealed class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
-    {
-        public void Report(T value) => handler(value);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs
@@ -1010,6 +1010,49 @@ public class ManifestGenerationServiceTests : IDisposable
     }
 
     /// <summary>
+    /// Tests that fallback directory scan shows info and success notifications when completing normally.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CreateGameInstallationManifestAsync_DirectoryScanFallback_DispatchesStartAndSuccessNotificationsAsync()
+    {
+        // Arrange
+        var notificationServiceMock = new Mock<INotificationService>();
+        var serviceWithNotifications = new ManifestGenerationService(
+            NullLogger<ManifestGenerationService>.Instance,
+            _hashProviderMock.Object,
+            _manifestIdServiceMock.Object,
+            _downloadServiceMock.Object,
+            _configProviderServiceMock.Object,
+            notificationService: notificationServiceMock.Object);
+
+        var installationPath = Path.Combine(_tempDirectory, "FallbackNotificationInstall");
+        Directory.CreateDirectory(installationPath);
+        await File.WriteAllTextAsync(Path.Combine(installationPath, "generals.exe"), "generals exe content");
+
+        // Act - Unsupported version forces directory scan fallback
+        var builder = await serviceWithNotifications.CreateGameInstallationManifestAsync(
+            installationPath,
+            GameType.Generals,
+            GameInstallationType.Steam,
+            "9.99",
+            "EN");
+        var manifest = builder.Build();
+
+        // Assert
+        Assert.NotNull(manifest);
+        notificationServiceMock.Verify(
+            n => n.ShowInfo(ManifestConstants.IndexingNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowSuccess(ManifestConstants.IndexedNotificationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        notificationServiceMock.Verify(
+            n => n.ShowWarning(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Cleans up temporary test files.
     /// </summary>
     public void Dispose()

--- a/GenHub/GenHub.Tools/CsvGenerator.cs
+++ b/GenHub/GenHub.Tools/CsvGenerator.cs
@@ -585,7 +585,7 @@ public class CsvGenerator(ILogger logger)
         var outputFileName = Path.GetFileName(options.OutputPath);
         var entryUrl = !string.IsNullOrWhiteSpace(options.DownloadUrl)
             ? options.DownloadUrl
-            : $"https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/{outputFileName}";
+            : $"{CsvConstants.DefaultRegistryBaseUrl}/{outputFileName}";
 
         if (existingEntry != null)
         {

--- a/GenHub/GenHub.Tools/CsvGenerator.cs
+++ b/GenHub/GenHub.Tools/CsvGenerator.cs
@@ -585,7 +585,7 @@ public class CsvGenerator(ILogger logger)
         var outputFileName = Path.GetFileName(options.OutputPath);
         var entryUrl = !string.IsNullOrWhiteSpace(options.DownloadUrl)
             ? options.DownloadUrl
-            : $"https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/{outputFileName}";
+            : $"https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/{outputFileName}";
 
         if (existingEntry != null)
         {

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/CNCLabsMapResolver.cs
@@ -228,6 +228,7 @@ public class CNCLabsMapResolver(
 
         var screenshots = document.QuerySelectorAll("img.Screenshot")
             .Select(img => img.GetAttribute("src"))
+            .OfType<string>()
             .Where(src => !string.IsNullOrEmpty(src))
             .Select(src => src.StartsWith("http", StringComparison.OrdinalIgnoreCase)
                 ? src

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/CsvResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/CsvResolver.cs
@@ -347,6 +347,29 @@ public class CsvResolver(
         return manifest;
     }
 
+    private static CsvContentLoadResult? TryLoadEmbeddedResource(Uri uri)
+    {
+        var fileName = Path.GetFileName(uri.AbsolutePath);
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        var embeddedResourceName = $"{CsvConstants.EmbeddedResourceNamespace}.{fileName}";
+        var assembly = typeof(CsvConstants).Assembly;
+        using var stream = assembly.GetManifestResourceStream(embeddedResourceName);
+        if (stream == null)
+        {
+            return null;
+        }
+
+        using var memoryStream = new MemoryStream();
+        stream.CopyTo(memoryStream);
+        var rawBytes = memoryStream.ToArray();
+        var content = Encoding.UTF8.GetString(rawBytes).TrimStart('\uFEFF');
+        return new CsvContentLoadResult(content, false, rawBytes);
+    }
+
     private async Task<OperationResult<CsvContentLoadResult>> LoadCsvContentAsync(string sourceUrl, CancellationToken cancellationToken)
     {
         if (Uri.TryCreate(sourceUrl, UriKind.Absolute, out var uri) &&
@@ -380,10 +403,29 @@ public class CsvResolver(
                 var content = Encoding.UTF8.GetString(rawBytes).TrimStart('\uFEFF');
                 return OperationResult<CsvContentLoadResult>.CreateSuccess(new CsvContentLoadResult(content, true, rawBytes));
             }
-            catch (Exception ex) when (cached != null && IsRecoverableRemoteFailure(ex, cancellationToken))
+            catch (Exception ex) when (IsRecoverableRemoteFailure(ex, cancellationToken))
             {
-                logger.LogWarning(ex, "Remote CSV catalog {SourceUrl} is unavailable; using stale cached content", sourceUrl);
-                return OperationResult<CsvContentLoadResult>.CreateSuccess(new CsvContentLoadResult(cached.Content, false, cached.RawBytes));
+                if (cached != null)
+                {
+                    logger.LogWarning(ex, "Remote CSV catalog {SourceUrl} is unavailable; using stale cached content", sourceUrl);
+                    return OperationResult<CsvContentLoadResult>.CreateSuccess(new CsvContentLoadResult(cached.Content, false, cached.RawBytes));
+                }
+
+                var embeddedResult = TryLoadEmbeddedResource(uri);
+                if (embeddedResult != null)
+                {
+                    logger.LogInformation(
+                        "Remote CSV catalog {SourceUrl} is unavailable ({Error}); falling back to bundled embedded catalog",
+                        sourceUrl,
+                        ex.Message);
+                    return OperationResult<CsvContentLoadResult>.CreateSuccess(embeddedResult);
+                }
+
+                logger.LogWarning(
+                    ex,
+                    "Remote CSV catalog {SourceUrl} is unavailable and no local cache or embedded fallback was found",
+                    sourceUrl);
+                return OperationResult<CsvContentLoadResult>.CreateFailure($"Failed to load remote CSV catalog: {ex.Message}");
             }
         }
 

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/CsvResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/CsvResolver.cs
@@ -453,7 +453,11 @@ public class CsvResolver(
             var content = Encoding.UTF8.GetString(rawBytes).TrimStart('\uFEFF');
             return OperationResult<CsvContentLoadResult>.CreateSuccess(new CsvContentLoadResult(content, false, rawBytes));
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             logger.LogError(ex, "Failed to read CSV catalog file at {FilePath}", resolvedPath);
             return OperationResult<CsvContentLoadResult>.CreateFailure($"Failed to read CSV catalog file: {ex.Message}");

--- a/GenHub/GenHub/Features/Content/Services/ContentResolvers/CsvResolver.cs
+++ b/GenHub/GenHub/Features/Content/Services/ContentResolvers/CsvResolver.cs
@@ -349,15 +349,24 @@ public class CsvResolver(
 
     private static CsvContentLoadResult? TryLoadEmbeddedResource(Uri uri)
     {
-        var fileName = Path.GetFileName(uri.AbsolutePath);
+        var unescapedPath = Uri.UnescapeDataString(uri.AbsolutePath);
+        var fileName = Path.GetFileName(unescapedPath);
         if (string.IsNullOrWhiteSpace(fileName))
         {
             return null;
         }
 
-        var embeddedResourceName = $"{CsvConstants.EmbeddedResourceNamespace}.{fileName}";
+        var expectedResourceName = $"{CsvConstants.EmbeddedResourceNamespace}.{fileName}";
         var assembly = typeof(CsvConstants).Assembly;
-        using var stream = assembly.GetManifestResourceStream(embeddedResourceName);
+        var actualResourceName = assembly.GetManifestResourceNames()
+            .FirstOrDefault(name => string.Equals(name, expectedResourceName, StringComparison.OrdinalIgnoreCase));
+
+        if (actualResourceName == null)
+        {
+            return null;
+        }
+
+        using var stream = assembly.GetManifestResourceStream(actualResourceName);
         if (stream == null)
         {
             return null;
@@ -414,7 +423,7 @@ public class CsvResolver(
                 var embeddedResult = TryLoadEmbeddedResource(uri);
                 if (embeddedResult != null)
                 {
-                    logger.LogInformation(
+                    logger.LogWarning(
                         "Remote CSV catalog {SourceUrl} is unavailable ({Error}); falling back to bundled embedded catalog",
                         sourceUrl,
                         ex.Message);
@@ -438,8 +447,16 @@ public class CsvResolver(
             return OperationResult<CsvContentLoadResult>.CreateFailure($"CSV file not found at: {resolvedPath}");
         }
 
-        var fileBytes = await File.ReadAllBytesAsync(resolvedPath, cancellationToken);
-        var fileContent = Encoding.UTF8.GetString(fileBytes).TrimStart('\uFEFF');
-        return OperationResult<CsvContentLoadResult>.CreateSuccess(new CsvContentLoadResult(fileContent, false, fileBytes));
+        try
+        {
+            var rawBytes = await File.ReadAllBytesAsync(resolvedPath, cancellationToken);
+            var content = Encoding.UTF8.GetString(rawBytes).TrimStart('\uFEFF');
+            return OperationResult<CsvContentLoadResult>.CreateSuccess(new CsvContentLoadResult(content, false, rawBytes));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to read CSV catalog file at {FilePath}", resolvedPath);
+            return OperationResult<CsvContentLoadResult>.CreateFailure($"Failed to read CSV catalog file: {ex.Message}");
+        }
     }
 }

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
@@ -147,17 +147,14 @@ public class GeneralsOnlineJsonCatalogParser(
     internal static string ResolveReleaseVersion(string? apiVersion, string? downloadUrl)
     {
         var urlVersion = ExtractVersionFromUrl(downloadUrl);
-        var hasUrl = !string.IsNullOrWhiteSpace(urlVersion);
-        var hasApi = !string.IsNullOrWhiteSpace(apiVersion);
-
-        if (!hasUrl)
+        if (string.IsNullOrWhiteSpace(urlVersion))
         {
-            return hasApi ? apiVersion! : GeneralsOnlineConstants.UnknownVersion;
+            return !string.IsNullOrWhiteSpace(apiVersion) ? apiVersion : GeneralsOnlineConstants.UnknownVersion;
         }
 
-        if (!hasApi)
+        if (string.IsNullOrWhiteSpace(apiVersion))
         {
-            return urlVersion!;
+            return urlVersion;
         }
 
         // Both are present and not empty.

--- a/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Infrastructure/GameProcessManager.cs
@@ -999,6 +999,11 @@ public class GameProcessManager(
         CancellationToken cancellationToken)
     {
         var expectedName = configuration.ExpectedChildProcessName;
+        if (string.IsNullOrWhiteSpace(expectedName))
+        {
+            return OperationResult<GameProcessInfo>.CreateFailure("Expected child process name is not specified.");
+        }
+
         var timeout = configuration.ExpectedChildDiscoveryTimeout
             ?? TimeSpan.FromMilliseconds(ProcessConstants.SpawnedChildDiscoveryTimeoutMs);
         var deadline = DateTime.UtcNow + timeout;

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -58,7 +58,7 @@ public class GameProfileManager(
             {
                 // Validate Tool profile content configuration
                 var validationError = await Core.Helpers.ToolProfileHelper.ValidateToolProfileContentAsync(
-                    request.EnabledContentIds,
+                    request.EnabledContentIds ?? [],
                     manifestPool,
                     cancellationToken);
 
@@ -68,7 +68,7 @@ public class GameProfileManager(
                 }
 
                 // Set toolContentId to the single ModdingTool content ID
-                toolContentId = request.EnabledContentIds.First();
+                toolContentId = request.EnabledContentIds!.First();
 
                 logger.LogInformation(
                     "Detected Tool profile creation for tool: {ToolContentId}",

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -621,10 +621,10 @@ public class ProfileLauncherFacade(
         };
 
         var prepareResult = await workspaceManager.PrepareWorkspaceAsync(workspaceConfig, progress: null, skipCleanup: false, cancellationToken: cancellationToken);
-        if (prepareResult.Failed)
+        if (prepareResult.Failed || prepareResult.Data == null)
         {
             return ProfileOperationResult<(string, string?)>.CreateFailure(
-                $"{ProfileValidationConstants.FailedToPrepareToolWorkspace}: {prepareResult.FirstError}");
+                $"{ProfileValidationConstants.FailedToPrepareToolWorkspace}: {prepareResult.FirstError ?? "Workspace preparation returned null data"}");
         }
 
         var toolWorkspacePath = prepareResult.Data.WorkspacePath;

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -704,6 +704,7 @@ public partial class GameProfileSettingsViewModel
         {
             WeakReferenceMessenger.Default.Send(new ProfileUpdatedMessage(result.Data));
         }
+
         ExecuteCancel();
     }
 
@@ -1240,8 +1241,8 @@ public partial class GameProfileSettingsViewModel
 
         if (string.IsNullOrWhiteSpace(LocalContentDirectoryPath))
         {
-             _localNotificationService.ShowWarning("Validation Error", "Please select a folder for the content.");
-             return;
+            _localNotificationService.ShowWarning("Validation Error", "Please select a folder for the content.");
+            return;
         }
 
         try
@@ -1256,14 +1257,14 @@ public partial class GameProfileSettingsViewModel
 
             if (result.Success)
             {
-                 IsAddLocalContentDialogOpen = false;
+                IsAddLocalContentDialogOpen = false;
 
-                 // Refresh filters and content to ensure new type appears and list updates
-                 await RefreshFiltersAndContentAsync();
+                // Refresh filters and content to ensure new type appears and list updates
+                await RefreshFiltersAndContentAsync();
 
-                 // If the added item matches current filter, ensure it's selected/visible (handled by LoadAvailableContent)
-                 // If the item introduced a new filter, user might want to switch to it.
-                 // For now, just refreshing ensures it's reachable.
+                // If the added item matches current filter, ensure it's selected/visible (handled by LoadAvailableContent)
+                // If the item introduced a new filter, user might want to switch to it.
+                // For now, just refreshing ensures it's reachable.
             }
             else
             {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -700,7 +700,10 @@ public partial class GameProfileSettingsViewModel
         StatusMessage = "Profile updated successfully";
         _logger?.LogInformation("Updated profile {ProfileId} with {ContentCount} enabled content items", CurrentProfileId, enabledContentIds.Count);
 
-        WeakReferenceMessenger.Default.Send(new ProfileUpdatedMessage(result.Data));
+        if (result.Data != null)
+        {
+            WeakReferenceMessenger.Default.Send(new ProfileUpdatedMessage(result.Data));
+        }
         ExecuteCancel();
     }
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
@@ -138,6 +138,14 @@ public partial class GameProfileSettingsViewModel
             CurrentProfileId = profileId;
             _logger?.LogInformation("InitializeForProfileAsync called with profileId: {ProfileId}", profileId);
 
+            if (_gameProfileManager == null)
+            {
+                _logger?.LogWarning("Failed to load profile {ProfileId}: GameProfileManager is null", profileId);
+                StatusMessage = "Failed to load profile";
+                LoadingError = true;
+                return;
+            }
+
             var profileResult = await _gameProfileManager.GetProfileAsync(profileId);
             if (!profileResult.Success || profileResult.Data == null)
             {
@@ -265,6 +273,11 @@ public partial class GameProfileSettingsViewModel
 
     private async Task SaveDefaultGameSettingsAsync(string profileId)
     {
+        if (_gameProfileManager == null)
+        {
+            return;
+        }
+
         var gameSettings = GameSettingsViewModel.GetProfileSettings();
         var updateRequest = new UpdateProfileRequest();
         PopulateGameSettings(updateRequest, gameSettings);

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
@@ -141,7 +141,7 @@ public partial class GameProfileSettingsViewModel
             if (_gameProfileManager == null)
             {
                 _logger?.LogWarning("Failed to load profile {ProfileId}: GameProfileManager is null", profileId);
-                StatusMessage = "Failed to load profile";
+                StatusMessage = "Error loading profile";
                 LoadingError = true;
                 return;
             }

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -34,6 +35,7 @@ namespace GenHub.Features.Manifest;
 /// Provides methods to create <see cref="ContentManifest"/> objects for different content types
 /// including GameInstallation and GameClient manifests with proper metadata and file references.
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "ManifestGenerationService coordinates manifest creation across file hashing, catalog resolution, configuration, and notification services injected via dependency injection.")]
 public class ManifestGenerationService(
     ILogger<ManifestGenerationService> logger,
     IFileHashProvider hashProvider,
@@ -942,7 +944,7 @@ public class ManifestGenerationService(
         notificationService?.ShowInfo(
             ManifestConstants.IndexingNotificationTitle,
             $"Scanning {gameType} installation files ({authoritativeEntries.Count} files to verify)...",
-            autoDismissMs: 4000);
+            autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
 
         var fileCount = 0;
         var totalEntries = authoritativeEntries.Count;
@@ -954,8 +956,6 @@ public class ManifestGenerationService(
             cancellationToken.ThrowIfCancellationRequested();
             var entry = authoritativeEntries[i];
             var currentIndex = i + 1;
-
-            progress?.Report(new ValidationProgress(currentIndex, totalEntries, entry.RelativePath));
 
             var result = await TryAddAuthoritativeEntryAsync(builder, installationPath, entry, cancellationToken);
             switch (result)
@@ -977,7 +977,9 @@ public class ManifestGenerationService(
                     break;
             }
 
-            if (currentIndex % 25 == 0 || currentIndex == totalEntries)
+            progress?.Report(new ValidationProgress(currentIndex, totalEntries, entry.RelativePath));
+
+            if (currentIndex % ManifestConstants.ProgressLoggingThrottleInterval == 0 || currentIndex == totalEntries)
             {
                 var percent = (double)currentIndex / totalEntries * 100;
                 logger.LogInformation(
@@ -998,19 +1000,24 @@ public class ManifestGenerationService(
 
         if (missingRequiredFiles.Count > 0)
         {
-            var fileList = string.Join(", ", missingRequiredFiles.Take(5));
-            var extra = missingRequiredFiles.Count > 5 ? $" and {missingRequiredFiles.Count - 5} more" : string.Empty;
+            var fileList = string.Join(", ", missingRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
+            var extra = missingRequiredFiles.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
+                ? $" and {missingRequiredFiles.Count - ManifestConstants.MaxMissingFilesNotificationDisplayCount} more"
+                : string.Empty;
             notificationService?.ShowWarning(
                 ManifestConstants.IncompleteInstallationNotificationTitle,
                 $"{gameType} is missing {missingRequiredFiles.Count} required file(s): {fileList}{extra}. A clean reinstall or repair via EA App/Steam is recommended.",
-                autoDismissMs: 10000);
+                autoDismissMs: ManifestConstants.WarningNotificationAutoDismissMs);
         }
         else
         {
+            var differingMessage = differingFiles.Count > 0
+                ? $" ({differingFiles.Count} differing from catalog)"
+                : string.Empty;
             notificationService?.ShowSuccess(
                 ManifestConstants.IndexedNotificationTitle,
-                $"Completed verification for {gameType} ({fileCount}/{totalEntries} files verified).",
-                autoDismissMs: 4000);
+                $"Completed verification for {gameType} ({fileCount}/{totalEntries} files verified{differingMessage}).",
+                autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
         }
     }
 

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -4,11 +4,13 @@ using GenHub.Core.Constants;
 using GenHub.Core.Features.GameInstallations;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Notifications;
 using GenHub.Core.Interfaces.Tools;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results.Content;
+using GenHub.Core.Models.Validation;
 using GenHub.Core.Utilities;
 using GenHub.Features.Content.Services.ContentResolvers;
 using Microsoft.Extensions.Logging;
@@ -39,7 +41,8 @@ public class ManifestGenerationService(
     IDownloadService downloadService,
     IConfigurationProviderService configurationProvider,
     ILanguageDetector? languageDetector = null,
-    CsvResolver? csvResolver = null) : IManifestGenerationService
+    CsvResolver? csvResolver = null,
+    INotificationService? notificationService = null) : IManifestGenerationService
 {
     private static readonly CsvConfiguration CsvConfig = new(CultureInfo.InvariantCulture)
     {
@@ -85,6 +88,15 @@ public class ManifestGenerationService(
         ".wav",
     };
 
+    private enum AuthoritativeFileStatus
+    {
+        AddedMatching,
+        AddedDiffering,
+        MissingRequired,
+        MissingOptional,
+        Skipped,
+    }
+
     private readonly ILanguageDetector _languageDetector = languageDetector ?? new LanguageDetector();
 
     /// <summary>
@@ -97,12 +109,42 @@ public class ManifestGenerationService(
     /// <param name="language">Optional explicit language code (e.g., "EN", "DE"). If null, language is detected automatically.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task"/> that returns a configured manifest builder.</returns>
-    public async Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
+    public Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
         string gameInstallationPath,
         GameType gameType,
         GameInstallationType installationType,
         string? manifestVersion = null,
         string? language = null,
+        CancellationToken cancellationToken = default)
+    {
+        return CreateGameInstallationManifestAsync(
+            gameInstallationPath,
+            gameType,
+            installationType,
+            manifestVersion,
+            language,
+            progress: null,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a manifest builder for a game installation with string version normalization and progress reporting.
+    /// </summary>
+    /// <param name="gameInstallationPath">Path to the game installation.</param>
+    /// <param name="gameType">The game type (Generals, ZeroHour).</param>
+    /// <param name="installationType">The installation type (Steam, EaApp).</param>
+    /// <param name="manifestVersion">The manifest version (e.g., "1.08", "1.04", or integer like 0, 1, 2). If null, defaults to 0.</param>
+    /// <param name="language">Optional explicit language code (e.g., "EN", "DE"). If null, language is detected automatically.</param>
+    /// <param name="progress">Optional progress reporter receiving file indexing progress updates.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> that returns a configured manifest builder.</returns>
+    public async Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
+        string gameInstallationPath,
+        GameType gameType,
+        GameInstallationType installationType,
+        string? manifestVersion,
+        string? language,
+        IProgress<ValidationProgress>? progress,
         CancellationToken cancellationToken = default)
     {
         try
@@ -131,7 +173,7 @@ public class ManifestGenerationService(
             builder.WithPublisher(publisher.Name, publisher.Website, publisher.SupportUrl, string.Empty, publisher.PublisherType);
 
             // Add essential game files
-            await AddGameFilesToManifest(builder, gameInstallationPath, gameType, resolvedVersion, language, cancellationToken);
+            await AddGameFilesToManifest(builder, gameInstallationPath, gameType, resolvedVersion, language, progress, cancellationToken);
 
             logger.LogInformation(
                 "Created GameInstallation manifest for {InstallationType} {GameType} (Publisher: {PublisherName})",
@@ -166,7 +208,7 @@ public class ManifestGenerationService(
     /// <param name="language">Optional explicit language code (e.g., "EN", "DE"). If null, language is detected automatically.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task"/> that returns a configured manifest builder.</returns>
-    public async Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
+    public Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
         string gameInstallationPath,
         GameType gameType,
         GameInstallationType installationType,
@@ -174,7 +216,44 @@ public class ManifestGenerationService(
         string? language = null,
         CancellationToken cancellationToken = default)
     {
-        return await CreateGameInstallationManifestAsync(gameInstallationPath, gameType, installationType, manifestVersion.ToString(), language, cancellationToken);
+        return CreateGameInstallationManifestAsync(
+            gameInstallationPath,
+            gameType,
+            installationType,
+            manifestVersion.ToString(),
+            language,
+            progress: null,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a manifest builder for a game installation with integer version and progress reporting.
+    /// </summary>
+    /// <param name="gameInstallationPath">Path to the game installation.</param>
+    /// <param name="gameType">The game type (Generals, ZeroHour).</param>
+    /// <param name="installationType">The installation type (Steam, EaApp).</param>
+    /// <param name="manifestVersion">The manifest version (e.g., 1, 2, 20). Defaults to 0 for first version.</param>
+    /// <param name="language">Optional explicit language code (e.g., "EN", "DE"). If null, language is detected automatically.</param>
+    /// <param name="progress">Optional progress reporter receiving file indexing progress updates.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> that returns a configured manifest builder.</returns>
+    public Task<IContentManifestBuilder> CreateGameInstallationManifestAsync(
+        string gameInstallationPath,
+        GameType gameType,
+        GameInstallationType installationType,
+        int manifestVersion,
+        string? language,
+        IProgress<ValidationProgress>? progress,
+        CancellationToken cancellationToken = default)
+    {
+        return CreateGameInstallationManifestAsync(
+            gameInstallationPath,
+            gameType,
+            installationType,
+            manifestVersion.ToString(),
+            language,
+            progress,
+            cancellationToken);
     }
 
     /// <summary>
@@ -818,6 +897,7 @@ public class ManifestGenerationService(
     /// <param name="gameType">The game type.</param>
     /// <param name="manifestVersion">Optional manifest version.</param>
     /// <param name="language">Optional explicit language code.</param>
+    /// <param name="progress">Optional progress reporter receiving file indexing progress updates.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     private async Task AddGameFilesToManifest(
@@ -826,6 +906,7 @@ public class ManifestGenerationService(
         GameType gameType,
         string? manifestVersion,
         string? language,
+        IProgress<ValidationProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -858,21 +939,77 @@ public class ManifestGenerationService(
             return;
         }
 
-        var fileCount = 0;
+        notificationService?.ShowInfo(
+            "Indexing Game Files",
+            $"Scanning {gameType} installation files ({authoritativeEntries.Count} files to verify)...",
+            autoDismissMs: 4000);
 
-        foreach (var entry in authoritativeEntries)
+        var fileCount = 0;
+        var totalEntries = authoritativeEntries.Count;
+        var missingRequiredFiles = new List<string>();
+        var differingFiles = new List<string>();
+
+        for (var i = 0; i < totalEntries; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (await TryAddAuthoritativeEntryAsync(builder, installationPath, entry, cancellationToken))
+            var entry = authoritativeEntries[i];
+            var currentIndex = i + 1;
+
+            progress?.Report(new ValidationProgress(currentIndex, totalEntries, entry.RelativePath));
+
+            var result = await TryAddAuthoritativeEntryAsync(builder, installationPath, entry, cancellationToken);
+            switch (result)
             {
-                fileCount++;
+                case AuthoritativeFileStatus.AddedMatching:
+                    fileCount++;
+                    break;
+                case AuthoritativeFileStatus.AddedDiffering:
+                    fileCount++;
+                    differingFiles.Add(entry.RelativePath);
+                    break;
+                case AuthoritativeFileStatus.MissingRequired:
+                    missingRequiredFiles.Add(entry.RelativePath);
+                    break;
+                case AuthoritativeFileStatus.MissingOptional:
+                case AuthoritativeFileStatus.Skipped:
+                    break;
+            }
+
+            if (currentIndex % 25 == 0 || currentIndex == totalEntries)
+            {
+                var percent = (double)currentIndex / totalEntries * 100;
+                logger.LogInformation(
+                    "Generating manifest for {GameType}: {Current}/{Total} files processed ({Percent:F0}%)",
+                    gameType,
+                    currentIndex,
+                    totalEntries,
+                    percent);
             }
         }
 
         logger.LogInformation(
-            "Completed authoritative manifest generation for {GameType}: {TotalFiles} vanilla files added",
+            "Completed authoritative manifest generation for {GameType}: {TotalFiles} vanilla files added ({DifferingCount} differed from catalog, {MissingCount} required files missing)",
             gameType,
-            fileCount);
+            fileCount,
+            differingFiles.Count,
+            missingRequiredFiles.Count);
+
+        if (missingRequiredFiles.Count > 0)
+        {
+            var fileList = string.Join(", ", missingRequiredFiles.Take(5));
+            var extra = missingRequiredFiles.Count > 5 ? $" and {missingRequiredFiles.Count - 5} more" : string.Empty;
+            notificationService?.ShowWarning(
+                "Incomplete Game Installation",
+                $"{gameType} is missing {missingRequiredFiles.Count} required file(s): {fileList}{extra}. A clean reinstall or repair via EA App/Steam is recommended.",
+                autoDismissMs: 10000);
+        }
+        else
+        {
+            notificationService?.ShowSuccess(
+                "Game Files Indexed",
+                $"Completed verification for {gameType} ({fileCount}/{totalEntries} files verified).",
+                autoDismissMs: 4000);
+        }
     }
 
     /// <summary>
@@ -995,7 +1132,7 @@ public class ManifestGenerationService(
         }
     }
 
-    private async Task<bool> TryAddAuthoritativeEntryAsync(
+    private async Task<AuthoritativeFileStatus> TryAddAuthoritativeEntryAsync(
         IContentManifestBuilder builder,
         string installationPath,
         CsvCatalogEntry entry,
@@ -1003,7 +1140,7 @@ public class ManifestGenerationService(
     {
         if (string.IsNullOrWhiteSpace(entry.RelativePath))
         {
-            return false;
+            return AuthoritativeFileStatus.Skipped;
         }
 
         try
@@ -1018,9 +1155,10 @@ public class ManifestGenerationService(
                     logger.LogWarning(
                         "Required vanilla file missing from installation: {RelativePath}",
                         entry.RelativePath);
+                    return AuthoritativeFileStatus.MissingRequired;
                 }
 
-                return false;
+                return AuthoritativeFileStatus.MissingOptional;
             }
 
             var sourcePath = ResolveSourcePathWithBackup(resolvedFilePath, entry.RelativePath);
@@ -1030,7 +1168,7 @@ public class ManifestGenerationService(
                     "Source path {SourcePath} for {RelativePath} is a reparse point or symbolic link and will be skipped",
                     sourcePath,
                     entry.RelativePath);
-                return false;
+                return AuthoritativeFileStatus.Skipped;
             }
 
             var fileInfo = new FileInfo(sourcePath);
@@ -1066,7 +1204,7 @@ public class ManifestGenerationService(
                 size: fileSize,
                 isRequired: entry.IsRequired);
 
-            return true;
+            return isAuthoritativeMatch ? AuthoritativeFileStatus.AddedMatching : AuthoritativeFileStatus.AddedDiffering;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -1078,7 +1216,7 @@ public class ManifestGenerationService(
                 ex,
                 "Failed to add authoritative vanilla file {RelativePath} to manifest",
                 entry.RelativePath);
-            return false;
+            return AuthoritativeFileStatus.Skipped;
         }
     }
 

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -635,7 +635,7 @@ public class ManifestGenerationService(
     /// </summary>
     /// <param name="files">The list of file paths.</param>
     /// <returns>A formatted comma-separated string of files, truncated if necessary.</returns>
-    internal string FormatFileListWithEllipsis(IReadOnlyList<string> files)
+    internal static string FormatFileListWithEllipsis(IReadOnlyList<string> files)
     {
         var list = string.Join(", ", files.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
         var extra = files.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
@@ -651,7 +651,7 @@ public class ManifestGenerationService(
     /// <param name="missingRequiredFiles">The list of required files missing from disk.</param>
     /// <param name="skippedRequiredFiles">The list of required files skipped due to access errors or symlinks.</param>
     /// <returns>A formatted warning message.</returns>
-    internal string GetIncompleteInstallationWarningMessage(
+    internal static string GetIncompleteInstallationWarningMessage(
         GameType gameType,
         IReadOnlyList<string> missingRequiredFiles,
         IReadOnlyList<string> skippedRequiredFiles)
@@ -936,6 +936,48 @@ public class ManifestGenerationService(
         }
     }
 
+    private static void RecordAuthoritativeStatus(
+        AuthoritativeFileStatus status,
+        CsvCatalogEntry entry,
+        ref int fileCount,
+        List<string> differingFiles,
+        List<string> missingRequiredFiles,
+        List<string> skippedRequiredFiles)
+    {
+        switch (status)
+        {
+            case AuthoritativeFileStatus.AddedMatching:
+                fileCount++;
+                break;
+            case AuthoritativeFileStatus.AddedDiffering:
+                fileCount++;
+                differingFiles.Add(entry.RelativePath);
+                break;
+            case AuthoritativeFileStatus.MissingRequired:
+                missingRequiredFiles.Add(entry.RelativePath);
+                break;
+            case AuthoritativeFileStatus.MissingOptional:
+                break;
+            case AuthoritativeFileStatus.Skipped:
+                if (entry.IsRequired)
+                {
+                    skippedRequiredFiles.Add(entry.RelativePath);
+                }
+
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static bool IsAuthoritativeMatch(CsvCatalogEntry entry, long actualLength, string computedHash)
+    {
+        return entry.Size > 0 &&
+               actualLength == entry.Size &&
+               !string.IsNullOrWhiteSpace(entry.Sha256) &&
+               string.Equals(computedHash, entry.Sha256, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// Adds authoritative vanilla game files to a manifest builder using the CSV catalog authority.
     /// </summary>
@@ -1016,17 +1058,14 @@ public class ManifestGenerationService(
                 cancellationToken.ThrowIfCancellationRequested();
                 var entry = authoritativeEntries[i];
                 var currentIndex = i + 1;
-                var percent = (double)currentIndex / totalEntries * 100;
 
-                if (currentIndex == 1 ||
-                    Stopwatch.GetElapsedTime(lastNotificationTimestamp).TotalMilliseconds >= ManifestConstants.NotificationUpdateThrottleMs)
-                {
-                    notificationService?.Update(
-                        progressNotificationId,
-                        $"Verifying {gameType} files: {currentIndex}/{totalEntries} ({percent:F0}%) - {entry.RelativePath}",
-                        ManifestConstants.IndexingNotificationTitle);
-                    lastNotificationTimestamp = Stopwatch.GetTimestamp();
-                }
+                UpdateVerificationNotification(
+                    progressNotificationId,
+                    gameType,
+                    currentIndex,
+                    totalEntries,
+                    entry.RelativePath,
+                    ref lastNotificationTimestamp);
 
                 var result = await TryAddAuthoritativeEntryAsync(
                     builder,
@@ -1036,47 +1075,23 @@ public class ManifestGenerationService(
                     totalEntries,
                     progressNotificationId,
                     cancellationToken);
-                switch (result)
-                {
-                    case AuthoritativeFileStatus.AddedMatching:
-                        fileCount++;
-                        break;
-                    case AuthoritativeFileStatus.AddedDiffering:
-                        fileCount++;
-                        differingFiles.Add(entry.RelativePath);
-                        break;
-                    case AuthoritativeFileStatus.MissingRequired:
-                        missingRequiredFiles.Add(entry.RelativePath);
-                        break;
-                    case AuthoritativeFileStatus.MissingOptional:
-                        break;
-                    case AuthoritativeFileStatus.Skipped:
-                        if (entry.IsRequired)
-                        {
-                            skippedRequiredFiles.Add(entry.RelativePath);
-                        }
 
-                        break;
-                    default:
-                        break;
-                }
+                RecordAuthoritativeStatus(
+                    result,
+                    entry,
+                    ref fileCount,
+                    differingFiles,
+                    missingRequiredFiles,
+                    skippedRequiredFiles);
 
                 progress?.Report(new ValidationProgress(currentIndex, totalEntries, entry.RelativePath));
 
-                if (currentIndex == 1 ||
-                    currentIndex % ManifestConstants.ProgressLoggingThrottleInterval == 0 ||
-                    currentIndex == totalEntries ||
-                    Stopwatch.GetElapsedTime(lastLogTimestamp).TotalSeconds >= ManifestConstants.ProgressLogThrottleSeconds)
-                {
-                    logger.LogInformation(
-                        "Generating manifest for {GameType}: {Current}/{Total} files processed ({Percent:F0}%) - {RelativePath}",
-                        gameType,
-                        currentIndex,
-                        totalEntries,
-                        percent,
-                        entry.RelativePath);
-                    lastLogTimestamp = Stopwatch.GetTimestamp();
-                }
+                LogVerificationProgress(
+                    gameType,
+                    currentIndex,
+                    totalEntries,
+                    entry.RelativePath,
+                    ref lastLogTimestamp);
             }
         }
         finally
@@ -1092,6 +1107,73 @@ public class ManifestGenerationService(
             missingRequiredFiles.Count,
             skippedRequiredFiles.Count);
 
+        NotifyManifestGenerationCompletion(
+            gameType,
+            fileCount,
+            totalEntries,
+            missingRequiredFiles,
+            skippedRequiredFiles,
+            differingFiles);
+    }
+
+    private void UpdateVerificationNotification(
+        Guid progressNotificationId,
+        GameType gameType,
+        int currentIndex,
+        int totalEntries,
+        string relativePath,
+        ref long lastNotificationTimestamp)
+    {
+        if (currentIndex != 1 &&
+            !(Stopwatch.GetElapsedTime(lastNotificationTimestamp).TotalMilliseconds >= ManifestConstants.NotificationUpdateThrottleMs))
+        {
+            return;
+        }
+
+        var percent = (double)currentIndex / totalEntries * 100;
+        notificationService?.Update(
+            progressNotificationId,
+            $"Verifying {gameType} files: {currentIndex}/{totalEntries} ({percent:F0}%) - {relativePath}",
+            ManifestConstants.IndexingNotificationTitle);
+        lastNotificationTimestamp = Stopwatch.GetTimestamp();
+    }
+
+    private void LogVerificationProgress(
+        GameType gameType,
+        int currentIndex,
+        int totalEntries,
+        string relativePath,
+        ref long lastLogTimestamp)
+    {
+        var isThrottled = currentIndex != 1 &&
+            currentIndex % ManifestConstants.ProgressLoggingThrottleInterval != 0 &&
+            currentIndex != totalEntries &&
+            !(Stopwatch.GetElapsedTime(lastLogTimestamp).TotalSeconds >= ManifestConstants.ProgressLogThrottleSeconds);
+
+        if (isThrottled)
+        {
+            return;
+        }
+
+        var percent = (double)currentIndex / totalEntries * 100;
+        logger.LogInformation(
+            "Generating manifest for {GameType}: {Current}/{Total} files processed ({Percent:F0}%) - {RelativePath}",
+            gameType,
+            currentIndex,
+            totalEntries,
+            percent,
+            relativePath);
+        lastLogTimestamp = Stopwatch.GetTimestamp();
+    }
+
+    private void NotifyManifestGenerationCompletion(
+        GameType gameType,
+        int fileCount,
+        int totalEntries,
+        IReadOnlyList<string> missingRequiredFiles,
+        IReadOnlyList<string> skippedRequiredFiles,
+        IReadOnlyList<string> differingFiles)
+    {
         var totalIncompleteRequiredCount = missingRequiredFiles.Count + skippedRequiredFiles.Count;
         if (totalIncompleteRequiredCount > 0)
         {
@@ -1356,33 +1438,18 @@ public class ManifestGenerationService(
             }
 
             var fileInfo = new FileInfo(sourcePath);
-            var isLargeFile = fileInfo.Length >= ManifestConstants.LargeFileProgressThresholdBytes;
-            if (isLargeFile)
+            if (fileInfo.Length >= ManifestConstants.LargeFileProgressThresholdBytes)
             {
-                var sizeMb = fileInfo.Length / (1024.0 * 1024.0);
-                var percent = (double)currentIndex / totalEntries * 100;
-                logger.LogInformation(
-                    "Calculating SHA-256 for {RelativePath} ({SizeMB:F1} MB) [{Current}/{Total} ({Percent:F0}%)]...",
+                ReportLargeFileHashProgress(
                     entry.RelativePath,
-                    sizeMb,
+                    fileInfo.Length,
                     currentIndex,
                     totalEntries,
-                    percent);
-
-                if (progressNotificationId.HasValue)
-                {
-                    notificationService?.Update(
-                        progressNotificationId.Value,
-                        $"Calculating SHA-256 for {entry.RelativePath} ({sizeMb:F1} MB) - {currentIndex}/{totalEntries} ({percent:F0}%)",
-                        ManifestConstants.IndexingNotificationTitle);
-                }
+                    progressNotificationId);
             }
 
             var computedHash = await hashProvider.ComputeFileHashAsync(sourcePath, cancellationToken);
-            var isAuthoritativeMatch = entry.Size > 0 &&
-                                       fileInfo.Length == entry.Size &&
-                                       !string.IsNullOrWhiteSpace(entry.Sha256) &&
-                                       string.Equals(computedHash, entry.Sha256, StringComparison.OrdinalIgnoreCase);
+            var isAuthoritativeMatch = IsAuthoritativeMatch(entry, fileInfo.Length, computedHash);
 
             if (entry.Size > 0 && !isAuthoritativeMatch)
             {
@@ -1398,16 +1465,13 @@ public class ManifestGenerationService(
 
             var isExecutable = ExecutableFileClassifier.RequiresExecutePermission(entry.RelativePath, sourcePath);
 
-            var fileHash = computedHash;
-            var fileSize = fileInfo.Length;
-
             await builder.AddGameInstallationFileAsync(
                 entry.RelativePath,
                 sourcePath,
                 isExecutable,
                 permissions: null,
-                hash: fileHash,
-                size: fileSize,
+                hash: computedHash,
+                size: fileInfo.Length,
                 isRequired: entry.IsRequired);
 
             return isAuthoritativeMatch ? AuthoritativeFileStatus.AddedMatching : AuthoritativeFileStatus.AddedDiffering;
@@ -1423,6 +1487,32 @@ public class ManifestGenerationService(
                 "Failed to add authoritative vanilla file {RelativePath} to manifest",
                 entry.RelativePath);
             return AuthoritativeFileStatus.Skipped;
+        }
+    }
+
+    private void ReportLargeFileHashProgress(
+        string relativePath,
+        long length,
+        int currentIndex,
+        int totalEntries,
+        Guid? progressNotificationId)
+    {
+        var sizeMb = length / (1024.0 * 1024.0);
+        var percent = (double)currentIndex / totalEntries * 100;
+        logger.LogInformation(
+            "Calculating SHA-256 for {RelativePath} ({SizeMB:F1} MB) [{Current}/{Total} ({Percent:F0}%)]...",
+            relativePath,
+            sizeMb,
+            currentIndex,
+            totalEntries,
+            percent);
+
+        if (progressNotificationId.HasValue)
+        {
+            notificationService?.Update(
+                progressNotificationId.Value,
+                $"Calculating SHA-256 for {relativePath} ({sizeMb:F1} MB) - {currentIndex}/{totalEntries} ({percent:F0}%)",
+                ManifestConstants.IndexingNotificationTitle);
         }
     }
 

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -961,6 +961,7 @@ public class ManifestGenerationService(
 
         var fileCount = 0;
         var missingRequiredFiles = new List<string>();
+        var skippedRequiredFiles = new List<string>();
         var differingFiles = new List<string>();
         var lastLogTimestamp = Stopwatch.GetTimestamp();
         var lastNotificationTimestamp = Stopwatch.GetTimestamp();
@@ -1009,7 +1010,7 @@ public class ManifestGenerationService(
                     case AuthoritativeFileStatus.Skipped:
                         if (entry.IsRequired)
                         {
-                            missingRequiredFiles.Add(entry.RelativePath);
+                            skippedRequiredFiles.Add(entry.RelativePath);
                         }
 
                         break;
@@ -1022,7 +1023,7 @@ public class ManifestGenerationService(
                 if (currentIndex == 1 ||
                     currentIndex % ManifestConstants.ProgressLoggingThrottleInterval == 0 ||
                     currentIndex == totalEntries ||
-                    Stopwatch.GetElapsedTime(lastLogTimestamp).TotalSeconds >= 5)
+                    Stopwatch.GetElapsedTime(lastLogTimestamp).TotalSeconds >= ManifestConstants.ProgressLogThrottleSeconds)
                 {
                     logger.LogInformation(
                         "Generating manifest for {GameType}: {Current}/{Total} files processed ({Percent:F0}%) - {RelativePath}",
@@ -1041,21 +1042,43 @@ public class ManifestGenerationService(
         }
 
         logger.LogInformation(
-            "Completed authoritative manifest generation for {GameType}: {TotalFiles} vanilla files added ({DifferingCount} differed from catalog, {MissingCount} required files missing)",
+            "Completed authoritative manifest generation for {GameType}: {TotalFiles} vanilla files added ({DifferingCount} differed from catalog, {MissingCount} required files missing, {SkippedCount} required files skipped)",
             gameType,
             fileCount,
             differingFiles.Count,
-            missingRequiredFiles.Count);
+            missingRequiredFiles.Count,
+            skippedRequiredFiles.Count);
 
-        if (missingRequiredFiles.Count > 0)
+        var totalIncompleteRequiredCount = missingRequiredFiles.Count + skippedRequiredFiles.Count;
+        if (totalIncompleteRequiredCount > 0)
         {
-            var fileList = string.Join(", ", missingRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
-            var extra = missingRequiredFiles.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
-                ? $" and {missingRequiredFiles.Count - ManifestConstants.MaxMissingFilesNotificationDisplayCount} more"
-                : string.Empty;
+            string warningMessage;
+            if (missingRequiredFiles.Count > 0 && skippedRequiredFiles.Count > 0)
+            {
+                var missingList = string.Join(", ", missingRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
+                var skippedList = string.Join(", ", skippedRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
+                warningMessage = $"{gameType} has {missingRequiredFiles.Count} missing required file(s) ({missingList}) and {skippedRequiredFiles.Count} unreadable/skipped file(s) ({skippedList}). A game repair or permission check is recommended.";
+            }
+            else if (missingRequiredFiles.Count > 0)
+            {
+                var fileList = string.Join(", ", missingRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
+                var extra = missingRequiredFiles.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
+                    ? $" and {missingRequiredFiles.Count - ManifestConstants.MaxMissingFilesNotificationDisplayCount} more"
+                    : string.Empty;
+                warningMessage = $"{gameType} is missing {missingRequiredFiles.Count} required file(s): {fileList}{extra}. A clean reinstall or repair via EA App/Steam is recommended.";
+            }
+            else
+            {
+                var fileList = string.Join(", ", skippedRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
+                var extra = skippedRequiredFiles.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
+                    ? $" and {skippedRequiredFiles.Count - ManifestConstants.MaxMissingFilesNotificationDisplayCount} more"
+                    : string.Empty;
+                warningMessage = $"{gameType} could not read {skippedRequiredFiles.Count} required file(s) (e.g. file lock, permissions, or symlink): {fileList}{extra}. Please verify permissions or close background processes.";
+            }
+
             notificationService?.ShowWarning(
                 ManifestConstants.IncompleteInstallationNotificationTitle,
-                $"{gameType} is missing {missingRequiredFiles.Count} required file(s): {fileList}{extra}. A clean reinstall or repair via EA App/Steam is recommended.",
+                warningMessage,
                 autoDismissMs: ManifestConstants.WarningNotificationAutoDismissMs);
         }
         else
@@ -1122,7 +1145,7 @@ public class ManifestGenerationService(
 
                 if (scannedFiles == 1 ||
                     scannedFiles % ManifestConstants.ProgressLoggingThrottleInterval == 0 ||
-                    Stopwatch.GetElapsedTime(lastScanLogTimestamp).TotalSeconds >= 5)
+                    Stopwatch.GetElapsedTime(lastScanLogTimestamp).TotalSeconds >= ManifestConstants.ProgressLogThrottleSeconds)
                 {
                     logger.LogInformation(
                         "Scanning {GameType} directory: {Count} files processed ({CurrentFile})",

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -44,6 +44,15 @@ public class ManifestGenerationService(
     CsvResolver? csvResolver = null,
     INotificationService? notificationService = null) : IManifestGenerationService
 {
+    private enum AuthoritativeFileStatus
+    {
+        AddedMatching,
+        AddedDiffering,
+        MissingRequired,
+        MissingOptional,
+        Skipped,
+    }
+
     private static readonly CsvConfiguration CsvConfig = new(CultureInfo.InvariantCulture)
     {
         HasHeaderRecord = true,
@@ -87,15 +96,6 @@ public class ManifestGenerationService(
         ".w3d",
         ".wav",
     };
-
-    private enum AuthoritativeFileStatus
-    {
-        AddedMatching,
-        AddedDiffering,
-        MissingRequired,
-        MissingOptional,
-        Skipped,
-    }
 
     private readonly ILanguageDetector _languageDetector = languageDetector ?? new LanguageDetector();
 
@@ -940,7 +940,7 @@ public class ManifestGenerationService(
         }
 
         notificationService?.ShowInfo(
-            "Indexing Game Files",
+            ManifestConstants.IndexingNotificationTitle,
             $"Scanning {gameType} installation files ({authoritativeEntries.Count} files to verify)...",
             autoDismissMs: 4000);
 
@@ -973,6 +973,8 @@ public class ManifestGenerationService(
                 case AuthoritativeFileStatus.MissingOptional:
                 case AuthoritativeFileStatus.Skipped:
                     break;
+                default:
+                    break;
             }
 
             if (currentIndex % 25 == 0 || currentIndex == totalEntries)
@@ -999,14 +1001,14 @@ public class ManifestGenerationService(
             var fileList = string.Join(", ", missingRequiredFiles.Take(5));
             var extra = missingRequiredFiles.Count > 5 ? $" and {missingRequiredFiles.Count - 5} more" : string.Empty;
             notificationService?.ShowWarning(
-                "Incomplete Game Installation",
+                ManifestConstants.IncompleteInstallationNotificationTitle,
                 $"{gameType} is missing {missingRequiredFiles.Count} required file(s): {fileList}{extra}. A clean reinstall or repair via EA App/Steam is recommended.",
                 autoDismissMs: 10000);
         }
         else
         {
             notificationService?.ShowSuccess(
-                "Game Files Indexed",
+                ManifestConstants.IndexedNotificationTitle,
                 $"Completed verification for {gameType} ({fileCount}/{totalEntries} files verified).",
                 autoDismissMs: 4000);
         }

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -1034,6 +1034,11 @@ public class ManifestGenerationService(
         cancellationToken.ThrowIfCancellationRequested();
         logger.LogInformation("Starting fallback directory scan manifest generation for {GameType} at {InstallationPath}", gameType, installationPath);
 
+        notificationService?.ShowInfo(
+            ManifestConstants.IndexingNotificationTitle,
+            $"Scanning {gameType} directory files...",
+            autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
+
         var executableName = gameType == GameType.Generals ? GameClientConstants.GeneralsExecutable : GameClientConstants.ZeroHourExecutable;
         await TryAddPrimaryExecutableAsync(builder, installationPath, executableName);
 
@@ -1060,6 +1065,11 @@ public class ManifestGenerationService(
         {
             logger.LogWarning(ex, "Failed to enumerate files during directory scan at {InstallationPath}", installationPath);
         }
+
+        notificationService?.ShowSuccess(
+            ManifestConstants.IndexedNotificationTitle,
+            $"Completed file scan for {gameType}.",
+            autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
     }
 
     private async Task TryAddPrimaryExecutableAsync(

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -631,6 +631,49 @@ public class ManifestGenerationService(
     }
 
     /// <summary>
+    /// Formats a list of file paths with truncation and an ellipsis suffix if count exceeds <see cref="ManifestConstants.MaxMissingFilesNotificationDisplayCount"/>.
+    /// </summary>
+    /// <param name="files">The list of file paths.</param>
+    /// <returns>A formatted comma-separated string of files, truncated if necessary.</returns>
+    internal string FormatFileListWithEllipsis(IReadOnlyList<string> files)
+    {
+        var list = string.Join(", ", files.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
+        var extra = files.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
+            ? $" and {files.Count - ManifestConstants.MaxMissingFilesNotificationDisplayCount} more"
+            : string.Empty;
+        return $"{list}{extra}";
+    }
+
+    /// <summary>
+    /// Constructs a user-facing warning notification message detailing missing and/or skipped required files.
+    /// </summary>
+    /// <param name="gameType">The target game type.</param>
+    /// <param name="missingRequiredFiles">The list of required files missing from disk.</param>
+    /// <param name="skippedRequiredFiles">The list of required files skipped due to access errors or symlinks.</param>
+    /// <returns>A formatted warning message.</returns>
+    internal string GetIncompleteInstallationWarningMessage(
+        GameType gameType,
+        IReadOnlyList<string> missingRequiredFiles,
+        IReadOnlyList<string> skippedRequiredFiles)
+    {
+        if (missingRequiredFiles.Count > 0 && skippedRequiredFiles.Count > 0)
+        {
+            var missingList = FormatFileListWithEllipsis(missingRequiredFiles);
+            var skippedList = FormatFileListWithEllipsis(skippedRequiredFiles);
+            return $"{gameType} has {missingRequiredFiles.Count} missing required file(s) ({missingList}) and {skippedRequiredFiles.Count} unreadable/skipped file(s) ({skippedList}). A game repair or permission check is recommended.";
+        }
+
+        if (missingRequiredFiles.Count > 0)
+        {
+            var missingList = FormatFileListWithEllipsis(missingRequiredFiles);
+            return $"{gameType} is missing {missingRequiredFiles.Count} required file(s): {missingList}. A clean reinstall or repair via EA App/Steam is recommended.";
+        }
+
+        var unreadableList = FormatFileListWithEllipsis(skippedRequiredFiles);
+        return $"{gameType} could not read {skippedRequiredFiles.Count} required file(s) (e.g. file lock, permissions, or symlink): {unreadableList}. Please verify permissions or close background processes.";
+    }
+
+    /// <summary>
     /// Determines if a file should be skipped during manifest generation.
     /// </summary>
     private static bool ShouldSkipFile(string relativePath)
@@ -1052,29 +1095,10 @@ public class ManifestGenerationService(
         var totalIncompleteRequiredCount = missingRequiredFiles.Count + skippedRequiredFiles.Count;
         if (totalIncompleteRequiredCount > 0)
         {
-            string warningMessage;
-            if (missingRequiredFiles.Count > 0 && skippedRequiredFiles.Count > 0)
-            {
-                var missingList = string.Join(", ", missingRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
-                var skippedList = string.Join(", ", skippedRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
-                warningMessage = $"{gameType} has {missingRequiredFiles.Count} missing required file(s) ({missingList}) and {skippedRequiredFiles.Count} unreadable/skipped file(s) ({skippedList}). A game repair or permission check is recommended.";
-            }
-            else if (missingRequiredFiles.Count > 0)
-            {
-                var fileList = string.Join(", ", missingRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
-                var extra = missingRequiredFiles.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
-                    ? $" and {missingRequiredFiles.Count - ManifestConstants.MaxMissingFilesNotificationDisplayCount} more"
-                    : string.Empty;
-                warningMessage = $"{gameType} is missing {missingRequiredFiles.Count} required file(s): {fileList}{extra}. A clean reinstall or repair via EA App/Steam is recommended.";
-            }
-            else
-            {
-                var fileList = string.Join(", ", skippedRequiredFiles.Take(ManifestConstants.MaxMissingFilesNotificationDisplayCount));
-                var extra = skippedRequiredFiles.Count > ManifestConstants.MaxMissingFilesNotificationDisplayCount
-                    ? $" and {skippedRequiredFiles.Count - ManifestConstants.MaxMissingFilesNotificationDisplayCount} more"
-                    : string.Empty;
-                warningMessage = $"{gameType} could not read {skippedRequiredFiles.Count} required file(s) (e.g. file lock, permissions, or symlink): {fileList}{extra}. Please verify permissions or close background processes.";
-            }
+            var warningMessage = GetIncompleteInstallationWarningMessage(
+                gameType,
+                missingRequiredFiles,
+                skippedRequiredFiles);
 
             notificationService?.ShowWarning(
                 ManifestConstants.IncompleteInstallationNotificationTitle,

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -1056,6 +1056,11 @@ public class ManifestGenerationService(
                 cancellationToken.ThrowIfCancellationRequested();
                 await TryAddFallbackFileAsync(builder, installationPath, file, executableName);
             }
+
+            notificationService?.ShowSuccess(
+                ManifestConstants.IndexedNotificationTitle,
+                $"Completed file scan for {gameType}.",
+                autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -1064,12 +1069,11 @@ public class ManifestGenerationService(
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             logger.LogWarning(ex, "Failed to enumerate files during directory scan at {InstallationPath}", installationPath);
+            notificationService?.ShowWarning(
+                ManifestConstants.DirectoryScanWarningNotificationTitle,
+                $"Failed to complete directory scan for {gameType}.",
+                autoDismissMs: ManifestConstants.WarningNotificationAutoDismissMs);
         }
-
-        notificationService?.ShowSuccess(
-            ManifestConstants.IndexedNotificationTitle,
-            $"Completed file scan for {gameType}.",
-            autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
     }
 
     private async Task TryAddPrimaryExecutableAsync(

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -1005,7 +1005,13 @@ public class ManifestGenerationService(
                         missingRequiredFiles.Add(entry.RelativePath);
                         break;
                     case AuthoritativeFileStatus.MissingOptional:
+                        break;
                     case AuthoritativeFileStatus.Skipped:
+                        if (entry.IsRequired)
+                        {
+                            missingRequiredFiles.Add(entry.RelativePath);
+                        }
+
                         break;
                     default:
                         break;
@@ -1092,11 +1098,11 @@ public class ManifestGenerationService(
             notificationService.Show(progressNotification);
         }
 
-        var executableName = gameType == GameType.Generals ? GameClientConstants.GeneralsExecutable : GameClientConstants.ZeroHourExecutable;
-        await TryAddPrimaryExecutableAsync(builder, installationPath, executableName);
-
         try
         {
+            var executableName = gameType == GameType.Generals ? GameClientConstants.GeneralsExecutable : GameClientConstants.ZeroHourExecutable;
+            await TryAddPrimaryExecutableAsync(builder, installationPath, executableName);
+
             var options = new EnumerationOptions
             {
                 IgnoreInaccessible = true,
@@ -1139,7 +1145,6 @@ public class ManifestGenerationService(
                 await TryAddFallbackFileAsync(builder, installationPath, file, executableName, progressNotificationId);
             }
 
-            notificationService?.Dismiss(progressNotificationId);
             notificationService?.ShowSuccess(
                 ManifestConstants.IndexedNotificationTitle,
                 $"Completed file scan for {gameType} ({scannedFiles} files scanned).",
@@ -1147,17 +1152,19 @@ public class ManifestGenerationService(
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            notificationService?.Dismiss(progressNotificationId);
             throw;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            notificationService?.Dismiss(progressNotificationId);
             logger.LogWarning(ex, "Failed to enumerate files during directory scan at {InstallationPath}", installationPath);
             notificationService?.ShowWarning(
                 ManifestConstants.DirectoryScanWarningNotificationTitle,
                 $"Failed to complete directory scan for {gameType}.",
                 autoDismissMs: ManifestConstants.WarningNotificationAutoDismissMs);
+        }
+        finally
+        {
+            notificationService?.Dismiss(progressNotificationId);
         }
     }
 

--- a/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
+++ b/GenHub/GenHub/Features/Manifest/ManifestGenerationService.cs
@@ -9,6 +9,7 @@ using GenHub.Core.Interfaces.Tools;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Notifications;
 using GenHub.Core.Models.Results.Content;
 using GenHub.Core.Models.Validation;
 using GenHub.Core.Utilities;
@@ -17,6 +18,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -941,54 +943,95 @@ public class ManifestGenerationService(
             return;
         }
 
-        notificationService?.ShowInfo(
-            ManifestConstants.IndexingNotificationTitle,
-            $"Scanning {gameType} installation files ({authoritativeEntries.Count} files to verify)...",
-            autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
+        var totalEntries = authoritativeEntries.Count;
+        var progressNotificationId = Guid.NewGuid();
+        if (notificationService != null)
+        {
+            var progressNotification = new NotificationMessage(
+                NotificationType.Info,
+                ManifestConstants.IndexingNotificationTitle,
+                $"Scanning {gameType} installation files (0/{totalEntries} verified)...",
+                autoDismissMilliseconds: null,
+                isPersistent: true)
+            {
+                Id = progressNotificationId,
+            };
+            notificationService.Show(progressNotification);
+        }
 
         var fileCount = 0;
-        var totalEntries = authoritativeEntries.Count;
         var missingRequiredFiles = new List<string>();
         var differingFiles = new List<string>();
+        var lastLogTimestamp = Stopwatch.GetTimestamp();
+        var lastNotificationTimestamp = Stopwatch.GetTimestamp();
 
-        for (var i = 0; i < totalEntries; i++)
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var entry = authoritativeEntries[i];
-            var currentIndex = i + 1;
-
-            var result = await TryAddAuthoritativeEntryAsync(builder, installationPath, entry, cancellationToken);
-            switch (result)
+            for (var i = 0; i < totalEntries; i++)
             {
-                case AuthoritativeFileStatus.AddedMatching:
-                    fileCount++;
-                    break;
-                case AuthoritativeFileStatus.AddedDiffering:
-                    fileCount++;
-                    differingFiles.Add(entry.RelativePath);
-                    break;
-                case AuthoritativeFileStatus.MissingRequired:
-                    missingRequiredFiles.Add(entry.RelativePath);
-                    break;
-                case AuthoritativeFileStatus.MissingOptional:
-                case AuthoritativeFileStatus.Skipped:
-                    break;
-                default:
-                    break;
-            }
-
-            progress?.Report(new ValidationProgress(currentIndex, totalEntries, entry.RelativePath));
-
-            if (currentIndex % ManifestConstants.ProgressLoggingThrottleInterval == 0 || currentIndex == totalEntries)
-            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var entry = authoritativeEntries[i];
+                var currentIndex = i + 1;
                 var percent = (double)currentIndex / totalEntries * 100;
-                logger.LogInformation(
-                    "Generating manifest for {GameType}: {Current}/{Total} files processed ({Percent:F0}%)",
-                    gameType,
+
+                if (currentIndex == 1 ||
+                    Stopwatch.GetElapsedTime(lastNotificationTimestamp).TotalMilliseconds >= ManifestConstants.NotificationUpdateThrottleMs)
+                {
+                    notificationService?.Update(
+                        progressNotificationId,
+                        $"Verifying {gameType} files: {currentIndex}/{totalEntries} ({percent:F0}%) - {entry.RelativePath}",
+                        ManifestConstants.IndexingNotificationTitle);
+                    lastNotificationTimestamp = Stopwatch.GetTimestamp();
+                }
+
+                var result = await TryAddAuthoritativeEntryAsync(
+                    builder,
+                    installationPath,
+                    entry,
                     currentIndex,
                     totalEntries,
-                    percent);
+                    progressNotificationId,
+                    cancellationToken);
+                switch (result)
+                {
+                    case AuthoritativeFileStatus.AddedMatching:
+                        fileCount++;
+                        break;
+                    case AuthoritativeFileStatus.AddedDiffering:
+                        fileCount++;
+                        differingFiles.Add(entry.RelativePath);
+                        break;
+                    case AuthoritativeFileStatus.MissingRequired:
+                        missingRequiredFiles.Add(entry.RelativePath);
+                        break;
+                    case AuthoritativeFileStatus.MissingOptional:
+                    case AuthoritativeFileStatus.Skipped:
+                        break;
+                    default:
+                        break;
+                }
+
+                progress?.Report(new ValidationProgress(currentIndex, totalEntries, entry.RelativePath));
+
+                if (currentIndex == 1 ||
+                    currentIndex % ManifestConstants.ProgressLoggingThrottleInterval == 0 ||
+                    currentIndex == totalEntries ||
+                    Stopwatch.GetElapsedTime(lastLogTimestamp).TotalSeconds >= 5)
+                {
+                    logger.LogInformation(
+                        "Generating manifest for {GameType}: {Current}/{Total} files processed ({Percent:F0}%) - {RelativePath}",
+                        gameType,
+                        currentIndex,
+                        totalEntries,
+                        percent,
+                        entry.RelativePath);
+                    lastLogTimestamp = Stopwatch.GetTimestamp();
+                }
             }
+        }
+        finally
+        {
+            notificationService?.Dismiss(progressNotificationId);
         }
 
         logger.LogInformation(
@@ -1034,10 +1077,20 @@ public class ManifestGenerationService(
         cancellationToken.ThrowIfCancellationRequested();
         logger.LogInformation("Starting fallback directory scan manifest generation for {GameType} at {InstallationPath}", gameType, installationPath);
 
-        notificationService?.ShowInfo(
-            ManifestConstants.IndexingNotificationTitle,
-            $"Scanning {gameType} directory files...",
-            autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
+        var progressNotificationId = Guid.NewGuid();
+        if (notificationService != null)
+        {
+            var progressNotification = new NotificationMessage(
+                NotificationType.Info,
+                ManifestConstants.IndexingNotificationTitle,
+                $"Scanning {gameType} directory files...",
+                autoDismissMilliseconds: null,
+                isPersistent: true)
+            {
+                Id = progressNotificationId,
+            };
+            notificationService.Show(progressNotification);
+        }
 
         var executableName = gameType == GameType.Generals ? GameClientConstants.GeneralsExecutable : GameClientConstants.ZeroHourExecutable;
         await TryAddPrimaryExecutableAsync(builder, installationPath, executableName);
@@ -1051,23 +1104,55 @@ public class ManifestGenerationService(
                 AttributesToSkip = FileAttributes.ReparsePoint,
             };
 
+            var scannedFiles = 0;
+            var lastScanNotificationTimestamp = Stopwatch.GetTimestamp();
+            var lastScanLogTimestamp = Stopwatch.GetTimestamp();
+
             foreach (var file in Directory.EnumerateFiles(installationPath, "*", options))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await TryAddFallbackFileAsync(builder, installationPath, file, executableName);
+                scannedFiles++;
+                var relativePath = Path.GetRelativePath(installationPath, file).Replace('\\', '/');
+
+                if (scannedFiles == 1 ||
+                    scannedFiles % ManifestConstants.ProgressLoggingThrottleInterval == 0 ||
+                    Stopwatch.GetElapsedTime(lastScanLogTimestamp).TotalSeconds >= 5)
+                {
+                    logger.LogInformation(
+                        "Scanning {GameType} directory: {Count} files processed ({CurrentFile})",
+                        gameType,
+                        scannedFiles,
+                        relativePath);
+                    lastScanLogTimestamp = Stopwatch.GetTimestamp();
+                }
+
+                if (scannedFiles == 1 ||
+                    Stopwatch.GetElapsedTime(lastScanNotificationTimestamp).TotalMilliseconds >= ManifestConstants.NotificationUpdateThrottleMs)
+                {
+                    notificationService?.Update(
+                        progressNotificationId,
+                        $"Scanning {gameType} directory: {scannedFiles} files processed ({relativePath})",
+                        ManifestConstants.IndexingNotificationTitle);
+                    lastScanNotificationTimestamp = Stopwatch.GetTimestamp();
+                }
+
+                await TryAddFallbackFileAsync(builder, installationPath, file, executableName, progressNotificationId);
             }
 
+            notificationService?.Dismiss(progressNotificationId);
             notificationService?.ShowSuccess(
                 ManifestConstants.IndexedNotificationTitle,
-                $"Completed file scan for {gameType}.",
+                $"Completed file scan for {gameType} ({scannedFiles} files scanned).",
                 autoDismissMs: ManifestConstants.DefaultNotificationAutoDismissMs);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            notificationService?.Dismiss(progressNotificationId);
             throw;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            notificationService?.Dismiss(progressNotificationId);
             logger.LogWarning(ex, "Failed to enumerate files during directory scan at {InstallationPath}", installationPath);
             notificationService?.ShowWarning(
                 ManifestConstants.DirectoryScanWarningNotificationTitle,
@@ -1122,7 +1207,8 @@ public class ManifestGenerationService(
         IContentManifestBuilder builder,
         string installationPath,
         string file,
-        string executableName)
+        string executableName,
+        Guid? progressNotificationId = null)
     {
         var relativePath = Path.GetRelativePath(installationPath, file).Replace('\\', '/');
 
@@ -1147,6 +1233,24 @@ public class ManifestGenerationService(
 
         try
         {
+            var fileInfo = new FileInfo(sourcePath);
+            if (fileInfo.Length >= ManifestConstants.LargeFileProgressThresholdBytes)
+            {
+                var sizeMb = fileInfo.Length / (1024.0 * 1024.0);
+                logger.LogInformation(
+                    "Calculating hash for fallback file {RelativePath} ({SizeMB:F1} MB)...",
+                    relativePath,
+                    sizeMb);
+
+                if (progressNotificationId.HasValue)
+                {
+                    notificationService?.Update(
+                        progressNotificationId.Value,
+                        $"Calculating hash for {relativePath} ({sizeMb:F1} MB)...",
+                        ManifestConstants.IndexingNotificationTitle);
+                }
+            }
+
             await builder.AddGameInstallationFileAsync(relativePath, sourcePath, isExecutable);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -1159,6 +1263,9 @@ public class ManifestGenerationService(
         IContentManifestBuilder builder,
         string installationPath,
         CsvCatalogEntry entry,
+        int currentIndex,
+        int totalEntries,
+        Guid? progressNotificationId,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(entry.RelativePath))
@@ -1195,6 +1302,28 @@ public class ManifestGenerationService(
             }
 
             var fileInfo = new FileInfo(sourcePath);
+            var isLargeFile = fileInfo.Length >= ManifestConstants.LargeFileProgressThresholdBytes;
+            if (isLargeFile)
+            {
+                var sizeMb = fileInfo.Length / (1024.0 * 1024.0);
+                var percent = (double)currentIndex / totalEntries * 100;
+                logger.LogInformation(
+                    "Calculating SHA-256 for {RelativePath} ({SizeMB:F1} MB) [{Current}/{Total} ({Percent:F0}%)]...",
+                    entry.RelativePath,
+                    sizeMb,
+                    currentIndex,
+                    totalEntries,
+                    percent);
+
+                if (progressNotificationId.HasValue)
+                {
+                    notificationService?.Update(
+                        progressNotificationId.Value,
+                        $"Calculating SHA-256 for {entry.RelativePath} ({sizeMb:F1} MB) - {currentIndex}/{totalEntries} ({percent:F0}%)",
+                        ManifestConstants.IndexingNotificationTitle);
+                }
+            }
+
             var computedHash = await hashProvider.ComputeFileHashAsync(sourcePath, cancellationToken);
             var isAuthoritativeMatch = entry.Size > 0 &&
                                        fileInfo.Length == entry.Size &&

--- a/GenHub/GenHub/appsettings.json
+++ b/GenHub/GenHub/appsettings.json
@@ -7,7 +7,7 @@
     "Cache": {
       "DefaultPath": ""
     },
-    "IndexFilePath": "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/index.json",
+    "IndexFilePath": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/index.json",
     "Downloads": {
       "DefaultTimeoutSeconds": 600,
       "DefaultUserAgent": "GenHub/1.0",

--- a/docs/GameInstallationFilesRegistry/README.md
+++ b/docs/GameInstallationFilesRegistry/README.md
@@ -21,11 +21,11 @@ docs/GameInstallationFilesRegistry/
 Files in this registry are accessible via GitHub Raw Content URLs:
 
 - **Index Metadata**:  
-  `https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/index.json`
+  `https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/index.json`
 - **Generals 1.08 Catalog**:  
-  `https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/Generals-1.08.csv`
+  `https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv`
 - **Zero Hour 1.04 Catalog**:  
-  `https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv`
+  `https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv`
 
 ---
 
@@ -43,13 +43,13 @@ The `index.json` manifest acts as the root index queried by `CsvDiscoverer` duri
       "id": "generals-1.08",
       "gameType": "Generals",
       "version": "1.08",
-      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
+      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
       "fileCount": 164,
       "totalSizeBytes": 48166,
       "languages": ["All", "EN", "DE", "FR", "ES", "IT", "KO", "PL", "PT-BR", "ZH-CN", "ZH-TW"],
       "checksum": {
         "md5": "41e3f06a608156eaea960d432d6be682",
-        "sha256": "97c72beab9b92918ccf2629cf104034007337873783f2f7f03855e9857fa6267"
+        "sha256": "0fba15bb0a0db434b5edce0475615d4f84c4f2a02b01610f42dc23b9f491099d"
       },
       "generatedAt": "2025-09-17T09:15:00Z",
       "generatorVersion": "1.0.0",

--- a/docs/GameInstallationFilesRegistry/README.md
+++ b/docs/GameInstallationFilesRegistry/README.md
@@ -45,10 +45,10 @@ The `index.json` manifest acts as the root index queried by `CsvDiscoverer` duri
       "version": "1.08",
       "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
       "fileCount": 164,
-      "totalSizeBytes": 48166,
+      "totalSizeBytes": 28977,
       "languages": ["All", "EN", "DE", "FR", "ES", "IT", "KO", "PL", "PT-BR", "ZH-CN", "ZH-TW"],
       "checksum": {
-        "md5": "41e3f06a608156eaea960d432d6be682",
+        "md5": "4b77bce0b4dd0301478e0e341757491f",
         "sha256": "0fba15bb0a0db434b5edce0475615d4f84c4f2a02b01610f42dc23b9f491099d"
       },
       "generatedAt": "2025-09-17T09:15:00Z",

--- a/docs/GameInstallationFilesRegistry/index.json
+++ b/docs/GameInstallationFilesRegistry/index.json
@@ -7,7 +7,7 @@
       "id": "generals-1.08",
       "gameType": "Generals",
       "version": "1.08",
-      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
+      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
       "fileCount": 164,
       "totalSizeBytes": 28977,
       "languages": [
@@ -35,7 +35,7 @@
       "id": "zerohour-1.04",
       "gameType": "ZeroHour",
       "version": "1.04",
-      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/main/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv",
+      "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/ZeroHour-1.04.csv",
       "fileCount": 175,
       "totalSizeBytes": 31246,
       "languages": [


### PR DESCRIPTION
## Description

Resolves scan errors and manifest creation stalls:
1. **GitHub Raw URL Branch Fix**: The repository's active development branch is `development`, while `main` is at an older release that lacks the authoritative game files registry (`docs/GameInstallationFilesRegistry/`), causing HTTP 404 Not Found errors during installation scans. Updated all registry URLs across constants, indices, tools, and appsettings to target `development`.
2. **Embedded Assembly Catalog Fallback**: Added graceful fallback in `CsvResolver` to load embedded assembly assets (`GenHub.Core.Assets.Registries.{FileName}`) whenever a remote catalog fetch encounters a recoverable error (e.g., 404, network offline, DNS failure) and no disk cache exists.
3. **Scan Progress & Notifications**:
   - Added `IProgress<ValidationProgress>?` overloads to `IManifestGenerationService` and `ManifestGenerationService`.
   - Dispatches an initial notification via `INotificationService` informing the user that file verification is underway.
   - Logs throttled progress every 25 files and upon completion so the user and logs clearly show active progress during large installation scans.
   - Reports completion status with total verified vanilla files, count of differing files, and missing required files.
   - If required vanilla files are missing from the installation (e.g. `game.dat`), surfaces an actionable warning notification detailing the missing files and advising a clean repair/reinstall via EA App or Steam.
   - If files differ from catalog (e.g. legitimate EA App executable wrappers or patches), accurately retains the local hash and size without blocking manifest generation.
4. **Unit Tests**:
   - Added test for embedded catalog fallback upon remote 404 responses.
   - Added tests for progress reporting during manifest generation.
   - Added tests for success and missing-required-file notification dispatches.

## Changes Made
- `GenHub.Core/Constants/CsvConstants.cs`: Switched catalog URLs from `main` to `development`
- `GenHub.Core/Assets/Registries/index.json`: Switched catalog URLs from `main` to `development`
- `docs/GameInstallationFilesRegistry/index.json`: Switched catalog URLs from `main` to `development`
- `GenHub/appsettings.json`: Switched `IndexFilePath` from `main` to `development`
- `GenHub.Tools/CsvGenerator.cs`: Switched default URL from `main` to `development`
- `docs/GameInstallationFilesRegistry/README.md`: Updated documentation URLs
- `GenHub/Features/Content/Services/ContentResolvers/CsvResolver.cs`: Added embedded asset fallback on remote fetch failure
- `GenHub.Core/Interfaces/Manifest/IManifestGenerationService.cs`: Added `IProgress<ValidationProgress>?` overloads
- `GenHub/Features/Manifest/ManifestGenerationService.cs`: Implemented progress reporting, notification dispatching, status tracking, and logging
- `GenHub.Tests.Core/Features/Content/CsvResolverTests.cs`: Added test for 404 embedded resource fallback
- `GenHub.Tests.Core/Features/Manifest/ManifestGenerationServiceTests.cs`: Added tests for progress reporting and notifications

## Validation
- `./scripts/build-check.sh` ran cleanly with 0 warnings and 0 errors.
- All 55 test cases across `CsvResolverTests` and `ManifestGenerationServiceTests` passed successfully.