### PR TITLE
fix(docs): resolve vue template compilation errors and correct netlify deploy directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,4 +49,4 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
-          netlify deploy --dir=docs/.vitepress/out --prod
+          netlify deploy --dir=docs/.vitepress/dist --prod

--- a/docs/features/downloads.md
+++ b/docs/features/downloads.md
@@ -605,7 +605,7 @@ if (result.WasContentSwapped)
 
 TheSuperHackers releases ship **both** a Generals and a Zero Hour executable in the same archive.
 Rather than showing one card and requiring a variant picker, the discoverer emits **one grid card per
-game-client variant** (e.g. "SuperHackers Weekly <date> — Generals" and "…— Zero Hour"). Each card
+game-client variant** (e.g. `SuperHackers Weekly <date> — Generals` and `…— Zero Hour`). Each card
 carries its own `TargetGame`, a distinct manifest ID suffix (`...gameclient.generals` /
 `...gameclient.zerohour`), and independent download state. Downloading a variant card downloads the
 release once and stores only that variant's manifest (`SuperHackersManifestFactory` honors the

--- a/docs/features/manifest.md
+++ b/docs/features/manifest.md
@@ -502,25 +502,25 @@ The `ContentDependency` class provides sophisticated dependency management with 
 - **exactVersion** (string, optional): Exact version required, overrides min/max.
   - Used for: Critical dependencies requiring specific versions
   - Example: `"1.04"` for Zero Hour, `"1.08"` for Generals
-- **compatibleVersions** (List<string>, optional): List of compatible versions.
+- **compatibleVersions** (`List<string>`, optional): List of compatible versions.
   - Alternative to version ranges for non-sequential versioning
   - Example: `["1.04", "1.04.1", "1.04.2"]`
-- **compatibleGameTypes** (List<GameType>, optional): Restricts which game types satisfy dependency.
+- **compatibleGameTypes** (`List<GameType>`, optional): Restricts which game types satisfy dependency.
   - Used when dependency can be satisfied by multiple game types
   - Example: GeneralsOnline client only compatible with `ZeroHour`
 - **isExclusive** (bool, optional): Whether this dependency cannot coexist with others.
   - Used for: Mutually exclusive content (e.g., different game clients)
   - Example: GeneralsOnline and Gentool cannot both be active
-- **conflictsWith** (List<ManifestId>, optional): Explicit list of conflicting content IDs.
+- **conflictsWith** (`List<ManifestId>`, optional): Explicit list of conflicting content IDs.
   - More granular than `isExclusive`
   - Example: Mod A conflicts with Mod B's specific version
 - **isOptional** (bool, optional): Whether dependency is optional.
   - Optional dependencies enhance functionality but aren't required
   - Example: Mod optionally depends on ControlBar for better UX
-- **requiredPublisherTypes** (List<string>, optional): Whitelist of acceptable publisher types.
+- **requiredPublisherTypes** (`List<string>`, optional): Whitelist of acceptable publisher types.
   - Dependency can only be satisfied by content from these publishers
   - Example: `["steam", "gog"]` excludes EA version
-- **incompatiblePublisherTypes** (List<string>, optional): Blacklist of unacceptable publisher types.
+- **incompatiblePublisherTypes** (`List<string>`, optional): Blacklist of unacceptable publisher types.
   - Content from these publishers cannot satisfy dependency
   - Example: `["ea"]` excludes EA version due to known incompatibilities
 
@@ -609,13 +609,13 @@ Beyond the basic structure shown earlier, `ContentManifest` includes advanced fi
 - **sourcePath** (string, optional): Original source path for local content.
   - Used for: GameInstallation manifests to persist installation paths
   - Example: `"C:/Program Files (x86)/EA Games/Command & Conquer Generals Zero Hour"`
-- **contentReferences** (List<ContentReference>, optional): Cross-publisher content links.
+- **contentReferences** (`List<ContentReference>`, optional): Cross-publisher content links.
   - Used for: Referencing related content from other publishers
   - Enables: Addon chains, recommended content, alternative versions
