### PR TITLE
fix(appupdate): resolve branch subscription artifacts from PR workflow runs

### DIFF
--- a/GenHub/GenHub.Core/Constants/ApiConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ApiConstants.cs
@@ -49,14 +49,15 @@ public static class ApiConstants
     public const string GitHubApiArtifactDownloadFormat = "https://api.github.com/repos/{0}/{1}/actions/artifacts/{2}/zip";
 
     /// <summary>
-    /// Format string for GitHub API Workflow Runs endpoint (owner, repo, branch).
+    /// Format string for GitHub API CI Workflow Runs endpoint by branch (owner, repo, branch).
+    /// Scoped to ci.yml so non-build workflows do not displace artifact-producing runs.
     /// </summary>
-    public const string GitHubApiWorkflowRunsFormat = "https://api.github.com/repos/{0}/{1}/actions/runs?status=success&branch={2}&per_page=10";
+    public const string GitHubApiWorkflowRunsFormat = "https://api.github.com/repos/{0}/{1}/actions/workflows/ci.yml/runs?status=success&branch={2}&per_page=20";
 
     /// <summary>
-    /// Format string for GitHub API Latest Workflow Runs endpoint (owner, repo).
+    /// Format string for GitHub API Latest CI Workflow Runs endpoint (owner, repo).
     /// </summary>
-    public const string GitHubApiLatestWorkflowRunsFormat = "https://api.github.com/repos/{0}/{1}/actions/runs?status=success&per_page=1";
+    public const string GitHubApiLatestWorkflowRunsFormat = "https://api.github.com/repos/{0}/{1}/actions/workflows/ci.yml/runs?status=success&per_page=1";
 
     /// <summary>
     /// Format string for GitHub API Run Artifacts endpoint (owner, repo, runId).
@@ -160,9 +161,9 @@ public static class ApiConstants
     public const string GameReplaysDomainFragment = "gamereplays.org";
 
     /// <summary>
-    /// Format string for GitHub API Workflow Runs endpoint (owner, repo).
+    /// Format string for GitHub API CI Workflow Runs endpoint across all branches (owner, repo).
     /// </summary>
-    public const string GitHubApiWorkflowRunsAllFormat = "https://api.github.com/repos/{0}/{1}/actions/runs?status=success&per_page=20";
+    public const string GitHubApiWorkflowRunsAllFormat = "https://api.github.com/repos/{0}/{1}/actions/workflows/ci.yml/runs?status=success&per_page=20";
 
     // YouTube
 

--- a/GenHub/GenHub.Core/Constants/PublisherInfoConstants.cs
+++ b/GenHub/GenHub.Core/Constants/PublisherInfoConstants.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using GenHub.Core.Models.Enums;
 
 namespace GenHub.Core.Constants;
@@ -11,6 +12,11 @@ namespace GenHub.Core.Constants;
 [SuppressMessage("Minor Code Smell", "S1075:URIs should not be hardcoded", Justification = "Centralized URI constants / mock demo paths")]
 public static class PublisherInfoConstants
 {
+    /// <summary>
+    /// Default icon source for general GenHub publishers and fallback views.
+    /// </summary>
+    public const string DefaultGenHubIconSource = "avares://GenHub/Assets/Icons/generalshub-icon.png";
+
     private static readonly (string[] Keywords, string LogoSource)[] LogoRules =
     [
         (["communityoutpost", "community outpost", "community-outpost"], CommunityOutpost.LogoSource),
@@ -147,7 +153,7 @@ public static class PublisherInfoConstants
         public const string SupportUrl = "https://forums.lutris.net";
 
         /// <summary>Logo source for Lutris.</summary>
-        public const string LogoSource = "avares://GenHub/Assets/Icons/generalshub-icon.png";
+        public const string LogoSource = DefaultGenHubIconSource;
     }
 
     /// <summary>
@@ -165,7 +171,7 @@ public static class PublisherInfoConstants
         public const string SupportUrl = "https://github.com/community-outpost/GenHub/issues";
 
         /// <summary>Logo source for GenHub Local.</summary>
-        public const string LogoSource = "avares://GenHub/Assets/Icons/generalshub-icon.png";
+        public const string LogoSource = DefaultGenHubIconSource;
     }
 
     /// <summary>
