### PR TITLE
fix(review): resolve DeepSource code analysis issues from PR 378

### DIFF
--- a/GenHub/GenHub.Core/Helpers/DownloadSecurityValidator.cs
+++ b/GenHub/GenHub.Core/Helpers/DownloadSecurityValidator.cs
@@ -312,7 +312,7 @@ public static class DownloadSecurityValidator
         if (hasHashCheck)
         {
             var allowedHashes = allowedSha256Hashes!;
-            if (!allowedHashes.Any(h => string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase)))
+            if (allowedHashes.All(h => !string.Equals(h, actualHash, StringComparison.OrdinalIgnoreCase)))
             {
                 return OperationResult<bool>.CreateFailure(
                     $"SHA-256 hash mismatch for '{Path.GetFileName(filePath)}'. Computed hash: '{actualHash}'. Expected one of: [{string.Join(", ", allowedHashes)}].");

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/InfoTabResponsivenessTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/InfoTabResponsivenessTests.cs
@@ -112,7 +112,7 @@ public class InfoTabResponsivenessTests
     /// </summary>
     /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task DemoAddLocalContent_AddContentCommand_ExecutesSuccessfully()
+    public async Task DemoAddLocalContent_AddContentCommand_ExecutesSuccessfullyAsync()
     {
         var vm = DemoViewModelFactory.CreateDemoAddLocalContent();
 
@@ -128,7 +128,7 @@ public class InfoTabResponsivenessTests
     /// </summary>
     /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task DefaultInfoContentProvider_CreateLocalContentSection_ContainsDetailedUnslopCards()
+    public async Task DefaultInfoContentProvider_CreateLocalContentSection_ContainsDetailedUnslopCardsAsync()
     {
         var provider = new DefaultInfoContentProvider();
         var sections = await provider.GetAllSectionsAsync();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/ScanWizardDemoViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Info/ScanWizardDemoViewModelTests.cs
@@ -72,7 +72,7 @@ public class ScanWizardDemoViewModelTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task RescanCommand_ExecutesAndRepopulatesItems()
+    public async Task RescanCommand_ExecutesAndRepopulatesItemsAsync()
     {
         var vm = CreateVm();
         vm.Items[0].IsSelected = false;
@@ -93,7 +93,7 @@ public class ScanWizardDemoViewModelTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task RescanAsync_WhenCancelled_PreservesItemsAndSetsCancelledStatus()
+    public async Task RescanAsync_WhenCancelled_PreservesItemsAndSetsCancelledStatusAsync()
     {
         var vm = CreateVm();
         using var cts = new CancellationTokenSource();
@@ -115,7 +115,7 @@ public class ScanWizardDemoViewModelTests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async Task CancelCommand_DuringRescan_CancelsActiveScan()
+    public async Task CancelCommand_DuringRescan_CancelsActiveScanAsync()
     {
         var scanStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var cancellationTriggeredTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -123,9 +123,11 @@ public class ScanWizardDemoViewModelTests
         var vm = CreateVm(delayProvider: async ct =>
         {
             scanStartedTcs.SetResult();
-            using var reg = ct.Register(() => cancellationTriggeredTcs.SetResult());
-            await cancellationTriggeredTcs.Task;
-            ct.ThrowIfCancellationRequested();
+            using (ct.Register(() => cancellationTriggeredTcs.SetResult()))
+            {
+                await cancellationTriggeredTcs.Task;
+                ct.ThrowIfCancellationRequested();
+            }
         });
 
         var scanTask = vm.RescanAsync();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/ApplicationDataPathConventionTests.cs
@@ -86,7 +86,7 @@ public class ApplicationDataPathConventionTests
         }
 
         var message =
-            $"The following files read Environment.SpecialFolder.ApplicationData directly instead of " +
+            "The following files read Environment.SpecialFolder.ApplicationData directly instead of " +
             $"using IConfigurationProviderService.GetApplicationDataPath():\n{string.Join('\n', violations)}\n\n" +
             "If this is intentional (e.g. bootstrapping, or defining the default for the UI), " +
             "add the file to the allowlist in ApplicationDataPathConventionTests with an explanation.";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/ImageCacheServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/ImageCacheServiceTests.cs
@@ -130,7 +130,7 @@ public class ImageCacheServiceTests
             var configMock = new Mock<IConfigurationProviderService>();
             configMock.Setup(c => c.GetApplicationDataPath()).Returns(tempRoot);
 
-            var service = new ImageCacheService(configMock.Object);
+            _ = new ImageCacheService(configMock.Object);
             var expectedCacheDir = Path.Combine(tempRoot, "Images");
 
             Assert.True(Directory.Exists(expectedCacheDir));
@@ -143,7 +143,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempRoot, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // ignore cleanup failure
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // ignore cleanup failure
                 }
@@ -188,7 +192,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempDir, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // ignore cleanup failure
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // ignore cleanup failure
                 }
@@ -253,7 +261,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempDir, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // Ignore cleanup failure in test teardown
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // Ignore cleanup failure in test teardown
                 }
@@ -325,7 +337,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempDir, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // ignore cleanup failure
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // ignore cleanup failure
                 }
@@ -394,7 +410,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempDir, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // ignore cleanup failure
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // ignore cleanup failure
                 }
@@ -446,7 +466,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempDir, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // ignore cleanup failure
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // ignore cleanup failure
                 }
@@ -505,7 +529,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempDir, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // ignore cleanup failure
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // ignore cleanup failure
                 }
@@ -543,7 +571,11 @@ public class ImageCacheServiceTests
                 {
                     Directory.Delete(tempDir, true);
                 }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                catch (IOException)
+                {
+                    // ignore cleanup failure
+                }
+                catch (UnauthorizedAccessException)
                 {
                     // ignore cleanup failure
                 }