-- **knownAddons** (List<string>, optional): Manifest IDs of known addons for this content.
+- **knownAddons** (`List<string>`, optional): Manifest IDs of known addons for this content.
   - Manifest-driven addon discovery (not hardcoded)
   - Example: Base mod lists its official addons
-- **requiredDirectories** (List<string>, optional): Directory structure that must exist.
+- **requiredDirectories** (`List<string>`, optional): Directory structure that must exist.
   - Created during workspace preparation
   - Example: `["Data/", "Maps/", "Shaders/"]`
 - **installationInstructions** (InstallationInstructions, optional): Installation behavior and lifecycle hooks.
@@ -660,7 +660,7 @@ The `ContentMetadata` class provides rich metadata for content discovery, presen
 
 **Advanced Field Descriptions**:
 
-- **variants** (List<ContentVariant>, optional): Available variants for this content.
+- **variants** (`List<ContentVariant>`, optional): Available variants for this content.
   - Enables: Resolution variants (ControlBar), language packs, quality settings
   - Each variant defines file filtering patterns
 - **requiresVariantSelection** (bool, optional): Whether user must select a variant before installation.
@@ -679,9 +679,9 @@ The `ContentMetadata` class provides rich metadata for content discovery, presen
 - **value** (string, required): Variant value (e.g., `"1920x1080"`, `"en-US"`, `"high"`).
 - **isDefault** (bool, optional): Whether this is the default variant.
 - **targetGame** (GameType, optional): Target game if different from parent content.
-- **includePatterns** (List<string>, required): File patterns to include for this variant. Supports wildcards.
-- **excludePatterns** (List<string>, optional): File patterns to exclude for this variant.
-- **tags** (List<string>, optional): Tags for filtering and discovery.
+- **includePatterns** (`List<string>`, required): File patterns to include for this variant. Supports wildcards.
+- **excludePatterns** (`List<string>`, optional): File patterns to exclude for this variant.
+- **tags** (`List<string>`, optional): Tags for filtering and discovery.
 
 ### PublisherInfo Advanced Fields
 
@@ -769,10 +769,10 @@ The `InstallationInstructions` class defines installation behavior, lifecycle ho
 
 **Field Descriptions**:
 
-- **preInstallSteps** (List<InstallationStep>, optional): Steps executed before file installation.
+- **preInstallSteps** (`List<InstallationStep>`, optional): Steps executed before file installation.
   - Used for: Validation, backups, prerequisite checks
   - Executed in order, installation aborts if any step fails
-- **postInstallSteps** (List<InstallationStep>, optional): Steps executed after file installation.
+- **postInstallSteps** (`List<InstallationStep>`, optional): Steps executed after file installation.
   - Used for: Configuration, script execution, user notifications
   - Executed in order, errors logged but don't abort installation
 - **workspaceStrategy** (WorkspaceStrategy, optional): Preferred workspace preparation strategy.


### PR DESCRIPTION
## Summary
Fixes VitePress build failures caused by unescaped raw HTML tags in documentation markdown files and corrects the Netlify deployment directory so documentation deploys succeed.

### Root Cause
1. In \docs/features/downloads.md:608\, raw \<date>\ within double quotes was parsed by \@vue/compiler-core\ as an unclosed HTML tag, crashing the static page generator.
2. In \docs/features/manifest.md\, raw \(List<T>, ...)\ generic type signatures were parsed as missing end tags by \@vue/compiler-core\.
3. In \.github/workflows/deploy.yml:52\, the Netlify CLI was instructed to deploy \docs/.vitepress/out\, but VitePress compiles to \docs/.vitepress/dist\ by default, causing missing artifact errors upon deployment.

### Changes
- **docs**: Escaped raw \<date>\ in \docs/features/downloads.md\ with backticks.
- **docs**: Escaped raw \List<T>\ generic type definitions in \docs/features/manifest.md\ with backticks.
- **ci**: Updated \.github/workflows/deploy.yml\ deploy directory from \docs/.vitepress/out\ to \docs/.vitepress/dist\.

### Verification
- [x] Tested full VitePress production build locally (\pnpm run build\) — succeeded cleanly with all client/server bundles and pages rendered.
- [x] Verified \docs/.vitepress/dist/_redirects\ is properly emitted to route traffic to \wiki.generalshub.com\.