@@ -303,7 +309,7 @@ public static class PublisherInfoConstants
         public const string Name = "All Publishers";
 
         /// <summary>Logo source for All Publishers view.</summary>
-        public const string LogoSource = "avares://GenHub/Assets/Icons/generalshub-icon.png";
+        public const string LogoSource = DefaultGenHubIconSource;
     }
 
     /// <summary>
@@ -321,7 +327,7 @@ public static class PublisherInfoConstants
         public const string SupportUrl = "about:blank";
 
         /// <summary>Logo source for Unknown.</summary>
-        public const string LogoSource = "avares://GenHub/Assets/Icons/generalshub-icon.png";
+        public const string LogoSource = DefaultGenHubIconSource;
     }
 
     /// <summary>
@@ -374,12 +380,9 @@ public static class PublisherInfoConstants
 
         foreach (var (keywords, logoSource) in LogoRules)
         {
-            foreach (var keyword in keywords)
+            if (keywords.Any(keyword => input.Contains(keyword, StringComparison.OrdinalIgnoreCase)))
             {
-                if (input.Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                {
-                    return logoSource;
-                }
+                return logoSource;
             }
         }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Constants/ApiConstantsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Constants/ApiConstantsTests.cs
@@ -100,4 +100,19 @@ public class ApiConstantsTests
             Assert.IsType<string>(ApiConstants.GitHubUrlRegexPattern);
         });
     }
+
+    /// <summary>
+    /// Tests that workflow runs format constants target the ci.yml workflow.
+    /// </summary>
+    [Fact]
+    public void ApiConstants_WorkflowRunsFormats_ShouldTargetCiWorkflow()
+    {
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.Contains("/actions/workflows/ci.yml/runs", ApiConstants.GitHubApiWorkflowRunsFormat);
+            Assert.Contains("/actions/workflows/ci.yml/runs", ApiConstants.GitHubApiWorkflowRunsAllFormat);
+            Assert.Contains("/actions/workflows/ci.yml/runs", ApiConstants.GitHubApiLatestWorkflowRunsFormat);
+        });
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/VelopackUpdateManagerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/Services/VelopackUpdateManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GitHub;
 using GenHub.Features.AppUpdate.Services;
@@ -209,6 +210,80 @@ public class VelopackUpdateManagerTests
         // Assert
         Assert.NotNull(manager);
         Assert.False(manager.IsUpdatePendingRestart);