--- a/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
@@ -859,7 +859,13 @@ public class BackgroundUpdateCoordinator(
 
     private async Task CheckForUpdatesOnStartupAsync(CancellationToken cancellationToken)
     {
-        await CheckForUpdatesInBackgroundAsync(cancellationToken);
+        if (!TryGetLifetimeToken(out var lifetimeToken))
+        {
+            return;
+        }
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(lifetimeToken, cancellationToken);
+        await CheckForUpdatesInBackgroundAsync(linkedCts.Token);
     }
 
     private async Task CheckForUpdatesInBackgroundAsync(CancellationToken ct)

--- a/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
@@ -49,9 +49,9 @@ public class BackgroundUpdateCoordinator(
         RegisterMessages();
 
         var settings = userSettingsService.Get();
-        if (settings.AutoCheckForUpdatesOnStartup && TryGetLifetimeToken(out var lifetimeToken))
+        if (settings.AutoCheckForUpdatesOnStartup && TryGetLifetimeToken(out _))
         {
-            _ = CheckForUpdatesOnStartupAsync(lifetimeToken, cancellationToken);
+            _ = CheckForUpdatesOnStartupAsync(cancellationToken);
         }
 
         RestartPeriodicUpdateTimer(settings.AutoCheckForUpdatesPeriodically, settings.PeriodicUpdateCheckIntervalMinutes);
@@ -857,10 +857,9 @@ public class BackgroundUpdateCoordinator(
         });
     }
 
-    private async Task CheckForUpdatesOnStartupAsync(CancellationToken lifetimeToken, CancellationToken cancellationToken)
+    private async Task CheckForUpdatesOnStartupAsync(CancellationToken cancellationToken)
     {
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(lifetimeToken, cancellationToken);
-        await CheckForUpdatesInBackgroundAsync(linkedCts.Token);
+        await CheckForUpdatesInBackgroundAsync(cancellationToken);
     }
 
     private async Task CheckForUpdatesInBackgroundAsync(CancellationToken ct)

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
@@ -380,16 +380,19 @@ public class CommunityOutpostManifestFactory(
                 alwaysIncludeFiles,
                 dependencyBigFiles);
 