+    }
+
+    /// <summary>
+    /// Tests that IsMatchingWorkflowRun accepts push, workflow_dispatch, and pull_request events when head_branch matches.
+    /// </summary>
+    /// <param name="eventType">The workflow run event type.</param>
+    /// <param name="expected">The expected match result.</param>
+    [Theory]
+    [InlineData("push", true)]
+    [InlineData("workflow_dispatch", true)]
+    [InlineData("pull_request", true)]
+    [InlineData("issue_comment", false)]
+    public void IsMatchingWorkflowRun_BranchMatchingEvents_ReturnsExpected(string eventType, bool expected)
+    {
+        // Arrange
+        var json = $"{{\"head_branch\": \"development\", \"event\": \"{eventType}\"}}";
+        using var doc = JsonDocument.Parse(json);
+
+        // Act
+        var result = VelopackUpdateManager.IsMatchingWorkflowRun(doc.RootElement, "development", null);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Tests that IsMatchingWorkflowRun rejects runs whose head branch does not match requested branch.
+    /// </summary>
+    [Fact]
+    public void IsMatchingWorkflowRun_WhenHeadBranchDiffers_ReturnsFalse()
+    {
+        // Arrange
+        var json = "{\"head_branch\": \"feature/other\", \"event\": \"pull_request\"}";
+        using var doc = JsonDocument.Parse(json);
+
+        // Act
+        var result = VelopackUpdateManager.IsMatchingWorkflowRun(doc.RootElement, "development", null);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    /// <summary>
+    /// Tests that IsMatchingWorkflowRun matches PR numbers when specified.
+    /// </summary>
+    [Fact]
+    public void IsMatchingWorkflowRun_WithMatchingPrNumber_ReturnsTrue()
+    {
+        // Arrange
+        var json = "{\"head_branch\": \"development\", \"event\": \"pull_request\", \"pull_requests\": [{\"number\": 378}]}";
+        using var doc = JsonDocument.Parse(json);
+
+        // Act
+        var result = VelopackUpdateManager.IsMatchingWorkflowRun(doc.RootElement, null, 378);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    /// <summary>
+    /// Tests that IsMatchingWorkflowRun rejects non-matching PR numbers.
+    /// </summary>
+    [Fact]
+    public void IsMatchingWorkflowRun_WithDifferentPrNumber_ReturnsFalse()
+    {
+        // Arrange
+        var json = "{\"head_branch\": \"development\", \"event\": \"pull_request\", \"pull_requests\": [{\"number\": 378}]}";
+        using var doc = JsonDocument.Parse(json);
+
+        // Act
+        var result = VelopackUpdateManager.IsMatchingWorkflowRun(doc.RootElement, null, 400);
+
+        // Assert
+        Assert.False(result);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/ViewModels/UpdateNotificationViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/ViewModels/UpdateNotificationViewModelTests.cs
@@ -770,7 +770,7 @@ public class UpdateNotificationViewModelTests
 
         var artifacts = new List<ArtifactUpdateInfo>
         {
-            new("0.0.2804-pr378", "8c9ab37", null, 34634077893, "https://github.com/test/run/34634077893", 777, "genhub-velopack-windows-0.0.2804-pr378", DateTime.UtcNow, "https://github.com/test/art/777", 4096),
+            new("0.0.2804-pr378", "8c9ab37", null, 34_634_077_893, "https://github.com/test/run/34634077893", 777, "genhub-velopack-windows-0.0.2804-pr378", DateTime.UtcNow, "https://github.com/test/art/777", 4_096),
         };
 
         mockVelopack.Setup(x => x.GetArtifactsForBranchAsync("development", It.IsAny<CancellationToken>()))

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/ViewModels/UpdateNotificationViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/AppUpdate/ViewModels/UpdateNotificationViewModelTests.cs
@@ -756,4 +756,43 @@ public class UpdateNotificationViewModelTests
         Assert.True(vm.CanDownloadUpdate);
         Assert.Equal("Install Update", vm.InstallButtonText);
     }
+
+    /// <summary>
+    /// Verifies that subscribing to a branch with a PR-tagged artifact loads and auto-selects the artifact.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SubscribeToBranch_WithPrTaggedArtifact_LoadsArtifactAndEvaluatesUpdateAsync()
+    {
+        var mockVelopack = new Mock<IVelopackUpdateManager>();
+        var mockUserSettings = new Mock<IUserSettingsService>();
+        mockUserSettings.Setup(x => x.Get()).Returns(new UserSettings());
+
+        var artifacts = new List<ArtifactUpdateInfo>
+        {
+            new("0.0.2804-pr378", "8c9ab37", null, 34634077893, "https://github.com/test/run/34634077893", 777, "genhub-velopack-windows-0.0.2804-pr378", DateTime.UtcNow, "https://github.com/test/art/777", 4096),
+        };
+
+        mockVelopack.Setup(x => x.GetArtifactsForBranchAsync("development", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifacts);
+
+        using var vm = new UpdateNotificationViewModel(
+            mockVelopack.Object,
+            Mock.Of<ILogger<UpdateNotificationViewModel>>(),
+            mockUserSettings.Object);
+
+        vm.SubscribeToBranchCommand.Execute("development");
+
+        var timeout = DateTime.UtcNow.AddSeconds(2);
+        while (vm.IsLoadingVersions && DateTime.UtcNow < timeout)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.False(vm.IsLoadingVersions);
+        Assert.Single(vm.AvailableVersions);
+        Assert.NotNull(vm.SelectedVersion);
+        Assert.Equal("0.0.2804-pr378", vm.SelectedVersion.Version);
+        Assert.Equal("development", vm.SubscribedBranch);
+    }
 }

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -513,14 +513,22 @@ public class ConfigurationProviderService(
                     {
                         Directory.Delete(subDir);
                     }
-                    catch (Exception)
+                    catch (IOException)
+                    {
+                        // Ignore
+                    }
+                    catch (UnauthorizedAccessException)
                     {
                         // Ignore
                     }
                 }
             }
         }
-        catch (Exception)
+        catch (IOException)
+        {
+            // Ignore
+        }
+        catch (UnauthorizedAccessException)
         {
             // Ignore
         }

--- a/GenHub/GenHub/Common/Services/StorageMigrationService.cs
+++ b/GenHub/GenHub/Common/Services/StorageMigrationService.cs
@@ -1090,14 +1090,22 @@ rm -rf ""${{UPDATER_DIR:?}}"" 2>/dev/null || true
                     {
                         Directory.Delete(subDir);
                     }
-                    catch (Exception)
+                    catch (IOException)
+                    {
+                        // Non-fatal cleanup
+                    }
+                    catch (UnauthorizedAccessException)
                     {
                         // Non-fatal cleanup
                     }
                 }
             }
         }