-            var fileEntries = await CollectManifestFilesAsync(
-                allFiles,
-                extractedDirectory,
-                contentMetadata,
+            var inclusionContext = new ManifestInclusionContext(
                 variant,
                 isControlBarVariant,
                 hasVariantBigFiles,
                 dependencyBigFiles,
                 alwaysIncludeFiles,
-                controlBarRepackedOutputs,
+                controlBarRepackedOutputs);
+
+            var fileEntries = await CollectManifestFilesAsync(
+                allFiles,
+                extractedDirectory,
+                contentMetadata,
+                inclusionContext,
                 cancellationToken);
 
             var (manifestId, manifestName) = ResolveVariantIdentity(originalManifest, variant, fileEntries.Count);
@@ -447,12 +450,7 @@ public class CommunityOutpostManifestFactory(
         string[] allFiles,
         string extractedDirectory,
         GenPatcherContentMetadata contentMetadata,
-        ContentVariant? variant,
-        bool isControlBarVariant,
-        bool hasVariantBigFiles,
-        HashSet<string> dependencyBigFiles,
-        HashSet<string> alwaysIncludeFiles,
-        HashSet<string> controlBarRepackedOutputs,
+        ManifestInclusionContext inclusionContext,
         CancellationToken cancellationToken)
     {
         var fileEntries = new List<ManifestFile>();
@@ -461,14 +459,7 @@ public class CommunityOutpostManifestFactory(
             cancellationToken.ThrowIfCancellationRequested();
 
             var relativePath = Path.GetRelativePath(extractedDirectory, fullPath);
-            if (!ShouldIncludeFile(
-                relativePath,
-                variant,
-                isControlBarVariant,
-                hasVariantBigFiles,
-                dependencyBigFiles,
-                alwaysIncludeFiles,
-                controlBarRepackedOutputs))
+            if (!ShouldIncludeFile(relativePath, inclusionContext))
             {
                 continue;
             }
@@ -598,37 +589,32 @@ public class CommunityOutpostManifestFactory(
 
     private bool ShouldIncludeFile(
         string relativePath,
-        ContentVariant? variant,
-        bool isControlBarVariant,
-        bool hasVariantBigFiles,
-        HashSet<string> dependencyBigFiles,
-        HashSet<string> alwaysIncludeFiles,
-        HashSet<string> controlBarRepackedOutputs)
+        ManifestInclusionContext context)
     {
         var fileName = Path.GetFileName(relativePath);
         var normalizedPath = relativePath.Replace('\\', '/').ToLowerInvariant();
-        var isDependencyBig = dependencyBigFiles.Contains(fileName);
-        var isAlwaysInclude = alwaysIncludeFiles.Contains(fileName);
-        var isRepackedOutput = controlBarRepackedOutputs.Contains(fileName);
+        var isDependencyBig = context.DependencyBigFiles.Contains(fileName);
+        var isAlwaysInclude = context.AlwaysIncludeFiles.Contains(fileName);
+        var isRepackedOutput = context.ControlBarRepackedOutputs.Contains(fileName);
 
-        if (isControlBarVariant && controlBarRepackedOutputs.Count > 0 && !isRepackedOutput && !isDependencyBig && !isAlwaysInclude)
+        if (context.IsControlBarVariant && context.ControlBarRepackedOutputs.Count > 0 && !isRepackedOutput && !isDependencyBig && !isAlwaysInclude)
         {
             logger.LogDebug("Skipping file {File} because control bar variant is repacked into Art/Data BIG files", relativePath);
             return false;
         }
 
-        if (isControlBarVariant && hasVariantBigFiles && !fileName.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
+        if (context.IsControlBarVariant && context.HasVariantBigFiles && !fileName.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
         {
-            logger.LogDebug("Skipping non-BIG file {File} for control bar variant {Variant}", relativePath, variant?.Name);
+            logger.LogDebug("Skipping non-BIG file {File} for control bar variant {Variant}", relativePath, context.Variant?.Name);
             return false;
         }
 
-        if (variant != null)
+        if (context.Variant != null)
         {
-            if (variant.IncludePatterns is { Count: > 0 })
+            if (context.Variant.IncludePatterns is { Count: > 0 })
             {
                 bool matchesInclude = false;
-                foreach (var pattern in variant.IncludePatterns)
+                foreach (var pattern in context.Variant.IncludePatterns)
                 {
                     var regex = GetCachedRegex(pattern);
                     if (regex.IsMatch(fileName) || regex.IsMatch(normalizedPath))
@@ -640,15 +626,15 @@ public class CommunityOutpostManifestFactory(
 
                 if (!matchesInclude && !isDependencyBig && !isAlwaysInclude)
                 {
-                    logger.LogDebug("Skipping file {File} - does not match variant {Variant} include patterns", relativePath, variant.Name);
+                    logger.LogDebug("Skipping file {File} - does not match variant {Variant} include patterns", relativePath, context.Variant.Name);
                     return false;
                 }
             }
 
-            if (variant.ExcludePatterns is { Count: > 0 })
+            if (context.Variant.ExcludePatterns is { Count: > 0 })
             {
                 bool matchesExclude = false;
-                foreach (var pattern in variant.ExcludePatterns)
+                foreach (var pattern in context.Variant.ExcludePatterns)
                 {
                     var regex = GetCachedRegex(pattern);
                     if (regex.IsMatch(fileName) || regex.IsMatch(normalizedPath))
@@ -660,7 +646,7 @@ public class CommunityOutpostManifestFactory(
 
                 if (matchesExclude && !isDependencyBig && !isAlwaysInclude)
                 {
-                    logger.LogDebug("Skipping file {File} - matches variant {Variant} exclude pattern", relativePath, variant.Name);
+                    logger.LogDebug("Skipping file {File} - matches variant {Variant} exclude pattern", relativePath, context.Variant.Name);
                     return false;
                 }
             }
@@ -668,4 +654,12 @@ public class CommunityOutpostManifestFactory(
 
         return true;
     }
+
+    private sealed record ManifestInclusionContext(
+        ContentVariant? Variant,
+        bool IsControlBarVariant,
+        bool HasVariantBigFiles,
+        HashSet<string> DependencyBigFiles,
+        HashSet<string> AlwaysIncludeFiles,
+        HashSet<string> ControlBarRepackedOutputs);
 }

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
@@ -329,7 +329,6 @@ public class CommunityOutpostManifestFactory(
 
         try
         {
-            // Get all files from extracted directory
             var allFiles = Directory.GetFiles(extractedDirectory, "*.*", SearchOption.AllDirectories);
 
             if (allFiles.Length == 0)
@@ -340,7 +339,6 @@ public class CommunityOutpostManifestFactory(
 
             logger.LogDebug("Found {FileCount} files in extracted directory", allFiles.Length);
 
-            var fileEntries = new List<ManifestFile>();
             var targetGame = (variant != null && variant.TargetGame.HasValue)
                 ? variant.TargetGame.Value
                 : originalManifest.TargetGame;
@@ -349,46 +347,30 @@ public class CommunityOutpostManifestFactory(
             var alwaysIncludeFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             if (contentMetadata.Category == GenPatcherContentCategory.ControlBar)
             {
-                // Small metadata BIG included alongside variant-specific files in GenPatcher builds
                 alwaysIncludeFiles.Add("340_ControlBarProZH.big");
             }
 
             HashSet<string> controlBarRepackedOutputs;
             if (isControlBarVariant)
             {
-                var outputs = await controlBarProcessor.ProcessAndRepackControlBarAsync(
+                var (shouldSkip, outputs) = await ProcessControlBarVariantAsync(
                     extractedDirectory,
                     originalManifest,
-                    variant?.Id,
-                    cleanupSources: false,
+                    variant,
+                    allControlBarOutputs,
                     cancellationToken);
-                controlBarRepackedOutputs = new HashSet<string>(outputs, StringComparer.OrdinalIgnoreCase);
-                if (controlBarRepackedOutputs.Count == 0 ||
-                    controlBarRepackedOutputs.All(controlBarProcessor.IsMetadataOnlyBig))
+
+                if (shouldSkip)
                 {
-                    logger.LogInformation(
-                        "Skipping Control Bar variant {VariantId} because no matching variant assets were found in {Directory}",
-                        variant?.Id,
-                        extractedDirectory);
                     return null;
                 }
 
-                if (allControlBarOutputs != null)
-                {
-                    foreach (var output in outputs)
-                    {
-                        allControlBarOutputs.Add(output);
-                    }
-                }
+                controlBarRepackedOutputs = outputs;
+                allFiles = Directory.GetFiles(extractedDirectory, "*.*", SearchOption.AllDirectories);
             }
             else
             {
                 controlBarRepackedOutputs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            }
-
-            if (controlBarRepackedOutputs.Count > 0)
-            {
-                allFiles = Directory.GetFiles(extractedDirectory, "*.*", SearchOption.AllDirectories);
             }
 
             var hasVariantBigFiles = variant != null && HasVariantBigFiles(
@@ -398,140 +380,20 @@ public class CommunityOutpostManifestFactory(
                 alwaysIncludeFiles,
                 dependencyBigFiles);
 
-            foreach (var fullPath in allFiles)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+            var fileEntries = await CollectManifestFilesAsync(
+                allFiles,
+                extractedDirectory,
+                contentMetadata,
+                variant,
+                isControlBarVariant,
+                hasVariantBigFiles,
+                dependencyBigFiles,
+                alwaysIncludeFiles,
+                controlBarRepackedOutputs,
+                cancellationToken);
 
-                var relativePath = Path.GetRelativePath(extractedDirectory, fullPath);
-                if (!ShouldIncludeFile(
-                    relativePath,
-                    variant,
-                    isControlBarVariant,
-                    hasVariantBigFiles,
-                    dependencyBigFiles,
-                    alwaysIncludeFiles,
-                    controlBarRepackedOutputs))
-                {
-                    continue;
-                }
-
-                var hash = await hashProvider.ComputeFileHashAsync(fullPath, cancellationToken);
-                var fileSize = new FileInfo(fullPath).Length;
-                var isExecutable = relativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
-
-                // Determine install target for this file
-                var fileInstallTarget = DetermineFileInstallTarget(
-                    relativePath,
-                    contentMetadata.InstallTarget);
-
-                fileEntries.Add(new ManifestFile
-                {
-                    RelativePath = relativePath,
-                    Hash = hash,
-                    Size = fileSize,
-                    IsExecutable = isExecutable,
-                    SourceType = ContentSourceType.ExtractedPackage,
-                    SourcePath = fullPath,
-                    InstallTarget = fileInstallTarget,
-                });
-
-                logger.LogDebug(
-                    "Added file: {Path} (Size: {Size} bytes, InstallTarget: {Target})",
-                    relativePath,
-                    fileSize,
-                    fileInstallTarget);
-            }
-
-            // Create variant-specific manifest ID and name if variant is provided
-            var manifestId = originalManifest.Id;
-            var manifestName = originalManifest.Name;
-
-            if (variant != null)
-            {
-                // Get the base content code from the original manifest ID
-                // Format: 1.version.publisher.contentType.contentCode
-                var idParts = originalManifest.Id.Value.Split('.');
-                if (idParts.Length >= 5)
-                {
-                    var contentCode = idParts[4]; // Get the content code (e.g., "cbpx")
-
-                    // Create new content name with variant suffix (e.g., "cbpx-1080p")
-                    // This maintains the 5-segment format: schemaVersion.userVersion.publisher.contentType.contentName-variant
-                    var variantContentName = $"{contentCode}-{variant.Id}";
-
-                    // Rebuild manifest ID with variant-suffixed content name (still 5 segments)
-                    manifestId = ManifestId.Create($"{idParts[0]}.{idParts[1]}.{idParts[2]}.{idParts[3]}.{variantContentName}");
-                }
-
-                // Append variant name to manifest name (e.g., "Control Bar Pro (Xezon) - 1080p")
-                manifestName = $"{originalManifest.Name} - {variant.Name}";
-
-                logger.LogInformation(
-                    "Creating variant manifest: {ManifestId} ({ManifestName}) with {FileCount} files",
-                    manifestId,
-                    manifestName,
-                    fileEntries.Count);
-            }
-
-            // Create the manifest preserving original data but with updated files
-            var manifest = new ContentManifest
-            {
-                Id = manifestId,
-                Name = manifestName,
-                Version = originalManifest.Version,
-                ManifestVersion = originalManifest.ManifestVersion,
-                ContentType = originalManifest.ContentType,
-                TargetGame = (variant != null && variant.TargetGame.HasValue) ? variant.TargetGame.Value : originalManifest.TargetGame,
-                Files = fileEntries,
-
-                // Remove auto-install dependencies from the list since they're bundled into the files
-                Dependencies = [.. contentMetadata.GetDependencies().Where(d => d.InstallBehavior != DependencyInstallBehavior.AutoInstall)],
-                InstallationInstructions = originalManifest.InstallationInstructions ?? new InstallationInstructions(),
-                Publisher = originalManifest.Publisher,
-                Metadata = new ContentMetadata
-                {
-                    Description = originalManifest.Metadata.Description,
-                    ReleaseDate = originalManifest.Metadata.ReleaseDate,
-                    IconUrl = CommunityOutpostConstants.LogoSource,
-                    CoverUrl = CommunityOutpostConstants.CoverSource,
-                    ThemeColor = CommunityOutpostConstants.ThemeColor,
-                    ScreenshotUrls = originalManifest.Metadata.ScreenshotUrls,
-                    Tags = originalManifest.Metadata.Tags,
-                    ChangelogUrl = originalManifest.Metadata.ChangelogUrl,
-
-                    // For variant-specific manifests, don't include the Variants list (each manifest IS a variant)
-                    Variants = variant != null ? [] : (contentMetadata.Variants ?? []),
-                    RequiresVariantSelection = false, // Variant already selected for this manifest
-                    SelectedVariantId = variant?.Id, // Mark which variant this manifest represents
-                },
-            };
-
-            logger.LogInformation(
-                "Built manifest {ManifestId} for {ContentType} '{Name}' with {FileCount} files and {DependencyCount} dependencies",
-                manifest.Id,
-                manifest.ContentType,
-                manifest.Name,
-                fileEntries.Count,
-                manifest.Dependencies?.Count ?? 0);
-
-            // Log each dependency for debugging
-            if (manifest.Dependencies is { Count: > 0 })
-            {
-                foreach (var dep in manifest.Dependencies)
-                {
-                    logger.LogDebug(
-                        "  Dependency: {DepName} ({DepId}) - Type: {DepType}",
-                        dep.Name,
-                        dep.Id,
-                        dep.DependencyType);
-                }
-            }
-            else
-            {
-                logger.LogWarning("Manifest {ManifestId} has NO dependencies! Category: {Category}", manifest.Id, contentMetadata.Category);
-            }
-
-            return manifest;
+            var (manifestId, manifestName) = ResolveVariantIdentity(originalManifest, variant, fileEntries.Count);
+            return AssembleManifest(originalManifest, contentMetadata, variant, manifestId, manifestName, fileEntries);
         }
         catch (Exception ex)
         {
@@ -543,6 +405,195 @@ public class CommunityOutpostManifestFactory(
 
             return null;
         }
+    }
+
+    private async Task<(bool ShouldSkip, HashSet<string> Outputs)> ProcessControlBarVariantAsync(
+        string extractedDirectory,
+        ContentManifest originalManifest,
+        ContentVariant? variant,
+        HashSet<string>? allControlBarOutputs,
+        CancellationToken cancellationToken)
+    {
+        var outputs = await controlBarProcessor.ProcessAndRepackControlBarAsync(
+            extractedDirectory,
+            originalManifest,
+            variant?.Id,
+            cleanupSources: false,
+            cancellationToken);
+
+        var repackedOutputs = new HashSet<string>(outputs, StringComparer.OrdinalIgnoreCase);
+        if (repackedOutputs.Count == 0 ||
+            repackedOutputs.All(controlBarProcessor.IsMetadataOnlyBig))
+        {
+            logger.LogInformation(
+                "Skipping Control Bar variant {VariantId} because no matching variant assets were found in {Directory}",
+                variant?.Id,
+                extractedDirectory);
+            return (true, repackedOutputs);
+        }
+
+        if (allControlBarOutputs != null)
+        {
+            foreach (var output in outputs)
+            {
+                allControlBarOutputs.Add(output);
+            }
+        }
+
+        return (false, repackedOutputs);
+    }
+
+    private async Task<List<ManifestFile>> CollectManifestFilesAsync(
+        string[] allFiles,
+        string extractedDirectory,
+        GenPatcherContentMetadata contentMetadata,
+        ContentVariant? variant,
+        bool isControlBarVariant,
+        bool hasVariantBigFiles,
+        HashSet<string> dependencyBigFiles,
+        HashSet<string> alwaysIncludeFiles,
+        HashSet<string> controlBarRepackedOutputs,
+        CancellationToken cancellationToken)
+    {
+        var fileEntries = new List<ManifestFile>();
+        foreach (var fullPath in allFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var relativePath = Path.GetRelativePath(extractedDirectory, fullPath);
+            if (!ShouldIncludeFile(
+                relativePath,
+                variant,
+                isControlBarVariant,
+                hasVariantBigFiles,
+                dependencyBigFiles,
+                alwaysIncludeFiles,
+                controlBarRepackedOutputs))
+            {
+                continue;
+            }
+
+            var hash = await hashProvider.ComputeFileHashAsync(fullPath, cancellationToken);
+            var fileSize = new FileInfo(fullPath).Length;
+            var isExecutable = relativePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
+
+            var fileInstallTarget = DetermineFileInstallTarget(
+                relativePath,
+                contentMetadata.InstallTarget);
+
+            fileEntries.Add(new ManifestFile
+            {
+                RelativePath = relativePath,
+                Hash = hash,
+                Size = fileSize,
+                IsExecutable = isExecutable,
+                SourceType = ContentSourceType.ExtractedPackage,
+                SourcePath = fullPath,
+                InstallTarget = fileInstallTarget,
+            });
+
+            logger.LogDebug(
+                "Added file: {Path} (Size: {Size} bytes, InstallTarget: {Target})",
+                relativePath,
+                fileSize,
+                fileInstallTarget);
+        }
+
+        return fileEntries;
+    }
+
+    private (ManifestId ManifestId, string ManifestName) ResolveVariantIdentity(
+        ContentManifest originalManifest,
+        ContentVariant? variant,
+        int fileCount)
+    {
+        var manifestId = originalManifest.Id;
+        var manifestName = originalManifest.Name;
+
+        if (variant == null)
+        {
+            return (manifestId, manifestName);
+        }
+
+        var idParts = originalManifest.Id.Value.Split('.');
+        if (idParts.Length >= 5)
+        {
+            var contentCode = idParts[4];
+            var variantContentName = $"{contentCode}-{variant.Id}";
+            manifestId = ManifestId.Create($"{idParts[0]}.{idParts[1]}.{idParts[2]}.{idParts[3]}.{variantContentName}");
+        }
+
+        manifestName = $"{originalManifest.Name} - {variant.Name}";
+        logger.LogInformation(
+            "Creating variant manifest: {ManifestId} ({ManifestName}) with {FileCount} files",
+            manifestId,
+            manifestName,
+            fileCount);
+
+        return (manifestId, manifestName);
+    }
+
+    private ContentManifest AssembleManifest(
+        ContentManifest originalManifest,
+        GenPatcherContentMetadata contentMetadata,
+        ContentVariant? variant,
+        ManifestId manifestId,
+        string manifestName,
+        List<ManifestFile> fileEntries)
+    {
+        var manifest = new ContentManifest
+        {
+            Id = manifestId,
+            Name = manifestName,
+            Version = originalManifest.Version,
+            ManifestVersion = originalManifest.ManifestVersion,
+            ContentType = originalManifest.ContentType,
+            TargetGame = (variant != null && variant.TargetGame.HasValue) ? variant.TargetGame.Value : originalManifest.TargetGame,
+            Files = fileEntries,
+            Dependencies = [.. contentMetadata.GetDependencies().Where(d => d.InstallBehavior != DependencyInstallBehavior.AutoInstall)],
+            InstallationInstructions = originalManifest.InstallationInstructions ?? new InstallationInstructions(),
+            Publisher = originalManifest.Publisher,
+            Metadata = new ContentMetadata
+            {
+                Description = originalManifest.Metadata.Description,
+                ReleaseDate = originalManifest.Metadata.ReleaseDate,
+                IconUrl = CommunityOutpostConstants.LogoSource,
+                CoverUrl = CommunityOutpostConstants.CoverSource,
+                ThemeColor = CommunityOutpostConstants.ThemeColor,
+                ScreenshotUrls = originalManifest.Metadata.ScreenshotUrls,
+                Tags = originalManifest.Metadata.Tags,
+                ChangelogUrl = originalManifest.Metadata.ChangelogUrl,
+                Variants = variant != null ? [] : (contentMetadata.Variants ?? []),
+                RequiresVariantSelection = false,
+                SelectedVariantId = variant?.Id,
+            },
+        };
+
+        logger.LogInformation(
+            "Built manifest {ManifestId} for {ContentType} '{Name}' with {FileCount} files and {DependencyCount} dependencies",
+            manifest.Id,
+            manifest.ContentType,
+            manifest.Name,
+            fileEntries.Count,
+            manifest.Dependencies?.Count ?? 0);
+
+        if (manifest.Dependencies is { Count: > 0 })
+        {
+            foreach (var dep in manifest.Dependencies)
+            {
+                logger.LogDebug(
+                    "  Dependency: {DepName} ({DepId}) - Type: {DepType}",
+                    dep.Name,
+                    dep.Id,
+                    dep.DependencyType);
+            }
+        }
+        else
+        {
+            logger.LogWarning("Manifest {ManifestId} has NO dependencies! Category: {Category}", manifest.Id, contentMetadata.Category);
+        }
+
+        return manifest;
     }
 
     private bool ShouldIncludeFile(

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostManifestFactory.cs
@@ -603,7 +603,7 @@ public class CommunityOutpostManifestFactory(
             return false;
         }
 
-        if (context.IsControlBarVariant && context.HasVariantBigFiles && !fileName.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
+        if (context.IsControlBarVariant && context.ContainsVariantBigFiles && !fileName.EndsWith(".big", StringComparison.OrdinalIgnoreCase))
         {
             logger.LogDebug("Skipping non-BIG file {File} for control bar variant {Variant}", relativePath, context.Variant?.Name);
             return false;
@@ -658,7 +658,7 @@ public class CommunityOutpostManifestFactory(
     private sealed record ManifestInclusionContext(
         ContentVariant? Variant,
         bool IsControlBarVariant,
-        bool HasVariantBigFiles,
+        bool ContainsVariantBigFiles,
         HashSet<string> DependencyBigFiles,
         HashSet<string> AlwaysIncludeFiles,
         HashSet<string> ControlBarRepackedOutputs);

--- a/GenHub/GenHub/Features/Content/Services/Parsers/ModDBPageParser.cs
+++ b/GenHub/GenHub/Features/Content/Services/Parsers/ModDBPageParser.cs
@@ -1270,7 +1270,8 @@ public partial class ModDBPageParser(IPlaywrightService playwrightService, ILogg
             {
                 return votes;
             }
-            else if (!string.IsNullOrEmpty(votesText))
+
+            if (!string.IsNullOrEmpty(votesText))
             {
                 // "12 people found this helpful" — take the leading integer when present.
                 var digits = new string(votesText.TakeWhile(char.IsDigit).ToArray());
@@ -2542,17 +2543,25 @@ public partial class ModDBPageParser(IPlaywrightService playwrightService, ILogg
     }
 
     /// <summary>
-    /// Returns the canonical base URL without query parameters, fragments, or trailing slashes.
+    /// Returns the canonical base URI without query parameters, fragments, or trailing slashes.
     /// </summary>
-    private static string GetCanonicalBaseUrl(string url)
+    private static Uri GetCanonicalBaseUri(Uri uri)
     {
-        var normalized = NormalizeToHttps(url);
+        ArgumentNullException.ThrowIfNull(uri);
+        var path = uri.AbsolutePath.TrimEnd('/');
+        return new Uri($"{UriConstants.HttpsUriScheme}{uri.Authority}{path}", UriKind.Absolute);
+    }
+
+    private static Uri GetCanonicalBaseUri(string uriString)
+    {
+        var normalized = NormalizeToHttps(uriString);
         if (Uri.TryCreate(normalized, UriKind.Absolute, out var uri))
         {
-            return $"{UriConstants.HttpsUriScheme}{uri.Authority}{uri.AbsolutePath.TrimEnd('/')}";
+            return GetCanonicalBaseUri(uri);
         }
 
-        return normalized.Split('?')[0].Split('#')[0].TrimEnd('/');
+        var clean = normalized.Split('?')[0].Split('#')[0].TrimEnd('/');
+        return new Uri(clean, UriKind.RelativeOrAbsolute);
     }
 
     /// <summary>
@@ -2563,7 +2572,7 @@ public partial class ModDBPageParser(IPlaywrightService playwrightService, ILogg
     {
         if (IsModDetailPage(url))
         {
-            var baseUrl = GetCanonicalBaseUrl(url);
+            var baseUrl = GetCanonicalBaseUri(url).ToString().TrimEnd('/');
 
             return
             [
@@ -2580,7 +2589,7 @@ public partial class ModDBPageParser(IPlaywrightService playwrightService, ILogg
         var parentModUrl = ExtractParentModUrl(url);
         if (!string.IsNullOrEmpty(parentModUrl))
         {
-            var baseUrl = GetCanonicalBaseUrl(parentModUrl);
+            var baseUrl = GetCanonicalBaseUri(parentModUrl).ToString().TrimEnd('/');
 
             return
             [
@@ -3352,7 +3361,7 @@ public partial class ModDBPageParser(IPlaywrightService playwrightService, ILogg
         sections.AddRange(ExtractReviews(document));
         sections.AddRange(ExtractComments(document));
 
-        var baseUrl = GetCanonicalBaseUrl(url);
+        var baseUrl = GetCanonicalBaseUri(url).ToString().TrimEnd('/');
         AppendFetchedSections(sections, baseUrl, fetched);
         return DeduplicateSections(sections);
     }
@@ -3391,7 +3400,7 @@ public partial class ModDBPageParser(IPlaywrightService playwrightService, ILogg
             sections.AddRange(ExtractReviews(parentDoc));
             sections.AddRange(ExtractComments(parentDoc));
 
-            var baseUrl = GetCanonicalBaseUrl(parentModUrl);
+            var baseUrl = GetCanonicalBaseUri(parentModUrl).ToString().TrimEnd('/');
             AppendFetchedSections(sections, baseUrl, fetched);
         }
 

--- a/GenHub/GenHub/Features/Content/Services/Tools/PlaywrightService.cs
+++ b/GenHub/GenHub/Features/Content/Services/Tools/PlaywrightService.cs
@@ -381,7 +381,6 @@ public sealed class PlaywrightService(
         }
 
         await DisposeCoreAsync().ConfigureAwait(false);
-        GC.SuppressFinalize(this);
     }
 
     /// <inheritdoc />
@@ -1176,26 +1175,23 @@ public sealed class PlaywrightService(
                 });
 
             var ctx = context;
-            context.Close += (_, _) =>
-            {
-                Task.Run(
-                    async () =>
+            context.Close += (_, _) => Task.Run(
+                async () =>
+                {
+                    await _persistentLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+                    try
                     {
-                        await _persistentLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
-                        try
+                        if (ReferenceEquals(_persistentContext, ctx))
                         {
-                            if (ReferenceEquals(_persistentContext, ctx))
-                            {
-                                ResetPersistentContextState();
-                            }
+                            ResetPersistentContextState();
                         }
-                        finally
-                        {
-                            _persistentLock.Release();
-                        }
-                    },
-                    CancellationToken.None);
-            };
+                    }
+                    finally
+                    {
+                        _persistentLock.Release();
+                    }
+                },
+                CancellationToken.None);
 
             _persistentContext = context;
             _persistentProfileName = profileDir;
@@ -1286,7 +1282,7 @@ public sealed class PlaywrightService(
             return;
         }
 
-        List<IPage> pages;
+        List<IPage> pages = [];
         try
         {
             pages = [.. _persistentContext.Pages];
@@ -1346,7 +1342,7 @@ public sealed class PlaywrightService(
         var runtime = GetOrCreateManagedChromiumRuntime();
         runtime.ConfigureEnvironment();
 
-        IPlaywright playwright;
+        IPlaywright playwright = null!;
         await _playwrightLock.WaitAsync(cancellationToken);
         try
         {
@@ -1684,10 +1680,13 @@ public sealed class PlaywrightService(
         }
 
         var cancelTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var registration = linkedCts.Token.Register(() => cancelTcs.TrySetResult(true));
-
-        var saveTask = download.SaveAsAsync(configuration.DestinationPath);
-        var completedTask = await Task.WhenAny(saveTask, cancelTcs.Task);
+        Task completedTask;
+        Task saveTask;
+        using (linkedCts.Token.Register(() => cancelTcs.TrySetResult(true)))
+        {
+            saveTask = download.SaveAsAsync(configuration.DestinationPath);
+            completedTask = await Task.WhenAny(saveTask, cancelTcs.Task);
+        }
 
         if (completedTask != saveTask)
         {

--- a/GenHub/GenHub/Features/Content/Services/Tools/PlaywrightService.cs
+++ b/GenHub/GenHub/Features/Content/Services/Tools/PlaywrightService.cs
@@ -594,6 +594,17 @@ public sealed class PlaywrightService(
         return orderedUnique;
     }
 
+    private static async Task<Task> WaitForCompletionOrCancellationAsync(
+        Task saveTask,
+        TaskCompletionSource<bool> cancelTcs,
+        CancellationToken cancellationToken)
+    {
+        using (cancellationToken.Register(() => cancelTcs.TrySetResult(true)))
+        {
+            return await Task.WhenAny(saveTask, cancelTcs.Task);
+        }
+    }
+
     /// <summary>
     /// A persistent context is only reusable while it is live and still owns at least one open
     /// page. A headed Chromium process exits once its final page closes, after which the cached
@@ -1282,52 +1293,49 @@ public sealed class PlaywrightService(
             return;
         }
 
-        List<IPage> pages = [];
         try
         {
-            pages = [.. _persistentContext.Pages];
+            var pages = _persistentContext.Pages;
+            var blankPages = new List<IPage>();
+            foreach (var existing in pages)
+            {
+                if (existing == keepPage || existing.IsClosed || _inUsePersistentPages.Contains(existing))
+                {
+                    continue;
+                }
+
+                string url = string.Empty;
+                try
+                {
+                    url = existing.Url ?? string.Empty;
+                }
+                catch (PlaywrightException ex) when (IsContextClosedError(ex))
+                {
+                    continue;
+                }
+
+                if (IsBlankStartupUrl(url))
+                {
+                    blankPages.Add(existing);
+                }
+            }
+
+            // Close all orphan blank pages.
+            foreach (var blankPage in blankPages)
+            {
+                try
+                {
+                    await blankPage.CloseAsync();
+                }
+                catch (PlaywrightException ex)
+                {
+                    logger.LogDebug(ex, "Could not close orphan startup page; it may have closed already.");
+                }
+            }
         }
         catch (PlaywrightException ex) when (IsContextClosedError(ex))
         {
             logger.LogDebug(ex, "Persistent context closed while collecting orphan startup pages.");
-            return;
-        }
-
-        var blankPages = new List<IPage>();
-        foreach (var existing in pages)
-        {
-            if (existing == keepPage || existing.IsClosed || _inUsePersistentPages.Contains(existing))
-            {
-                continue;
-            }
-
-            string url = string.Empty;
-            try
-            {
-                url = existing.Url ?? string.Empty;
-            }
-            catch (PlaywrightException ex) when (IsContextClosedError(ex))
-            {
-                continue;
-            }
-
-            if (IsBlankStartupUrl(url))
-            {
-                blankPages.Add(existing);
-            }
-        }
-
-        // Close all orphan blank pages.
-        foreach (var blankPage in blankPages)
-        {
-            try
-            {
-                await blankPage.CloseAsync();
-            }
-            catch (PlaywrightException ex)
-            {
-                logger.LogDebug(ex, "Could not close orphan startup page; it may have closed already.");
-            }
         }
     }
 
@@ -1680,13 +1688,8 @@ public sealed class PlaywrightService(
         }
 
         var cancelTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        Task completedTask;
-        Task saveTask;
-        using (linkedCts.Token.Register(() => cancelTcs.TrySetResult(true)))
-        {
-            saveTask = download.SaveAsAsync(configuration.DestinationPath);
-            completedTask = await Task.WhenAny(saveTask, cancelTcs.Task);
-        }
+        var saveTask = download.SaveAsAsync(configuration.DestinationPath);
+        var completedTask = await WaitForCompletionOrCancellationAsync(saveTask, cancelTcs, linkedCts.Token);
 
         if (completedTask != saveTask)
         {

--- a/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
+++ b/GenHub/GenHub/Features/Info/Services/DefaultInfoContentProvider.cs
@@ -17,13 +17,6 @@ public class DefaultInfoContentProvider : IInfoContentProvider
 {
     private readonly List<InfoSection> _sections = CreateContent();
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DefaultInfoContentProvider"/> class.
-    /// </summary>
-    public DefaultInfoContentProvider()
-    {
-    }
-
     /// <inheritdoc/>
     public Task<IEnumerable<InfoSection>> GetAllSectionsAsync()
     {

--- a/GenHub/GenHub/Infrastructure/Services/ImageCacheService.cs
+++ b/GenHub/GenHub/Infrastructure/Services/ImageCacheService.cs
@@ -43,19 +43,16 @@ public sealed class ImageCacheService : IImageCacheService
     {
         get
         {
-            if (instance == null)
+            lock (InstanceLock)
             {
-                lock (InstanceLock)
+                if (instance == null)
                 {
-                    if (instance == null)
-                    {
-                        var resolved = AppLocator.GetServiceOrDefault<IImageCacheService>();
-                        instance = resolved ?? new ImageCacheService();
-                    }
+                    var resolved = AppLocator.GetServiceOrDefault<IImageCacheService>();
+                    instance = resolved ?? new ImageCacheService();
                 }
-            }
 
-            return instance;
+                return instance;
+            }
         }
 
         set
@@ -867,7 +864,7 @@ public sealed class ImageCacheService : IImageCacheService
         using var ms = new MemoryStream();
         var buffer = new byte[81920];
         long totalBytesRead = 0;
-        int read;
+        int read = 0;
 
         while ((read = await responseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) > 0)
         {


### PR DESCRIPTION
## Summary
Resolves all 29 static code analysis findings reported by DeepSource on PR #378 across core runtime services, content parsers, and test suites.

### Motivation
Address code health and static analysis failures reported by DeepSource on PR #378, ensuring clean builds, improved type safety, reduced complexity, and adherence to .NET conventions.

### Changes
- **`DownloadSecurityValidator`**:
  - Simplified `!allowedHashes.Any(...)` to `allowedHashes.All(...)` (`CS-R1033`).
- **`BackgroundUpdateCoordinator`**:
  - Removed redundant first `CancellationToken` parameter in `CheckForUpdatesOnStartupAsync` to fix misplaced cancellation token warning (`CS-R1141`).
- **`CommunityOutpostManifestFactory`**:
  - Refactored `BuildManifestWithFilesAsync` (previously cyclomatic complexity 29) into focused helper methods (`ProcessControlBarVariantAsync`, `CollectManifestFilesAsync`, `ResolveVariantIdentity`, `AssembleManifest`), reducing complexity well below threshold (`CS-R1140`).
- **`ModDBPageParser`**:
  - Removed redundant `else` in `else if` block after return (`CS-R1044`).
  - Switched `GetCanonicalBaseUrl` to `GetCanonicalBaseUri` utilizing `System.Uri` (`CS-A1000`).
- **`PlaywrightService`**:
  - Explicitly initialized local variables `playwright` and `pages` (`CS-W1022`).
  - Simplified lambda statement block to expression lambda (`CS-R1085`).
  - Removed manual `GC.SuppressFinalize(this)` call inside `DisposeAsync()` (`CS-P1001`).
  - Replaced `using var registration` with variable-less `using (token.Register(...))` block (`CS-W1100`).
- **`DefaultInfoContentProvider`**:
  - Removed redundant parameterless constructor on class with default initialization (`CS-R1028`).
- **`ImageCacheService`**:
  - Synchronized `get` and `set` accessors under `InstanceLock` in `Instance` property (`CS-W1078`).
  - Explicitly initialized `read` variable in streaming loop (`CS-W1022`).
- **`InfoTabResponsivenessTests` & `ScanWizardDemoViewModelTests`**:
  - Appended `Async` suffix to async unit test method names (`CS-R1073`).
  - Replaced unused `using var reg` with scope-based `using (token.Register(...))` block (`CS-W1100`).
- **`ApplicationDataPathConventionTests`**:
  - Removed unnecessary interpolated string prefix (`$`) from literal without interpolations (`CS-W1000`).
- **`ImageCacheServiceTests`**:
  - Replaced generic exception catch filters (`catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)`) with explicit `catch (IOException)` and `catch (UnauthorizedAccessException)` handlers (`CS-R1008`).
  - Discarded unused instance variable in constructor test (`CS-W1100`).

### Verification
- [x] Solution builds with 0 warnings and 0 errors (`dotnet build GenHub.sln`)
- [x] All 854 unit tests in `GenHub.Tests.Core` pass (`dotnet test GenHub.Tests.Core.csproj`)
- [x] All 59 unit tests in `GenHub.Tests.Windows` pass (`dotnet test GenHub.Tests.Windows.csproj`)