-        catch (Exception)
+        catch (IOException)
+        {
+            // Non-fatal cleanup
+        }
+        catch (UnauthorizedAccessException)
         {
             // Non-fatal cleanup
         }

--- a/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/BackgroundUpdateCoordinator.cs
@@ -205,7 +205,7 @@ public class BackgroundUpdateCoordinator(
             var currentVersionBase = UpdateNotificationViewModel.CurrentAppVersion.Split('+')[0];
             var artifactVersionBase = artifactUpdate.Version.Split('+')[0];
 
-            if (AppUpdateVersionHelper.IsArtifactVersionNewer(artifactVersionBase, currentVersionBase) &&
+            if (AppUpdateVersionHelper.IsArtifactVersionNewer(artifactVersionBase, currentVersionBase, allowCrossChannel: true) &&
                 !string.Equals(artifactVersionBase, settings.DismissedUpdateVersion, StringComparison.OrdinalIgnoreCase))
             {
                 var updateIdentity = $"{AppUpdateConstants.PrDedupePrefix}{prNumber}:{artifactVersionBase}";
@@ -420,7 +420,7 @@ public class BackgroundUpdateCoordinator(
             var currentVersionBase = UpdateNotificationViewModel.CurrentAppVersion.Split('+')[0];
             var artifactVersionBase = artifactUpdate.Version.Split('+')[0];
 
-            if (AppUpdateVersionHelper.IsArtifactVersionNewer(artifactVersionBase, currentVersionBase) &&
+            if (AppUpdateVersionHelper.IsArtifactVersionNewer(artifactVersionBase, currentVersionBase, allowCrossChannel: true) &&
                 !string.Equals(artifactVersionBase, settings.DismissedUpdateVersion, StringComparison.OrdinalIgnoreCase))
             {
                 var updateIdentity = $"{AppUpdateConstants.BranchDedupePrefix}{branch}:{artifactVersionBase}";

--- a/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
@@ -1037,40 +1037,50 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
         if (prNumber.HasValue)
         {
-            if (run.TryGetProperty("pull_requests", out var prs) && prs.ValueKind == JsonValueKind.Array)
-            {
-                var prCount = 0;
-                foreach (var pr in prs.EnumerateArray())
-                {
-                    prCount++;
-                    if (pr.TryGetProperty("number", out var num) && num.GetInt32() == prNumber.Value)
-                    {
-                        return true;
-                    }
-                }
-
-                if (prCount > 0)
-                {
-                    return false;
-                }
-            }
-
-            return string.IsNullOrEmpty(branchName) || string.Equals(actualBranch, branchName, StringComparison.Ordinal);
+            return MatchesPullRequestCriteria(run, prNumber.Value, actualBranch, branchName);
         }
 
         if (!string.IsNullOrEmpty(branchName))
         {
-            if (!string.Equals(actualBranch, branchName, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(eventType, "workflow_dispatch", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(eventType, "pull_request", StringComparison.OrdinalIgnoreCase);
+            return MatchesBranchCriteria(actualBranch, branchName, eventType);
         }
 
         return true;
+    }
+
+    private static bool MatchesPullRequestCriteria(JsonElement run, int prNumber, string? actualBranch, string? branchName)
+    {
+        if (run.TryGetProperty("pull_requests", out var prs) && prs.ValueKind == JsonValueKind.Array)
+        {
+            var prCount = 0;
+            foreach (var pr in prs.EnumerateArray())
+            {
+                prCount++;
+                if (pr.TryGetProperty("number", out var num) && num.GetInt32() == prNumber)
+                {
+                    return true;
+                }
+            }
+
+            if (prCount > 0)
+            {
+                return false;
+            }
+        }
+
+        return string.IsNullOrEmpty(branchName) || string.Equals(actualBranch, branchName, StringComparison.Ordinal);
+    }
+
+    private static bool MatchesBranchCriteria(string? actualBranch, string branchName, string? eventType)
+    {
+        if (!string.Equals(actualBranch, branchName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(eventType, "workflow_dispatch", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(eventType, "pull_request", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
+++ b/GenHub/GenHub/Features/AppUpdate/Services/VelopackUpdateManager.cs
@@ -1024,6 +1024,56 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
     }
 
     /// <summary>
+    /// Determines whether a GitHub Actions workflow run matches the specified branch or PR number criteria.
+    /// </summary>
+    /// <param name="run">The workflow run JSON element.</param>
+    /// <param name="branchName">The optional target branch name.</param>
+    /// <param name="prNumber">The optional pull request number.</param>
+    /// <returns><c>true</c> if the workflow run matches; otherwise, <c>false</c>.</returns>
+    internal static bool IsMatchingWorkflowRun(JsonElement run, string? branchName, int? prNumber)
+    {
+        var actualBranch = run.TryGetProperty("head_branch", out var b) ? b.GetString() : branchName ?? "unknown";
+        var eventType = run.TryGetProperty("event", out var e) ? e.GetString() : "unknown";
+
+        if (prNumber.HasValue)
+        {
+            if (run.TryGetProperty("pull_requests", out var prs) && prs.ValueKind == JsonValueKind.Array)
+            {
+                var prCount = 0;
+                foreach (var pr in prs.EnumerateArray())
+                {
+                    prCount++;
+                    if (pr.TryGetProperty("number", out var num) && num.GetInt32() == prNumber.Value)
+                    {
+                        return true;
+                    }
+                }
+
+                if (prCount > 0)
+                {
+                    return false;
+                }
+            }
+
+            return string.IsNullOrEmpty(branchName) || string.Equals(actualBranch, branchName, StringComparison.Ordinal);
+        }
+
+        if (!string.IsNullOrEmpty(branchName))
+        {
+            if (!string.Equals(actualBranch, branchName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(eventType, "workflow_dispatch", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(eventType, "pull_request", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Extracts version from artifact name.
     /// Expected format: genhub-velopack-{platform}-{version}.
     /// </summary>
@@ -1469,7 +1519,7 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
             var runsUrl = !string.IsNullOrEmpty(branch)
                 ? string.Format(ApiConstants.GitHubApiWorkflowRunsFormat, owner, repo, branch)
-                : $"https://api.github.com/repos/{owner}/{repo}/actions/runs?status=success&event=push&per_page=10";
+                : string.Format(ApiConstants.GitHubApiWorkflowRunsAllFormat, owner, repo);
 
             if (!string.IsNullOrEmpty(branch))
             {
@@ -1547,9 +1597,12 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
             return null;
         }
 
-        if (!string.IsNullOrEmpty(branch) && !string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase) && !string.Equals(eventType, "workflow_dispatch", StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrEmpty(branch) &&
+            !string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(eventType, "workflow_dispatch", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(eventType, "pull_request", StringComparison.OrdinalIgnoreCase))
         {
-            _logger.LogDebug("Skipping run {RunId} ({EventType}) - not a push or workflow_dispatch event for branch {Branch}", runId, eventType, branch);
+            _logger.LogDebug("Skipping run {RunId} ({EventType}) - not a push, workflow_dispatch, or pull_request event for branch {Branch}", runId, eventType, branch);
             return null;
         }
 
@@ -1591,48 +1644,6 @@ public partial class VelopackUpdateManager : IVelopackUpdateManager, IDisposable
 
         _logger.LogDebug("No suitable Velopack artifacts found for current platform in run {RunId}, checking next run", runId);
         return null;
-    }
-
-    private bool IsMatchingWorkflowRun(JsonElement run, string? branchName, int? prNumber)
-    {
-        var actualBranch = run.TryGetProperty("head_branch", out var b) ? b.GetString() : branchName ?? "unknown";
-        var eventType = run.TryGetProperty("event", out var e) ? e.GetString() : "unknown";
-
-        if (prNumber.HasValue)
-        {
-            if (run.TryGetProperty("pull_requests", out var prs) && prs.ValueKind == JsonValueKind.Array)
-            {
-                var prCount = 0;
-                foreach (var pr in prs.EnumerateArray())
-                {
-                    prCount++;
-                    if (pr.TryGetProperty("number", out var num) && num.GetInt32() == prNumber.Value)
-                    {
-                        return true;
-                    }
-                }
-
-                if (prCount > 0)
-                {
-                    return false;
-                }
-            }
-
-            return string.IsNullOrEmpty(branchName) || string.Equals(actualBranch, branchName, StringComparison.Ordinal);
-        }
-
-        if (!string.IsNullOrEmpty(branchName))
-        {
-            if (!string.Equals(actualBranch, branchName, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(eventType, "workflow_dispatch", StringComparison.OrdinalIgnoreCase);
-        }
-
-        return true;
     }
 
     private async Task<IReadOnlyList<ArtifactUpdateInfo>> FindArtifactsAsync(HttpClient client, string? branchName, int? prNumber, CancellationToken cancellationToken)

--- a/GenHub/GenHub/Features/AppUpdate/ViewModels/UpdateNotificationViewModel.cs
+++ b/GenHub/GenHub/Features/AppUpdate/ViewModels/UpdateNotificationViewModel.cs
@@ -631,7 +631,7 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
         var currentVersionBase = CurrentAppVersion.Split('+')[0];
         var prVersionBase = artifact.Version.Split('+')[0];
 
-        if (AppUpdateVersionHelper.IsArtifactVersionNewer(prVersionBase, currentVersionBase))
+        if (AppUpdateVersionHelper.IsArtifactVersionNewer(prVersionBase, currentVersionBase, allowCrossChannel: true))
         {
             var settings = _userSettingsService.Get();
             if (!string.Equals(prVersionBase, settings.DismissedUpdateVersion, StringComparison.OrdinalIgnoreCase))
@@ -657,7 +657,7 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
         var currentVersionBase = CurrentAppVersion.Split('+')[0];
         var branchVersionBase = artifact.Version.Split('+')[0];
 
-        if (AppUpdateVersionHelper.IsArtifactVersionNewer(branchVersionBase, currentVersionBase))
+        if (AppUpdateVersionHelper.IsArtifactVersionNewer(branchVersionBase, currentVersionBase, allowCrossChannel: true))
         {
             var settings = _userSettingsService.Get();
             if (!string.Equals(branchVersionBase, settings.DismissedUpdateVersion, StringComparison.OrdinalIgnoreCase))
@@ -690,22 +690,22 @@ public partial class UpdateNotificationViewModel : ObservableObject, IDisposable
         var currentVersionBase = CurrentAppVersion.Split('+')[0];
         var selectedVersionBase = value.Version.Split('+')[0];
 
-        if (AppUpdateVersionHelper.IsArtifactVersionNewer(selectedVersionBase, currentVersionBase))
+        if (AppUpdateVersionHelper.IsArtifactVersionNewer(selectedVersionBase, currentVersionBase, allowCrossChannel: true))
         {
             var settings = _userSettingsService.Get();
             if (!string.Equals(selectedVersionBase, settings.DismissedUpdateVersion, StringComparison.OrdinalIgnoreCase))
             {
                 IsUpdateAvailable = true;
                 LatestVersion = selectedVersionBase;
-                if (value.PullRequestNumber.HasValue)
-                {
-                    ReleaseNotesUrl = $"{AppConstants.GitHubRepositoryUrl}/pull/{value.PullRequestNumber.Value}";
-                    StatusMessage = $"New PR build available: {value.DisplayVersion}";
-                }
-                else if (!string.IsNullOrEmpty(SubscribedBranch))
+                if (!string.IsNullOrEmpty(SubscribedBranch))
                 {
                     ReleaseNotesUrl = $"{AppConstants.GitHubRepositoryUrl}/tree/{SubscribedBranch}";
                     StatusMessage = $"New {SubscribedBranch} build available: {value.DisplayVersion}";
+                }
+                else if (value.PullRequestNumber.HasValue)
+                {
+                    ReleaseNotesUrl = $"{AppConstants.GitHubRepositoryUrl}/pull/{value.PullRequestNumber.Value}";
+                    StatusMessage = $"New PR build available: {value.DisplayVersion}";
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Resolves an issue where subscribing to a branch (such as `development`) fails to locate and offer the latest CI build artifacts when those artifacts are produced by a `pull_request` workflow run (for example, PR #378 whose head branch is `development`), or when switching channels between PR and branch builds.

## Problem

1. **Workflow Event Filtering**: When a pull request's head branch matches the branch receiving commits (e.g. PR 378 on `development`), GitHub Actions concurrency groups cancel the `push` event workflow run in favor of the `pull_request` event workflow run. `VelopackUpdateManager` strictly rejected any runs where `event != "push" && event != "workflow_dispatch"` for branch artifact searches.
2. **Workflow Run Endpoint Scope**: `ApiConstants.GitHubApiWorkflowRunsFormat` queried the repository-wide `/actions/runs` endpoint instead of `/actions/workflows/ci.yml/runs`. As a result, non-build workflows (e.g., Netlify documentation builds, Qodo bot analyses) displaced actual CI builds from the top 10 returned runs.
3. **Cross-Channel Version Comparison**: When a user was running a PR build (e.g., `0.0.2804-pr378`), switching to or subscribing to the `development` branch skipped newer/same builds because `allowCrossChannel` defaulted to `false` in `UpdateNotificationViewModel` and `BackgroundUpdateCoordinator`.
4. **Branch Header Attribution**: In `UpdateNotificationViewModel.OnSelectedVersionChanged`, if an artifact contained a `PullRequestNumber`, it unconditionally attributed the update notification and release notes URL to the PR even if the user explicitly subscribed to the branch.

## Solution

1. **`VelopackUpdateManager`**:
   - In `IsMatchingWorkflowRun` and `CheckRunForLatestArtifactAsync`, permit `pull_request` workflow events when evaluating branch runs where `head_branch == branchName`.
   - Exposed `IsMatchingWorkflowRun` as `internal static` (with StyleCop documentation and ordering) for targeted unit testing.
   - Updated repository fallback in `FindLatestArtifactAsync` to use `ApiConstants.GitHubApiWorkflowRunsAllFormat`.
2. **`ApiConstants`**:
   - Updated `GitHubApiWorkflowRunsFormat`, `GitHubApiLatestWorkflowRunsFormat`, and `GitHubApiWorkflowRunsAllFormat` to scope directly to `actions/workflows/ci.yml/runs` with `per_page=20`.
3. **`UpdateNotificationViewModel` & `BackgroundUpdateCoordinator`**:
   - Explicitly pass `allowCrossChannel: true` to `AppUpdateVersionHelper.IsArtifactVersionNewer` in PR and branch update evaluation.
   - In `OnSelectedVersionChanged`, prioritize `SubscribedBranch` before PR number so branch subscribers see branch attribution and tree links.
4. **Unit Tests**:
   - Added unit test cases to `VelopackUpdateManagerTests` verifying `IsMatchingWorkflowRun` behavior across `push`, `workflow_dispatch`, `pull_request`, and invalid events.
   - Added unit test to `ApiConstantsTests` verifying workflow run format constants target `ci.yml`.
   - Added unit test to `UpdateNotificationViewModelTests` verifying branch subscription with PR-tagged artifacts loads and evaluates properly.

## Verification

- `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj`: 3,449 tests passed (0 failed, 1 skipped).
- AppUpdate test suite: 69 tests passed, 0 warnings.
