### PR TITLE
fix(settings): preserve Options.ini transition speed and TSH settings on profile creation

### DIFF
--- a/GenHub/GenHub.Core/Constants/ActionSetConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ActionSetConstants.cs
@@ -56,7 +56,7 @@ public static class ActionSetConstants
         /// <summary>
         /// Gets the TheSuperHackers section name for Options.ini files.
         /// </summary>
-        public const string TheSuperHackersSection = "TheSuperHackers";
+        public const string TheSuperHackersSection = GameSettingsTheSuperHackersConstants.SectionName;
 
         // Keys
 
@@ -95,7 +95,7 @@ public static class ActionSetConstants
         /// <summary>
         /// Gets the ScrollFactor key name for edge scrolling settings.
         /// </summary>
-        public const string ScrollFactorKey = "ScrollFactor";
+        public const string ScrollFactorKey = GameSettingsTheSuperHackersConstants.ScrollFactorKey;
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
@@ -111,6 +111,31 @@ public static class GameSettingsTheSuperHackersConstants
     public const string MoneyTransactionVolumeKey = "MoneyTransactionVolume";
 
     /// <summary>
+    /// Configuration key for game time font size.
+    /// </summary>
+    public const string GameTimeFontSizeKey = "GameTimeFontSize";
+
+    /// <summary>
+    /// Configuration key for draw scroll anchor.
+    /// </summary>
+    public const string DrawScrollAnchorKey = "DrawScrollAnchor";
+
+    /// <summary>
+    /// Configuration key for move scroll anchor.
+    /// </summary>
+    public const string MoveScrollAnchorKey = "MoveScrollAnchor";
+
+    /// <summary>
+    /// Configuration key for language filter.
+    /// </summary>
+    public const string LanguageFilterKey = "LanguageFilter";
+
+    /// <summary>
+    /// Configuration key for send delay.
+    /// </summary>
+    public const string SendDelayKey = "SendDelay";
+
+    /// <summary>
     /// Minimum font size value.
     /// </summary>
     public const int MinFontSize = 0;

--- a/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameSettingsTheSuperHackersConstants.cs
@@ -6,6 +6,111 @@ namespace GenHub.Core.Constants;
 public static class GameSettingsTheSuperHackersConstants
 {
     /// <summary>
+    /// Section name for TheSuperHackers settings in Options.ini.
+    /// </summary>
+    public const string SectionName = "TheSuperHackers";
+
+    /// <summary>
+    /// Configuration key for use double click attack move.
+    /// </summary>
+    public const string UseDoubleClickAttackMoveKey = "UseDoubleClickAttackMove";
+
+    /// <summary>
+    /// Configuration key for fallback use double click.
+    /// </summary>
+    public const string UseDoubleClickKey = "UseDoubleClick";
+
+    /// <summary>
+    /// Configuration key for scroll factor.
+    /// </summary>
+    public const string ScrollFactorKey = "ScrollFactor";
+
+    /// <summary>
+    /// Configuration key for retaliation.
+    /// </summary>
+    public const string RetaliationKey = "Retaliation";
+
+    /// <summary>
+    /// Configuration key for dynamic LOD.
+    /// </summary>
+    public const string DynamicLODKey = "DynamicLOD";
+
+    /// <summary>
+    /// Configuration key for max particle count.
+    /// </summary>
+    public const string MaxParticleCountKey = "MaxParticleCount";
+
+    /// <summary>
+    /// Configuration key for archive replays.
+    /// </summary>
+    public const string ArchiveReplaysKey = "ArchiveReplays";
+
+    /// <summary>
+    /// Configuration key for show money per minute.
+    /// </summary>
+    public const string ShowMoneyPerMinuteKey = "ShowMoneyPerMinute";
+
+    /// <summary>
+    /// Configuration key for player observer enabled.
+    /// </summary>
+    public const string PlayerObserverEnabledKey = "PlayerObserverEnabled";
+
+    /// <summary>
+    /// Configuration key for system time font size.
+    /// </summary>
+    public const string SystemTimeFontSizeKey = "SystemTimeFontSize";
+
+    /// <summary>
+    /// Configuration key for network latency font size.
+    /// </summary>
+    public const string NetworkLatencyFontSizeKey = "NetworkLatencyFontSize";
+
+    /// <summary>
+    /// Configuration key for render FPS font size.
+    /// </summary>
+    public const string RenderFpsFontSizeKey = "RenderFpsFontSize";
+
+    /// <summary>
+    /// Configuration key for resolution font adjustment.
+    /// </summary>
+    public const string ResolutionFontAdjustmentKey = "ResolutionFontAdjustment";
+
+    /// <summary>
+    /// Configuration key for cursor capture in fullscreen game.
+    /// </summary>
+    public const string CursorCaptureEnabledInFullscreenGameKey = "CursorCaptureEnabledInFullscreenGame";
+
+    /// <summary>
+    /// Configuration key for cursor capture in fullscreen menu.
+    /// </summary>
+    public const string CursorCaptureEnabledInFullscreenMenuKey = "CursorCaptureEnabledInFullscreenMenu";
+
+    /// <summary>
+    /// Configuration key for cursor capture in windowed game.
+    /// </summary>
+    public const string CursorCaptureEnabledInWindowedGameKey = "CursorCaptureEnabledInWindowedGame";
+
+    /// <summary>
+    /// Configuration key for cursor capture in windowed menu.
+    /// </summary>
+    public const string CursorCaptureEnabledInWindowedMenuKey = "CursorCaptureEnabledInWindowedMenu";
+
+    /// <summary>
+    /// Configuration key for screen edge scroll in fullscreen app.
+    /// </summary>
+    public const string ScreenEdgeScrollEnabledInFullscreenAppKey = "ScreenEdgeScrollEnabledInFullscreenApp";
+
+    /// <summary>
+    /// Configuration key for screen edge scroll in windowed app.
+    /// </summary>
+    public const string ScreenEdgeScrollEnabledInWindowedAppKey = "ScreenEdgeScrollEnabledInWindowedApp";
+
+    /// <summary>
+    /// Configuration key for money transaction volume.
+    /// </summary>
+    public const string MoneyTransactionVolumeKey = "MoneyTransactionVolume";
+
+    /// <summary>
     /// Minimum font size value.
     /// </summary>
     public const int MinFontSize = 0;

--- a/GenHub/GenHub.Core/Extensions/DictionaryExtensions.cs
+++ b/GenHub/GenHub.Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GenHub.Core.Extensions;
+
+/// <summary>
+/// Extension methods for dictionary collections.
+/// </summary>
+public static class DictionaryExtensions
+{
+    /// <summary>
+    /// Attempts to retrieve a value from the dictionary by key using case-insensitive matching.
+    /// </summary>
+    /// <param name="dict">The dictionary to search.</param>
+    /// <param name="key">The key to locate.</param>
+    /// <param name="value">When this method returns, contains the value associated with the specified key, or empty string if not found.</param>
+    /// <returns><c>true</c> if the key was found; otherwise, <c>false</c>.</returns>
+    public static bool TryGetCaseInsensitive(this IReadOnlyDictionary<string, string> dict, string key, out string value)
+    {
+        if (dict.TryGetValue(key, out var val))
+        {
+            value = val;
+            return true;
+        }
+
+        var match = dict.FirstOrDefault(kvp => string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase));
+        if (match.Key != null)
+        {
+            value = match.Value;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+}

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using GenHub.Core.Constants;
+using GenHub.Core.Extensions;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameProfile;
 using GenHub.Core.Models.GameSettings;
@@ -510,100 +511,6 @@ public static class GameSettingsMapper
     }
 
     /// <summary>
-    /// Copies settings from one GameProfile to another.
-    /// </summary>
-    /// <param name="target">The target GameProfile.</param>
-    /// <param name="source">The source GameProfile.</param>
-    public static void CopySettings(GameProfile target, GameProfile source)
-    {
-        target.VideoResolutionWidth = source.VideoResolutionWidth;
-        target.VideoResolutionHeight = source.VideoResolutionHeight;
-        target.VideoWindowed = source.VideoWindowed;
-        target.VideoTextureQuality = source.VideoTextureQuality;
-        target.EnableVideoShadows = source.EnableVideoShadows;
-        target.VideoParticleEffects = source.VideoParticleEffects;
-        target.VideoExtraAnimations = source.VideoExtraAnimations;
-        target.VideoBuildingAnimations = source.VideoBuildingAnimations;
-        target.VideoGamma = source.VideoGamma;
-        target.VideoAlternateMouseSetup = source.VideoAlternateMouseSetup;
-        target.VideoHeatEffects = source.VideoHeatEffects;
-        target.VideoStaticGameLOD = source.VideoStaticGameLOD;
-        target.VideoIdealStaticGameLOD = source.VideoIdealStaticGameLOD;
-        target.VideoUseDoubleClickAttackMove = source.VideoUseDoubleClickAttackMove;
-        target.VideoScrollFactor = source.VideoScrollFactor;
-        target.VideoRetaliation = source.VideoRetaliation;
-        target.VideoDynamicLOD = source.VideoDynamicLOD;
-        target.VideoMaxParticleCount = source.VideoMaxParticleCount;
-        target.VideoAntiAliasing = source.VideoAntiAliasing;
-        target.VideoDrawScrollAnchor = source.VideoDrawScrollAnchor;
-        target.VideoMoveScrollAnchor = source.VideoMoveScrollAnchor;
-        target.VideoGameTimeFontSize = source.VideoGameTimeFontSize;
-        target.GameLanguageFilter = source.GameLanguageFilter;
-        target.NetworkSendDelay = source.NetworkSendDelay;
-        target.VideoShowSoftWaterEdge = source.VideoShowSoftWaterEdge;
-        target.VideoShowTrees = source.VideoShowTrees;
-        target.VideoUseCloudMap = source.VideoUseCloudMap;
-        target.VideoUseLightMap = source.VideoUseLightMap;
-
-        target.AudioSoundVolume = source.AudioSoundVolume;
-        target.AudioThreeDSoundVolume = source.AudioThreeDSoundVolume;
-        target.AudioSpeechVolume = source.AudioSpeechVolume;
-        target.AudioMusicVolume = source.AudioMusicVolume;
-        target.AudioEnabled = source.AudioEnabled;
-        target.AudioNumSounds = source.AudioNumSounds;
-
-        target.TshArchiveReplays = source.TshArchiveReplays;
-        target.TshShowMoneyPerMinute = source.TshShowMoneyPerMinute;
-        target.TshPlayerObserverEnabled = source.TshPlayerObserverEnabled;
-        target.TshSystemTimeFontSize = source.TshSystemTimeFontSize;
-        target.TshNetworkLatencyFontSize = source.TshNetworkLatencyFontSize;
-        target.TshRenderFpsFontSize = source.TshRenderFpsFontSize;
-        target.TshResolutionFontAdjustment = source.TshResolutionFontAdjustment;
-        target.TshCursorCaptureEnabledInFullscreenGame = source.TshCursorCaptureEnabledInFullscreenGame;
-        target.TshCursorCaptureEnabledInFullscreenMenu = source.TshCursorCaptureEnabledInFullscreenMenu;
-        target.TshCursorCaptureEnabledInWindowedGame = source.TshCursorCaptureEnabledInWindowedGame;
-        target.TshCursorCaptureEnabledInWindowedMenu = source.TshCursorCaptureEnabledInWindowedMenu;
-        target.TshScreenEdgeScrollEnabledInFullscreenApp = source.TshScreenEdgeScrollEnabledInFullscreenApp;
-        target.TshScreenEdgeScrollEnabledInWindowedApp = source.TshScreenEdgeScrollEnabledInWindowedApp;
-        target.TshMoneyTransactionVolume = source.TshMoneyTransactionVolume;
-        target.TshGameWindowTransitionSpeedMultiplier = source.TshGameWindowTransitionSpeedMultiplier;
-
-        target.GoShowFps = source.GoShowFps;
-        target.GoShowPing = source.GoShowPing;
-        target.GoShowPlayerRanks = source.GoShowPlayerRanks;
-        target.GoAutoLogin = source.GoAutoLogin;
-        target.GoRememberUsername = source.GoRememberUsername;
-        target.GoEnableNotifications = source.GoEnableNotifications;
-        target.GoEnableSoundNotifications = source.GoEnableSoundNotifications;
-        target.GoChatFontSize = source.GoChatFontSize;
-
-        target.GoCameraMaxHeightOnlyWhenLobbyHost = source.GoCameraMaxHeightOnlyWhenLobbyHost;
-        target.GoCameraMinHeight = source.GoCameraMinHeight;
-        target.GoCameraMoveSpeedRatio = source.GoCameraMoveSpeedRatio;
-
-        target.GoChatDurationSecondsUntilFadeOut = source.GoChatDurationSecondsUntilFadeOut;
-
-        target.GoDebugVerboseLogging = source.GoDebugVerboseLogging;
-
-        target.GoRenderFpsLimit = source.GoRenderFpsLimit;
-        target.GoRenderLimitFramerate = source.GoRenderLimitFramerate;
-        target.GoRenderStatsOverlay = source.GoRenderStatsOverlay;
-
-        target.GoSocialNotificationFriendComesOnlineGameplay = source.GoSocialNotificationFriendComesOnlineGameplay;
-        target.GoSocialNotificationFriendComesOnlineMenus = source.GoSocialNotificationFriendComesOnlineMenus;
-        target.GoSocialNotificationFriendGoesOfflineGameplay = source.GoSocialNotificationFriendGoesOfflineGameplay;
-        target.GoSocialNotificationFriendGoesOfflineMenus = source.GoSocialNotificationFriendGoesOfflineMenus;
-        target.GoSocialNotificationPlayerAcceptsRequestGameplay = source.GoSocialNotificationPlayerAcceptsRequestGameplay;
-        target.GoSocialNotificationPlayerAcceptsRequestMenus = source.GoSocialNotificationPlayerAcceptsRequestMenus;
-        target.GoSocialNotificationPlayerSendsRequestGameplay = source.GoSocialNotificationPlayerSendsRequestGameplay;
-        target.GoSocialNotificationPlayerSendsRequestMenus = source.GoSocialNotificationPlayerSendsRequestMenus;
-
-        target.UseSteamLaunch = source.UseSteamLaunch;
-        target.GameSpyIPAddress = source.GameSpyIPAddress;
-        target.VideoSkipEALogo = source.VideoSkipEALogo;
-    }
-
-    /// <summary>
     /// Normalizes and clamps a transition speed multiplier value to the supported range.
     /// </summary>
     /// <param name="value">The float value.</param>
@@ -685,27 +592,6 @@ public static class GameSettingsMapper
         ApplyTshHierarchicalSettingsFromOptions(options, profile);
     }
 
-    private static bool TryGetSetting(Dictionary<string, string> dict, string key, out string value)
-    {
-        if (dict.TryGetValue(key, out var val))
-        {
-            value = val;
-            return true;
-        }
-
-        foreach (var kvp in dict)
-        {
-            if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
-            {
-                value = kvp.Value;
-                return true;
-            }
-        }
-
-        value = string.Empty;
-        return false;
-    }
-
     private static void ApplyTshFlatSettingsFromOptions(IniOptions options, GameProfile profile)
     {
         ApplyTshProperties(options.Video.AdditionalProperties, profile);
@@ -715,7 +601,7 @@ public static class GameSettingsMapper
     {
         var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
             string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
-        if (tshKvp.Value != null)
+        if (tshKvp.Value is { Count: > 0 })
         {
             ApplyTshProperties(tshKvp.Value, profile);
         }
@@ -723,20 +609,29 @@ public static class GameSettingsMapper
 
     private static void ApplyTshProperties(Dictionary<string, string> tsh, GameProfile profile)
     {
-        if (TryGetSetting(tsh, "UseDoubleClickAttackMove", out var doubleClickTsh))
+        ApplyTshVideoSettings(tsh, profile);
+        ApplyTshFeatureSettings(tsh, profile);
+        ApplyTshFontSettings(tsh, profile);
+        ApplyTshCursorSettings(tsh, profile);
+        ApplyTshScrollAndAudioSettings(tsh, profile);
+    }
+
+    private static void ApplyTshVideoSettings(Dictionary<string, string> tsh, GameProfile profile)
+    {
+        if (tsh.TryGetCaseInsensitive("UseDoubleClickAttackMove", out var doubleClickTsh))
             profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClickTsh);
-        else if (TryGetSetting(tsh, "UseDoubleClick", out var dblTsh))
+        else if (tsh.TryGetCaseInsensitive("UseDoubleClick", out var dblTsh))
             profile.VideoUseDoubleClickAttackMove = ParseBool(dblTsh);
 
-        if (TryGetSetting(tsh, "ScrollFactor", out var scrollTsh) && int.TryParse(scrollTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollTshVal))
+        if (tsh.TryGetCaseInsensitive("ScrollFactor", out var scrollTsh) && int.TryParse(scrollTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollTshVal))
             profile.VideoScrollFactor = scrollTshVal;
-        if (TryGetSetting(tsh, "Retaliation", out var retaliationTsh))
+        if (tsh.TryGetCaseInsensitive("Retaliation", out var retaliationTsh))
             profile.VideoRetaliation = ParseBool(retaliationTsh);
-        if (TryGetSetting(tsh, "DynamicLOD", out var dynLODTsh))
+        if (tsh.TryGetCaseInsensitive("DynamicLOD", out var dynLODTsh))
             profile.VideoDynamicLOD = ParseBool(dynLODTsh);
-        if (TryGetSetting(tsh, "MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particlesTshVal))
+        if (tsh.TryGetCaseInsensitive("MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particlesTshVal))
             profile.VideoMaxParticleCount = particlesTshVal;
-        if (TryGetSetting(tsh, GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedTsh))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedTsh))
         {
             var parsed = ParseTransitionSpeedMultiplier(speedTsh);
             if (parsed.HasValue)
@@ -744,34 +639,49 @@ public static class GameSettingsMapper
                 profile.TshGameWindowTransitionSpeedMultiplier = parsed.Value;
             }
         }
+    }
 
-        if (TryGetSetting(tsh, "ArchiveReplays", out var archiveReplays))
+    private static void ApplyTshFeatureSettings(Dictionary<string, string> tsh, GameProfile profile)
+    {
+        if (tsh.TryGetCaseInsensitive("ArchiveReplays", out var archiveReplays))
             profile.TshArchiveReplays = ParseBool(archiveReplays);
-        if (TryGetSetting(tsh, "ShowMoneyPerMinute", out var showMoney))
+        if (tsh.TryGetCaseInsensitive("ShowMoneyPerMinute", out var showMoney))
             profile.TshShowMoneyPerMinute = ParseBool(showMoney);
-        if (TryGetSetting(tsh, "PlayerObserverEnabled", out var playerObserver))
+        if (tsh.TryGetCaseInsensitive("PlayerObserverEnabled", out var playerObserver))
             profile.TshPlayerObserverEnabled = ParseBool(playerObserver);
-        if (TryGetSetting(tsh, "SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
+    }
+
+    private static void ApplyTshFontSettings(Dictionary<string, string> tsh, GameProfile profile)
+    {
+        if (tsh.TryGetCaseInsensitive("SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
             profile.TshSystemTimeFontSize = stf;
-        if (TryGetSetting(tsh, "NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
+        if (tsh.TryGetCaseInsensitive("NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
             profile.TshNetworkLatencyFontSize = nlf;
-        if (TryGetSetting(tsh, "RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
+        if (tsh.TryGetCaseInsensitive("RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
             profile.TshRenderFpsFontSize = ff;
-        if (TryGetSetting(tsh, "ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
+        if (tsh.TryGetCaseInsensitive("ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
             profile.TshResolutionFontAdjustment = rfa;
-        if (TryGetSetting(tsh, "CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
+    }
+
+    private static void ApplyTshCursorSettings(Dictionary<string, string> tsh, GameProfile profile)
+    {
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
             profile.TshCursorCaptureEnabledInFullscreenGame = ParseBool(cursorFullscreenGame);
-        if (TryGetSetting(tsh, "CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
             profile.TshCursorCaptureEnabledInFullscreenMenu = ParseBool(cursorFullscreenMenu);
-        if (TryGetSetting(tsh, "CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
             profile.TshCursorCaptureEnabledInWindowedGame = ParseBool(cursorWindowedGame);
-        if (TryGetSetting(tsh, "CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
             profile.TshCursorCaptureEnabledInWindowedMenu = ParseBool(cursorWindowedMenu);
-        if (TryGetSetting(tsh, "ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
+    }
+
+    private static void ApplyTshScrollAndAudioSettings(Dictionary<string, string> tsh, GameProfile profile)
+    {
+        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
             profile.TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(scrollFullscreen);
-        if (TryGetSetting(tsh, "ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
+        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
             profile.TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(scrollWindowed);
-        if (TryGetSetting(tsh, "MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
+        if (tsh.TryGetCaseInsensitive("MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
             profile.TshMoneyTransactionVolume = mv;
     }
 

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -690,13 +690,13 @@ public static class GameSettingsMapper
             }
         }
 
-        if (tsh.TryGetCaseInsensitive("DrawScrollAnchor", out var dsa))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey, out var dsa))
             profile.VideoDrawScrollAnchor = ParseBool(dsa);
-        if (tsh.TryGetCaseInsensitive("MoveScrollAnchor", out var msa))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey, out var msa))
             profile.VideoMoveScrollAnchor = ParseBool(msa);
-        if (tsh.TryGetCaseInsensitive("LanguageFilter", out var lf))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.LanguageFilterKey, out var lf))
             profile.GameLanguageFilter = ParseBool(lf);
-        if (tsh.TryGetCaseInsensitive("SendDelay", out var sd))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.SendDelayKey, out var sd))
             profile.NetworkSendDelay = ParseBool(sd);
     }
 
@@ -720,7 +720,7 @@ public static class GameSettingsMapper
             profile.TshRenderFpsFontSize = ff;
         if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey, out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
             profile.TshResolutionFontAdjustment = rfa;
-        if (tsh.TryGetCaseInsensitive("GameTimeFontSize", out var gtfs) && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfVal))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey, out var gtfs) && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfVal))
             profile.VideoGameTimeFontSize = gtfVal;
     }
 
@@ -759,9 +759,9 @@ public static class GameSettingsMapper
     private static void ApplyNetworkFromOptions(IniOptions options, GameProfile profile)
     {
         profile.GameSpyIPAddress = options.Network.GameSpyIPAddress;
-        if (options.Network.AdditionalProperties.TryGetValue("SendDelay", out var sd))
+        if (options.Network.AdditionalProperties.TryGetValue(GameSettingsTheSuperHackersConstants.SendDelayKey, out var sd))
             profile.NetworkSendDelay = ParseBool(sd);
-        if (options.Network.AdditionalProperties.TryGetValue("LanguageFilter", out var lf))
+        if (options.Network.AdditionalProperties.TryGetValue(GameSettingsTheSuperHackersConstants.LanguageFilterKey, out var lf))
             profile.GameLanguageFilter = ParseBool(lf);
     }
 
@@ -860,6 +860,13 @@ public static class GameSettingsMapper
 
     private static void ApplyVideoAdditionalToOptions(GameProfile profile, IniOptions options, ILogger? logger)
     {
+        ApplyVideoVisualEffectsToOptions(profile, options, logger);
+        ApplyVideoGameplayToOptions(profile, options);
+        ApplyVideoRenderingTogglesToOptions(profile, options);
+    }
+
+    private static void ApplyVideoVisualEffectsToOptions(GameProfile profile, IniOptions options, ILogger? logger)
+    {
         if (profile.EnableVideoShadows.HasValue)
         {
             options.Video.UseShadowVolumes = profile.EnableVideoShadows.Value;
@@ -904,7 +911,10 @@ public static class GameSettingsMapper
 
         if (profile.VideoParticleEffects.HasValue)
             options.Video.AdditionalProperties["GenHubParticleEffects"] = profile.VideoParticleEffects.Value ? "yes" : "no";
+    }
 
+    private static void ApplyVideoGameplayToOptions(GameProfile profile, IniOptions options)
+    {
         if (profile.VideoStaticGameLOD != null)
             options.Video.AdditionalProperties["StaticGameLOD"] = profile.VideoStaticGameLOD;
 
@@ -936,19 +946,22 @@ public static class GameSettingsMapper
             options.Video.AdditionalProperties["SkipEALogo"] = profile.VideoSkipEALogo.Value ? "yes" : "no";
 
         if (profile.VideoGameTimeFontSize.HasValue)
-            options.Video.AdditionalProperties["GameTimeFontSize"] = profile.VideoGameTimeFontSize.Value.ToString(CultureInfo.InvariantCulture);
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey] = profile.VideoGameTimeFontSize.Value.ToString(CultureInfo.InvariantCulture);
+    }
 
+    private static void ApplyVideoRenderingTogglesToOptions(GameProfile profile, IniOptions options)
+    {
         if (profile.VideoDrawScrollAnchor.HasValue)
-            options.Video.AdditionalProperties["DrawScrollAnchor"] = profile.VideoDrawScrollAnchor.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey] = profile.VideoDrawScrollAnchor.Value ? "yes" : "no";
 
         if (profile.VideoMoveScrollAnchor.HasValue)
-            options.Video.AdditionalProperties["MoveScrollAnchor"] = profile.VideoMoveScrollAnchor.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey] = profile.VideoMoveScrollAnchor.Value ? "yes" : "no";
 
         if (profile.GameLanguageFilter.HasValue)
-            options.Video.AdditionalProperties["LanguageFilter"] = profile.GameLanguageFilter.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.LanguageFilterKey] = profile.GameLanguageFilter.Value ? "yes" : "no";
 
         if (profile.NetworkSendDelay.HasValue)
-            options.Video.AdditionalProperties["SendDelay"] = profile.NetworkSendDelay.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.SendDelayKey] = profile.NetworkSendDelay.Value ? "yes" : "no";
 
         if (profile.VideoShowSoftWaterEdge.HasValue)
             options.Video.AdditionalProperties["ShowSoftWaterEdge"] = profile.VideoShowSoftWaterEdge.Value ? "yes" : "no";
@@ -1089,16 +1102,16 @@ public static class GameSettingsMapper
         ApplyTshUiSettingsToDict(profile, tshDict);
         ApplyTshControlsSettingsToDict(profile, tshDict);
 
-        if (profile.VideoGameTimeFontSize.HasValue && tshDict.ContainsKey("GameTimeFontSize"))
-            tshDict["GameTimeFontSize"] = profile.VideoGameTimeFontSize.Value.ToString(CultureInfo.InvariantCulture);
-        if (profile.VideoDrawScrollAnchor.HasValue && tshDict.ContainsKey("DrawScrollAnchor"))
-            tshDict["DrawScrollAnchor"] = BoolToString(profile.VideoDrawScrollAnchor.Value);
-        if (profile.VideoMoveScrollAnchor.HasValue && tshDict.ContainsKey("MoveScrollAnchor"))
-            tshDict["MoveScrollAnchor"] = BoolToString(profile.VideoMoveScrollAnchor.Value);
-        if (profile.GameLanguageFilter.HasValue && tshDict.ContainsKey("LanguageFilter"))
-            tshDict["LanguageFilter"] = BoolToString(profile.GameLanguageFilter.Value);
-        if (profile.NetworkSendDelay.HasValue && tshDict.ContainsKey("SendDelay"))
-            tshDict["SendDelay"] = BoolToString(profile.NetworkSendDelay.Value);
+        if (profile.VideoGameTimeFontSize.HasValue && tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey))
+            tshDict[GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey] = profile.VideoGameTimeFontSize.Value.ToString(CultureInfo.InvariantCulture);
+        if (profile.VideoDrawScrollAnchor.HasValue && tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey))
+            tshDict[GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey] = BoolToString(profile.VideoDrawScrollAnchor.Value);
+        if (profile.VideoMoveScrollAnchor.HasValue && tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey))
+            tshDict[GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey] = BoolToString(profile.VideoMoveScrollAnchor.Value);
+        if (profile.GameLanguageFilter.HasValue && tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.LanguageFilterKey))
+            tshDict[GameSettingsTheSuperHackersConstants.LanguageFilterKey] = BoolToString(profile.GameLanguageFilter.Value);
+        if (profile.NetworkSendDelay.HasValue && tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.SendDelayKey))
+            tshDict[GameSettingsTheSuperHackersConstants.SendDelayKey] = BoolToString(profile.NetworkSendDelay.Value);
     }
 
     private static void ApplyTshUiSettingsToDict(GameProfile profile, Dictionary<string, string> tshDict)
@@ -1129,6 +1142,12 @@ public static class GameSettingsMapper
 
     private static void PatchVideoSettings(GameProfile profile, CreateProfileRequest request)
     {
+        PatchBasicVideoSettings(profile, request);
+        PatchAdvancedVideoSettings(profile, request);
+    }
+
+    private static void PatchBasicVideoSettings(GameProfile profile, CreateProfileRequest request)
+    {
         profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
         profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
         profile.VideoWindowed = request.VideoWindowed ?? profile.VideoWindowed;
@@ -1140,6 +1159,11 @@ public static class GameSettingsMapper
         profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
         profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
         profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
+        profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
+    }
+
+    private static void PatchAdvancedVideoSettings(GameProfile profile, CreateProfileRequest request)
+    {
         profile.VideoStaticGameLOD = request.VideoStaticGameLOD ?? profile.VideoStaticGameLOD;
         profile.VideoIdealStaticGameLOD = request.VideoIdealStaticGameLOD ?? profile.VideoIdealStaticGameLOD;
         profile.VideoUseDoubleClickAttackMove = request.VideoUseDoubleClickAttackMove ?? profile.VideoUseDoubleClickAttackMove;
@@ -1147,7 +1171,6 @@ public static class GameSettingsMapper
         profile.VideoRetaliation = request.VideoRetaliation ?? profile.VideoRetaliation;
         profile.VideoDynamicLOD = request.VideoDynamicLOD ?? profile.VideoDynamicLOD;
         profile.VideoMaxParticleCount = request.VideoMaxParticleCount ?? profile.VideoMaxParticleCount;
-        profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
         profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
         profile.VideoDrawScrollAnchor = request.VideoDrawScrollAnchor ?? profile.VideoDrawScrollAnchor;
         profile.VideoMoveScrollAnchor = request.VideoMoveScrollAnchor ?? profile.VideoMoveScrollAnchor;
@@ -1225,6 +1248,12 @@ public static class GameSettingsMapper
 
     private static void UpdateVideoFromRequest(GameProfile profile, UpdateProfileRequest request)
     {
+        UpdateBasicVideoFromRequest(profile, request);
+        UpdateAdvancedVideoFromRequest(profile, request);
+    }
+
+    private static void UpdateBasicVideoFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
         profile.VideoResolutionWidth = request.VideoResolutionWidth ?? profile.VideoResolutionWidth;
         profile.VideoResolutionHeight = request.VideoResolutionHeight ?? profile.VideoResolutionHeight;
         profile.VideoWindowed = request.VideoWindowed ?? profile.VideoWindowed;
@@ -1236,6 +1265,11 @@ public static class GameSettingsMapper
         profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
         profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
         profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
+        profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
+    }
+
+    private static void UpdateAdvancedVideoFromRequest(GameProfile profile, UpdateProfileRequest request)
+    {
         profile.VideoStaticGameLOD = request.VideoStaticGameLOD ?? profile.VideoStaticGameLOD;
         profile.VideoIdealStaticGameLOD = request.VideoIdealStaticGameLOD ?? profile.VideoIdealStaticGameLOD;
         profile.VideoUseDoubleClickAttackMove = request.VideoUseDoubleClickAttackMove ?? profile.VideoUseDoubleClickAttackMove;
@@ -1243,7 +1277,6 @@ public static class GameSettingsMapper
         profile.VideoRetaliation = request.VideoRetaliation ?? profile.VideoRetaliation;
         profile.VideoDynamicLOD = request.VideoDynamicLOD ?? profile.VideoDynamicLOD;
         profile.VideoMaxParticleCount = request.VideoMaxParticleCount ?? profile.VideoMaxParticleCount;
-        profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
         profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
         profile.VideoUseLightMap = request.VideoUseLightMap ?? profile.VideoUseLightMap;
         profile.VideoUseShadowDecals = request.VideoUseShadowDecals ?? profile.VideoUseShadowDecals;

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using GenHub.Core.Constants;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameProfile;
@@ -68,23 +71,6 @@ public static class GameSettingsMapper
         profile.GoSocialNotificationPlayerAcceptsRequestMenus = settings.Social.NotificationPlayerAcceptsRequestMenus;
         profile.GoSocialNotificationPlayerSendsRequestGameplay = settings.Social.NotificationPlayerSendsRequestGameplay;
         profile.GoSocialNotificationPlayerSendsRequestMenus = settings.Social.NotificationPlayerSendsRequestMenus;
-
-        // TSH settings (that exist in GeneralsOnlineSettings via inheritance)
-        profile.TshArchiveReplays = settings.ArchiveReplays;
-        profile.TshMoneyTransactionVolume = settings.MoneyTransactionVolume;
-        profile.TshShowMoneyPerMinute = settings.ShowMoneyPerMinute;
-        profile.TshPlayerObserverEnabled = settings.PlayerObserverEnabled;
-        profile.TshSystemTimeFontSize = settings.SystemTimeFontSize;
-        profile.TshNetworkLatencyFontSize = settings.NetworkLatencyFontSize;
-        profile.TshRenderFpsFontSize = settings.RenderFpsFontSize;
-        profile.TshResolutionFontAdjustment = settings.ResolutionFontAdjustment;
-        profile.TshCursorCaptureEnabledInFullscreenGame = settings.CursorCaptureEnabledInFullscreenGame;
-        profile.TshCursorCaptureEnabledInFullscreenMenu = settings.CursorCaptureEnabledInFullscreenMenu;
-        profile.TshCursorCaptureEnabledInWindowedGame = settings.CursorCaptureEnabledInWindowedGame;
-        profile.TshCursorCaptureEnabledInWindowedMenu = settings.CursorCaptureEnabledInWindowedMenu;
-        profile.TshScreenEdgeScrollEnabledInFullscreenApp = settings.ScreenEdgeScrollEnabledInFullscreenApp;
-        profile.TshScreenEdgeScrollEnabledInWindowedApp = settings.ScreenEdgeScrollEnabledInWindowedApp;
-        profile.TshGameWindowTransitionSpeedMultiplier = settings.GameWindowTransitionSpeedMultiplier;
     }
 
     /// <summary>
@@ -106,7 +92,6 @@ public static class GameSettingsMapper
         ApplyGoCameraAndChatSettings(profile, settings);
         ApplyGoRenderAndDebugSettings(profile, settings);
         ApplyGoSocialSettings(profile, settings);
-        ApplyGoTshSettings(profile, settings);
     }
 
     /// <summary>
@@ -521,6 +506,98 @@ public static class GameSettingsMapper
         target.GoSocialNotificationPlayerSendsRequestGameplay = source.GoSocialNotificationPlayerSendsRequestGameplay;
         target.GoSocialNotificationPlayerSendsRequestMenus = source.GoSocialNotificationPlayerSendsRequestMenus;
 
+        target.GameSpyIPAddress = source.GameSpyIPAddress;
+    }
+
+    /// <summary>
+    /// Copies settings from one GameProfile to another.
+    /// </summary>
+    /// <param name="target">The target GameProfile.</param>
+    /// <param name="source">The source GameProfile.</param>
+    public static void CopySettings(GameProfile target, GameProfile source)
+    {
+        target.VideoResolutionWidth = source.VideoResolutionWidth;
+        target.VideoResolutionHeight = source.VideoResolutionHeight;
+        target.VideoWindowed = source.VideoWindowed;
+        target.VideoTextureQuality = source.VideoTextureQuality;
+        target.EnableVideoShadows = source.EnableVideoShadows;
+        target.VideoParticleEffects = source.VideoParticleEffects;
+        target.VideoExtraAnimations = source.VideoExtraAnimations;
+        target.VideoBuildingAnimations = source.VideoBuildingAnimations;
+        target.VideoGamma = source.VideoGamma;
+        target.VideoAlternateMouseSetup = source.VideoAlternateMouseSetup;
+        target.VideoHeatEffects = source.VideoHeatEffects;
+        target.VideoStaticGameLOD = source.VideoStaticGameLOD;
+        target.VideoIdealStaticGameLOD = source.VideoIdealStaticGameLOD;
+        target.VideoUseDoubleClickAttackMove = source.VideoUseDoubleClickAttackMove;
+        target.VideoScrollFactor = source.VideoScrollFactor;
+        target.VideoRetaliation = source.VideoRetaliation;
+        target.VideoDynamicLOD = source.VideoDynamicLOD;
+        target.VideoMaxParticleCount = source.VideoMaxParticleCount;
+        target.VideoAntiAliasing = source.VideoAntiAliasing;
+        target.VideoDrawScrollAnchor = source.VideoDrawScrollAnchor;
+        target.VideoMoveScrollAnchor = source.VideoMoveScrollAnchor;
+        target.VideoGameTimeFontSize = source.VideoGameTimeFontSize;
+        target.GameLanguageFilter = source.GameLanguageFilter;
+        target.NetworkSendDelay = source.NetworkSendDelay;
+        target.VideoShowSoftWaterEdge = source.VideoShowSoftWaterEdge;
+        target.VideoShowTrees = source.VideoShowTrees;
+        target.VideoUseCloudMap = source.VideoUseCloudMap;
+        target.VideoUseLightMap = source.VideoUseLightMap;
+
+        target.AudioSoundVolume = source.AudioSoundVolume;
+        target.AudioThreeDSoundVolume = source.AudioThreeDSoundVolume;
+        target.AudioSpeechVolume = source.AudioSpeechVolume;
+        target.AudioMusicVolume = source.AudioMusicVolume;
+        target.AudioEnabled = source.AudioEnabled;
+        target.AudioNumSounds = source.AudioNumSounds;
+
+        target.TshArchiveReplays = source.TshArchiveReplays;
+        target.TshShowMoneyPerMinute = source.TshShowMoneyPerMinute;
+        target.TshPlayerObserverEnabled = source.TshPlayerObserverEnabled;
+        target.TshSystemTimeFontSize = source.TshSystemTimeFontSize;
+        target.TshNetworkLatencyFontSize = source.TshNetworkLatencyFontSize;
+        target.TshRenderFpsFontSize = source.TshRenderFpsFontSize;
+        target.TshResolutionFontAdjustment = source.TshResolutionFontAdjustment;
+        target.TshCursorCaptureEnabledInFullscreenGame = source.TshCursorCaptureEnabledInFullscreenGame;
+        target.TshCursorCaptureEnabledInFullscreenMenu = source.TshCursorCaptureEnabledInFullscreenMenu;
+        target.TshCursorCaptureEnabledInWindowedGame = source.TshCursorCaptureEnabledInWindowedGame;
+        target.TshCursorCaptureEnabledInWindowedMenu = source.TshCursorCaptureEnabledInWindowedMenu;
+        target.TshScreenEdgeScrollEnabledInFullscreenApp = source.TshScreenEdgeScrollEnabledInFullscreenApp;
+        target.TshScreenEdgeScrollEnabledInWindowedApp = source.TshScreenEdgeScrollEnabledInWindowedApp;
+        target.TshMoneyTransactionVolume = source.TshMoneyTransactionVolume;
+        target.TshGameWindowTransitionSpeedMultiplier = source.TshGameWindowTransitionSpeedMultiplier;
+
+        target.GoShowFps = source.GoShowFps;
+        target.GoShowPing = source.GoShowPing;
+        target.GoShowPlayerRanks = source.GoShowPlayerRanks;
+        target.GoAutoLogin = source.GoAutoLogin;
+        target.GoRememberUsername = source.GoRememberUsername;
+        target.GoEnableNotifications = source.GoEnableNotifications;
+        target.GoEnableSoundNotifications = source.GoEnableSoundNotifications;
+        target.GoChatFontSize = source.GoChatFontSize;
+
+        target.GoCameraMaxHeightOnlyWhenLobbyHost = source.GoCameraMaxHeightOnlyWhenLobbyHost;
+        target.GoCameraMinHeight = source.GoCameraMinHeight;
+        target.GoCameraMoveSpeedRatio = source.GoCameraMoveSpeedRatio;
+
+        target.GoChatDurationSecondsUntilFadeOut = source.GoChatDurationSecondsUntilFadeOut;
+
+        target.GoDebugVerboseLogging = source.GoDebugVerboseLogging;
+
+        target.GoRenderFpsLimit = source.GoRenderFpsLimit;
+        target.GoRenderLimitFramerate = source.GoRenderLimitFramerate;
+        target.GoRenderStatsOverlay = source.GoRenderStatsOverlay;
+
+        target.GoSocialNotificationFriendComesOnlineGameplay = source.GoSocialNotificationFriendComesOnlineGameplay;
+        target.GoSocialNotificationFriendComesOnlineMenus = source.GoSocialNotificationFriendComesOnlineMenus;
+        target.GoSocialNotificationFriendGoesOfflineGameplay = source.GoSocialNotificationFriendGoesOfflineGameplay;
+        target.GoSocialNotificationFriendGoesOfflineMenus = source.GoSocialNotificationFriendGoesOfflineMenus;
+        target.GoSocialNotificationPlayerAcceptsRequestGameplay = source.GoSocialNotificationPlayerAcceptsRequestGameplay;
+        target.GoSocialNotificationPlayerAcceptsRequestMenus = source.GoSocialNotificationPlayerAcceptsRequestMenus;
+        target.GoSocialNotificationPlayerSendsRequestGameplay = source.GoSocialNotificationPlayerSendsRequestGameplay;
+        target.GoSocialNotificationPlayerSendsRequestMenus = source.GoSocialNotificationPlayerSendsRequestMenus;
+
         target.UseSteamLaunch = source.UseSteamLaunch;
         target.GameSpyIPAddress = source.GameSpyIPAddress;
         target.VideoSkipEALogo = source.VideoSkipEALogo;
@@ -556,7 +633,8 @@ public static class GameSettingsMapper
             return null;
         }
 
-        if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var speed))
+        if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var speed) ||
+            float.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out speed))
         {
             return NormalizeTransitionSpeedMultiplier(speed);
         }
@@ -607,52 +685,58 @@ public static class GameSettingsMapper
         ApplyTshHierarchicalSettingsFromOptions(options, profile);
     }
 
-    private static void ApplyTshFlatSettingsFromOptions(IniOptions options, GameProfile profile)
+    private static bool TryGetSetting(Dictionary<string, string> dict, string key, out string value)
     {
-        if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
-            profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClick);
-        else if (options.Video.AdditionalProperties.TryGetValue("UseDoubleClick", out var dbl))
-            profile.VideoUseDoubleClickAttackMove = ParseBool(dbl);
-
-        if (options.Video.AdditionalProperties.TryGetValue("ScrollFactor", out var scroll) && int.TryParse(scroll, out var scrollVal))
-            profile.VideoScrollFactor = scrollVal;
-        if (options.Video.AdditionalProperties.TryGetValue("Retaliation", out var retaliation))
-            profile.VideoRetaliation = ParseBool(retaliation);
-        if (options.Video.AdditionalProperties.TryGetValue("DynamicLOD", out var dynLOD))
-            profile.VideoDynamicLOD = ParseBool(dynLOD);
-        if (options.Video.AdditionalProperties.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
-            profile.VideoMaxParticleCount = particleVal;
-        if (options.Video.AdditionalProperties.TryGetValue(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speed))
+        if (dict.TryGetValue(key, out var val))
         {
-            var parsed = ParseTransitionSpeedMultiplier(speed);
-            if (parsed.HasValue)
+            value = val;
+            return true;
+        }
+
+        foreach (var kvp in dict)
+        {
+            if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
             {
-                profile.TshGameWindowTransitionSpeedMultiplier = parsed.Value;
+                value = kvp.Value;
+                return true;
             }
         }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static void ApplyTshFlatSettingsFromOptions(IniOptions options, GameProfile profile)
+    {
+        ApplyTshProperties(options.Video.AdditionalProperties, profile);
     }
 
     private static void ApplyTshHierarchicalSettingsFromOptions(IniOptions options, GameProfile profile)
     {
-        if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var tsh))
+        var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
+            string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+        if (tshKvp.Value != null)
         {
-            ApplyTshHierarchicalProperties(tsh, profile);
+            ApplyTshProperties(tshKvp.Value, profile);
         }
     }
 
-    private static void ApplyTshHierarchicalProperties(Dictionary<string, string> tsh, GameProfile profile)
+    private static void ApplyTshProperties(Dictionary<string, string> tsh, GameProfile profile)
     {
-        if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClickTsh))
+        if (TryGetSetting(tsh, "UseDoubleClickAttackMove", out var doubleClickTsh))
             profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClickTsh);
-        if (tsh.TryGetValue("ScrollFactor", out var scrollTsh) && int.TryParse(scrollTsh, out var scrollTshVal))
+        else if (TryGetSetting(tsh, "UseDoubleClick", out var dblTsh))
+            profile.VideoUseDoubleClickAttackMove = ParseBool(dblTsh);
+
+        if (TryGetSetting(tsh, "ScrollFactor", out var scrollTsh) && int.TryParse(scrollTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollTshVal))
             profile.VideoScrollFactor = scrollTshVal;
-        if (tsh.TryGetValue("Retaliation", out var retaliationTsh))
+        if (TryGetSetting(tsh, "Retaliation", out var retaliationTsh))
             profile.VideoRetaliation = ParseBool(retaliationTsh);
-        if (tsh.TryGetValue("DynamicLOD", out var dynLODTsh))
+        if (TryGetSetting(tsh, "DynamicLOD", out var dynLODTsh))
             profile.VideoDynamicLOD = ParseBool(dynLODTsh);
-        if (tsh.TryGetValue("MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, out var particlesTshVal))
+        if (TryGetSetting(tsh, "MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particlesTshVal))
             profile.VideoMaxParticleCount = particlesTshVal;
-        if (tsh.TryGetValue(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedTsh))
+        if (TryGetSetting(tsh, GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedTsh))
         {
             var parsed = ParseTransitionSpeedMultiplier(speedTsh);
             if (parsed.HasValue)
@@ -660,6 +744,35 @@ public static class GameSettingsMapper
                 profile.TshGameWindowTransitionSpeedMultiplier = parsed.Value;
             }
         }
+
+        if (TryGetSetting(tsh, "ArchiveReplays", out var archiveReplays))
+            profile.TshArchiveReplays = ParseBool(archiveReplays);
+        if (TryGetSetting(tsh, "ShowMoneyPerMinute", out var showMoney))
+            profile.TshShowMoneyPerMinute = ParseBool(showMoney);
+        if (TryGetSetting(tsh, "PlayerObserverEnabled", out var playerObserver))
+            profile.TshPlayerObserverEnabled = ParseBool(playerObserver);
+        if (TryGetSetting(tsh, "SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
+            profile.TshSystemTimeFontSize = stf;
+        if (TryGetSetting(tsh, "NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
+            profile.TshNetworkLatencyFontSize = nlf;
+        if (TryGetSetting(tsh, "RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
+            profile.TshRenderFpsFontSize = ff;
+        if (TryGetSetting(tsh, "ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
+            profile.TshResolutionFontAdjustment = rfa;
+        if (TryGetSetting(tsh, "CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
+            profile.TshCursorCaptureEnabledInFullscreenGame = ParseBool(cursorFullscreenGame);
+        if (TryGetSetting(tsh, "CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
+            profile.TshCursorCaptureEnabledInFullscreenMenu = ParseBool(cursorFullscreenMenu);
+        if (TryGetSetting(tsh, "CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
+            profile.TshCursorCaptureEnabledInWindowedGame = ParseBool(cursorWindowedGame);
+        if (TryGetSetting(tsh, "CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
+            profile.TshCursorCaptureEnabledInWindowedMenu = ParseBool(cursorWindowedMenu);
+        if (TryGetSetting(tsh, "ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
+            profile.TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(scrollFullscreen);
+        if (TryGetSetting(tsh, "ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
+            profile.TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(scrollWindowed);
+        if (TryGetSetting(tsh, "MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
+            profile.TshMoneyTransactionVolume = mv;
     }
 
     private static void ApplyAudioFromOptions(IniOptions options, GameProfile profile)
@@ -717,28 +830,6 @@ public static class GameSettingsMapper
         if (profile.GoSocialNotificationPlayerSendsRequestMenus.HasValue) settings.Social.NotificationPlayerSendsRequestMenus = profile.GoSocialNotificationPlayerSendsRequestMenus.Value;
     }
 
-    private static void ApplyGoTshSettings(GameProfile profile, GeneralsOnlineSettings settings)
-    {
-        if (profile.TshArchiveReplays.HasValue) settings.ArchiveReplays = profile.TshArchiveReplays.Value;
-        if (profile.TshMoneyTransactionVolume.HasValue) settings.MoneyTransactionVolume = profile.TshMoneyTransactionVolume.Value;
-        if (profile.TshShowMoneyPerMinute.HasValue) settings.ShowMoneyPerMinute = profile.TshShowMoneyPerMinute.Value;
-        if (profile.TshPlayerObserverEnabled.HasValue) settings.PlayerObserverEnabled = profile.TshPlayerObserverEnabled.Value;
-        if (profile.TshSystemTimeFontSize.HasValue) settings.SystemTimeFontSize = profile.TshSystemTimeFontSize.Value;
-        if (profile.TshNetworkLatencyFontSize.HasValue) settings.NetworkLatencyFontSize = profile.TshNetworkLatencyFontSize.Value;
-        if (profile.TshRenderFpsFontSize.HasValue) settings.RenderFpsFontSize = profile.TshRenderFpsFontSize.Value;
-        if (profile.TshResolutionFontAdjustment.HasValue) settings.ResolutionFontAdjustment = profile.TshResolutionFontAdjustment.Value;
-        if (profile.TshCursorCaptureEnabledInFullscreenGame.HasValue) settings.CursorCaptureEnabledInFullscreenGame = profile.TshCursorCaptureEnabledInFullscreenGame.Value;
-        if (profile.TshCursorCaptureEnabledInFullscreenMenu.HasValue) settings.CursorCaptureEnabledInFullscreenMenu = profile.TshCursorCaptureEnabledInFullscreenMenu.Value;
-        if (profile.TshCursorCaptureEnabledInWindowedGame.HasValue) settings.CursorCaptureEnabledInWindowedGame = profile.TshCursorCaptureEnabledInWindowedGame.Value;
-        if (profile.TshCursorCaptureEnabledInWindowedMenu.HasValue) settings.CursorCaptureEnabledInWindowedMenu = profile.TshCursorCaptureEnabledInWindowedMenu.Value;
-        if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) settings.ScreenEdgeScrollEnabledInFullscreenApp = profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value;
-        if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) settings.ScreenEdgeScrollEnabledInWindowedApp = profile.TshScreenEdgeScrollEnabledInWindowedApp.Value;
-        if (NormalizeTransitionSpeedMultiplier(profile.TshGameWindowTransitionSpeedMultiplier) is { } speedMult)
-        {
-            settings.GameWindowTransitionSpeedMultiplier = speedMult;
-        }
-    }
-
     private static void ApplyVideoResolutionAndQualityToOptions(GameProfile profile, IniOptions options, ILogger? logger)
     {
         if (profile.VideoResolutionWidth.HasValue)
@@ -789,8 +880,7 @@ public static class GameSettingsMapper
                 TextureQuality.Low => GameSettingsConstants.TextureQuality.TextureReductionLow,
                 TextureQuality.Medium => GameSettingsConstants.TextureQuality.TextureReductionMedium,
                 TextureQuality.High => GameSettingsConstants.TextureQuality.TextureReductionHigh,
-                TextureQuality.VeryHigh => GameSettingsConstants.TextureQuality.TextureReductionHigh,
-                _ => GameSettingsConstants.TextureQuality.TextureReductionHigh,
+                _ => options.Video.TextureReduction,
             };
         }
 
@@ -972,14 +1062,22 @@ public static class GameSettingsMapper
 
     private static void ApplyTshToOptions(GameProfile profile, IniOptions options)
     {
-        var tshDict = new Dictionary<string, string>();
+        var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k =>
+            string.Equals(k, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)) ?? "TheSuperHackers";
+
+        Dictionary<string, string> tshDict;
+        if (options.AdditionalSections.TryGetValue(tshKey, out var existingTsh) && existingTsh != null)
+        {
+            tshDict = existingTsh;
+        }
+        else
+        {
+            tshDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            options.AdditionalSections[tshKey] = tshDict;
+        }
+
         ApplyTshUiSettingsToDict(profile, tshDict);
         ApplyTshControlsSettingsToDict(profile, tshDict);
-
-        if (tshDict.Count > 0)
-        {
-            options.AdditionalSections["TheSuperHackers"] = tshDict;
-        }
     }
 
     private static void ApplyTshUiSettingsToDict(GameProfile profile, Dictionary<string, string> tshDict)

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -128,6 +128,27 @@ public static class GameSettingsMapper
         profile.VideoGamma = request.VideoGamma;
         profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup;
         profile.VideoHeatEffects = request.VideoHeatEffects;
+        profile.VideoStaticGameLOD = request.VideoStaticGameLOD;
+        profile.VideoIdealStaticGameLOD = request.VideoIdealStaticGameLOD;
+        profile.VideoUseDoubleClickAttackMove = request.VideoUseDoubleClickAttackMove;
+        profile.VideoScrollFactor = request.VideoScrollFactor;
+        profile.VideoRetaliation = request.VideoRetaliation;
+        profile.VideoDynamicLOD = request.VideoDynamicLOD;
+        profile.VideoMaxParticleCount = request.VideoMaxParticleCount;
+        profile.VideoAntiAliasing = request.VideoAntiAliasing;
+        profile.VideoSkipEALogo = request.VideoSkipEALogo;
+        profile.VideoDrawScrollAnchor = request.VideoDrawScrollAnchor;
+        profile.VideoMoveScrollAnchor = request.VideoMoveScrollAnchor;
+        profile.VideoGameTimeFontSize = request.VideoGameTimeFontSize;
+        profile.GameLanguageFilter = request.GameLanguageFilter;
+        profile.NetworkSendDelay = request.NetworkSendDelay;
+        profile.VideoShowSoftWaterEdge = request.VideoShowSoftWaterEdge;
+        profile.VideoShowTrees = request.VideoShowTrees;
+        profile.VideoUseCloudMap = request.VideoUseCloudMap;
+        profile.VideoUseLightMap = request.VideoUseLightMap;
+        profile.VideoUseShadowDecals = request.VideoUseShadowDecals;
+        profile.VideoBuildingOcclusion = request.VideoBuildingOcclusion;
+        profile.VideoShowProps = request.VideoShowProps;
 
         // Audio settings
         profile.AudioSoundVolume = request.AudioSoundVolume;
@@ -191,7 +212,6 @@ public static class GameSettingsMapper
         profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus;
 
         profile.GameSpyIPAddress = request.GameSpyIPAddress;
-        profile.VideoSkipEALogo = request.VideoSkipEALogo;
     }
 
     /// <summary>
@@ -223,6 +243,17 @@ public static class GameSettingsMapper
         profile.VideoAntiAliasing = request.VideoAntiAliasing;
         profile.VideoUseLightMap = request.VideoUseLightMap;
         profile.VideoSkipEALogo = request.VideoSkipEALogo;
+        profile.VideoUseShadowDecals = request.VideoUseShadowDecals;
+        profile.VideoBuildingOcclusion = request.VideoBuildingOcclusion;
+        profile.VideoShowProps = request.VideoShowProps;
+        profile.VideoDrawScrollAnchor = request.VideoDrawScrollAnchor;
+        profile.VideoMoveScrollAnchor = request.VideoMoveScrollAnchor;
+        profile.VideoGameTimeFontSize = request.VideoGameTimeFontSize;
+        profile.GameLanguageFilter = request.GameLanguageFilter;
+        profile.NetworkSendDelay = request.NetworkSendDelay;
+        profile.VideoShowSoftWaterEdge = request.VideoShowSoftWaterEdge;
+        profile.VideoShowTrees = request.VideoShowTrees;
+        profile.VideoUseCloudMap = request.VideoUseCloudMap;
 
         // Audio settings
         profile.AudioSoundVolume = request.AudioSoundVolume;
@@ -286,7 +317,6 @@ public static class GameSettingsMapper
         profile.GoSocialNotificationPlayerSendsRequestMenus = request.GoSocialNotificationPlayerSendsRequestMenus;
 
         profile.GameSpyIPAddress = request.GameSpyIPAddress;
-        profile.VideoSkipEALogo = request.VideoSkipEALogo;
     }
 
     /// <summary>
@@ -360,6 +390,9 @@ public static class GameSettingsMapper
         target.VideoUseCloudMap = source.VideoUseCloudMap;
         target.VideoUseLightMap = source.VideoUseLightMap;
         target.VideoSkipEALogo = source.VideoSkipEALogo;
+        target.VideoUseShadowDecals = source.VideoUseShadowDecals;
+        target.VideoBuildingOcclusion = source.VideoBuildingOcclusion;
+        target.VideoShowProps = source.VideoShowProps;
 
         target.AudioSoundVolume = source.AudioSoundVolume;
         target.AudioThreeDSoundVolume = source.AudioThreeDSoundVolume;
@@ -454,6 +487,9 @@ public static class GameSettingsMapper
         target.VideoUseCloudMap = source.VideoUseCloudMap;
         target.VideoUseLightMap = source.VideoUseLightMap;
         target.VideoSkipEALogo = source.VideoSkipEALogo;
+        target.VideoUseShadowDecals = source.VideoUseShadowDecals;
+        target.VideoBuildingOcclusion = source.VideoBuildingOcclusion;
+        target.VideoShowProps = source.VideoShowProps;
 
         target.AudioSoundVolume = source.AudioSoundVolume;
         target.AudioThreeDSoundVolume = source.AudioThreeDSoundVolume;
@@ -567,6 +603,9 @@ public static class GameSettingsMapper
         };
 
         profile.EnableVideoShadows = options.Video.UseShadowVolumes;
+        profile.VideoUseShadowDecals = options.Video.UseShadowDecals;
+        profile.VideoBuildingOcclusion = options.Video.BuildingOcclusion;
+        profile.VideoShowProps = options.Video.ShowProps;
 
         if (options.Video.AdditionalProperties.TryGetValue("GenHubBuildingAnimations", out var ba))
             profile.VideoBuildingAnimations = ParseBool(ba);
@@ -587,6 +626,15 @@ public static class GameSettingsMapper
 
         if (options.Video.AdditionalProperties.TryGetValue("SkipEALogo", out var sel))
             profile.VideoSkipEALogo = ParseBool(sel);
+
+        if (options.Video.AdditionalProperties.TryGetValue("ShowSoftWaterEdge", out var swe))
+            profile.VideoShowSoftWaterEdge = ParseBool(swe);
+        if (options.Video.AdditionalProperties.TryGetValue("ShowTrees", out var st))
+            profile.VideoShowTrees = ParseBool(st);
+        if (options.Video.AdditionalProperties.TryGetValue("UseCloudMap", out var ucm))
+            profile.VideoUseCloudMap = ParseBool(ucm);
+        if (options.Video.AdditionalProperties.TryGetValue("UseLightMap", out var ulm))
+            profile.VideoUseLightMap = ParseBool(ulm);
 
         profile.VideoAntiAliasing ??= options.Video.AntiAliasing;
 
@@ -641,6 +689,15 @@ public static class GameSettingsMapper
                 profile.TshGameWindowTransitionSpeedMultiplier = parsed.Value;
             }
         }
+
+        if (tsh.TryGetCaseInsensitive("DrawScrollAnchor", out var dsa))
+            profile.VideoDrawScrollAnchor = ParseBool(dsa);
+        if (tsh.TryGetCaseInsensitive("MoveScrollAnchor", out var msa))
+            profile.VideoMoveScrollAnchor = ParseBool(msa);
+        if (tsh.TryGetCaseInsensitive("LanguageFilter", out var lf))
+            profile.GameLanguageFilter = ParseBool(lf);
+        if (tsh.TryGetCaseInsensitive("SendDelay", out var sd))
+            profile.NetworkSendDelay = ParseBool(sd);
     }
 
     private static void ApplyTshFeatureSettings(Dictionary<string, string> tsh, GameProfile profile)
@@ -663,6 +720,8 @@ public static class GameSettingsMapper
             profile.TshRenderFpsFontSize = ff;
         if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey, out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
             profile.TshResolutionFontAdjustment = rfa;
+        if (tsh.TryGetCaseInsensitive("GameTimeFontSize", out var gtfs) && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfVal))
+            profile.VideoGameTimeFontSize = gtfVal;
     }
 
     private static void ApplyTshCursorSettings(Dictionary<string, string> tsh, GameProfile profile)
@@ -700,6 +759,10 @@ public static class GameSettingsMapper
     private static void ApplyNetworkFromOptions(IniOptions options, GameProfile profile)
     {
         profile.GameSpyIPAddress = options.Network.GameSpyIPAddress;
+        if (options.Network.AdditionalProperties.TryGetValue("SendDelay", out var sd))
+            profile.NetworkSendDelay = ParseBool(sd);
+        if (options.Network.AdditionalProperties.TryGetValue("LanguageFilter", out var lf))
+            profile.GameLanguageFilter = ParseBool(lf);
     }
 
     private static void ApplyGoGeneralSettings(GameProfile profile, GeneralsOnlineSettings settings)
@@ -781,9 +844,7 @@ public static class GameSettingsMapper
         }
 
         if (profile.VideoWindowed.HasValue)
-        {
             options.Video.Windowed = profile.VideoWindowed.Value;
-        }
 
         if (profile.VideoTextureQuality.HasValue)
         {
@@ -791,26 +852,26 @@ public static class GameSettingsMapper
             {
                 TextureQuality.Low => GameSettingsConstants.TextureQuality.TextureReductionLow,
                 TextureQuality.Medium => GameSettingsConstants.TextureQuality.TextureReductionMedium,
-                TextureQuality.High => GameSettingsConstants.TextureQuality.TextureReductionHigh,
-                TextureQuality.VeryHigh => GameSettingsConstants.TextureQuality.TextureReductionVeryHigh,
+                TextureQuality.High or TextureQuality.VeryHigh => GameSettingsConstants.TextureQuality.TextureReductionHigh,
                 _ => options.Video.TextureReduction,
             };
-        }
-
-        if (profile.EnableVideoShadows.HasValue)
-        {
-            options.Video.UseShadowVolumes = profile.EnableVideoShadows.Value;
-            options.Video.UseShadowDecals = profile.EnableVideoShadows.Value;
-        }
-
-        if (profile.VideoExtraAnimations.HasValue)
-        {
-            options.Video.ExtraAnimations = profile.VideoExtraAnimations.Value;
         }
     }
 
     private static void ApplyVideoAdditionalToOptions(GameProfile profile, IniOptions options, ILogger? logger)
     {
+        if (profile.EnableVideoShadows.HasValue)
+        {
+            options.Video.UseShadowVolumes = profile.EnableVideoShadows.Value;
+            options.Video.AdditionalProperties["UseShadowVolumes"] = profile.EnableVideoShadows.Value ? "yes" : "no";
+        }
+
+        if (profile.VideoExtraAnimations.HasValue)
+        {
+            options.Video.ExtraAnimations = profile.VideoExtraAnimations.Value;
+            options.Video.AdditionalProperties["ExtraAnimations"] = profile.VideoExtraAnimations.Value ? "yes" : "no";
+        }
+
         if (profile.VideoGamma.HasValue)
         {
             if (profile.VideoGamma.Value >= GameSettingsConstants.Gamma.Min &&
@@ -873,6 +934,42 @@ public static class GameSettingsMapper
 
         if (profile.VideoSkipEALogo.HasValue)
             options.Video.AdditionalProperties["SkipEALogo"] = profile.VideoSkipEALogo.Value ? "yes" : "no";
+
+        if (profile.VideoGameTimeFontSize.HasValue)
+            options.Video.AdditionalProperties["GameTimeFontSize"] = profile.VideoGameTimeFontSize.Value.ToString(CultureInfo.InvariantCulture);
+
+        if (profile.VideoDrawScrollAnchor.HasValue)
+            options.Video.AdditionalProperties["DrawScrollAnchor"] = profile.VideoDrawScrollAnchor.Value ? "yes" : "no";
+
+        if (profile.VideoMoveScrollAnchor.HasValue)
+            options.Video.AdditionalProperties["MoveScrollAnchor"] = profile.VideoMoveScrollAnchor.Value ? "yes" : "no";
+
+        if (profile.GameLanguageFilter.HasValue)
+            options.Video.AdditionalProperties["LanguageFilter"] = profile.GameLanguageFilter.Value ? "yes" : "no";
+
+        if (profile.NetworkSendDelay.HasValue)
+            options.Video.AdditionalProperties["SendDelay"] = profile.NetworkSendDelay.Value ? "yes" : "no";
+
+        if (profile.VideoShowSoftWaterEdge.HasValue)
+            options.Video.AdditionalProperties["ShowSoftWaterEdge"] = profile.VideoShowSoftWaterEdge.Value ? "yes" : "no";
+
+        if (profile.VideoShowTrees.HasValue)
+            options.Video.AdditionalProperties["ShowTrees"] = profile.VideoShowTrees.Value ? "yes" : "no";
+
+        if (profile.VideoUseCloudMap.HasValue)
+            options.Video.AdditionalProperties["UseCloudMap"] = profile.VideoUseCloudMap.Value ? "yes" : "no";
+
+        if (profile.VideoUseLightMap.HasValue)
+            options.Video.AdditionalProperties["UseLightMap"] = profile.VideoUseLightMap.Value ? "yes" : "no";
+
+        if (profile.VideoUseShadowDecals.HasValue)
+            options.Video.UseShadowDecals = profile.VideoUseShadowDecals.Value;
+
+        if (profile.VideoBuildingOcclusion.HasValue)
+            options.Video.BuildingOcclusion = profile.VideoBuildingOcclusion.Value;
+
+        if (profile.VideoShowProps.HasValue)
+            options.Video.ShowProps = profile.VideoShowProps.Value;
     }
 
     private static void ApplyAudioToOptions(GameProfile profile, IniOptions options, ILogger? logger)
@@ -991,6 +1088,17 @@ public static class GameSettingsMapper
 
         ApplyTshUiSettingsToDict(profile, tshDict);
         ApplyTshControlsSettingsToDict(profile, tshDict);
+
+        if (profile.VideoGameTimeFontSize.HasValue && tshDict.ContainsKey("GameTimeFontSize"))
+            tshDict["GameTimeFontSize"] = profile.VideoGameTimeFontSize.Value.ToString(CultureInfo.InvariantCulture);
+        if (profile.VideoDrawScrollAnchor.HasValue && tshDict.ContainsKey("DrawScrollAnchor"))
+            tshDict["DrawScrollAnchor"] = BoolToString(profile.VideoDrawScrollAnchor.Value);
+        if (profile.VideoMoveScrollAnchor.HasValue && tshDict.ContainsKey("MoveScrollAnchor"))
+            tshDict["MoveScrollAnchor"] = BoolToString(profile.VideoMoveScrollAnchor.Value);
+        if (profile.GameLanguageFilter.HasValue && tshDict.ContainsKey("LanguageFilter"))
+            tshDict["LanguageFilter"] = BoolToString(profile.GameLanguageFilter.Value);
+        if (profile.NetworkSendDelay.HasValue && tshDict.ContainsKey("SendDelay"))
+            tshDict["SendDelay"] = BoolToString(profile.NetworkSendDelay.Value);
     }
 
     private static void ApplyTshUiSettingsToDict(GameProfile profile, Dictionary<string, string> tshDict)
@@ -1032,6 +1140,27 @@ public static class GameSettingsMapper
         profile.VideoGamma = request.VideoGamma ?? profile.VideoGamma;
         profile.VideoAlternateMouseSetup = request.VideoAlternateMouseSetup ?? profile.VideoAlternateMouseSetup;
         profile.VideoHeatEffects = request.VideoHeatEffects ?? profile.VideoHeatEffects;
+        profile.VideoStaticGameLOD = request.VideoStaticGameLOD ?? profile.VideoStaticGameLOD;
+        profile.VideoIdealStaticGameLOD = request.VideoIdealStaticGameLOD ?? profile.VideoIdealStaticGameLOD;
+        profile.VideoUseDoubleClickAttackMove = request.VideoUseDoubleClickAttackMove ?? profile.VideoUseDoubleClickAttackMove;
+        profile.VideoScrollFactor = request.VideoScrollFactor ?? profile.VideoScrollFactor;
+        profile.VideoRetaliation = request.VideoRetaliation ?? profile.VideoRetaliation;
+        profile.VideoDynamicLOD = request.VideoDynamicLOD ?? profile.VideoDynamicLOD;
+        profile.VideoMaxParticleCount = request.VideoMaxParticleCount ?? profile.VideoMaxParticleCount;
+        profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
+        profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
+        profile.VideoDrawScrollAnchor = request.VideoDrawScrollAnchor ?? profile.VideoDrawScrollAnchor;
+        profile.VideoMoveScrollAnchor = request.VideoMoveScrollAnchor ?? profile.VideoMoveScrollAnchor;
+        profile.VideoGameTimeFontSize = request.VideoGameTimeFontSize ?? profile.VideoGameTimeFontSize;
+        profile.GameLanguageFilter = request.GameLanguageFilter ?? profile.GameLanguageFilter;
+        profile.NetworkSendDelay = request.NetworkSendDelay ?? profile.NetworkSendDelay;
+        profile.VideoShowSoftWaterEdge = request.VideoShowSoftWaterEdge ?? profile.VideoShowSoftWaterEdge;
+        profile.VideoShowTrees = request.VideoShowTrees ?? profile.VideoShowTrees;
+        profile.VideoUseCloudMap = request.VideoUseCloudMap ?? profile.VideoUseCloudMap;
+        profile.VideoUseLightMap = request.VideoUseLightMap ?? profile.VideoUseLightMap;
+        profile.VideoUseShadowDecals = request.VideoUseShadowDecals ?? profile.VideoUseShadowDecals;
+        profile.VideoBuildingOcclusion = request.VideoBuildingOcclusion ?? profile.VideoBuildingOcclusion;
+        profile.VideoShowProps = request.VideoShowProps ?? profile.VideoShowProps;
     }
 
     private static void PatchAudioSettings(GameProfile profile, CreateProfileRequest request)
@@ -1115,6 +1244,19 @@ public static class GameSettingsMapper
         profile.VideoDynamicLOD = request.VideoDynamicLOD ?? profile.VideoDynamicLOD;
         profile.VideoMaxParticleCount = request.VideoMaxParticleCount ?? profile.VideoMaxParticleCount;
         profile.VideoAntiAliasing = request.VideoAntiAliasing ?? profile.VideoAntiAliasing;
+        profile.VideoSkipEALogo = request.VideoSkipEALogo ?? profile.VideoSkipEALogo;
+        profile.VideoUseLightMap = request.VideoUseLightMap ?? profile.VideoUseLightMap;
+        profile.VideoUseShadowDecals = request.VideoUseShadowDecals ?? profile.VideoUseShadowDecals;
+        profile.VideoBuildingOcclusion = request.VideoBuildingOcclusion ?? profile.VideoBuildingOcclusion;
+        profile.VideoShowProps = request.VideoShowProps ?? profile.VideoShowProps;
+        profile.VideoDrawScrollAnchor = request.VideoDrawScrollAnchor ?? profile.VideoDrawScrollAnchor;
+        profile.VideoMoveScrollAnchor = request.VideoMoveScrollAnchor ?? profile.VideoMoveScrollAnchor;
+        profile.VideoGameTimeFontSize = request.VideoGameTimeFontSize ?? profile.VideoGameTimeFontSize;
+        profile.GameLanguageFilter = request.GameLanguageFilter ?? profile.GameLanguageFilter;
+        profile.NetworkSendDelay = request.NetworkSendDelay ?? profile.NetworkSendDelay;
+        profile.VideoShowSoftWaterEdge = request.VideoShowSoftWaterEdge ?? profile.VideoShowSoftWaterEdge;
+        profile.VideoShowTrees = request.VideoShowTrees ?? profile.VideoShowTrees;
+        profile.VideoUseCloudMap = request.VideoUseCloudMap ?? profile.VideoUseCloudMap;
     }
 
     private static void UpdateAudioFromRequest(GameProfile profile, UpdateProfileRequest request)

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -416,7 +416,6 @@ public static class GameSettingsMapper
 
         target.UseSteamLaunch = source.UseSteamLaunch;
         target.GameSpyIPAddress = source.GameSpyIPAddress;
-        target.VideoSkipEALogo = source.VideoSkipEALogo;
     }
 
     /// <summary>
@@ -511,7 +510,6 @@ public static class GameSettingsMapper
 
         target.UseSteamLaunch = source.UseSteamLaunch;
         target.GameSpyIPAddress = source.GameSpyIPAddress;
-        target.VideoSkipEALogo = source.VideoSkipEALogo;
     }
 
     /// <summary>
@@ -1000,10 +998,10 @@ public static class GameSettingsMapper
         if (profile.TshArchiveReplays.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ArchiveReplaysKey] = BoolToString(profile.TshArchiveReplays.Value);
         if (profile.TshShowMoneyPerMinute.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey] = BoolToString(profile.TshShowMoneyPerMinute.Value);
         if (profile.TshPlayerObserverEnabled.HasValue) tshDict[GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey] = BoolToString(profile.TshPlayerObserverEnabled.Value);
-        if (profile.TshSystemTimeFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = profile.TshSystemTimeFontSize.Value.ToString();
-        if (profile.TshNetworkLatencyFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = profile.TshNetworkLatencyFontSize.Value.ToString();
-        if (profile.TshRenderFpsFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = profile.TshRenderFpsFontSize.Value.ToString();
-        if (profile.TshResolutionFontAdjustment.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = profile.TshResolutionFontAdjustment.Value.ToString();
+        if (profile.TshSystemTimeFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = profile.TshSystemTimeFontSize.Value.ToString(CultureInfo.InvariantCulture);
+        if (profile.TshNetworkLatencyFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = profile.TshNetworkLatencyFontSize.Value.ToString(CultureInfo.InvariantCulture);
+        if (profile.TshRenderFpsFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = profile.TshRenderFpsFontSize.Value.ToString(CultureInfo.InvariantCulture);
+        if (profile.TshResolutionFontAdjustment.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = profile.TshResolutionFontAdjustment.Value.ToString(CultureInfo.InvariantCulture);
     }
 
     private static void ApplyTshControlsSettingsToDict(GameProfile profile, Dictionary<string, string> tshDict)
@@ -1014,7 +1012,7 @@ public static class GameSettingsMapper
         if (profile.TshCursorCaptureEnabledInWindowedMenu.HasValue) tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey] = BoolToString(profile.TshCursorCaptureEnabledInWindowedMenu.Value);
         if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey] = BoolToString(profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value);
         if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey] = BoolToString(profile.TshScreenEdgeScrollEnabledInWindowedApp.Value);
-        if (profile.TshMoneyTransactionVolume.HasValue) tshDict[GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = profile.TshMoneyTransactionVolume.Value.ToString();
+        if (profile.TshMoneyTransactionVolume.HasValue) tshDict[GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = profile.TshMoneyTransactionVolume.Value.ToString(CultureInfo.InvariantCulture);
         if (NormalizeTransitionSpeedMultiplier(profile.TshGameWindowTransitionSpeedMultiplier) is { } speedMultiplier)
         {
             tshDict[GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = speedMultiplier.ToString(CultureInfo.InvariantCulture);

--- a/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
+++ b/GenHub/GenHub.Core/Helpers/GameSettingsMapper.cs
@@ -414,7 +414,9 @@ public static class GameSettingsMapper
         target.GoSocialNotificationPlayerSendsRequestGameplay = source.GoSocialNotificationPlayerSendsRequestGameplay;
         target.GoSocialNotificationPlayerSendsRequestMenus = source.GoSocialNotificationPlayerSendsRequestMenus;
 
+        target.UseSteamLaunch = source.UseSteamLaunch;
         target.GameSpyIPAddress = source.GameSpyIPAddress;
+        target.VideoSkipEALogo = source.VideoSkipEALogo;
     }
 
     /// <summary>
@@ -507,7 +509,9 @@ public static class GameSettingsMapper
         target.GoSocialNotificationPlayerSendsRequestGameplay = source.GoSocialNotificationPlayerSendsRequestGameplay;
         target.GoSocialNotificationPlayerSendsRequestMenus = source.GoSocialNotificationPlayerSendsRequestMenus;
 
+        target.UseSteamLaunch = source.UseSteamLaunch;
         target.GameSpyIPAddress = source.GameSpyIPAddress;
+        target.VideoSkipEALogo = source.VideoSkipEALogo;
     }
 
     /// <summary>
@@ -600,7 +604,7 @@ public static class GameSettingsMapper
     private static void ApplyTshHierarchicalSettingsFromOptions(IniOptions options, GameProfile profile)
     {
         var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
-            string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+            string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
         if (tshKvp.Value is { Count: > 0 })
         {
             ApplyTshProperties(tshKvp.Value, profile);
@@ -618,18 +622,18 @@ public static class GameSettingsMapper
 
     private static void ApplyTshVideoSettings(Dictionary<string, string> tsh, GameProfile profile)
     {
-        if (tsh.TryGetCaseInsensitive("UseDoubleClickAttackMove", out var doubleClickTsh))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey, out var doubleClickTsh))
             profile.VideoUseDoubleClickAttackMove = ParseBool(doubleClickTsh);
-        else if (tsh.TryGetCaseInsensitive("UseDoubleClick", out var dblTsh))
+        else if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.UseDoubleClickKey, out var dblTsh))
             profile.VideoUseDoubleClickAttackMove = ParseBool(dblTsh);
 
-        if (tsh.TryGetCaseInsensitive("ScrollFactor", out var scrollTsh) && int.TryParse(scrollTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollTshVal))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScrollFactorKey, out var scrollTsh) && int.TryParse(scrollTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollTshVal))
             profile.VideoScrollFactor = scrollTshVal;
-        if (tsh.TryGetCaseInsensitive("Retaliation", out var retaliationTsh))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.RetaliationKey, out var retaliationTsh))
             profile.VideoRetaliation = ParseBool(retaliationTsh);
-        if (tsh.TryGetCaseInsensitive("DynamicLOD", out var dynLODTsh))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.DynamicLODKey, out var dynLODTsh))
             profile.VideoDynamicLOD = ParseBool(dynLODTsh);
-        if (tsh.TryGetCaseInsensitive("MaxParticleCount", out var particlesTsh) && int.TryParse(particlesTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particlesTshVal))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MaxParticleCountKey, out var particlesTsh) && int.TryParse(particlesTsh, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particlesTshVal))
             profile.VideoMaxParticleCount = particlesTshVal;
         if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedTsh))
         {
@@ -643,45 +647,45 @@ public static class GameSettingsMapper
 
     private static void ApplyTshFeatureSettings(Dictionary<string, string> tsh, GameProfile profile)
     {
-        if (tsh.TryGetCaseInsensitive("ArchiveReplays", out var archiveReplays))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ArchiveReplaysKey, out var archiveReplays))
             profile.TshArchiveReplays = ParseBool(archiveReplays);
-        if (tsh.TryGetCaseInsensitive("ShowMoneyPerMinute", out var showMoney))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey, out var showMoney))
             profile.TshShowMoneyPerMinute = ParseBool(showMoney);
-        if (tsh.TryGetCaseInsensitive("PlayerObserverEnabled", out var playerObserver))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey, out var playerObserver))
             profile.TshPlayerObserverEnabled = ParseBool(playerObserver);
     }
 
     private static void ApplyTshFontSettings(Dictionary<string, string> tsh, GameProfile profile)
     {
-        if (tsh.TryGetCaseInsensitive("SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey, out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
             profile.TshSystemTimeFontSize = stf;
-        if (tsh.TryGetCaseInsensitive("NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey, out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
             profile.TshNetworkLatencyFontSize = nlf;
-        if (tsh.TryGetCaseInsensitive("RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey, out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
             profile.TshRenderFpsFontSize = ff;
-        if (tsh.TryGetCaseInsensitive("ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey, out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
             profile.TshResolutionFontAdjustment = rfa;
     }
 
     private static void ApplyTshCursorSettings(Dictionary<string, string> tsh, GameProfile profile)
     {
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey, out var cursorFullscreenGame))
             profile.TshCursorCaptureEnabledInFullscreenGame = ParseBool(cursorFullscreenGame);
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey, out var cursorFullscreenMenu))
             profile.TshCursorCaptureEnabledInFullscreenMenu = ParseBool(cursorFullscreenMenu);
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey, out var cursorWindowedGame))
             profile.TshCursorCaptureEnabledInWindowedGame = ParseBool(cursorWindowedGame);
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey, out var cursorWindowedMenu))
             profile.TshCursorCaptureEnabledInWindowedMenu = ParseBool(cursorWindowedMenu);
     }
 
     private static void ApplyTshScrollAndAudioSettings(Dictionary<string, string> tsh, GameProfile profile)
     {
-        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey, out var scrollFullscreen))
             profile.TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(scrollFullscreen);
-        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey, out var scrollWindowed))
             profile.TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(scrollWindowed);
-        if (tsh.TryGetCaseInsensitive("MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey, out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
             profile.TshMoneyTransactionVolume = mv;
     }
 
@@ -790,6 +794,7 @@ public static class GameSettingsMapper
                 TextureQuality.Low => GameSettingsConstants.TextureQuality.TextureReductionLow,
                 TextureQuality.Medium => GameSettingsConstants.TextureQuality.TextureReductionMedium,
                 TextureQuality.High => GameSettingsConstants.TextureQuality.TextureReductionHigh,
+                TextureQuality.VeryHigh => GameSettingsConstants.TextureQuality.TextureReductionVeryHigh,
                 _ => options.Video.TextureReduction,
             };
         }
@@ -852,21 +857,21 @@ public static class GameSettingsMapper
 
         if (profile.VideoUseDoubleClickAttackMove.HasValue)
         {
-            options.Video.AdditionalProperties["UseDoubleClickAttackMove"] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
-            options.Video.AdditionalProperties["UseDoubleClick"] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.UseDoubleClickKey] = profile.VideoUseDoubleClickAttackMove.Value ? "yes" : "no";
         }
 
         if (profile.VideoScrollFactor.HasValue)
-            options.Video.AdditionalProperties["ScrollFactor"] = profile.VideoScrollFactor.Value.ToString();
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.ScrollFactorKey] = profile.VideoScrollFactor.Value.ToString();
 
         if (profile.VideoRetaliation.HasValue)
-            options.Video.AdditionalProperties["Retaliation"] = profile.VideoRetaliation.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.RetaliationKey] = profile.VideoRetaliation.Value ? "yes" : "no";
 
         if (profile.VideoDynamicLOD.HasValue)
-            options.Video.AdditionalProperties["DynamicLOD"] = profile.VideoDynamicLOD.Value ? "yes" : "no";
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.DynamicLODKey] = profile.VideoDynamicLOD.Value ? "yes" : "no";
 
         if (profile.VideoMaxParticleCount.HasValue)
-            options.Video.AdditionalProperties["MaxParticleCount"] = profile.VideoMaxParticleCount.Value.ToString();
+            options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.MaxParticleCountKey] = profile.VideoMaxParticleCount.Value.ToString();
 
         if (profile.VideoSkipEALogo.HasValue)
             options.Video.AdditionalProperties["SkipEALogo"] = profile.VideoSkipEALogo.Value ? "yes" : "no";
@@ -973,7 +978,7 @@ public static class GameSettingsMapper
     private static void ApplyTshToOptions(GameProfile profile, IniOptions options)
     {
         var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k =>
-            string.Equals(k, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)) ?? "TheSuperHackers";
+            string.Equals(k, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase)) ?? GameSettingsTheSuperHackersConstants.SectionName;
 
         Dictionary<string, string> tshDict;
         if (options.AdditionalSections.TryGetValue(tshKey, out var existingTsh) && existingTsh != null)
@@ -992,24 +997,24 @@ public static class GameSettingsMapper
 
     private static void ApplyTshUiSettingsToDict(GameProfile profile, Dictionary<string, string> tshDict)
     {
-        if (profile.TshArchiveReplays.HasValue) tshDict["ArchiveReplays"] = BoolToString(profile.TshArchiveReplays.Value);
-        if (profile.TshShowMoneyPerMinute.HasValue) tshDict["ShowMoneyPerMinute"] = BoolToString(profile.TshShowMoneyPerMinute.Value);
-        if (profile.TshPlayerObserverEnabled.HasValue) tshDict["PlayerObserverEnabled"] = BoolToString(profile.TshPlayerObserverEnabled.Value);
-        if (profile.TshSystemTimeFontSize.HasValue) tshDict["SystemTimeFontSize"] = profile.TshSystemTimeFontSize.Value.ToString();
-        if (profile.TshNetworkLatencyFontSize.HasValue) tshDict["NetworkLatencyFontSize"] = profile.TshNetworkLatencyFontSize.Value.ToString();
-        if (profile.TshRenderFpsFontSize.HasValue) tshDict["RenderFpsFontSize"] = profile.TshRenderFpsFontSize.Value.ToString();
-        if (profile.TshResolutionFontAdjustment.HasValue) tshDict["ResolutionFontAdjustment"] = profile.TshResolutionFontAdjustment.Value.ToString();
+        if (profile.TshArchiveReplays.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ArchiveReplaysKey] = BoolToString(profile.TshArchiveReplays.Value);
+        if (profile.TshShowMoneyPerMinute.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey] = BoolToString(profile.TshShowMoneyPerMinute.Value);
+        if (profile.TshPlayerObserverEnabled.HasValue) tshDict[GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey] = BoolToString(profile.TshPlayerObserverEnabled.Value);
+        if (profile.TshSystemTimeFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = profile.TshSystemTimeFontSize.Value.ToString();
+        if (profile.TshNetworkLatencyFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = profile.TshNetworkLatencyFontSize.Value.ToString();
+        if (profile.TshRenderFpsFontSize.HasValue) tshDict[GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = profile.TshRenderFpsFontSize.Value.ToString();
+        if (profile.TshResolutionFontAdjustment.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = profile.TshResolutionFontAdjustment.Value.ToString();
     }
 
     private static void ApplyTshControlsSettingsToDict(GameProfile profile, Dictionary<string, string> tshDict)
     {
-        if (profile.TshCursorCaptureEnabledInFullscreenGame.HasValue) tshDict["CursorCaptureEnabledInFullscreenGame"] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenGame.Value);
-        if (profile.TshCursorCaptureEnabledInFullscreenMenu.HasValue) tshDict["CursorCaptureEnabledInFullscreenMenu"] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenMenu.Value);
-        if (profile.TshCursorCaptureEnabledInWindowedGame.HasValue) tshDict["CursorCaptureEnabledInWindowedGame"] = BoolToString(profile.TshCursorCaptureEnabledInWindowedGame.Value);
-        if (profile.TshCursorCaptureEnabledInWindowedMenu.HasValue) tshDict["CursorCaptureEnabledInWindowedMenu"] = BoolToString(profile.TshCursorCaptureEnabledInWindowedMenu.Value);
-        if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) tshDict["ScreenEdgeScrollEnabledInFullscreenApp"] = BoolToString(profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value);
-        if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) tshDict["ScreenEdgeScrollEnabledInWindowedApp"] = BoolToString(profile.TshScreenEdgeScrollEnabledInWindowedApp.Value);
-        if (profile.TshMoneyTransactionVolume.HasValue) tshDict["MoneyTransactionVolume"] = profile.TshMoneyTransactionVolume.Value.ToString();
+        if (profile.TshCursorCaptureEnabledInFullscreenGame.HasValue) tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenGame.Value);
+        if (profile.TshCursorCaptureEnabledInFullscreenMenu.HasValue) tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey] = BoolToString(profile.TshCursorCaptureEnabledInFullscreenMenu.Value);
+        if (profile.TshCursorCaptureEnabledInWindowedGame.HasValue) tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey] = BoolToString(profile.TshCursorCaptureEnabledInWindowedGame.Value);
+        if (profile.TshCursorCaptureEnabledInWindowedMenu.HasValue) tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey] = BoolToString(profile.TshCursorCaptureEnabledInWindowedMenu.Value);
+        if (profile.TshScreenEdgeScrollEnabledInFullscreenApp.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey] = BoolToString(profile.TshScreenEdgeScrollEnabledInFullscreenApp.Value);
+        if (profile.TshScreenEdgeScrollEnabledInWindowedApp.HasValue) tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey] = BoolToString(profile.TshScreenEdgeScrollEnabledInWindowedApp.Value);
+        if (profile.TshMoneyTransactionVolume.HasValue) tshDict[GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = profile.TshMoneyTransactionVolume.Value.ToString();
         if (NormalizeTransitionSpeedMultiplier(profile.TshGameWindowTransitionSpeedMultiplier) is { } speedMultiplier)
         {
             tshDict[GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = speedMultiplier.ToString(CultureInfo.InvariantCulture);

--- a/GenHub/GenHub.Core/Interfaces/GameSettings/IGameSettingsService.cs
+++ b/GenHub/GenHub.Core/Interfaces/GameSettings/IGameSettingsService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GameSettings;
 using GenHub.Core.Models.Results;
@@ -60,9 +62,24 @@ public interface IGameSettingsService
     Task<OperationResult<GeneralsOnlineSettings>> LoadGeneralsOnlineSettingsAsync();
 
     /// <summary>
+    /// Loads GeneralsOnline-specific settings from settings.json.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for cancelling the load operation.</param>
+    /// <returns>An operation result containing the loaded GeneralsOnline settings or errors.</returns>
+    Task<OperationResult<GeneralsOnlineSettings>> LoadGeneralsOnlineSettingsAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     /// Saves GeneralsOnline-specific settings to settings.json.
     /// </summary>
     /// <param name="settings">The GeneralsOnline settings to save.</param>
     /// <returns>An operation result indicating success or failure.</returns>
     Task<OperationResult<bool>> SaveGeneralsOnlineSettingsAsync(GeneralsOnlineSettings settings);
+
+    /// <summary>
+    /// Saves GeneralsOnline-specific settings to settings.json.
+    /// </summary>
+    /// <param name="settings">The GeneralsOnline settings to save.</param>
+    /// <param name="cancellationToken">Cancellation token for cancelling the save operation.</param>
+    /// <returns>An operation result indicating success or failure.</returns>
+    Task<OperationResult<bool>> SaveGeneralsOnlineSettingsAsync(GeneralsOnlineSettings settings, CancellationToken cancellationToken);
 }

--- a/GenHub/GenHub.Core/Models/GameProfile/CreateProfileRequest.cs
+++ b/GenHub/GenHub.Core/Models/GameProfile/CreateProfileRequest.cs
@@ -145,6 +145,15 @@ public class CreateProfileRequest
     /// <summary>Gets or sets a value indicating whether to use light maps (yes/no).</summary>
     public bool? VideoUseLightMap { get; set; }
 
+    /// <summary>Gets or sets a value indicating whether to use shadow decals.</summary>
+    public bool? VideoUseShadowDecals { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether building occlusion is enabled.</summary>
+    public bool? VideoBuildingOcclusion { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether to show props.</summary>
+    public bool? VideoShowProps { get; set; }
+
     // ===== Audio Settings =====
 
     /// <summary>Gets or sets the sound volume.</summary>

--- a/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
+++ b/GenHub/GenHub.Core/Models/GameSettings/GeneralsOnlineSettings.cs
@@ -5,8 +5,8 @@ using GenHub.Core.Constants;
 
 namespace GenHub.Core.Models.GameSettings;
 
-/// <summary>GeneralsOnline game client settings (inherits TheSuperHackers settings plus GeneralsOnline-specific options).</summary>
-public class GeneralsOnlineSettings : TheSuperHackersSettings
+/// <summary>GeneralsOnline game client settings (manages GeneralsOnline settings.json configuration).</summary>
+public class GeneralsOnlineSettings
 {
     /// <summary>Gets or sets a value indicating whether to show FPS counter.</summary>
     public bool ShowFps { get; set; }

--- a/GenHub/GenHub.Core/Models/GameSettings/IniOptions.cs
+++ b/GenHub/GenHub.Core/Models/GameSettings/IniOptions.cs
@@ -1,9 +1,10 @@
+using System;
+using System.Collections.Generic;
+
 namespace GenHub.Core.Models.GameSettings;
 
 /// <summary>
-/// Represents the Options.ini file for Command and Conquer Generals and Zero Hour.
-/// File locations: Documents\Command and Conquer Generals Data\Options.ini
-/// or Documents\Command and Conquer Generals Zero Hour Data\Options.ini.
+/// Represents the parsed structure of an Options.ini file.
 /// </summary>
 public class IniOptions
 {
@@ -25,5 +26,5 @@ public class IniOptions
     /// <summary>
     /// Gets or sets additional key-value pairs not covered by structured settings.
     /// </summary>
-    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; set; } = [];
+    public Dictionary<string, Dictionary<string, string>> AdditionalSections { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/DictionaryExtensionsTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Extensions/DictionaryExtensionsTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using GenHub.Core.Extensions;
+
+namespace GenHub.Tests.Core.Extensions;
+
+/// <summary>
+/// Tests for <see cref="DictionaryExtensions"/>.
+/// </summary>
+public class DictionaryExtensionsTests
+{
+    /// <summary>
+    /// Verifies that looking up a key with exact casing returns true and the value.
+    /// </summary>
+    [Fact]
+    public void TryGetCaseInsensitive_ExactKey_ReturnsTrueAndValue()
+    {
+        var dict = new Dictionary<string, string>
+        {
+            ["ArchiveReplays"] = "yes",
+        };
+
+        var result = dict.TryGetCaseInsensitive("ArchiveReplays", out var value);
+
+        Assert.True(result);
+        Assert.Equal("yes", value);
+    }
+
+    /// <summary>
+    /// Verifies that looking up a key with different casing returns true and the value.
+    /// </summary>
+    [Fact]
+    public void TryGetCaseInsensitive_DifferentCasing_ReturnsTrueAndValue()
+    {
+        var dict = new Dictionary<string, string>
+        {
+            ["archivereplays"] = "yes",
+        };
+
+        var result = dict.TryGetCaseInsensitive("ArchiveReplays", out var value);
+
+        Assert.True(result);
+        Assert.Equal("yes", value);
+    }
+
+    /// <summary>
+    /// Verifies that looking up a non-existent key returns false and an empty string.
+    /// </summary>
+    [Fact]
+    public void TryGetCaseInsensitive_NonExistentKey_ReturnsFalseAndEmptyString()
+    {
+        var dict = new Dictionary<string, string>
+        {
+            ["ExistingKey"] = "value",
+        };
+
+        var result = dict.TryGetCaseInsensitive("MissingKey", out var value);
+
+        Assert.False(result);
+        Assert.Equal(string.Empty, value);
+    }
+
+    /// <summary>
+    /// Verifies that searching an empty dictionary returns false and an empty string.
+    /// </summary>
+    [Fact]
+    public void TryGetCaseInsensitive_EmptyDictionary_ReturnsFalseAndEmptyString()
+    {
+        var dict = new Dictionary<string, string>();
+
+        var result = dict.TryGetCaseInsensitive("AnyKey", out var value);
+
+        Assert.False(result);
+        Assert.Equal(string.Empty, value);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -421,8 +421,7 @@ public class GameSettingsViewModelTests
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        await InitializeAndSaveProfileAsync(CreateGeneralsOnlineProfile());
 
         // Assert
         Assert.NotNull(saved);
@@ -447,12 +446,9 @@ public class GameSettingsViewModelTests
         _gameSettingsServiceMock.SetupSequence(x => x.LoadGeneralsOnlineSettingsAsync())
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()))
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"));
-        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", profile);
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        await InitializeAndSaveProfileAsync(profile);
 
         // Assert
         _gameSettingsServiceMock.Verify(
@@ -477,17 +473,11 @@ public class GameSettingsViewModelTests
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
-        GeneralsOnlineSettings? saved = null;
-        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
-            .Callback<GeneralsOnlineSettings>(s => saved = s)
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
-
         var profile = CreateGeneralsOnlineProfile();
         profile.GoCameraMinHeight = 200.0f;
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", profile);
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        var saved = await InitializeAndSaveGoProfileWithCaptureAsync(profile);
 
         // Assert
         Assert.NotNull(saved);
@@ -508,14 +498,11 @@ public class GameSettingsViewModelTests
         profile.GoShowFps = true;
         _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
-        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
         _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", profile);
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        await InitializeAndSaveProfileAsync(profile);
 
         // Assert - once to seed the view model, once more as the baseline for the rewrite
         _gameSettingsServiceMock.Verify(x => x.LoadGeneralsOnlineSettingsAsync(), Times.Exactly(2));
@@ -545,17 +532,11 @@ public class GameSettingsViewModelTests
         _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
-        GeneralsOnlineSettings? saved = null;
-        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
-            .Callback<GeneralsOnlineSettings>(s => saved = s)
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
-
         var profile = CreateGeneralsOnlineProfile();
         profile.GoShowFps = true;
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", profile);
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        var saved = await InitializeAndSaveGoProfileWithCaptureAsync(profile);
 
         // Assert
         Assert.NotNull(saved);
@@ -576,15 +557,11 @@ public class GameSettingsViewModelTests
         _gameSettingsServiceMock.SetupSequence(x => x.LoadGeneralsOnlineSettingsAsync())
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateFailure("settings.json is locked"))
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
-        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
-
         var profile = CreateGeneralsOnlineProfile();
         profile.GoShowFps = true;
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", profile);
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        await InitializeAndSaveProfileAsync(profile);
 
         // Assert
         _gameSettingsServiceMock.Verify(
@@ -610,8 +587,7 @@ public class GameSettingsViewModelTests
             .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        await InitializeAndSaveProfileAsync(CreateGeneralsOnlineProfile());
 
         // Assert
         Assert.DoesNotContain("Failed to save settings", _viewModel.StatusMessage);
@@ -637,8 +613,7 @@ public class GameSettingsViewModelTests
             .ReturnsAsync(OperationResult<bool>.CreateFailure("settings.json is read-only"));
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", CreateGeneralsOnlineProfile());
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        await InitializeAndSaveProfileAsync(CreateGeneralsOnlineProfile());
 
         // Assert
         Assert.DoesNotContain("Failed to save settings", _viewModel.StatusMessage);
@@ -756,17 +731,9 @@ public class GameSettingsViewModelTests
 
         _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(existing));
-        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
-
-        GeneralsOnlineSettings? saved = null;
-        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
-            .Callback<GeneralsOnlineSettings>(s => saved = s)
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", profile);
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        var saved = await InitializeAndSaveGoProfileWithCaptureAsync(profile);
 
         // Assert
         Assert.NotNull(saved);
@@ -793,17 +760,9 @@ public class GameSettingsViewModelTests
 
         _gameSettingsServiceMock.Setup(x => x.LoadGeneralsOnlineSettingsAsync())
             .ReturnsAsync(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings()));
-        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
-
-        GeneralsOnlineSettings? saved = null;
-        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
-            .Callback<GeneralsOnlineSettings>(s => saved = s)
-            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
 
         // Act
-        await _viewModel.InitializeForProfileAsync("go-profile", profile);
-        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+        var saved = await InitializeAndSaveGoProfileWithCaptureAsync(profile);
 
         // Assert
         Assert.NotNull(saved);
@@ -1223,5 +1182,23 @@ public class GameSettingsViewModelTests
                 PublisherType = PublisherTypeConstants.GeneralsOnline,
             },
         };
+    }
+
+    private async Task InitializeAndSaveProfileAsync(GameProfile profile)
+    {
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+        await _viewModel.InitializeForProfileAsync("go-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+    }
+
+    private async Task<GeneralsOnlineSettings?> InitializeAndSaveGoProfileWithCaptureAsync(GameProfile profile)
+    {
+        GeneralsOnlineSettings? saved = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveGeneralsOnlineSettingsAsync(It.IsAny<GeneralsOnlineSettings>()))
+            .Callback<GeneralsOnlineSettings>(s => saved = s)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+        await InitializeAndSaveProfileAsync(profile);
+        return saved;
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -1132,20 +1132,6 @@ public class GameSettingsViewModelTests
         Assert.Equal(1080, _viewModel.ResolutionHeight);
     }
 
-    private static GameProfile CreateGeneralsOnlineProfile()
-    {
-        return new GameProfile
-        {
-            Id = "go-profile",
-            Name = "GeneralsOnline Profile",
-            GameClient = new GameClient
-            {
-                GameType = GameType.ZeroHour,
-                PublisherType = PublisherTypeConstants.GeneralsOnline,
-            },
-        };
-    }
-
     /// <summary>
     /// Should load GameTimeFontSize from Options.ini when placed in Video.AdditionalProperties or in TheSuperHackers section,
     /// preventing reset to default 10.
@@ -1223,5 +1209,18 @@ public class GameSettingsViewModelTests
         Assert.True(savedOptions.AdditionalSections.TryGetValue(GameSettingsTheSuperHackersConstants.SectionName, out var tsh));
         Assert.True(tsh.TryGetValue("GameTimeFontSize", out var syncedFontSize));
         Assert.Equal("18", syncedFontSize);
+    }
+    private static GameProfile CreateGeneralsOnlineProfile()
+    {
+        return new GameProfile
+        {
+            Id = "go-profile",
+            Name = "GeneralsOnline Profile",
+            GameClient = new GameClient
+            {
+                GameType = GameType.ZeroHour,
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+            },
+        };
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -1062,6 +1062,76 @@ public class GameSettingsViewModelTests
         Assert.Equal(2.5f, _viewModel.TshGameWindowTransitionSpeedMultiplier);
     }
 
+    /// <summary>
+    /// Should clear loading flags even when game settings service is null.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task LoadSettings_Should_ClearLoadingFlag_WhenGameSettingsServiceIsNullAsync()
+    {
+        // Arrange
+        var vm = new GameSettingsViewModel(null!, _loggerMock.Object);
+
+        // Act
+        await vm.LoadSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(vm.IsLoading);
+        Assert.Equal("Game settings service not available", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Should clear loading flags even when selected game type is unknown.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task LoadSettings_Should_ClearLoadingFlag_WhenGameTypeIsUnknownAsync()
+    {
+        // Arrange
+        _viewModel.SelectedGameType = GameType.Unknown;
+
+        // Act
+        await _viewModel.LoadSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(_viewModel.IsLoading);
+        Assert.Contains("Game type is Unknown", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
+    /// Should discard loaded Options.ini settings if the selected game type changed concurrently before load completed.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task LoadSettings_Should_DiscardResult_WhenGameTypeChangedConcurrentlyAsync()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<OperationResult<IniOptions>>();
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.Generals))
+            .Returns(tcs.Task);
+
+        var generalsOptions = new IniOptions
+        {
+            Video = new VideoSettings { ResolutionWidth = 1024, ResolutionHeight = 768 },
+        };
+
+        _viewModel.SelectedGameType = GameType.Generals;
+        var loadTask = _viewModel.LoadSettingsCommand.ExecuteAsync(null);
+
+        // Simulate game type switch to ZeroHour before Generals load completes
+        _viewModel.SelectedGameType = GameType.ZeroHour;
+        _viewModel.ResolutionWidth = 1920;
+        _viewModel.ResolutionHeight = 1080;
+
+        // Complete Generals load
+        tcs.SetResult(OperationResult<IniOptions>.CreateSuccess(generalsOptions));
+        await loadTask;
+
+        // Assert: ResolutionWidth/Height should NOT have been overwritten by Generals options (1024x768)
+        Assert.Equal(1920, _viewModel.ResolutionWidth);
+        Assert.Equal(1080, _viewModel.ResolutionHeight);
+    }
+
     private static GameProfile CreateGeneralsOnlineProfile()
     {
         return new GameProfile

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -335,7 +335,7 @@ public class GameSettingsViewModelTests
     }
 
     /// <summary>
-    /// Should not load settings when game type is set before initialization.
+    /// Should not load settings for pre-initialization game type when game type is set before initialization.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
@@ -345,7 +345,7 @@ public class GameSettingsViewModelTests
         var profile = new GameProfile
         {
             GameClient = new GameClient { GameType = GameType.ZeroHour },
-            VideoResolutionWidth = 1920, // Add settings so initialization loads from profile, not Options.ini
+            VideoResolutionWidth = 1920,
         };
 
         _viewModel.SelectedGameType = GameType.Generals; // Set before initialization
@@ -353,8 +353,8 @@ public class GameSettingsViewModelTests
         // Act - Start initialization
         await _viewModel.InitializeForProfileAsync("test", profile);
 
-        // Assert - Should have loaded from profile during initialization, not from Options.ini
-        _gameSettingsServiceMock.Verify(x => x.LoadOptionsAsync(It.IsAny<GameType>()), Times.Never);
+        // Assert - Should not have loaded settings for the pre-initialization game type
+        _gameSettingsServiceMock.Verify(x => x.LoadOptionsAsync(GameType.Generals), Times.Never);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -1210,6 +1210,7 @@ public class GameSettingsViewModelTests
         Assert.True(tsh.TryGetValue("GameTimeFontSize", out var syncedFontSize));
         Assert.Equal("18", syncedFontSize);
     }
+
     private static GameProfile CreateGeneralsOnlineProfile()
     {
         return new GameProfile

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -951,6 +951,117 @@ public class GameSettingsViewModelTests
         Assert.Equal(3.55f, request.TshGameWindowTransitionSpeedMultiplier);
     }
 
+    /// <summary>
+    /// Should seed baseline values from Options.ini when profile has settings,
+    /// so that properties not declared on the profile retain their Options.ini values.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task InitializeForProfileAsync_Should_SeedOptionsIniValues_WhenProfileHasSettingsAsync()
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            Id = "custom-profile",
+            Name = "Custom Profile",
+            GameClient = new GameClient { GameType = GameType.ZeroHour },
+            VideoResolutionWidth = 2560,
+            VideoResolutionHeight = 1440,
+        };
+
+        var options = new IniOptions();
+        options.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = "1.5",
+        };
+
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.ZeroHour))
+            .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(options));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("custom-profile", profile);
+
+        // Assert
+        Assert.Equal(2560, _viewModel.ResolutionWidth);
+        Assert.Equal(1440, _viewModel.ResolutionHeight);
+        Assert.Equal(1.5f, _viewModel.TshGameWindowTransitionSpeedMultiplier);
+    }
+
+    /// <summary>
+    /// Should preserve Options.ini transition speed when saving a profile that does not override it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_PreserveOptionsIniTransitionSpeed_WhenProfileDoesNotOverrideItAsync()
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            Id = "custom-profile",
+            Name = "Custom Profile",
+            GameClient = new GameClient { GameType = GameType.ZeroHour },
+            VideoResolutionWidth = 2560,
+            VideoResolutionHeight = 1440,
+        };
+
+        var options = new IniOptions();
+        options.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = "1.5",
+        };
+
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.ZeroHour))
+            .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(options));
+
+        IniOptions? savedOptions = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .Callback<GameType, IniOptions>((_, opt) => savedOptions = opt)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("custom-profile", profile);
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.NotNull(savedOptions);
+        Assert.True(savedOptions.AdditionalSections.TryGetValue(GameSettingsTheSuperHackersConstants.SectionName, out var tsh));
+        Assert.True(tsh.TryGetValue(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speed));
+        Assert.Equal("1.5", speed);
+    }
+
+    /// <summary>
+    /// Should override Options.ini transition speed with profile value when configured in profile.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task InitializeForProfileAsync_Should_OverrideOptionsIni_WhenProfileConfiguresTransitionSpeedAsync()
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            Id = "custom-profile",
+            Name = "Custom Profile",
+            GameClient = new GameClient { GameType = GameType.ZeroHour },
+            VideoResolutionWidth = 2560,
+            TshGameWindowTransitionSpeedMultiplier = 2.5f,
+        };
+
+        var options = new IniOptions();
+        options.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = "1.5",
+        };
+
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.ZeroHour))
+            .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(options));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("custom-profile", profile);
+
+        // Assert
+        Assert.Equal(2.5f, _viewModel.TshGameWindowTransitionSpeedMultiplier);
+    }
+
     private static GameProfile CreateGeneralsOnlineProfile()
     {
         return new GameProfile

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameSettingsViewModelTests.cs
@@ -1145,4 +1145,83 @@ public class GameSettingsViewModelTests
             },
         };
     }
+
+    /// <summary>
+    /// Should load GameTimeFontSize from Options.ini when placed in Video.AdditionalProperties or in TheSuperHackers section,
+    /// preventing reset to default 10.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task InitializeForProfileAsync_Should_LoadGameTimeFontSize_FromVideoOrTheSuperHackersSectionAsync()
+    {
+        // Arrange - test loading when categorized into TheSuperHackers section
+        var profile = new GameProfile
+        {
+            Id = "tsh-profile",
+            Name = "TSH Profile",
+            GameClient = new GameClient { GameType = GameType.ZeroHour },
+        };
+
+        var options = new IniOptions();
+        options.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["GameTimeFontSize"] = "15",
+            ["DrawScrollAnchor"] = "yes",
+            ["MoveScrollAnchor"] = "no",
+        };
+
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.ZeroHour))
+            .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(options));
+
+        // Act
+        await _viewModel.InitializeForProfileAsync("tsh-profile", profile);
+
+        // Assert - should be 15, NOT the default 10!
+        Assert.Equal(15, _viewModel.GameTimeFontSize);
+        Assert.True(_viewModel.DrawScrollAnchor);
+        Assert.False(_viewModel.MoveScrollAnchor);
+    }
+
+    /// <summary>
+    /// Should synchronize GameTimeFontSize and related properties to TheSuperHackers section on save when section exists.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task SaveSettings_Should_SynchronizeGameTimeFontSize_ToTheSuperHackersSectionAsync()
+    {
+        // Arrange
+        var profile = new GameProfile
+        {
+            Id = "tsh-profile",
+            Name = "TSH Profile",
+            GameClient = new GameClient { GameType = GameType.ZeroHour },
+        };
+
+        var initialOptions = new IniOptions();
+        initialOptions.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["GameTimeFontSize"] = "10",
+        };
+
+        _gameSettingsServiceMock.Setup(x => x.LoadOptionsAsync(GameType.ZeroHour))
+            .ReturnsAsync(OperationResult<IniOptions>.CreateSuccess(initialOptions));
+
+        IniOptions? savedOptions = null;
+        _gameSettingsServiceMock.Setup(x => x.SaveOptionsAsync(GameType.ZeroHour, It.IsAny<IniOptions>()))
+            .Callback<GameType, IniOptions>((_, opt) => savedOptions = opt)
+            .ReturnsAsync(OperationResult<bool>.CreateSuccess(true));
+
+        await _viewModel.InitializeForProfileAsync("tsh-profile", profile);
+        _viewModel.GameTimeFontSize = 18;
+
+        // Act
+        await _viewModel.SaveSettingsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.NotNull(savedOptions);
+        Assert.Equal("18", savedOptions.Video.AdditionalProperties["GameTimeFontSize"]);
+        Assert.True(savedOptions.AdditionalSections.TryGetValue(GameSettingsTheSuperHackersConstants.SectionName, out var tsh));
+        Assert.True(tsh.TryGetValue("GameTimeFontSize", out var syncedFontSize));
+        Assert.Equal("18", syncedFontSize);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameSettings/GameSettingsServiceTests.cs
@@ -610,6 +610,57 @@ MoneyTransactionVolume=60
         }
     }
 
+    /// <summary>
+    /// Verifies that flat root TheSuperHackers settings in Options.ini merge with existing [TheSuperHackers] section
+    /// and preserve section-only keys like GameWindowTransitionSpeedMultiplier, while video keys like ShowTrees
+    /// are categorized into Video.AdditionalProperties.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task LoadOptionsAsync_Should_MergeRootTshSettingsWithSectionSettingsAsync()
+    {
+        // Arrange
+        var content = @"ShowTrees = yes
+UseCloudMap = yes
+ScrollFactor = 55
+[TheSuperHackers]
+GameWindowTransitionSpeedMultiplier = 2.5
+MoneyTransactionVolume = 70
+";
+        var tempFile = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tempFile, content);
+
+        var mockService = new Mock<GameSettingsService>(MockBehavior.Loose, _loggerMock.Object, _pathProviderMock.Object)
+        {
+            CallBase = true,
+        };
+        mockService.Setup(x => x.GetOptionsFilePath(It.IsAny<GameType>())).Returns(tempFile);
+
+        try
+        {
+            // Act
+            var result = await mockService.Object.LoadOptionsAsync(GameType.ZeroHour);
+
+            // Assert
+            Assert.True(result.Success, result.FirstError);
+            var options = result.Data!;
+
+            // Video keys moved to Video.AdditionalProperties
+            Assert.Equal("yes", options.Video.AdditionalProperties["ShowTrees"]);
+            Assert.Equal("yes", options.Video.AdditionalProperties["UseCloudMap"]);
+
+            // Merged TheSuperHackers section preserves both section keys and root TSH keys
+            Assert.True(options.AdditionalSections.TryGetValue("TheSuperHackers", out var tshSection));
+            Assert.Equal("2.5", tshSection["GameWindowTransitionSpeedMultiplier"]);
+            Assert.Equal("70", tshSection["MoneyTransactionVolume"]);
+            Assert.Equal("55", tshSection["ScrollFactor"]);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
     private GameSettingsService CreateServiceWritingGeneralsOnlineSettingsTo(string settingsPath)
     {
         var mockService = new Mock<GameSettingsService>(MockBehavior.Loose, _loggerMock.Object, _pathProviderMock.Object)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -20,7 +20,7 @@ public class GameSettingsMapperTests
     [InlineData(TextureQuality.Low, GameSettingsConstants.TextureQuality.TextureReductionLow)]
     [InlineData(TextureQuality.Medium, GameSettingsConstants.TextureQuality.TextureReductionMedium)]
     [InlineData(TextureQuality.High, GameSettingsConstants.TextureQuality.TextureReductionHigh)]
-    [InlineData(TextureQuality.VeryHigh, GameSettingsConstants.TextureQuality.TextureReductionHigh)]
+    [InlineData(TextureQuality.VeryHigh, GameSettingsConstants.TextureQuality.TextureReductionVeryHigh)]
     public void ApplyToOptions_AllTextureQualities_SetsCorrectReduction(TextureQuality quality, int expectedReduction)
     {
         // Arrange
@@ -28,7 +28,10 @@ public class GameSettingsMapperTests
         {
             VideoTextureQuality = quality,
         };
-        var options = new IniOptions();
+        var options = new IniOptions
+        {
+            Video = { TextureReduction = 99 },
+        };
 
         // Act
         GameSettingsMapper.ApplyToOptions(profile, options);
@@ -462,5 +465,68 @@ public class GameSettingsMapperTests
 
         Assert.True(options.AdditionalSections.TryGetValue("TheSuperHackers", out var tshDict));
         Assert.Equal("4", tshDict["GameWindowTransitionSpeedMultiplier"]);
+    }
+
+    /// <summary>
+    /// Verifies that PopulateRequest from UpdateProfileRequest to CreateProfileRequest copies all properties including UseSteamLaunch and VideoSkipEALogo.
+    /// </summary>
+    [Fact]
+    public void PopulateRequest_CreateProfileRequest_CopiesAllSettingsIncludingUseSteamLaunchAndVideoSkipEALogo()
+    {
+        // Arrange
+        var source = new UpdateProfileRequest
+        {
+            UseSteamLaunch = true,
+            VideoSkipEALogo = true,
+            GameSpyIPAddress = "192.168.1.1",
+            VideoResolutionWidth = 1920,
+            VideoResolutionHeight = 1080,
+            TshGameWindowTransitionSpeedMultiplier = 2.5f,
+        };
+        var target = new CreateProfileRequest
+        {
+            Name = "Test",
+        };
+
+        // Act
+        GameSettingsMapper.PopulateRequest(target, source);
+
+        // Assert
+        Assert.True(target.UseSteamLaunch);
+        Assert.True(target.VideoSkipEALogo);
+        Assert.Equal("192.168.1.1", target.GameSpyIPAddress);
+        Assert.Equal(1920, target.VideoResolutionWidth);
+        Assert.Equal(1080, target.VideoResolutionHeight);
+        Assert.Equal(2.5f, target.TshGameWindowTransitionSpeedMultiplier);
+    }
+
+    /// <summary>
+    /// Verifies that PopulateRequest from UpdateProfileRequest to UpdateProfileRequest copies all properties including UseSteamLaunch and VideoSkipEALogo.
+    /// </summary>
+    [Fact]
+    public void PopulateRequest_UpdateProfileRequest_CopiesAllSettingsIncludingUseSteamLaunchAndVideoSkipEALogo()
+    {
+        // Arrange
+        var source = new UpdateProfileRequest
+        {
+            UseSteamLaunch = true,
+            VideoSkipEALogo = true,
+            GameSpyIPAddress = "192.168.1.1",
+            VideoResolutionWidth = 1920,
+            VideoResolutionHeight = 1080,
+            TshGameWindowTransitionSpeedMultiplier = 2.5f,
+        };
+        var target = new UpdateProfileRequest();
+
+        // Act
+        GameSettingsMapper.PopulateRequest(target, source);
+
+        // Assert
+        Assert.True(target.UseSteamLaunch);
+        Assert.True(target.VideoSkipEALogo);
+        Assert.Equal("192.168.1.1", target.GameSpyIPAddress);
+        Assert.Equal(1920, target.VideoResolutionWidth);
+        Assert.Equal(1080, target.VideoResolutionHeight);
+        Assert.Equal(2.5f, target.TshGameWindowTransitionSpeedMultiplier);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -655,6 +655,7 @@ public class GameSettingsMapperTests
 
         Assert.Equal(20, profile.VideoGameTimeFontSize);
         Assert.False(profile.VideoUseShadowDecals);
+
         // Untouched fields in update request retain original values
         Assert.True(profile.VideoDrawScrollAnchor);
         Assert.False(profile.VideoBuildingOcclusion);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -562,4 +562,101 @@ public class GameSettingsMapperTests
             System.Globalization.CultureInfo.CurrentCulture = currentCulture;
         }
     }
+
+    /// <summary>
+    /// Verifies that GameTimeFontSize is loaded from flat Video properties or TheSuperHackers section.
+    /// </summary>
+    [Fact]
+    public void ApplyFromOptions_GameTimeFontSize_LoadsFromFlatOrSection()
+    {
+        // 1. From flat Video properties
+        var flatOptions = new IniOptions();
+        flatOptions.Video.AdditionalProperties["GameTimeFontSize"] = "14";
+        var flatProfile = new GameProfile();
+        GameSettingsMapper.ApplyFromOptions(flatOptions, flatProfile);
+        Assert.Equal(14, flatProfile.VideoGameTimeFontSize);
+
+        // 2. From TheSuperHackers section
+        var tshOptions = new IniOptions();
+        tshOptions.AdditionalSections["TheSuperHackers"] = new Dictionary<string, string>
+        {
+            ["GameTimeFontSize"] = "16",
+        };
+        var tshProfile = new GameProfile();
+        GameSettingsMapper.ApplyFromOptions(tshOptions, tshProfile);
+        Assert.Equal(16, tshProfile.VideoGameTimeFontSize);
+    }
+
+    /// <summary>
+    /// Verifies that ApplyToOptions writes VideoGameTimeFontSize to root properties and synchronizes TheSuperHackers.
+    /// </summary>
+    [Fact]
+    public void ApplyToOptions_VideoGameTimeFontSize_WritesToRootAndSyncsSection()
+    {
+        var profile = new GameProfile
+        {
+            VideoGameTimeFontSize = 18,
+            VideoDrawScrollAnchor = true,
+            VideoMoveScrollAnchor = false,
+        };
+
+        var options = new IniOptions();
+        options.AdditionalSections["TheSuperHackers"] = new Dictionary<string, string>
+        {
+            ["GameTimeFontSize"] = "10",
+        };
+
+        GameSettingsMapper.ApplyToOptions(profile, options);
+
+        Assert.Equal("18", options.Video.AdditionalProperties["GameTimeFontSize"]);
+        Assert.Equal("18", options.AdditionalSections["TheSuperHackers"]["GameTimeFontSize"]);
+        Assert.Equal("yes", options.Video.AdditionalProperties["DrawScrollAnchor"]);
+        Assert.Equal("no", options.Video.AdditionalProperties["MoveScrollAnchor"]);
+    }
+
+    /// <summary>
+    /// Verifies that PopulateGameProfile and UpdateFromRequest preserve all additional video and engine settings.
+    /// </summary>
+    [Fact]
+    public void PopulateAndUpdate_PreservesGameTimeFontSizeAndAdditionalSettings()
+    {
+        var createRequest = new CreateProfileRequest
+        {
+            Name = "TestProfile",
+            VideoGameTimeFontSize = 16,
+            VideoDrawScrollAnchor = true,
+            VideoMoveScrollAnchor = false,
+            VideoUseShadowDecals = true,
+            VideoBuildingOcclusion = false,
+            VideoShowProps = true,
+            GameLanguageFilter = false,
+            NetworkSendDelay = false,
+        };
+        var profile = new GameProfile();
+
+        GameSettingsMapper.PopulateGameProfile(profile, createRequest);
+
+        Assert.Equal(16, profile.VideoGameTimeFontSize);
+        Assert.True(profile.VideoDrawScrollAnchor);
+        Assert.False(profile.VideoMoveScrollAnchor);
+        Assert.True(profile.VideoUseShadowDecals);
+        Assert.False(profile.VideoBuildingOcclusion);
+        Assert.True(profile.VideoShowProps);
+        Assert.False(profile.GameLanguageFilter);
+        Assert.False(profile.NetworkSendDelay);
+
+        var updateRequest = new UpdateProfileRequest
+        {
+            VideoGameTimeFontSize = 20,
+            VideoUseShadowDecals = false,
+        };
+
+        GameSettingsMapper.UpdateFromRequest(profile, updateRequest);
+
+        Assert.Equal(20, profile.VideoGameTimeFontSize);
+        Assert.False(profile.VideoUseShadowDecals);
+        // Untouched fields in update request retain original values
+        Assert.True(profile.VideoDrawScrollAnchor);
+        Assert.False(profile.VideoBuildingOcclusion);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -61,30 +61,31 @@ public class GameSettingsMapperTests
     }
 
     /// <summary>
-    /// Verifies that font sizes the profile leaves unset keep the values already in settings.json,
-    /// which is where the values a user configured inside the client itself live.
+    /// Verifies that font sizes the profile leaves unset keep the values already in TheSuperHackers section.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_UnsetFontSizes_PreservesExistingValues()
+    public void ApplyToOptions_TheSuperHackersUnsetFontSizes_PreservesExistingValues()
     {
         // Arrange - seed with values no GenHub default would produce
         var profile = new GameProfile();
-        var settings = new GeneralsOnlineSettings
+        var options = new IniOptions();
+        options.AdditionalSections["TheSuperHackers"] = new Dictionary<string, string>
         {
-            SystemTimeFontSize = 99,
-            NetworkLatencyFontSize = 98,
-            RenderFpsFontSize = 97,
-            ResolutionFontAdjustment = 96,
+            ["SystemTimeFontSize"] = "99",
+            ["NetworkLatencyFontSize"] = "98",
+            ["RenderFpsFontSize"] = "97",
+            ["ResolutionFontAdjustment"] = "96",
         };
 
         // Act
-        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+        GameSettingsMapper.ApplyToOptions(profile, options);
 
         // Assert
-        Assert.Equal(99, settings.SystemTimeFontSize);
-        Assert.Equal(98, settings.NetworkLatencyFontSize);
-        Assert.Equal(97, settings.RenderFpsFontSize);
-        Assert.Equal(96, settings.ResolutionFontAdjustment);
+        var tsh = options.AdditionalSections["TheSuperHackers"];
+        Assert.Equal("99", tsh["SystemTimeFontSize"]);
+        Assert.Equal("98", tsh["NetworkLatencyFontSize"]);
+        Assert.Equal("97", tsh["RenderFpsFontSize"]);
+        Assert.Equal("96", tsh["ResolutionFontAdjustment"]);
     }
 
     /// <summary>
@@ -120,10 +121,10 @@ public class GameSettingsMapperTests
     }
 
     /// <summary>
-    /// Verifies that explicit TheSuperHackers font sizes on the profile are written through unchanged.
+    /// Verifies that explicit TheSuperHackers font sizes on the profile are written to Options.ini unchanged.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_ExplicitFontSizes_ArePreserved()
+    public void ApplyToOptions_ExplicitFontSizes_ArePreserved()
     {
         // Arrange
         var profile = new GameProfile
@@ -133,75 +134,80 @@ public class GameSettingsMapperTests
             TshRenderFpsFontSize = 22,
             TshResolutionFontAdjustment = 23,
         };
-        var settings = new GeneralsOnlineSettings();
+        var options = new IniOptions();
 
         // Act
-        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+        GameSettingsMapper.ApplyToOptions(profile, options);
 
         // Assert
-        Assert.Equal(20, settings.SystemTimeFontSize);
-        Assert.Equal(21, settings.NetworkLatencyFontSize);
-        Assert.Equal(22, settings.RenderFpsFontSize);
-        Assert.Equal(23, settings.ResolutionFontAdjustment);
+        var tsh = options.AdditionalSections["TheSuperHackers"];
+        Assert.Equal("20", tsh["SystemTimeFontSize"]);
+        Assert.Equal("21", tsh["NetworkLatencyFontSize"]);
+        Assert.Equal("22", tsh["RenderFpsFontSize"]);
+        Assert.Equal("23", tsh["ResolutionFontAdjustment"]);
     }
 
     /// <summary>
-    /// Verifies that a fresh settings.json keeps money transaction audio audible, so that the
-    /// model default and the settings screen agree on what an unconfigured profile writes.
+    /// Verifies that an unconfigured profile preserves existing MoneyTransactionVolume in Options.ini.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_UnsetMoneyTransactionVolume_StaysAudible()
+    public void ApplyToOptions_UnsetMoneyTransactionVolume_PreservesExistingValue()
     {
         // Arrange
         var profile = new GameProfile();
-        var settings = new GeneralsOnlineSettings();
+        var options = new IniOptions();
+        options.AdditionalSections["TheSuperHackers"] = new Dictionary<string, string>
+        {
+            ["MoneyTransactionVolume"] = "75",
+        };
 
         // Act
-        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+        GameSettingsMapper.ApplyToOptions(profile, options);
 
         // Assert
-        Assert.Equal(GameSettingsTheSuperHackersConstants.DefaultMoneyTransactionVolume, settings.MoneyTransactionVolume);
-        Assert.NotEqual(0, settings.MoneyTransactionVolume);
+        Assert.Equal("75", options.AdditionalSections["TheSuperHackers"]["MoneyTransactionVolume"]);
     }
 
     /// <summary>
     /// Verifies that cursor capture, edge scroll and observer toggles the profile leaves unset
-    /// keep the values already in settings.json.
+    /// keep the values already in TheSuperHackers section.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_UnsetToggles_PreservesExistingValues()
+    public void ApplyToOptions_UnsetToggles_PreservesExistingValues()
     {
         // Arrange - seed each toggle inverted relative to its GenHub default
         var profile = new GameProfile();
-        var settings = new GeneralsOnlineSettings
+        var options = new IniOptions();
+        options.AdditionalSections["TheSuperHackers"] = new Dictionary<string, string>
         {
-            PlayerObserverEnabled = false,
-            CursorCaptureEnabledInFullscreenGame = false,
-            CursorCaptureEnabledInFullscreenMenu = false,
-            CursorCaptureEnabledInWindowedGame = false,
-            CursorCaptureEnabledInWindowedMenu = true,
-            ScreenEdgeScrollEnabledInFullscreenApp = false,
-            ScreenEdgeScrollEnabledInWindowedApp = true,
+            ["PlayerObserverEnabled"] = "no",
+            ["CursorCaptureEnabledInFullscreenGame"] = "no",
+            ["CursorCaptureEnabledInFullscreenMenu"] = "no",
+            ["CursorCaptureEnabledInWindowedGame"] = "no",
+            ["CursorCaptureEnabledInWindowedMenu"] = "yes",
+            ["ScreenEdgeScrollEnabledInFullscreenApp"] = "no",
+            ["ScreenEdgeScrollEnabledInWindowedApp"] = "yes",
         };
 
         // Act
-        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+        GameSettingsMapper.ApplyToOptions(profile, options);
 
         // Assert
-        Assert.False(settings.PlayerObserverEnabled);
-        Assert.False(settings.CursorCaptureEnabledInFullscreenGame);
-        Assert.False(settings.CursorCaptureEnabledInFullscreenMenu);
-        Assert.False(settings.CursorCaptureEnabledInWindowedGame);
-        Assert.True(settings.CursorCaptureEnabledInWindowedMenu);
-        Assert.False(settings.ScreenEdgeScrollEnabledInFullscreenApp);
-        Assert.True(settings.ScreenEdgeScrollEnabledInWindowedApp);
+        var tsh = options.AdditionalSections["TheSuperHackers"];
+        Assert.Equal("no", tsh["PlayerObserverEnabled"]);
+        Assert.Equal("no", tsh["CursorCaptureEnabledInFullscreenGame"]);
+        Assert.Equal("no", tsh["CursorCaptureEnabledInFullscreenMenu"]);
+        Assert.Equal("no", tsh["CursorCaptureEnabledInWindowedGame"]);
+        Assert.Equal("yes", tsh["CursorCaptureEnabledInWindowedMenu"]);
+        Assert.Equal("no", tsh["ScreenEdgeScrollEnabledInFullscreenApp"]);
+        Assert.Equal("yes", tsh["ScreenEdgeScrollEnabledInWindowedApp"]);
     }
 
     /// <summary>
-    /// Verifies that explicit toggle values on the profile are written through unchanged.
+    /// Verifies that explicit toggle values on the profile are written to Options.ini unchanged.
     /// </summary>
     [Fact]
-    public void ApplyToGeneralsOnlineSettings_ExplicitToggles_ArePreserved()
+    public void ApplyToOptions_ExplicitToggles_ArePreserved()
     {
         // Arrange - every value is the opposite of its default
         var profile = new GameProfile
@@ -214,19 +220,20 @@ public class GameSettingsMapperTests
             TshScreenEdgeScrollEnabledInFullscreenApp = false,
             TshScreenEdgeScrollEnabledInWindowedApp = true,
         };
-        var settings = new GeneralsOnlineSettings();
+        var options = new IniOptions();
 
         // Act
-        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+        GameSettingsMapper.ApplyToOptions(profile, options);
 
         // Assert
-        Assert.False(settings.PlayerObserverEnabled);
-        Assert.False(settings.CursorCaptureEnabledInFullscreenGame);
-        Assert.False(settings.CursorCaptureEnabledInFullscreenMenu);
-        Assert.False(settings.CursorCaptureEnabledInWindowedGame);
-        Assert.True(settings.CursorCaptureEnabledInWindowedMenu);
-        Assert.False(settings.ScreenEdgeScrollEnabledInFullscreenApp);
-        Assert.True(settings.ScreenEdgeScrollEnabledInWindowedApp);
+        var tsh = options.AdditionalSections["TheSuperHackers"];
+        Assert.Equal("no", tsh["PlayerObserverEnabled"]);
+        Assert.Equal("no", tsh["CursorCaptureEnabledInFullscreenGame"]);
+        Assert.Equal("no", tsh["CursorCaptureEnabledInFullscreenMenu"]);
+        Assert.Equal("no", tsh["CursorCaptureEnabledInWindowedGame"]);
+        Assert.Equal("yes", tsh["CursorCaptureEnabledInWindowedMenu"]);
+        Assert.Equal("no", tsh["ScreenEdgeScrollEnabledInFullscreenApp"]);
+        Assert.Equal("yes", tsh["ScreenEdgeScrollEnabledInWindowedApp"]);
     }
 
     /// <summary>
@@ -291,30 +298,56 @@ public class GameSettingsMapperTests
     }
 
     /// <summary>
-    /// Verifies that ApplyToGeneralsOnlineSettings and ApplyFromGeneralsOnlineSettings preserve GameWindowTransitionSpeedMultiplier.
+    /// Verifies that ApplyToOptions and ApplyFromOptions preserve GameWindowTransitionSpeedMultiplier.
     /// </summary>
     [Fact]
-    public void ApplyToAndFromGeneralsOnlineSettings_GameWindowTransitionSpeedMultiplier_RoundTrips()
+    public void ApplyToAndFromOptions_GameWindowTransitionSpeedMultiplier_RoundTrips()
     {
         // Arrange
         var profile = new GameProfile
         {
             TshGameWindowTransitionSpeedMultiplier = 4.0f,
         };
-        var settings = new GeneralsOnlineSettings();
+        var options = new IniOptions();
 
         // Act
-        GameSettingsMapper.ApplyToGeneralsOnlineSettings(profile, settings);
+        GameSettingsMapper.ApplyToOptions(profile, options);
 
         // Assert
-        Assert.Equal(4.0f, settings.GameWindowTransitionSpeedMultiplier);
+        var tsh = options.AdditionalSections["TheSuperHackers"];
+        Assert.Equal("4", tsh["GameWindowTransitionSpeedMultiplier"]);
 
         // Act back
         var targetProfile = new GameProfile();
-        GameSettingsMapper.ApplyFromGeneralsOnlineSettings(settings, targetProfile);
+        GameSettingsMapper.ApplyFromOptions(options, targetProfile);
 
         // Assert back
         Assert.Equal(4.0f, targetProfile.TshGameWindowTransitionSpeedMultiplier);
+    }
+
+    /// <summary>
+    /// Verifies that ApplyFromOptions parses TheSuperHackers section case-insensitively.
+    /// </summary>
+    [Fact]
+    public void ApplyFromOptions_CaseInsensitiveTheSuperHackersSection_LoadsProperties()
+    {
+        // Arrange
+        var options = new IniOptions();
+        options.AdditionalSections["thesuperhackers"] = new Dictionary<string, string>
+        {
+            ["gamewindowtransitionspeedmultiplier"] = "1.5",
+            ["archivereplays"] = "yes",
+            ["systemtimefontsize"] = "18",
+        };
+        var profile = new GameProfile();
+
+        // Act
+        GameSettingsMapper.ApplyFromOptions(options, profile);
+
+        // Assert
+        Assert.Equal(1.5f, profile.TshGameWindowTransitionSpeedMultiplier);
+        Assert.True(profile.TshArchiveReplays);
+        Assert.Equal(18, profile.TshSystemTimeFontSize);
     }
 
     /// <summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Helpers/GameSettingsMapperTests.cs
@@ -13,6 +13,8 @@ public class GameSettingsMapperTests
 {
     /// <summary>
     /// Verifies that all texture quality levels map to the correct engine values.
+    /// Note: In the retail engine, both High and VeryHigh map to TextureReduction 0 (no reduction).
+    /// VeryHigh exists in GenHub's enum to support modern renderers/mods, but Options.ini uses 0 for both.
     /// </summary>
     /// <param name="quality">The texture quality level.</param>
     /// <param name="expectedReduction">The expected texture reduction value in Options.ini.</param>
@@ -528,5 +530,36 @@ public class GameSettingsMapperTests
         Assert.Equal(1920, target.VideoResolutionWidth);
         Assert.Equal(1080, target.VideoResolutionHeight);
         Assert.Equal(2.5f, target.TshGameWindowTransitionSpeedMultiplier);
+    }
+
+    /// <summary>
+    /// Verifies that GameSettingsMapper uses InvariantCulture when formatting numeric values.
+    /// </summary>
+    [Fact]
+    public void ApplyToOptions_NumericFormatting_UsesInvariantCulture()
+    {
+        var currentCulture = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            // Use German culture where comma is the decimal separator
+            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
+
+            var profile = new GameProfile
+            {
+                TshGameWindowTransitionSpeedMultiplier = 2.5f,
+                TshSystemTimeFontSize = 14,
+            };
+            var options = new IniOptions();
+
+            GameSettingsMapper.ApplyToOptions(profile, options);
+
+            var tsh = options.AdditionalSections["TheSuperHackers"];
+            Assert.Equal("2.5", tsh["GameWindowTransitionSpeedMultiplier"]);
+            Assert.Equal("14", tsh["SystemTimeFontSize"]);
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = currentCulture;
+        }
     }
 }

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
+using GenHub.Core.Extensions;
 using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameProfiles;
@@ -431,6 +432,25 @@ public class GameProfileManager(
             else
             {
                 logger.LogDebug("No existing Options.ini found for {GameType}, profile {ProfileName} will use defaults", gameType, profile.Name);
+            }
+
+            // If this is a GeneralsOnline profile, also inherit existing settings.json settings
+            if (profile.IsGeneralsOnlineProfile())
+            {
+                try
+                {
+                    logger.LogDebug("Loading existing GeneralsOnline settings.json to populate new profile {ProfileName}", profile.Name);
+                    var goLoadResult = await gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+                    if (goLoadResult.Success && goLoadResult.Data != null)
+                    {
+                        GameSettingsMapper.ApplyFromGeneralsOnlineSettings(goLoadResult.Data, profile);
+                        logger.LogInformation("Populated profile {ProfileName} with existing GeneralsOnline settings", profile.Name);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to load existing GeneralsOnline settings for profile {ProfileName}", profile.Name);
+                }
             }
         }
         catch (Exception ex)

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -437,19 +437,12 @@ public class GameProfileManager(
             // If this is a GeneralsOnline profile, also inherit existing settings.json settings
             if (profile.IsGeneralsOnlineProfile())
             {
-                try
+                logger.LogDebug("Loading existing GeneralsOnline settings.json to populate new profile {ProfileName}", profile.Name);
+                var goLoadResult = await gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+                if (goLoadResult.Success && goLoadResult.Data != null)
                 {
-                    logger.LogDebug("Loading existing GeneralsOnline settings.json to populate new profile {ProfileName}", profile.Name);
-                    var goLoadResult = await gameSettingsService.LoadGeneralsOnlineSettingsAsync();
-                    if (goLoadResult.Success && goLoadResult.Data != null)
-                    {
-                        GameSettingsMapper.ApplyFromGeneralsOnlineSettings(goLoadResult.Data, profile);
-                        logger.LogInformation("Populated profile {ProfileName} with existing GeneralsOnline settings", profile.Name);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "Failed to load existing GeneralsOnline settings for profile {ProfileName}", profile.Name);
+                    GameSettingsMapper.ApplyFromGeneralsOnlineSettings(goLoadResult.Data, profile);
+                    logger.LogInformation("Populated profile {ProfileName} with existing GeneralsOnline settings", profile.Name);
                 }
             }
         }

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -145,7 +145,7 @@ public class GameProfileManager(
 
                 // Load existing Options.ini settings only if they weren't explicitly provided in the request
                 // This ensures we still have a baseline for unset fields but respect wizard selections.
-                await LoadExistingSettingsIntoProfileAsync(profile, gameClient.GameType);
+                await LoadExistingSettingsIntoProfileAsync(profile, gameClient.GameType, cancellationToken);
 
                 // Re-apply request settings over the loaded ones (in case LoadExistingSettingsIntoProfileAsync overwrote them)
                 GameSettingsMapper.PatchGameProfile(profile, request);
@@ -413,7 +413,10 @@ public class GameProfileManager(
     /// Loads existing Options.ini settings and populates the profile with them.
     /// This ensures new profiles inherit existing game settings.
     /// </summary>
-    private async Task LoadExistingSettingsIntoProfileAsync(GameProfile profile, Core.Models.Enums.GameType gameType)
+    private async Task LoadExistingSettingsIntoProfileAsync(
+        GameProfile profile,
+        Core.Models.Enums.GameType gameType,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -438,7 +441,7 @@ public class GameProfileManager(
             if (profile.IsGeneralsOnlineProfile())
             {
                 logger.LogDebug("Loading existing GeneralsOnline settings.json to populate new profile {ProfileName}", profile.Name);
-                var goLoadResult = await gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+                var goLoadResult = await gameSettingsService.LoadGeneralsOnlineSettingsAsync(cancellationToken);
                 if (goLoadResult.Success && goLoadResult.Data != null)
                 {
                     GameSettingsMapper.ApplyFromGeneralsOnlineSettings(goLoadResult.Data, profile);

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
@@ -69,12 +69,7 @@ public partial class GameProfileSettingsViewModel
 
             GameSettingsViewModel.ColorValue = ColorValue;
 
-            if (SelectedGameInstallation != null)
-            {
-                GameSettingsViewModel.SelectedGameType = SelectedGameInstallation.GameType;
-            }
-
-            await GameSettingsViewModel.InitializeForProfileAsync(null, null);
+            await GameSettingsViewModel.InitializeForProfileAsync(null, null, SelectedGameInstallation?.GameType);
 
             StatusMessage = $"Found {AvailableGameInstallations.Count} installations and {AvailableContent.Count} content items";
         }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Initialization.cs
@@ -69,39 +69,12 @@ public partial class GameProfileSettingsViewModel
 
             GameSettingsViewModel.ColorValue = ColorValue;
 
-            if (_gameSettingsService != null)
-            {
-                try
-                {
-                    var existingGoSettings = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
-                    if (existingGoSettings.Success && existingGoSettings.Data != null)
-                    {
-                        _logger?.LogInformation("Pre-loading existing GeneralsOnline settings for new profile");
-                        var data = existingGoSettings.Data;
-                        var tempProfile = new GameProfile { Id = "temp_new" };
-                        GameSettingsMapper.ApplyFromGeneralsOnlineSettings(data, tempProfile);
-                        await GameSettingsViewModel.InitializeForProfileAsync(null, tempProfile);
-                    }
-                    else
-                    {
-                        await GameSettingsViewModel.InitializeForProfileAsync(null, null);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger?.LogWarning(ex, "Failed to pre-load existing settings for new profile, using defaults");
-                    await GameSettingsViewModel.InitializeForProfileAsync(null, null);
-                }
-            }
-            else
-            {
-                await GameSettingsViewModel.InitializeForProfileAsync(null, null);
-            }
-
             if (SelectedGameInstallation != null)
             {
                 GameSettingsViewModel.SelectedGameType = SelectedGameInstallation.GameType;
             }
+
+            await GameSettingsViewModel.InitializeForProfileAsync(null, null);
 
             StatusMessage = $"Found {AvailableGameInstallations.Count} installations and {AvailableContent.Count} content items";
         }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -222,6 +222,21 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         };
     }
 
+    /// <summary>
+    /// Updates the hotswap state for a sequence of content display items.
+    /// </summary>
+    /// <param name="items">The items to update.</param>
+    /// <param name="hotswapMode">Whether hotswap mode is currently active.</param>
+    private static void UpdateContentItemsHotswapState(IEnumerable<ContentDisplayItem> items, bool hotswapMode)
+    {
+        foreach (var item in items)
+        {
+            var (isLocked, canToggle) = GetItemHotswapState(hotswapMode, item.ContentType, item.Manifest);
+            item.IsLocked = isLocked;
+            item.CanToggle = canToggle;
+        }
+    }
+
     private ContentDisplayItem ConvertToViewModelContentDisplayItem(Core.Models.Content.ContentDisplayItem coreItem)
     {
         var (isLocked, canToggle) = GetItemHotswapState(IsHotswapMode, coreItem.ContentType, coreItem.Manifest);
@@ -250,19 +265,8 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
     private void UpdateAllItemsHotswapState()
     {
         var hotswapMode = IsHotswapMode;
-        foreach (var item in EnabledContent)
-        {
-            var (isLocked, canToggle) = GetItemHotswapState(hotswapMode, item.ContentType, item.Manifest);
-            item.IsLocked = isLocked;
-            item.CanToggle = canToggle;
-        }
-
-        foreach (var item in AvailableContent)
-        {
-            var (isLocked, canToggle) = GetItemHotswapState(hotswapMode, item.ContentType, item.Manifest);
-            item.IsLocked = isLocked;
-            item.CanToggle = canToggle;
-        }
+        UpdateContentItemsHotswapState(EnabledContent, hotswapMode);
+        UpdateContentItemsHotswapState(AvailableContent, hotswapMode);
 
         foreach (var item in AvailableGameInstallations)
         {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -636,10 +636,7 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
             _logger?.LogInformation("Auto-synced GameTypeFilter to {GameType} based on SelectedGameInstallation", value.GameType);
         }
 
-        if (GameSettingsViewModel.SelectedGameType != value.GameType)
-        {
-            GameSettingsViewModel.SelectedGameType = value.GameType;
-        }
+        GameSettingsViewModel.SelectedGameType = value.GameType;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2325:Methods and properties that don't access instance data should be static", Justification = "Mutates SelectedGameInstallation and instance collections in partial view model")]

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -636,7 +636,10 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
             _logger?.LogInformation("Auto-synced GameTypeFilter to {GameType} based on SelectedGameInstallation", value.GameType);
         }
 
-        GameSettingsViewModel.SelectedGameType = value.GameType;
+        if (!IsInitializing && GameSettingsViewModel.SelectedGameType != value.GameType)
+        {
+            GameSettingsViewModel.SelectedGameType = value.GameType;
+        }
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2325:Methods and properties that don't access instance data should be static", Justification = "Mutates SelectedGameInstallation and instance collections in partial view model")]

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -272,7 +272,6 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
     }
 
     private readonly IGameProfileManager? _gameProfileManager;
-    private readonly IGameSettingsService? _gameSettingsService;
     private readonly IConfigurationProviderService? _configurationProvider;
     private readonly IProfileContentLoader? _profileContentLoader;
     private readonly Services.ProfileResourceService? _profileResourceService;
@@ -348,7 +347,6 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         ILaunchRegistry? launchRegistry = null)
     {
         _gameProfileManager = gameProfileManager;
-        _gameSettingsService = gameSettingsService;
         _configurationProvider = configurationProvider;
         _profileContentLoader = profileContentLoader;
         _profileResourceService = profileResourceService;
@@ -636,6 +634,11 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         {
             GameTypeFilter = value.GameType;
             _logger?.LogInformation("Auto-synced GameTypeFilter to {GameType} based on SelectedGameInstallation", value.GameType);
+        }
+
+        if (GameSettingsViewModel.SelectedGameType != value.GameType)
+        {
+            GameSettingsViewModel.SelectedGameType = value.GameType;
         }
     }
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -435,81 +435,13 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             _currentProfileIsGeneralsOnline = profile?.IsGeneralsOnlineProfile() == true;
             _generalsOnlineSettingsSeeded = false;
 
-            // Auto-select game type from profile
-            if (profile != null)
+            if (!ResolveInitialGameType(profile, initialGameType, profileId))
             {
-                if (profile.IsToolProfile)
-                {
-                    StatusMessage = ProfileValidationConstants.ToolProfileSettingsNotApplicable;
-                    _logger.LogInformation("Skipping settings load for Tool profile {ProfileId}", profileId);
-                    return;
-                }
-
-                if ((profile.GameClient?.GameType ?? GameType.Unknown) == GameType.Unknown)
-                {
-                    _logger.LogWarning("Cannot initialize settings for profile {Id} with Unknown game type", profile.Id);
-                    SelectedGameType = GameType.Unknown;
-                    StatusMessage = "Profile has an unknown game type. Settings cannot be loaded.";
-                    return;
-                }
-
-                SelectedGameType = profile.GameClient?.GameType ?? GameType.Unknown;
-                _logger.LogInformation(
-                    "Auto-selected game type {GameType} for profile {ProfileId}",
-                    SelectedGameType,
-                    profileId);
-            }
-            else if (initialGameType.HasValue && initialGameType.Value != GameType.Unknown)
-            {
-                SelectedGameType = initialGameType.Value;
-                _logger.LogInformation("Using initial GameType {GameType} for new profile initialization", SelectedGameType);
-            }
-            else
-            {
-                // Ensure we log what we're doing
-                _logger.LogInformation("Using pre-selected GameType {GameType} for new profile initialization", SelectedGameType);
+                return;
             }
 
-            // Seed baseline settings and _currentOptions from Options.ini first so that
-            // options the profile does not declare show, and are saved back as, what the user
-            // configured in Options.ini rather than view model defaults, and unmanaged keys are preserved.
-            var optionsLoaded = false;
-            if (SelectedGameType != GameType.Unknown)
-            {
-                optionsLoaded = await LoadOptionsFromIniAsync(SelectedGameType);
-                if (!optionsLoaded)
-                {
-                    _currentOptions = null;
-                }
-            }
-
-            // If profile has settings, load them
-            if (profile?.HasCustomSettings() == true)
-            {
-                // Seeded from settings.json first so that the options the profile does not declare
-                // show, and are saved back as, what the user configured inside the GeneralsOnline
-                // client rather than this view model's defaults.
-                await LoadGeneralsOnlineSettingsFromClientAsync();
-                LoadSettingsFromProfile(profile);
-            }
-            else
-            {
-                // For new profiles or profiles without settings, also load GeneralsOnline settings
-                if (_gameSettingsService != null)
-                {
-                    var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
-                    if (goResult?.Success == true && goResult.Data != null)
-                    {
-                        ApplyGeneralsOnlineSettings(goResult.Data);
-                        _generalsOnlineSettingsSeeded = true;
-                    }
-                }
-
-                if (optionsLoaded)
-                {
-                    StatusMessage = "Loaded default settings from Options.ini. Save the profile to persist these settings.";
-                }
-            }
+            var optionsLoaded = await SeedBaselineOptionsAsync();
+            await SeedProfileOrDefaultsAsync(profile, optionsLoaded);
         }
         finally
         {
@@ -690,6 +622,103 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     /// Seeding them from disk is what keeps that from replacing options the profile does not declare with defaults.
     /// Populating <see cref="_currentOptions"/> also preserves unmanaged sections and properties.
     /// </remarks>
+    /// <summary>
+    /// Determines and sets the initial game type during profile initialization.
+    /// </summary>
+    /// <param name="profile">The game profile.</param>
+    /// <param name="initialGameType">The initial game type override.</param>
+    /// <param name="profileId">The profile ID.</param>
+    /// <returns><see langword="true"/> if game type resolution succeeded and initialization can continue; otherwise, <see langword="false"/>.</returns>
+    private bool ResolveInitialGameType(Core.Models.GameProfile.GameProfile? profile, GameType? initialGameType, string? profileId)
+    {
+        if (profile != null)
+        {
+            if (profile.IsToolProfile)
+            {
+                StatusMessage = ProfileValidationConstants.ToolProfileSettingsNotApplicable;
+                _logger.LogInformation("Skipping settings load for Tool profile {ProfileId}", profileId);
+                return false;
+            }
+
+            var clientGameType = profile.GameClient?.GameType ?? GameType.Unknown;
+            if (clientGameType == GameType.Unknown)
+            {
+                _logger.LogWarning("Cannot initialize settings for profile {Id} with Unknown game type", profile.Id);
+                SelectedGameType = GameType.Unknown;
+                StatusMessage = "Profile has an unknown game type. Settings cannot be loaded.";
+                return false;
+            }
+
+            SelectedGameType = clientGameType;
+            _logger.LogInformation(
+                "Auto-selected game type {GameType} for profile {ProfileId}",
+                SelectedGameType,
+                profileId);
+            return true;
+        }
+
+        if (initialGameType.HasValue && initialGameType.Value != GameType.Unknown)
+        {
+            SelectedGameType = initialGameType.Value;
+            _logger.LogInformation("Using initial GameType {GameType} for new profile initialization", SelectedGameType);
+            return true;
+        }
+
+        _logger.LogInformation("Using pre-selected GameType {GameType} for new profile initialization", SelectedGameType);
+        return true;
+    }
+
+    /// <summary>
+    /// Seeds baseline settings and current options from Options.ini.
+    /// </summary>
+    /// <returns>A task returning <see langword="true"/> if options were loaded successfully; otherwise, <see langword="false"/>.</returns>
+    private async Task<bool> SeedBaselineOptionsAsync()
+    {
+        if (SelectedGameType == GameType.Unknown)
+        {
+            return false;
+        }
+
+        var optionsLoaded = await LoadOptionsFromIniAsync(SelectedGameType);
+        if (!optionsLoaded)
+        {
+            _currentOptions = null;
+        }
+
+        return optionsLoaded;
+    }
+
+    /// <summary>
+    /// Seeds profile custom settings or default GeneralsOnline settings.
+    /// </summary>
+    /// <param name="profile">The game profile.</param>
+    /// <param name="optionsLoaded"><see langword="true"/> if Options.ini options were loaded; otherwise, <see langword="false"/>.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private async Task SeedProfileOrDefaultsAsync(Core.Models.GameProfile.GameProfile? profile, bool optionsLoaded)
+    {
+        if (profile?.HasCustomSettings() == true)
+        {
+            await LoadGeneralsOnlineSettingsFromClientAsync();
+            LoadSettingsFromProfile(profile);
+            return;
+        }
+
+        if (_gameSettingsService != null)
+        {
+            var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+            if (goResult?.Success == true && goResult.Data != null)
+            {
+                ApplyGeneralsOnlineSettings(goResult.Data);
+                _generalsOnlineSettingsSeeded = true;
+            }
+        }
+
+        if (optionsLoaded)
+        {
+            StatusMessage = "Loaded default settings from Options.ini. Save the profile to persist these settings.";
+        }
+    }
+
     private async Task<bool> LoadOptionsFromIniAsync(GameType gameType)
     {
         if (_gameSettingsService == null || gameType == GameType.Unknown)
@@ -703,6 +732,15 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             OptionsFileExists = _gameSettingsService.OptionsFileExists(gameType);
 
             var result = await _gameSettingsService.LoadOptionsAsync(gameType);
+            if (gameType != SelectedGameType)
+            {
+                _logger.LogInformation(
+                    "Discarding Options.ini load for {GameType} because SelectedGameType changed to {SelectedType}",
+                    gameType,
+                    SelectedGameType);
+                return false;
+            }
+
             if (result?.Success == true && result.Data != null)
             {
                 _currentOptions = result.Data;
@@ -720,6 +758,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         }
         catch (Exception ex)
         {
+            if (gameType != SelectedGameType)
+            {
+                return false;
+            }
+
             _currentOptions = null;
             _logger.LogError(ex, "Error loading Options.ini for {GameType}", gameType);
             StatusMessage = $"Error loading settings: {ex.Message}";
@@ -733,28 +776,33 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     [RelayCommand]
     private async Task LoadSettings()
     {
-        if (_gameSettingsService == null)
-        {
-            StatusMessage = "Game settings service not available";
-            return;
-        }
-
-        if (SelectedGameType == GameType.Unknown)
-        {
-             StatusMessage = "Cannot load settings: Game type is Unknown";
-             _logger.LogWarning("LoadSettings called with Unknown GameType");
-             return;
-        }
-
-        GameType gameType = SelectedGameType;
         try
         {
             IsLoading = true;
             _isLoadingFromOptions = true;
 
+            if (_gameSettingsService == null)
+            {
+                StatusMessage = "Game settings service not available";
+                return;
+            }
+
+            if (SelectedGameType == GameType.Unknown)
+            {
+                StatusMessage = "Cannot load settings: Game type is Unknown";
+                _logger.LogWarning("LoadSettings called with Unknown GameType");
+                return;
+            }
+
+            GameType gameType = SelectedGameType;
             StatusMessage = $"Loading {gameType} settings...";
 
             var loaded = await LoadOptionsFromIniAsync(gameType);
+            if (gameType != SelectedGameType)
+            {
+                return;
+            }
+
             if (loaded)
             {
                 StatusMessage = OptionsFileExists
@@ -764,6 +812,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
             // Load GeneralsOnline settings separately
             var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+            if (gameType != SelectedGameType)
+            {
+                return;
+            }
+
             if (goResult?.Success == true && goResult.Data != null)
             {
                 ApplyGeneralsOnlineSettings(goResult.Data);
@@ -779,7 +832,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error loading settings for {GameType}", gameType);
+            _logger.LogError(ex, "Error loading settings for {GameType}", SelectedGameType);
             StatusMessage = $"Error loading settings: {ex.Message}";
         }
         finally

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -464,6 +464,14 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                 _logger.LogInformation("Using pre-selected GameType {GameType} for new profile initialization", SelectedGameType);
             }
 
+            // Seed baseline settings and _currentOptions from Options.ini first so that
+            // options the profile does not declare show, and are saved back as, what the user
+            // configured in Options.ini rather than view model defaults, and unmanaged keys are preserved.
+            if (SelectedGameType != GameType.Unknown)
+            {
+                await LoadOptionsFromIniAsync(SelectedGameType);
+            }
+
             // If profile has settings, load them
             if (profile?.HasCustomSettings() == true)
             {
@@ -475,10 +483,17 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             }
             else
             {
-                // For new profiles or profiles without settings, load from Options.ini as defaults
-                _isLoadingFromOptions = true;
-                await LoadSettingsCommand.ExecuteAsync(null);
-                _isLoadingFromOptions = false;
+                // For new profiles or profiles without settings, also load GeneralsOnline settings
+                if (_gameSettingsService != null)
+                {
+                    var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
+                    if (goResult?.Success == true && goResult.Data != null)
+                    {
+                        ApplyGeneralsOnlineSettings(goResult.Data);
+                        _generalsOnlineSettingsSeeded = true;
+                    }
+                }
+
                 StatusMessage = "Loaded default settings from Options.ini. Save the profile to persist these settings.";
             }
         }
@@ -653,6 +668,46 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _isLoadingFromOptions;
 
     /// <summary>
+    /// Reads Options.ini for the specified game type and populates the view model and baseline options.
+    /// </summary>
+    /// <remarks>
+    /// View model properties have no unset state, so all of them are written back on save.
+    /// Seeding them from disk is what keeps that from replacing options the profile does not declare with defaults.
+    /// Populating <see cref="_currentOptions"/> also preserves unmanaged sections and properties.
+    /// </remarks>
+    private async Task LoadOptionsFromIniAsync(GameType gameType)
+    {
+        if (_gameSettingsService == null || gameType == GameType.Unknown)
+        {
+            return;
+        }
+
+        try
+        {
+            OptionsFilePath = _gameSettingsService.GetOptionsFilePath(gameType);
+            OptionsFileExists = _gameSettingsService.OptionsFileExists(gameType);
+
+            var result = await _gameSettingsService.LoadOptionsAsync(gameType);
+            if (result?.Success == true && result.Data != null)
+            {
+                _currentOptions = result.Data;
+                ApplyOptionsToViewModel(_currentOptions);
+
+                _logger.LogInformation("Loaded settings from Options.ini for {GameType}", gameType);
+            }
+            else
+            {
+                var errors = result?.Errors ?? ["LoadOptions result was null"];
+                _logger.LogWarning("Failed to load Options.ini for {GameType}: {Errors}", gameType, string.Join(", ", errors));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading Options.ini for {GameType}", gameType);
+        }
+    }
+
+    /// <summary>
     /// Loads the options.ini settings for the selected game type.
     /// </summary>
     [RelayCommand]
@@ -678,28 +733,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
             StatusMessage = $"Loading {gameType} settings...";
 
-            OptionsFilePath = _gameSettingsService.GetOptionsFilePath(gameType);
-            OptionsFileExists = _gameSettingsService.OptionsFileExists(gameType);
+            await LoadOptionsFromIniAsync(gameType);
 
-            var result = await _gameSettingsService.LoadOptionsAsync(gameType);
-
-            if (result?.Success == true && result.Data != null)
-            {
-                _currentOptions = result.Data;
-                ApplyOptionsToViewModel(_currentOptions);
-
-                StatusMessage = OptionsFileExists
-                    ? $"Loaded {gameType} settings from {Path.GetFileName(OptionsFilePath)}"
-                    : $"Using default {gameType} settings (file not found)";
-
-                _logger.LogInformation("Loaded settings for {GameType}", gameType);
-            }
-            else
-            {
-                var errors = result?.Errors ?? ["LoadOptions result was null"];
-                StatusMessage = $"Failed to load settings: {string.Join(", ", errors)}";
-                _logger.LogWarning("Failed to load settings for {GameType}: {Errors}", gameType, string.Join(", ", errors));
-            }
+            StatusMessage = OptionsFileExists
+                ? $"Loaded {gameType} settings from {Path.GetFileName(OptionsFilePath)}"
+                : $"Using default {gameType} settings (file not found)";
 
             // Load GeneralsOnline settings separately
             var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -72,27 +72,6 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         return true;
     }
 
-    private static bool TryGetCaseInsensitive(Dictionary<string, string> dict, string key, out string value)
-    {
-        if (dict.TryGetValue(key, out var val))
-        {
-            value = val;
-            return true;
-        }
-
-        foreach (var kvp in dict)
-        {
-            if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
-            {
-                value = kvp.Value;
-                return true;
-            }
-        }
-
-        value = string.Empty;
-        return false;
-    }
-
     private readonly IGameSettingsService? _gameSettingsService = gameSettingsService;
     private readonly ILogger<GameSettingsViewModel> _logger = logger;
 
@@ -1237,21 +1216,21 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyTshGameplayProperties(Dictionary<string, string> tsh)
     {
-        if (TryGetCaseInsensitive(tsh, "UseDoubleClickAttackMove", out var doubleClick))
+        if (tsh.TryGetCaseInsensitive("UseDoubleClickAttackMove", out var doubleClick))
             UseDoubleClickAttackMove = ParseBool(doubleClick);
-        if (TryGetCaseInsensitive(tsh, "ScrollFactor", out var scroll) && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
+        if (tsh.TryGetCaseInsensitive("ScrollFactor", out var scroll) && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
             ScrollFactor = scrollVal;
-        if (TryGetCaseInsensitive(tsh, "Retaliation", out var retaliation))
+        if (tsh.TryGetCaseInsensitive("Retaliation", out var retaliation))
             Retaliation = ParseBool(retaliation);
-        if (TryGetCaseInsensitive(tsh, "DynamicLOD", out var dynLOD))
+        if (tsh.TryGetCaseInsensitive("DynamicLOD", out var dynLOD))
             DynamicLOD = ParseBool(dynLOD);
-        if (TryGetCaseInsensitive(tsh, "MaxParticleCount", out var particles) && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
+        if (tsh.TryGetCaseInsensitive("MaxParticleCount", out var particles) && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
             MaxParticleCount = particleVal;
-        if (TryGetCaseInsensitive(tsh, "ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
-        if (TryGetCaseInsensitive(tsh, "ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
-        if (TryGetCaseInsensitive(tsh, "PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
-        if (TryGetCaseInsensitive(tsh, "MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
-        if (TryGetCaseInsensitive(tsh, GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
+        if (tsh.TryGetCaseInsensitive("ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
+        if (tsh.TryGetCaseInsensitive("ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
+        if (tsh.TryGetCaseInsensitive("PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
+        if (tsh.TryGetCaseInsensitive("MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
         {
             var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(gwt);
             if (parsed.HasValue)
@@ -1263,16 +1242,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyTshUiCursorProperties(Dictionary<string, string> tsh)
     {
-        if (TryGetCaseInsensitive(tsh, "SystemTimeFontSize", out var stfs) && int.TryParse(stfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
-        if (TryGetCaseInsensitive(tsh, "NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
-        if (TryGetCaseInsensitive(tsh, "RenderFpsFontSize", out var rffs) && int.TryParse(rffs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
-        if (TryGetCaseInsensitive(tsh, "ResolutionFontAdjustment", out var rfa) && int.TryParse(rfa, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
-        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInFullscreenGame", out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
-        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInFullscreenMenu", out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
-        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInWindowedGame", out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
-        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
-        if (TryGetCaseInsensitive(tsh, "ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
-        if (TryGetCaseInsensitive(tsh, "ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
+        if (tsh.TryGetCaseInsensitive("SystemTimeFontSize", out var stfs) && int.TryParse(stfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
+        if (tsh.TryGetCaseInsensitive("NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
+        if (tsh.TryGetCaseInsensitive("RenderFpsFontSize", out var rffs) && int.TryParse(rffs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
+        if (tsh.TryGetCaseInsensitive("ResolutionFontAdjustment", out var rfa) && int.TryParse(rfa, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenGame", out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenMenu", out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedGame", out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
+        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
+        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
+        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
     }
 
     private IniOptions CreateOptionsFromViewModel()

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -48,6 +48,9 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private const int MinNumSounds = GameSettingsConstants.Audio.MinNumSounds;
     private const int MaxNumSounds = GameSettingsConstants.Audio.MaxNumSounds;
 
+    private readonly IGameSettingsService? _gameSettingsService = gameSettingsService;
+    private readonly ILogger<GameSettingsViewModel> _logger = logger;
+
     private static bool ParseBool(string value) =>
         value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
         value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
@@ -72,8 +75,40 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         return true;
     }
 
-    private readonly IGameSettingsService? _gameSettingsService = gameSettingsService;
-    private readonly ILogger<GameSettingsViewModel> _logger = logger;
+    private static bool TryGetAnySetting(IniOptions options, string key, out string value)
+    {
+        if (options.Video.AdditionalProperties.TryGetValue(key, out var vVal))
+        {
+            value = vVal;
+            return true;
+        }
+
+        var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
+            string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
+        if (tshKvp.Value?.TryGetCaseInsensitive(key, out var tshVal) == true)
+        {
+            value = tshVal!;
+            return true;
+        }
+
+        if (options.Network.AdditionalProperties.TryGetValue(key, out var nVal))
+        {
+            value = nVal;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static string? GetFirstSettingValue(Dictionary<string, string>? primary, Dictionary<string, string>? fallback, string key)
+    {
+        if (primary?.TryGetCaseInsensitive(key, out var primaryVal) == true)
+            return primaryVal;
+        if (fallback?.TryGetCaseInsensitive(key, out var fallbackVal) == true)
+            return fallbackVal;
+        return null;
+    }
 
     /// <summary>
     /// Gets or sets the action triggered when the view needs to scroll to a specific section.
@@ -1324,32 +1359,6 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         SelectedResolutionPreset = ResolutionPresets.Contains(currentRes) ? currentRes : null;
     }
 
-    private static bool TryGetAnySetting(IniOptions options, string key, out string value)
-    {
-        if (options.Video.AdditionalProperties.TryGetValue(key, out var vVal))
-        {
-            value = vVal;
-            return true;
-        }
-
-        var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
-            string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
-        if (tshKvp.Value?.TryGetCaseInsensitive(key, out var tshVal) == true)
-        {
-            value = tshVal!;
-            return true;
-        }
-
-        if (options.Network.AdditionalProperties.TryGetValue(key, out var nVal))
-        {
-            value = nVal;
-            return true;
-        }
-
-        value = string.Empty;
-        return false;
-    }
-
     private void ApplyVideoAdditionalProperties(IniOptions options)
     {
         if (options.Video.AdditionalProperties.TryGetValue("GenHubParticleEffects", out var particleEffects))
@@ -1434,15 +1443,6 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                 TshGameWindowTransitionSpeedMultiplier = parsed.Value;
             }
         }
-    }
-
-    private static string? GetFirstSettingValue(Dictionary<string, string>? primary, Dictionary<string, string>? fallback, string key)
-    {
-        if (primary?.TryGetCaseInsensitive(key, out var primaryVal) == true)
-            return primaryVal;
-        if (fallback?.TryGetCaseInsensitive(key, out var fallbackVal) == true)
-            return fallbackVal;
-        return null;
     }
 
     private void ApplyTshUiCursorProperties(Dictionary<string, string> tsh)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -1324,6 +1324,32 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         SelectedResolutionPreset = ResolutionPresets.Contains(currentRes) ? currentRes : null;
     }
 
+    private bool TryGetAnySetting(IniOptions options, string key, out string value)
+    {
+        if (options.Video.AdditionalProperties.TryGetValue(key, out var vVal))
+        {
+            value = vVal;
+            return true;
+        }
+
+        var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
+            string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
+        if (tshKvp.Value != null && tshKvp.Value.TryGetCaseInsensitive(key, out var tshVal))
+        {
+            value = tshVal;
+            return true;
+        }
+
+        if (options.Network.AdditionalProperties.TryGetValue(key, out var nVal))
+        {
+            value = nVal;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
     private void ApplyVideoAdditionalProperties(IniOptions options)
     {
         if (options.Video.AdditionalProperties.TryGetValue("GenHubParticleEffects", out var particleEffects))
@@ -1341,49 +1367,71 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (options.Video.AdditionalProperties.TryGetValue("UseCloudMap", out var ucm)) UseCloudMap = ParseBool(ucm);
         if (options.Video.AdditionalProperties.TryGetValue("UseLightMap", out var ulm)) UseLightMap = ParseBool(ulm);
 
-        if (options.Video.AdditionalProperties.TryGetValue("DrawScrollAnchor", out var draws)) DrawScrollAnchor = ParseBool(draws);
-        if (options.Video.AdditionalProperties.TryGetValue("MoveScrollAnchor", out var moves)) MoveScrollAnchor = ParseBool(moves);
-        if (options.Video.AdditionalProperties.TryGetValue("GameTimeFontSize", out var gtfs) && int.TryParse(gtfs, out var gtfsVal)) GameTimeFontSize = gtfsVal;
-        if (options.Video.AdditionalProperties.TryGetValue("LanguageFilter", out var lf)) LanguageFilter = ParseBool(lf);
-        if (options.Video.AdditionalProperties.TryGetValue("SendDelay", out var sd)) SendDelay = ParseBool(sd);
-        if (options.Video.AdditionalProperties.TryGetValue("SkipEALogo", out var sel)) SkipEALogo = ParseBool(sel);
+        if (TryGetAnySetting(options, "DrawScrollAnchor", out var draws)) DrawScrollAnchor = ParseBool(draws);
+        if (TryGetAnySetting(options, "MoveScrollAnchor", out var moves)) MoveScrollAnchor = ParseBool(moves);
+        if (TryGetAnySetting(options, "GameTimeFontSize", out var gtfs) && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfsVal)) GameTimeFontSize = gtfsVal;
+        if (TryGetAnySetting(options, "LanguageFilter", out var lf)) LanguageFilter = ParseBool(lf);
+        if (TryGetAnySetting(options, "SendDelay", out var sd)) SendDelay = ParseBool(sd);
+        if (TryGetAnySetting(options, "SkipEALogo", out var sel)) SkipEALogo = ParseBool(sel);
     }
 
     private void ApplyTshAdditionalProperties(IniOptions options)
     {
         var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
             string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
-        if (tshKvp.Value == null)
-        {
-            return;
-        }
 
-        ApplyTshGameplayProperties(tshKvp.Value);
-        ApplyTshUiCursorProperties(tshKvp.Value);
+        ApplyTshGameplayProperties(tshKvp.Value, options.Video.AdditionalProperties);
+        if (tshKvp.Value != null)
+        {
+            ApplyTshUiCursorProperties(tshKvp.Value);
+        }
     }
 
-    private void ApplyTshGameplayProperties(Dictionary<string, string> tsh)
+    private void ApplyTshGameplayProperties(Dictionary<string, string>? tsh, Dictionary<string, string>? videoAdditional)
     {
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey, out var doubleClick))
-            UseDoubleClickAttackMove = ParseBool(doubleClick);
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScrollFactorKey, out var scroll) && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
-            ScrollFactor = scrollVal;
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.RetaliationKey, out var retaliation))
-            Retaliation = ParseBool(retaliation);
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.DynamicLODKey, out var dynLOD))
-            DynamicLOD = ParseBool(dynLOD);
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MaxParticleCountKey, out var particles) && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
-            MaxParticleCount = particleVal;
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ArchiveReplaysKey, out var ar)) TshArchiveReplays = ParseBool(ar);
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey, out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey, out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey, out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
-        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
+        string? GetVal(string key)
         {
-            var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(gwt);
-            if (parsed.HasValue)
+            if (tsh != null && tsh.TryGetCaseInsensitive(key, out var v))
+                return v;
+            if (videoAdditional != null && videoAdditional.TryGetCaseInsensitive(key, out var v2))
+                return v2;
+            return null;
+        }
+
+        var doubleClick = GetVal(GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey)
+            ?? GetVal(GameSettingsTheSuperHackersConstants.UseDoubleClickKey);
+        if (doubleClick != null)
+            UseDoubleClickAttackMove = ParseBool(doubleClick);
+
+        var scroll = GetVal(GameSettingsTheSuperHackersConstants.ScrollFactorKey);
+        if (scroll != null && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
+            ScrollFactor = scrollVal;
+
+        var retaliation = GetVal(GameSettingsTheSuperHackersConstants.RetaliationKey);
+        if (retaliation != null)
+            Retaliation = ParseBool(retaliation);
+
+        var dynLOD = GetVal(GameSettingsTheSuperHackersConstants.DynamicLODKey);
+        if (dynLOD != null)
+            DynamicLOD = ParseBool(dynLOD);
+
+        var particles = GetVal(GameSettingsTheSuperHackersConstants.MaxParticleCountKey);
+        if (particles != null && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
+            MaxParticleCount = particleVal;
+
+        if (tsh != null)
+        {
+            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ArchiveReplaysKey, out var ar)) TshArchiveReplays = ParseBool(ar);
+            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey, out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
+            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey, out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
+            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey, out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
+            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
             {
-                TshGameWindowTransitionSpeedMultiplier = parsed.Value;
+                var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(gwt);
+                if (parsed.HasValue)
+                {
+                    TshGameWindowTransitionSpeedMultiplier = parsed.Value;
+                }
             }
         }
     }
@@ -1472,6 +1520,28 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             tshDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             options.AdditionalSections[tshKey] = tshDict;
         }
+
+        // Synchronize settings if they already exist in tshDict to prevent desync/overwrites
+        if (tshDict.ContainsKey("GameTimeFontSize"))
+            tshDict["GameTimeFontSize"] = GameTimeFontSize.ToString(CultureInfo.InvariantCulture);
+        if (tshDict.ContainsKey("DrawScrollAnchor"))
+            tshDict["DrawScrollAnchor"] = BoolToString(DrawScrollAnchor);
+        if (tshDict.ContainsKey("MoveScrollAnchor"))
+            tshDict["MoveScrollAnchor"] = BoolToString(MoveScrollAnchor);
+        if (tshDict.ContainsKey("LanguageFilter"))
+            tshDict["LanguageFilter"] = BoolToString(LanguageFilter);
+        if (tshDict.ContainsKey("SendDelay"))
+            tshDict["SendDelay"] = BoolToString(SendDelay);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.ScrollFactorKey))
+            tshDict[GameSettingsTheSuperHackersConstants.ScrollFactorKey] = ScrollFactor.ToString(CultureInfo.InvariantCulture);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey))
+            tshDict[GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey] = BoolToString(UseDoubleClickAttackMove);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.RetaliationKey))
+            tshDict[GameSettingsTheSuperHackersConstants.RetaliationKey] = BoolToString(Retaliation);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.DynamicLODKey))
+            tshDict[GameSettingsTheSuperHackersConstants.DynamicLODKey] = BoolToString(DynamicLOD);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.MaxParticleCountKey))
+            tshDict[GameSettingsTheSuperHackersConstants.MaxParticleCountKey] = MaxParticleCount.ToString(CultureInfo.InvariantCulture);
 
         // Update only the remaining settings we know about in the ViewModel, preserve all others
         tshDict[GameSettingsTheSuperHackersConstants.ArchiveReplaysKey] = BoolToString(TshArchiveReplays);

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -696,13 +696,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                 _logger.LogInformation("Loaded settings from Options.ini for {GameType}", gameType);
                 return true;
             }
-            else
-            {
-                var errors = result?.Errors ?? ["LoadOptions result was null"];
-                StatusMessage = $"Failed to load settings: {string.Join(", ", errors)}";
-                _logger.LogWarning("Failed to load Options.ini for {GameType}: {Errors}", gameType, string.Join(", ", errors));
-                return false;
-            }
+
+            var errors = result?.Errors ?? ["LoadOptions result was null"];
+            StatusMessage = $"Failed to load settings: {string.Join(", ", errors)}";
+            _logger.LogWarning("Failed to load Options.ini for {GameType}: {Errors}", gameType, string.Join(", ", errors));
+            return false;
         }
         catch (Exception ex)
         {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -675,11 +675,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     /// Seeding them from disk is what keeps that from replacing options the profile does not declare with defaults.
     /// Populating <see cref="_currentOptions"/> also preserves unmanaged sections and properties.
     /// </remarks>
-    private async Task LoadOptionsFromIniAsync(GameType gameType)
+    private async Task<bool> LoadOptionsFromIniAsync(GameType gameType)
     {
         if (_gameSettingsService == null || gameType == GameType.Unknown)
         {
-            return;
+            return false;
         }
 
         try
@@ -694,16 +694,21 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                 ApplyOptionsToViewModel(_currentOptions);
 
                 _logger.LogInformation("Loaded settings from Options.ini for {GameType}", gameType);
+                return true;
             }
             else
             {
                 var errors = result?.Errors ?? ["LoadOptions result was null"];
+                StatusMessage = $"Failed to load settings: {string.Join(", ", errors)}";
                 _logger.LogWarning("Failed to load Options.ini for {GameType}: {Errors}", gameType, string.Join(", ", errors));
+                return false;
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error loading Options.ini for {GameType}", gameType);
+            StatusMessage = $"Error loading settings: {ex.Message}";
+            return false;
         }
     }
 
@@ -730,14 +735,17 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         try
         {
             IsLoading = true;
+            _isLoadingFromOptions = true;
 
             StatusMessage = $"Loading {gameType} settings...";
 
-            await LoadOptionsFromIniAsync(gameType);
-
-            StatusMessage = OptionsFileExists
-                ? $"Loaded {gameType} settings from {Path.GetFileName(OptionsFilePath)}"
-                : $"Using default {gameType} settings (file not found)";
+            var loaded = await LoadOptionsFromIniAsync(gameType);
+            if (loaded)
+            {
+                StatusMessage = OptionsFileExists
+                    ? $"Loaded {gameType} settings from {Path.GetFileName(OptionsFilePath)}"
+                    : $"Using default {gameType} settings (file not found)";
+            }
 
             // Load GeneralsOnline settings separately
             var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
@@ -761,6 +769,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         }
         finally
         {
+            _isLoadingFromOptions = false;
             IsLoading = false;
         }
     }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -72,6 +72,27 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         return true;
     }
 
+    private static bool TryGetCaseInsensitive(Dictionary<string, string> dict, string key, out string value)
+    {
+        if (dict.TryGetValue(key, out var val))
+        {
+            value = val;
+            return true;
+        }
+
+        foreach (var kvp in dict)
+        {
+            if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = kvp.Value;
+                return true;
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
     private readonly IGameSettingsService? _gameSettingsService = gameSettingsService;
     private readonly ILogger<GameSettingsViewModel> _logger = logger;
 
@@ -1203,32 +1224,34 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyTshAdditionalProperties(IniOptions options)
     {
-        if (!options.AdditionalSections.TryGetValue("TheSuperHackers", out var tsh))
+        var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
+            string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+        if (tshKvp.Value == null)
         {
             return;
         }
 
-        ApplyTshGameplayProperties(tsh);
-        ApplyTshUiCursorProperties(tsh);
+        ApplyTshGameplayProperties(tshKvp.Value);
+        ApplyTshUiCursorProperties(tshKvp.Value);
     }
 
     private void ApplyTshGameplayProperties(Dictionary<string, string> tsh)
     {
-        if (tsh.TryGetValue("UseDoubleClickAttackMove", out var doubleClick))
+        if (TryGetCaseInsensitive(tsh, "UseDoubleClickAttackMove", out var doubleClick))
             UseDoubleClickAttackMove = ParseBool(doubleClick);
-        if (tsh.TryGetValue("ScrollFactor", out var scroll) && int.TryParse(scroll, out var scrollVal))
+        if (TryGetCaseInsensitive(tsh, "ScrollFactor", out var scroll) && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
             ScrollFactor = scrollVal;
-        if (tsh.TryGetValue("Retaliation", out var retaliation))
+        if (TryGetCaseInsensitive(tsh, "Retaliation", out var retaliation))
             Retaliation = ParseBool(retaliation);
-        if (tsh.TryGetValue("DynamicLOD", out var dynLOD))
+        if (TryGetCaseInsensitive(tsh, "DynamicLOD", out var dynLOD))
             DynamicLOD = ParseBool(dynLOD);
-        if (tsh.TryGetValue("MaxParticleCount", out var particles) && int.TryParse(particles, out var particleVal))
+        if (TryGetCaseInsensitive(tsh, "MaxParticleCount", out var particles) && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
             MaxParticleCount = particleVal;
-        if (tsh.TryGetValue("ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
-        if (tsh.TryGetValue("ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
-        if (tsh.TryGetValue("PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
-        if (tsh.TryGetValue("MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
-        if (tsh.TryGetValue(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
+        if (TryGetCaseInsensitive(tsh, "ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
+        if (TryGetCaseInsensitive(tsh, "ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
+        if (TryGetCaseInsensitive(tsh, "PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
+        if (TryGetCaseInsensitive(tsh, "MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
+        if (TryGetCaseInsensitive(tsh, GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
         {
             var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(gwt);
             if (parsed.HasValue)
@@ -1240,16 +1263,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyTshUiCursorProperties(Dictionary<string, string> tsh)
     {
-        if (tsh.TryGetValue("SystemTimeFontSize", out var stfs) && int.TryParse(stfs, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
-        if (tsh.TryGetValue("NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
-        if (tsh.TryGetValue("RenderFpsFontSize", out var rffs) && int.TryParse(rffs, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
-        if (tsh.TryGetValue("ResolutionFontAdjustment", out var rfa) && int.TryParse(rfa, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
-        if (tsh.TryGetValue("CursorCaptureEnabledInFullscreenGame", out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
-        if (tsh.TryGetValue("CursorCaptureEnabledInFullscreenMenu", out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
-        if (tsh.TryGetValue("CursorCaptureEnabledInWindowedGame", out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
-        if (tsh.TryGetValue("CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
-        if (tsh.TryGetValue("ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
-        if (tsh.TryGetValue("ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
+        if (TryGetCaseInsensitive(tsh, "SystemTimeFontSize", out var stfs) && int.TryParse(stfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
+        if (TryGetCaseInsensitive(tsh, "NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
+        if (TryGetCaseInsensitive(tsh, "RenderFpsFontSize", out var rffs) && int.TryParse(rffs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
+        if (TryGetCaseInsensitive(tsh, "ResolutionFontAdjustment", out var rfa) && int.TryParse(rfa, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
+        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInFullscreenGame", out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
+        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInFullscreenMenu", out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
+        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInWindowedGame", out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
+        if (TryGetCaseInsensitive(tsh, "CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
+        if (TryGetCaseInsensitive(tsh, "ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
+        if (TryGetCaseInsensitive(tsh, "ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
     }
 
     private IniOptions CreateOptionsFromViewModel()
@@ -1314,10 +1337,13 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         options.Network.GameSpyIPAddress = GameSpyIPAddress;
 
         // TheSuperHackers settings - preserve existing settings, only update the ones we manage
-        if (!options.AdditionalSections.TryGetValue("TheSuperHackers", out var tshDict))
+        var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k =>
+            string.Equals(k, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)) ?? "TheSuperHackers";
+
+        if (!options.AdditionalSections.TryGetValue(tshKey, out var tshDict) || tshDict == null)
         {
-            tshDict = [];
-            options.AdditionalSections["TheSuperHackers"] = tshDict;
+            tshDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            options.AdditionalSections[tshKey] = tshDict;
         }
 
         // Update only the remaining settings we know about in the ViewModel, preserve all others

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -422,8 +422,9 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     /// </summary>
     /// <param name="profileId">The profile ID to load settings for.</param>
     /// <param name="profile">The game profile with settings.</param>
+    /// <param name="initialGameType">The initial game type to select when creating a new profile.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public async Task InitializeForProfileAsync(string? profileId, Core.Models.GameProfile.GameProfile? profile = null)
+    public async Task InitializeForProfileAsync(string? profileId, Core.Models.GameProfile.GameProfile? profile = null, GameType? initialGameType = null)
     {
         _initializationDepth++;
         IsLoading = true;  // Provide UI feedback for loading state
@@ -458,6 +459,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                     SelectedGameType,
                     profileId);
             }
+            else if (initialGameType.HasValue && initialGameType.Value != GameType.Unknown)
+            {
+                SelectedGameType = initialGameType.Value;
+                _logger.LogInformation("Using initial GameType {GameType} for new profile initialization", SelectedGameType);
+            }
             else
             {
                 // Ensure we log what we're doing
@@ -467,9 +473,14 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             // Seed baseline settings and _currentOptions from Options.ini first so that
             // options the profile does not declare show, and are saved back as, what the user
             // configured in Options.ini rather than view model defaults, and unmanaged keys are preserved.
+            var optionsLoaded = false;
             if (SelectedGameType != GameType.Unknown)
             {
-                await LoadOptionsFromIniAsync(SelectedGameType);
+                optionsLoaded = await LoadOptionsFromIniAsync(SelectedGameType);
+                if (!optionsLoaded)
+                {
+                    _currentOptions = null;
+                }
             }
 
             // If profile has settings, load them
@@ -494,7 +505,10 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
                     }
                 }
 
-                StatusMessage = "Loaded default settings from Options.ini. Save the profile to persist these settings.";
+                if (optionsLoaded)
+                {
+                    StatusMessage = "Loaded default settings from Options.ini. Save the profile to persist these settings.";
+                }
             }
         }
         finally
@@ -665,7 +679,8 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private bool _currentProfileIsGeneralsOnline;
     private string? _currentProfileId;
     private int _initializationDepth;
-    private bool _isLoadingFromOptions;
+    private volatile bool _isLoadingFromOptions;
+    private GameType? _pendingGameTypeLoad;
 
     /// <summary>
     /// Reads Options.ini for the specified game type and populates the view model and baseline options.
@@ -698,12 +713,14 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             }
 
             var errors = result?.Errors ?? ["LoadOptions result was null"];
+            _currentOptions = null;
             StatusMessage = $"Failed to load settings: {string.Join(", ", errors)}";
             _logger.LogWarning("Failed to load Options.ini for {GameType}: {Errors}", gameType, string.Join(", ", errors));
             return false;
         }
         catch (Exception ex)
         {
+            _currentOptions = null;
             _logger.LogError(ex, "Error loading Options.ini for {GameType}", gameType);
             StatusMessage = $"Error loading settings: {ex.Message}";
             return false;
@@ -769,6 +786,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         {
             _isLoadingFromOptions = false;
             IsLoading = false;
+            CheckAndDispatchPendingGameTypeLoad();
         }
     }
 
@@ -971,6 +989,13 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             return;
         }
 
+        if (OptionsFileExists && _currentOptions == null)
+        {
+            StatusMessage = "Cannot save settings: Options.ini could not be loaded and saving would overwrite existing unmanaged settings.";
+            _logger.LogWarning("Aborting SaveSettings for {GameType} because Options.ini exists but _currentOptions is null", SelectedGameType);
+            return;
+        }
+
         try
         {
             IsLoading = true;
@@ -1147,29 +1172,54 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     partial void OnSelectedGameTypeChanged(GameType value)
     {
-        if (_initializationDepth == 0 && !_isLoadingFromOptions)
-        {
-            _logger.LogInformation("GameType changed to {GameType} - loading from Options.ini", value);
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    await LoadSettingsCommand.ExecuteAsync(null);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Failed to load settings for {GameType}", value);
-                    StatusMessage = $"Error loading settings: {ex.Message}";
-                }
-            });
-        }
-        else if (_isLoadingFromOptions)
-        {
-            _logger.LogInformation("GameType changed to {GameType} while loading from Options.ini - skipping auto-load", value);
-        }
-        else
+        if (_initializationDepth > 0)
         {
             _logger.LogInformation("GameType set to {GameType} during initialization - skipping auto-load", value);
+            return;
+        }
+
+        if (_isLoadingFromOptions)
+        {
+            _pendingGameTypeLoad = value;
+            _logger.LogInformation("GameType changed to {GameType} while loading from Options.ini - scheduled pending reload", value);
+            return;
+        }
+
+        TriggerAutoLoadSettings(value);
+    }
+
+    private void TriggerAutoLoadSettings(GameType value)
+    {
+        _logger.LogInformation("GameType changed to {GameType} - loading from Options.ini", value);
+        _isLoadingFromOptions = true;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await LoadSettingsCommand.ExecuteAsync(null);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load settings for {GameType}", value);
+                StatusMessage = $"Error loading settings: {ex.Message}";
+            }
+        });
+    }
+
+    private void CheckAndDispatchPendingGameTypeLoad()
+    {
+        if (_pendingGameTypeLoad.HasValue)
+        {
+            var pending = _pendingGameTypeLoad.Value;
+            _pendingGameTypeLoad = null;
+            if (pending != SelectedGameType)
+            {
+                SelectedGameType = pending;
+            }
+            else
+            {
+                TriggerAutoLoadSettings(pending);
+            }
         }
     }
 
@@ -1339,13 +1389,13 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
         // TSH settings (writing to root for maximum compatibility as some clients prefer flat Options.ini)
         options.Video.AdditionalProperties["UseDoubleClickAttackMove"] = BoolToString(UseDoubleClickAttackMove);
-        options.Video.AdditionalProperties["ScrollFactor"] = ScrollFactor.ToString();
+        options.Video.AdditionalProperties["ScrollFactor"] = ScrollFactor.ToString(CultureInfo.InvariantCulture);
         options.Video.AdditionalProperties["Retaliation"] = BoolToString(Retaliation);
         options.Video.AdditionalProperties["DynamicLOD"] = BoolToString(DynamicLOD);
-        options.Video.AdditionalProperties["MaxParticleCount"] = MaxParticleCount.ToString();
+        options.Video.AdditionalProperties["MaxParticleCount"] = MaxParticleCount.ToString(CultureInfo.InvariantCulture);
         options.Video.AdditionalProperties["DrawScrollAnchor"] = BoolToString(DrawScrollAnchor);
         options.Video.AdditionalProperties["MoveScrollAnchor"] = BoolToString(MoveScrollAnchor);
-        options.Video.AdditionalProperties["GameTimeFontSize"] = GameTimeFontSize.ToString();
+        options.Video.AdditionalProperties["GameTimeFontSize"] = GameTimeFontSize.ToString(CultureInfo.InvariantCulture);
         options.Video.AdditionalProperties["LanguageFilter"] = BoolToString(LanguageFilter);
         options.Video.AdditionalProperties["SendDelay"] = BoolToString(SendDelay);
 
@@ -1374,17 +1424,17 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         tshDict[GameSettingsTheSuperHackersConstants.ArchiveReplaysKey] = BoolToString(TshArchiveReplays);
         tshDict[GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey] = BoolToString(TshShowMoneyPerMinute);
         tshDict[GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey] = BoolToString(TshPlayerObserverEnabled);
-        tshDict[GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = TshSystemTimeFontSize.ToString();
-        tshDict[GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = TshNetworkLatencyFontSize.ToString();
-        tshDict[GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = TshRenderFpsFontSize.ToString();
-        tshDict[GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = TshResolutionFontAdjustment.ToString();
+        tshDict[GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = TshSystemTimeFontSize.ToString(CultureInfo.InvariantCulture);
+        tshDict[GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = TshNetworkLatencyFontSize.ToString(CultureInfo.InvariantCulture);
+        tshDict[GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = TshRenderFpsFontSize.ToString(CultureInfo.InvariantCulture);
+        tshDict[GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = TshResolutionFontAdjustment.ToString(CultureInfo.InvariantCulture);
         tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey] = BoolToString(TshCursorCaptureEnabledInFullscreenGame);
         tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey] = BoolToString(TshCursorCaptureEnabledInFullscreenMenu);
         tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey] = BoolToString(TshCursorCaptureEnabledInWindowedGame);
         tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey] = BoolToString(TshCursorCaptureEnabledInWindowedMenu);
         tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey] = BoolToString(TshScreenEdgeScrollEnabledInFullscreenApp);
         tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey] = BoolToString(TshScreenEdgeScrollEnabledInWindowedApp);
-        tshDict[GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = TshMoneyTransactionVolume.ToString();
+        tshDict[GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = TshMoneyTransactionVolume.ToString(CultureInfo.InvariantCulture);
         tshDict[GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = (GameSettingsMapper.NormalizeTransitionSpeedMultiplier(TshGameWindowTransitionSpeedMultiplier) ?? GameSettingsTheSuperHackersConstants.DefaultGameWindowTransitionSpeedMultiplier).ToString(CultureInfo.InvariantCulture);
 
         return options;

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -1204,7 +1204,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private void ApplyTshAdditionalProperties(IniOptions options)
     {
         var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
-            string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+            string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
         if (tshKvp.Value == null)
         {
             return;
@@ -1216,20 +1216,20 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyTshGameplayProperties(Dictionary<string, string> tsh)
     {
-        if (tsh.TryGetCaseInsensitive("UseDoubleClickAttackMove", out var doubleClick))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey, out var doubleClick))
             UseDoubleClickAttackMove = ParseBool(doubleClick);
-        if (tsh.TryGetCaseInsensitive("ScrollFactor", out var scroll) && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScrollFactorKey, out var scroll) && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
             ScrollFactor = scrollVal;
-        if (tsh.TryGetCaseInsensitive("Retaliation", out var retaliation))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.RetaliationKey, out var retaliation))
             Retaliation = ParseBool(retaliation);
-        if (tsh.TryGetCaseInsensitive("DynamicLOD", out var dynLOD))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.DynamicLODKey, out var dynLOD))
             DynamicLOD = ParseBool(dynLOD);
-        if (tsh.TryGetCaseInsensitive("MaxParticleCount", out var particles) && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MaxParticleCountKey, out var particles) && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
             MaxParticleCount = particleVal;
-        if (tsh.TryGetCaseInsensitive("ArchiveReplays", out var ar)) TshArchiveReplays = ParseBool(ar);
-        if (tsh.TryGetCaseInsensitive("ShowMoneyPerMinute", out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
-        if (tsh.TryGetCaseInsensitive("PlayerObserverEnabled", out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
-        if (tsh.TryGetCaseInsensitive("MoneyTransactionVolume", out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ArchiveReplaysKey, out var ar)) TshArchiveReplays = ParseBool(ar);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey, out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey, out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey, out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
         if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
         {
             var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(gwt);
@@ -1242,16 +1242,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyTshUiCursorProperties(Dictionary<string, string> tsh)
     {
-        if (tsh.TryGetCaseInsensitive("SystemTimeFontSize", out var stfs) && int.TryParse(stfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
-        if (tsh.TryGetCaseInsensitive("NetworkLatencyFontSize", out var nlfs) && int.TryParse(nlfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
-        if (tsh.TryGetCaseInsensitive("RenderFpsFontSize", out var rffs) && int.TryParse(rffs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
-        if (tsh.TryGetCaseInsensitive("ResolutionFontAdjustment", out var rfa) && int.TryParse(rfa, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenGame", out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenMenu", out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedGame", out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
-        if (tsh.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedMenu", out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
-        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInFullscreenApp", out var sesefa)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(sesefa);
-        if (tsh.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInWindowedApp", out var sesewa)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(sesewa);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey, out var stfs) && int.TryParse(stfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stfsVal)) TshSystemTimeFontSize = stfsVal;
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey, out var nlfs) && int.TryParse(nlfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlfsVal)) TshNetworkLatencyFontSize = nlfsVal;
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey, out var rffs) && int.TryParse(rffs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rffsVal)) TshRenderFpsFontSize = rffsVal;
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey, out var rfa) && int.TryParse(rfa, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfaVal)) TshResolutionFontAdjustment = rfaVal;
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey, out var ccefg)) TshCursorCaptureEnabledInFullscreenGame = ParseBool(ccefg);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey, out var ccefm)) TshCursorCaptureEnabledInFullscreenMenu = ParseBool(ccefm);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey, out var ccewg)) TshCursorCaptureEnabledInWindowedGame = ParseBool(ccewg);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey, out var ccewm)) TshCursorCaptureEnabledInWindowedMenu = ParseBool(ccewm);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey, out var scrollApp)) TshScreenEdgeScrollEnabledInFullscreenApp = ParseBool(scrollApp);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey, out var scrollWinApp)) TshScreenEdgeScrollEnabledInWindowedApp = ParseBool(scrollWinApp);
     }
 
     private IniOptions CreateOptionsFromViewModel()
@@ -1317,7 +1317,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
         // TheSuperHackers settings - preserve existing settings, only update the ones we manage
         var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k =>
-            string.Equals(k, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)) ?? "TheSuperHackers";
+            string.Equals(k, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase)) ?? GameSettingsTheSuperHackersConstants.SectionName;
 
         if (!options.AdditionalSections.TryGetValue(tshKey, out var tshDict) || tshDict == null)
         {
@@ -1326,20 +1326,20 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         }
 
         // Update only the remaining settings we know about in the ViewModel, preserve all others
-        tshDict["ArchiveReplays"] = BoolToString(TshArchiveReplays);
-        tshDict["ShowMoneyPerMinute"] = BoolToString(TshShowMoneyPerMinute);
-        tshDict["PlayerObserverEnabled"] = BoolToString(TshPlayerObserverEnabled);
-        tshDict["SystemTimeFontSize"] = TshSystemTimeFontSize.ToString();
-        tshDict["NetworkLatencyFontSize"] = TshNetworkLatencyFontSize.ToString();
-        tshDict["RenderFpsFontSize"] = TshRenderFpsFontSize.ToString();
-        tshDict["ResolutionFontAdjustment"] = TshResolutionFontAdjustment.ToString();
-        tshDict["CursorCaptureEnabledInFullscreenGame"] = BoolToString(TshCursorCaptureEnabledInFullscreenGame);
-        tshDict["CursorCaptureEnabledInFullscreenMenu"] = BoolToString(TshCursorCaptureEnabledInFullscreenMenu);
-        tshDict["CursorCaptureEnabledInWindowedGame"] = BoolToString(TshCursorCaptureEnabledInWindowedGame);
-        tshDict["CursorCaptureEnabledInWindowedMenu"] = BoolToString(TshCursorCaptureEnabledInWindowedMenu);
-        tshDict["ScreenEdgeScrollEnabledInFullscreenApp"] = BoolToString(TshScreenEdgeScrollEnabledInFullscreenApp);
-        tshDict["ScreenEdgeScrollEnabledInWindowedApp"] = BoolToString(TshScreenEdgeScrollEnabledInWindowedApp);
-        tshDict["MoneyTransactionVolume"] = TshMoneyTransactionVolume.ToString();
+        tshDict[GameSettingsTheSuperHackersConstants.ArchiveReplaysKey] = BoolToString(TshArchiveReplays);
+        tshDict[GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey] = BoolToString(TshShowMoneyPerMinute);
+        tshDict[GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey] = BoolToString(TshPlayerObserverEnabled);
+        tshDict[GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = TshSystemTimeFontSize.ToString();
+        tshDict[GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = TshNetworkLatencyFontSize.ToString();
+        tshDict[GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = TshRenderFpsFontSize.ToString();
+        tshDict[GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = TshResolutionFontAdjustment.ToString();
+        tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey] = BoolToString(TshCursorCaptureEnabledInFullscreenGame);
+        tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey] = BoolToString(TshCursorCaptureEnabledInFullscreenMenu);
+        tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey] = BoolToString(TshCursorCaptureEnabledInWindowedGame);
+        tshDict[GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey] = BoolToString(TshCursorCaptureEnabledInWindowedMenu);
+        tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey] = BoolToString(TshScreenEdgeScrollEnabledInFullscreenApp);
+        tshDict[GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey] = BoolToString(TshScreenEdgeScrollEnabledInWindowedApp);
+        tshDict[GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = TshMoneyTransactionVolume.ToString();
         tshDict[GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = (GameSettingsMapper.NormalizeTransitionSpeedMultiplier(TshGameWindowTransitionSpeedMultiplier) ?? GameSettingsTheSuperHackersConstants.DefaultGameWindowTransitionSpeedMultiplier).ToString(CultureInfo.InvariantCulture);
 
         return options;

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -615,14 +615,6 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
     private GameType? _pendingGameTypeLoad;
 
     /// <summary>
-    /// Reads Options.ini for the specified game type and populates the view model and baseline options.
-    /// </summary>
-    /// <remarks>
-    /// View model properties have no unset state, so all of them are written back on save.
-    /// Seeding them from disk is what keeps that from replacing options the profile does not declare with defaults.
-    /// Populating <see cref="_currentOptions"/> also preserves unmanaged sections and properties.
-    /// </remarks>
-    /// <summary>
     /// Determines and sets the initial game type during profile initialization.
     /// </summary>
     /// <param name="profile">The game profile.</param>
@@ -719,6 +711,14 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         }
     }
 
+    /// <summary>
+    /// Reads Options.ini for the specified game type and populates the view model and baseline options.
+    /// </summary>
+    /// <remarks>
+    /// View model properties have no unset state, so all of them are written back on save.
+    /// Seeding them from disk is what keeps that from replacing options the profile does not declare with defaults.
+    /// Populating <see cref="_currentOptions"/> also preserves unmanaged sections and properties.
+    /// </remarks>
     private async Task<bool> LoadOptionsFromIniAsync(GameType gameType)
     {
         if (_gameSettingsService == null || gameType == GameType.Unknown)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -75,30 +75,26 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         return true;
     }
 
-    private static bool TryGetAnySetting(IniOptions options, string key, out string value)
+    private static string? GetAnySettingValue(IniOptions options, string key)
     {
         if (options.Video.AdditionalProperties.TryGetValue(key, out var vVal))
         {
-            value = vVal;
-            return true;
+            return vVal;
         }
 
         var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
             string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
         if (tshKvp.Value?.TryGetCaseInsensitive(key, out var tshVal) == true)
         {
-            value = tshVal!;
-            return true;
+            return tshVal;
         }
 
         if (options.Network.AdditionalProperties.TryGetValue(key, out var nVal))
         {
-            value = nVal;
-            return true;
+            return nVal;
         }
 
-        value = string.Empty;
-        return false;
+        return null;
     }
 
     private static string? GetFirstSettingValue(Dictionary<string, string>? primary, Dictionary<string, string>? fallback, string key)
@@ -730,7 +726,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
             return;
         }
 
-        if (_gameSettingsService != null)
+        if (_gameSettingsService != null && _currentProfileIsGeneralsOnline)
         {
             var goResult = await _gameSettingsService.LoadGeneralsOnlineSettingsAsync();
             if (goResult?.Success == true && goResult.Data != null)
@@ -1376,12 +1372,12 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (options.Video.AdditionalProperties.TryGetValue("UseCloudMap", out var ucm)) UseCloudMap = ParseBool(ucm);
         if (options.Video.AdditionalProperties.TryGetValue("UseLightMap", out var ulm)) UseLightMap = ParseBool(ulm);
 
-        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey, out var draws)) DrawScrollAnchor = ParseBool(draws);
-        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey, out var moves)) MoveScrollAnchor = ParseBool(moves);
-        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey, out var gtfs) && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfsVal)) GameTimeFontSize = gtfsVal;
-        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.LanguageFilterKey, out var lf)) LanguageFilter = ParseBool(lf);
-        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.SendDelayKey, out var sd)) SendDelay = ParseBool(sd);
-        if (TryGetAnySetting(options, "SkipEALogo", out var sel)) SkipEALogo = ParseBool(sel);
+        if (GetAnySettingValue(options, GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey) is { } draws) DrawScrollAnchor = ParseBool(draws);
+        if (GetAnySettingValue(options, GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey) is { } moves) MoveScrollAnchor = ParseBool(moves);
+        if (GetAnySettingValue(options, GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey) is { } gtfs && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfsVal)) GameTimeFontSize = gtfsVal;
+        if (GetAnySettingValue(options, GameSettingsTheSuperHackersConstants.LanguageFilterKey) is { } lf) LanguageFilter = ParseBool(lf);
+        if (GetAnySettingValue(options, GameSettingsTheSuperHackersConstants.SendDelayKey) is { } sd) SendDelay = ParseBool(sd);
+        if (GetAnySettingValue(options, "SkipEALogo") is { } sel) SkipEALogo = ParseBool(sel);
     }
 
     private void ApplyTshAdditionalProperties(IniOptions options)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameSettingsViewModel.cs
@@ -1324,7 +1324,7 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         SelectedResolutionPreset = ResolutionPresets.Contains(currentRes) ? currentRes : null;
     }
 
-    private bool TryGetAnySetting(IniOptions options, string key, out string value)
+    private static bool TryGetAnySetting(IniOptions options, string key, out string value)
     {
         if (options.Video.AdditionalProperties.TryGetValue(key, out var vVal))
         {
@@ -1334,9 +1334,9 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
         var tshKvp = options.AdditionalSections.FirstOrDefault(s =>
             string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
-        if (tshKvp.Value != null && tshKvp.Value.TryGetCaseInsensitive(key, out var tshVal))
+        if (tshKvp.Value?.TryGetCaseInsensitive(key, out var tshVal) == true)
         {
-            value = tshVal;
+            value = tshVal!;
             return true;
         }
 
@@ -1367,11 +1367,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         if (options.Video.AdditionalProperties.TryGetValue("UseCloudMap", out var ucm)) UseCloudMap = ParseBool(ucm);
         if (options.Video.AdditionalProperties.TryGetValue("UseLightMap", out var ulm)) UseLightMap = ParseBool(ulm);
 
-        if (TryGetAnySetting(options, "DrawScrollAnchor", out var draws)) DrawScrollAnchor = ParseBool(draws);
-        if (TryGetAnySetting(options, "MoveScrollAnchor", out var moves)) MoveScrollAnchor = ParseBool(moves);
-        if (TryGetAnySetting(options, "GameTimeFontSize", out var gtfs) && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfsVal)) GameTimeFontSize = gtfsVal;
-        if (TryGetAnySetting(options, "LanguageFilter", out var lf)) LanguageFilter = ParseBool(lf);
-        if (TryGetAnySetting(options, "SendDelay", out var sd)) SendDelay = ParseBool(sd);
+        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey, out var draws)) DrawScrollAnchor = ParseBool(draws);
+        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey, out var moves)) MoveScrollAnchor = ParseBool(moves);
+        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey, out var gtfs) && int.TryParse(gtfs, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gtfsVal)) GameTimeFontSize = gtfsVal;
+        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.LanguageFilterKey, out var lf)) LanguageFilter = ParseBool(lf);
+        if (TryGetAnySetting(options, GameSettingsTheSuperHackersConstants.SendDelayKey, out var sd)) SendDelay = ParseBool(sd);
         if (TryGetAnySetting(options, "SkipEALogo", out var sel)) SkipEALogo = ParseBool(sel);
     }
 
@@ -1389,51 +1389,60 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
 
     private void ApplyTshGameplayProperties(Dictionary<string, string>? tsh, Dictionary<string, string>? videoAdditional)
     {
-        string? GetVal(string key)
+        ApplySharedEngineProperties(tsh, videoAdditional);
+        if (tsh != null)
         {
-            if (tsh != null && tsh.TryGetCaseInsensitive(key, out var v))
-                return v;
-            if (videoAdditional != null && videoAdditional.TryGetCaseInsensitive(key, out var v2))
-                return v2;
-            return null;
+            ApplyTshExclusiveGameplayProperties(tsh);
         }
+    }
 
-        var doubleClick = GetVal(GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey)
-            ?? GetVal(GameSettingsTheSuperHackersConstants.UseDoubleClickKey);
+    private void ApplySharedEngineProperties(Dictionary<string, string>? tsh, Dictionary<string, string>? videoAdditional)
+    {
+        var doubleClick = GetFirstSettingValue(tsh, videoAdditional, GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey)
+            ?? GetFirstSettingValue(tsh, videoAdditional, GameSettingsTheSuperHackersConstants.UseDoubleClickKey);
         if (doubleClick != null)
             UseDoubleClickAttackMove = ParseBool(doubleClick);
 
-        var scroll = GetVal(GameSettingsTheSuperHackersConstants.ScrollFactorKey);
+        var scroll = GetFirstSettingValue(tsh, videoAdditional, GameSettingsTheSuperHackersConstants.ScrollFactorKey);
         if (scroll != null && int.TryParse(scroll, NumberStyles.Integer, CultureInfo.InvariantCulture, out var scrollVal))
             ScrollFactor = scrollVal;
 
-        var retaliation = GetVal(GameSettingsTheSuperHackersConstants.RetaliationKey);
+        var retaliation = GetFirstSettingValue(tsh, videoAdditional, GameSettingsTheSuperHackersConstants.RetaliationKey);
         if (retaliation != null)
             Retaliation = ParseBool(retaliation);
 
-        var dynLOD = GetVal(GameSettingsTheSuperHackersConstants.DynamicLODKey);
+        var dynLOD = GetFirstSettingValue(tsh, videoAdditional, GameSettingsTheSuperHackersConstants.DynamicLODKey);
         if (dynLOD != null)
             DynamicLOD = ParseBool(dynLOD);
 
-        var particles = GetVal(GameSettingsTheSuperHackersConstants.MaxParticleCountKey);
+        var particles = GetFirstSettingValue(tsh, videoAdditional, GameSettingsTheSuperHackersConstants.MaxParticleCountKey);
         if (particles != null && int.TryParse(particles, NumberStyles.Integer, CultureInfo.InvariantCulture, out var particleVal))
             MaxParticleCount = particleVal;
+    }
 
-        if (tsh != null)
+    private void ApplyTshExclusiveGameplayProperties(Dictionary<string, string> tsh)
+    {
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ArchiveReplaysKey, out var ar)) TshArchiveReplays = ParseBool(ar);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey, out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey, out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey, out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
+        if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
         {
-            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ArchiveReplaysKey, out var ar)) TshArchiveReplays = ParseBool(ar);
-            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey, out var smpm)) TshShowMoneyPerMinute = ParseBool(smpm);
-            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey, out var poe)) TshPlayerObserverEnabled = ParseBool(poe);
-            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey, out var mtv) && int.TryParse(mtv, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mtvVal)) TshMoneyTransactionVolume = mtvVal;
-            if (tsh.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var gwt))
+            var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(gwt);
+            if (parsed.HasValue)
             {
-                var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(gwt);
-                if (parsed.HasValue)
-                {
-                    TshGameWindowTransitionSpeedMultiplier = parsed.Value;
-                }
+                TshGameWindowTransitionSpeedMultiplier = parsed.Value;
             }
         }
+    }
+
+    private static string? GetFirstSettingValue(Dictionary<string, string>? primary, Dictionary<string, string>? fallback, string key)
+    {
+        if (primary?.TryGetCaseInsensitive(key, out var primaryVal) == true)
+            return primaryVal;
+        if (fallback?.TryGetCaseInsensitive(key, out var fallbackVal) == true)
+            return fallbackVal;
+        return null;
     }
 
     private void ApplyTshUiCursorProperties(Dictionary<string, string> tsh)
@@ -1494,11 +1503,11 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         options.Video.AdditionalProperties["Retaliation"] = BoolToString(Retaliation);
         options.Video.AdditionalProperties["DynamicLOD"] = BoolToString(DynamicLOD);
         options.Video.AdditionalProperties["MaxParticleCount"] = MaxParticleCount.ToString(CultureInfo.InvariantCulture);
-        options.Video.AdditionalProperties["DrawScrollAnchor"] = BoolToString(DrawScrollAnchor);
-        options.Video.AdditionalProperties["MoveScrollAnchor"] = BoolToString(MoveScrollAnchor);
-        options.Video.AdditionalProperties["GameTimeFontSize"] = GameTimeFontSize.ToString(CultureInfo.InvariantCulture);
-        options.Video.AdditionalProperties["LanguageFilter"] = BoolToString(LanguageFilter);
-        options.Video.AdditionalProperties["SendDelay"] = BoolToString(SendDelay);
+        options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey] = BoolToString(DrawScrollAnchor);
+        options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey] = BoolToString(MoveScrollAnchor);
+        options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey] = GameTimeFontSize.ToString(CultureInfo.InvariantCulture);
+        options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.LanguageFilterKey] = BoolToString(LanguageFilter);
+        options.Video.AdditionalProperties[GameSettingsTheSuperHackersConstants.SendDelayKey] = BoolToString(SendDelay);
 
         options.Video.ExtraAnimations = ExtraAnimations;
         options.Video.Gamma = Gamma;
@@ -1522,16 +1531,16 @@ public partial class GameSettingsViewModel(IGameSettingsService gameSettingsServ
         }
 
         // Synchronize settings if they already exist in tshDict to prevent desync/overwrites
-        if (tshDict.ContainsKey("GameTimeFontSize"))
-            tshDict["GameTimeFontSize"] = GameTimeFontSize.ToString(CultureInfo.InvariantCulture);
-        if (tshDict.ContainsKey("DrawScrollAnchor"))
-            tshDict["DrawScrollAnchor"] = BoolToString(DrawScrollAnchor);
-        if (tshDict.ContainsKey("MoveScrollAnchor"))
-            tshDict["MoveScrollAnchor"] = BoolToString(MoveScrollAnchor);
-        if (tshDict.ContainsKey("LanguageFilter"))
-            tshDict["LanguageFilter"] = BoolToString(LanguageFilter);
-        if (tshDict.ContainsKey("SendDelay"))
-            tshDict["SendDelay"] = BoolToString(SendDelay);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey))
+            tshDict[GameSettingsTheSuperHackersConstants.GameTimeFontSizeKey] = GameTimeFontSize.ToString(CultureInfo.InvariantCulture);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey))
+            tshDict[GameSettingsTheSuperHackersConstants.DrawScrollAnchorKey] = BoolToString(DrawScrollAnchor);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey))
+            tshDict[GameSettingsTheSuperHackersConstants.MoveScrollAnchorKey] = BoolToString(MoveScrollAnchor);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.LanguageFilterKey))
+            tshDict[GameSettingsTheSuperHackersConstants.LanguageFilterKey] = BoolToString(LanguageFilter);
+        if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.SendDelayKey))
+            tshDict[GameSettingsTheSuperHackersConstants.SendDelayKey] = BoolToString(SendDelay);
         if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.ScrollFactorKey))
             tshDict[GameSettingsTheSuperHackersConstants.ScrollFactorKey] = ScrollFactor.ToString(CultureInfo.InvariantCulture);
         if (tshDict.ContainsKey(GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey))

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -237,11 +237,17 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     }
 
     /// <inheritdoc/>
-    public async Task<OperationResult<GeneralsOnlineSettings>> LoadGeneralsOnlineSettingsAsync()
+    public Task<OperationResult<GeneralsOnlineSettings>> LoadGeneralsOnlineSettingsAsync()
+    {
+        return LoadGeneralsOnlineSettingsAsync(CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async Task<OperationResult<GeneralsOnlineSettings>> LoadGeneralsOnlineSettingsAsync(CancellationToken cancellationToken)
     {
         using (_logger.BeginScope(new Dictionary<string, object> { ["Section"] = "GeneralsOnline" }))
         {
-            await _generalsOnlineSettingsSemaphore.WaitAsync();
+            await _generalsOnlineSettingsSemaphore.WaitAsync(cancellationToken);
             try
             {
                 var settingsPath = GetGeneralsOnlineSettingsPath();
@@ -253,7 +259,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                     return OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings());
                 }
 
-                var json = await File.ReadAllTextAsync(settingsPath);
+                var json = await File.ReadAllTextAsync(settingsPath, cancellationToken);
                 var settings = JsonSerializer.Deserialize<GeneralsOnlineSettings>(json, _jsonSerializerOptions);
 
                 if (settings == null)
@@ -280,12 +286,18 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     }
 
     /// <inheritdoc/>
-    public async Task<OperationResult<bool>> SaveGeneralsOnlineSettingsAsync(GeneralsOnlineSettings settings)
+    public Task<OperationResult<bool>> SaveGeneralsOnlineSettingsAsync(GeneralsOnlineSettings settings)
+    {
+        return SaveGeneralsOnlineSettingsAsync(settings, CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async Task<OperationResult<bool>> SaveGeneralsOnlineSettingsAsync(GeneralsOnlineSettings settings, CancellationToken cancellationToken)
     {
         using (_logger.BeginScope(new Dictionary<string, object> { ["Section"] = "GeneralsOnline" }))
         {
             string? temporaryPath = null;
-            await _generalsOnlineSettingsSemaphore.WaitAsync();
+            await _generalsOnlineSettingsSemaphore.WaitAsync(cancellationToken);
             try
             {
                 var settingsPath = GetGeneralsOnlineSettingsPath();
@@ -304,8 +316,8 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 // so a truncating write that is interrupted, or that overlaps a second launch writing
                 // the same path, would leave the client with a settings.json it cannot read.
                 temporaryPath = $"{settingsPath}.{Guid.NewGuid():N}{GameSettingsGeneralsOnlineConstants.TemporarySettingsFileExtension}";
-                await File.WriteAllTextAsync(temporaryPath, json, Encoding.UTF8);
-                await ReplaceSettingsFileAsync(temporaryPath, settingsPath);
+                await File.WriteAllTextAsync(temporaryPath, json, Encoding.UTF8, cancellationToken);
+                await ReplaceSettingsFileAsync(temporaryPath, settingsPath, cancellationToken);
                 temporaryPath = null;
 
                 _logger.LogInformation("Saved GeneralsOnline settings to {SettingsPath}", settingsPath);
@@ -400,24 +412,23 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
                 if (string.IsNullOrEmpty(currentSection))
                 {
-                    // Flat format - store in root dict
+                    // Flat format (no section header yet)
                     rootDict[key] = value;
                 }
                 else
                 {
-                    // Sectioned format - store in current section
                     currentDict[key] = value;
                 }
             }
         }
 
-        // Process last section if any
+        // Process the last section
         if (!string.IsNullOrEmpty(currentSection))
         {
             ProcessSection(options, currentSection, currentDict);
         }
 
-        // Process root dict (flat format) - categorize by key name
+        // Process root-level settings if any were found (flat format)
         if (rootDict.Count > 0)
         {
             CategorizeRootSettings(options, rootDict);
@@ -443,7 +454,8 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             "Resolution", "Windowed", "TextureReduction", "AntiAliasing",
             "UseShadowVolumes", "UseShadowDecals", "ExtraAnimations", "Gamma",
             "IdealStaticGameLOD", "StaticGameLOD", "AlternateMouseSetup", "HeatEffects",
-            "BuildingOcclusion", "ShowProps",
+            "BuildingOcclusion", "ShowProps", "ShowSoftWaterEdge", "ShowTrees",
+            "UseCloudMap", "UseLightMap",
         };
 
         var networkKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -477,12 +489,8 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             GameSettingsTheSuperHackersConstants.ScrollFactorKey,
             "SendDelay",
             GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey,
-            "ShowSoftWaterEdge",
-            "ShowTrees",
             GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey,
-            "UseCloudMap",
             GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey,
-            "UseLightMap",
         };
 
         Dictionary<string, string> audioDict = new(StringComparer.OrdinalIgnoreCase);
@@ -542,7 +550,27 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
         // Store TheSuperHackers settings in AdditionalSections to preserve them
         if (theSuperHackersDict.Count > 0)
-            options.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] = new Dictionary<string, string>(theSuperHackersDict, StringComparer.OrdinalIgnoreCase);
+        {
+            var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k =>
+                string.Equals(k, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
+
+            if (tshKey != null && options.AdditionalSections.TryGetValue(tshKey, out var existingTshDict) && existingTshDict != null)
+            {
+                // Merge flat root settings; existing section values win on conflict
+                foreach (var kvp in theSuperHackersDict)
+                {
+                    if (!existingTshDict.ContainsKey(kvp.Key))
+                    {
+                        existingTshDict[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+            else
+            {
+                options.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] =
+                    new Dictionary<string, string>(theSuperHackersDict, StringComparer.OrdinalIgnoreCase);
+            }
+        }
     }
 
     private static void ProcessSection(IniOptions options, string sectionName, Dictionary<string, string> values)
@@ -845,15 +873,15 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             [GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey] = BoolToString(settings.CursorCaptureEnabledInWindowedGame),
             [GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey] = BoolToString(settings.CursorCaptureEnabledInWindowedMenu),
             [GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = (GameSettingsMapper.NormalizeTransitionSpeedMultiplier(settings.GameWindowTransitionSpeedMultiplier) ?? GameSettingsTheSuperHackersConstants.DefaultGameWindowTransitionSpeedMultiplier).ToString(CultureInfo.InvariantCulture),
-            [GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = settings.MoneyTransactionVolume.ToString(),
-            [GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = settings.NetworkLatencyFontSize.ToString(),
+            [GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = settings.MoneyTransactionVolume.ToString(CultureInfo.InvariantCulture),
+            [GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = settings.NetworkLatencyFontSize.ToString(CultureInfo.InvariantCulture),
             [GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey] = BoolToString(settings.PlayerObserverEnabled),
-            [GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = settings.RenderFpsFontSize.ToString(),
-            [GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = settings.ResolutionFontAdjustment.ToString(),
+            [GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = settings.RenderFpsFontSize.ToString(CultureInfo.InvariantCulture),
+            [GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = settings.ResolutionFontAdjustment.ToString(CultureInfo.InvariantCulture),
             [GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey] = BoolToString(settings.ScreenEdgeScrollEnabledInFullscreenApp),
             [GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey] = BoolToString(settings.ScreenEdgeScrollEnabledInWindowedApp),
             [GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey] = BoolToString(settings.ShowMoneyPerMinute),
-            [GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = settings.SystemTimeFontSize.ToString(),
+            [GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = settings.SystemTimeFontSize.ToString(CultureInfo.InvariantCulture),
         };
     }
 
@@ -885,8 +913,9 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     /// </remarks>
     /// <param name="temporaryPath">The completed file to move.</param>
     /// <param name="settingsPath">The settings.json path to replace.</param>
+    /// <param name="cancellationToken">Cancellation token for cancelling retry delays.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    private async Task ReplaceSettingsFileAsync(string temporaryPath, string settingsPath)
+    private async Task ReplaceSettingsFileAsync(string temporaryPath, string settingsPath, CancellationToken cancellationToken = default)
     {
         for (var attempt = 1; attempt < GameSettingsGeneralsOnlineConstants.SettingsReplaceAttemptLimit; attempt++)
         {
@@ -903,7 +932,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                     attempt,
                     GameSettingsGeneralsOnlineConstants.SettingsReplaceAttemptLimit,
                     settingsPath);
-                await Task.Delay(GameSettingsGeneralsOnlineConstants.SettingsReplaceRetryDelayMilliseconds);
+                await Task.Delay(GameSettingsGeneralsOnlineConstants.SettingsReplaceRetryDelayMilliseconds, cancellationToken);
             }
         }
 

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Extensions;
 using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Models.Enums;
@@ -721,7 +722,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
         // TheSuperHackers settings
         var tshKvp = options.AdditionalSections.FirstOrDefault(s => string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
-        if (tshKvp.Value != null && tshKvp.Value.Count > 0)
+        if (tshKvp.Value is { Count: > 0 })
         {
             lines.Add(string.Empty);
             lines.Add("[TheSuperHackers]");
@@ -759,72 +760,51 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
     private static string BoolToString(bool value) => value ? "yes" : "no";
 
-    private static bool TryGetCaseInsensitive(Dictionary<string, string> values, string key, out string value)
-    {
-        if (values.TryGetValue(key, out var val))
-        {
-            value = val;
-            return true;
-        }
-
-        foreach (var kvp in values)
-        {
-            if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
-            {
-                value = kvp.Value;
-                return true;
-            }
-        }
-
-        value = string.Empty;
-        return false;
-    }
-
     private static void ParseTheSuperHackersSection(TheSuperHackersSettings settings, Dictionary<string, string> values)
     {
-        if (TryGetCaseInsensitive(values, "ArchiveReplays", out var archiveReplays))
+        if (values.TryGetCaseInsensitive("ArchiveReplays", out var archiveReplays))
             settings.ArchiveReplays = ParseBool(archiveReplays);
 
-        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
+        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
             settings.CursorCaptureEnabledInFullscreenGame = ParseBool(cursorFullscreenGame);
 
-        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
+        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
             settings.CursorCaptureEnabledInFullscreenMenu = ParseBool(cursorFullscreenMenu);
 
-        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
+        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
             settings.CursorCaptureEnabledInWindowedGame = ParseBool(cursorWindowedGame);
 
-        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
+        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
             settings.CursorCaptureEnabledInWindowedMenu = ParseBool(cursorWindowedMenu);
 
-        if (TryGetCaseInsensitive(values, "MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
+        if (values.TryGetCaseInsensitive("MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
             settings.MoneyTransactionVolume = mv;
 
-        if (TryGetCaseInsensitive(values, "NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
+        if (values.TryGetCaseInsensitive("NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
             settings.NetworkLatencyFontSize = nlf;
 
-        if (TryGetCaseInsensitive(values, "PlayerObserverEnabled", out var playerObserver))
+        if (values.TryGetCaseInsensitive("PlayerObserverEnabled", out var playerObserver))
             settings.PlayerObserverEnabled = ParseBool(playerObserver);
 
-        if (TryGetCaseInsensitive(values, "RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
+        if (values.TryGetCaseInsensitive("RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
             settings.RenderFpsFontSize = ff;
 
-        if (TryGetCaseInsensitive(values, "ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
+        if (values.TryGetCaseInsensitive("ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
             settings.ResolutionFontAdjustment = rfa;
 
-        if (TryGetCaseInsensitive(values, "ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
+        if (values.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
             settings.ScreenEdgeScrollEnabledInFullscreenApp = ParseBool(scrollFullscreen);
 
-        if (TryGetCaseInsensitive(values, "ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
+        if (values.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
             settings.ScreenEdgeScrollEnabledInWindowedApp = ParseBool(scrollWindowed);
 
-        if (TryGetCaseInsensitive(values, "ShowMoneyPerMinute", out var showMoney))
+        if (values.TryGetCaseInsensitive("ShowMoneyPerMinute", out var showMoney))
             settings.ShowMoneyPerMinute = ParseBool(showMoney);
 
-        if (TryGetCaseInsensitive(values, "SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
+        if (values.TryGetCaseInsensitive("SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
             settings.SystemTimeFontSize = stf;
 
-        if (TryGetCaseInsensitive(values, GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedMult))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedMult))
         {
             var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(speedMult);
             if (parsed.HasValue)

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -454,6 +454,9 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         // TheSuperHackers / GeneralsOnline specific keys that appear in flat format
         var theSuperHackersKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
+            GameSettingsTheSuperHackersConstants.ArchiveReplaysKey,
+            GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey,
+            GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey,
             GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey,
             GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey,
             "DrawScrollAnchor",

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -178,9 +178,10 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 var settings = new TheSuperHackersSettings();
                 var options = optionsResult.Data;
 
-                if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var tshSection))
+                var tshKvp = options.AdditionalSections.FirstOrDefault(s => string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+                if (tshKvp.Value != null)
                 {
-                    ParseTheSuperHackersSection(settings, tshSection);
+                    ParseTheSuperHackersSection(settings, tshKvp.Value);
                 }
 
                 _logger.LogInformation("Loaded TheSuperHackers settings for {GameType}", gameType);
@@ -208,8 +209,9 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 }
 
                 var options = optionsResult.Data;
+                var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k => string.Equals(k, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)) ?? "TheSuperHackers";
                 Dictionary<string, string> tshSection = [];
-                if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var existingTsh) && existingTsh != null)
+                if (options.AdditionalSections.TryGetValue(tshKey, out var existingTsh) && existingTsh != null)
                 {
                     tshSection = new Dictionary<string, string>(existingTsh, StringComparer.OrdinalIgnoreCase);
                 }
@@ -220,7 +222,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                     tshSection[kvp.Key] = kvp.Value;
                 }
 
-                options.AdditionalSections["TheSuperHackers"] = tshSection;
+                options.AdditionalSections[tshKey] = tshSection;
 
                 var saveResult = await SaveOptionsAsync(gameType, options);
                 return saveResult;
@@ -360,8 +362,8 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     {
         var options = new IniOptions();
         var currentSection = string.Empty;
-        Dictionary<string, string> currentDict = [];
-        Dictionary<string, string> rootDict = []; // For flat format
+        Dictionary<string, string> currentDict = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> rootDict = new(StringComparer.OrdinalIgnoreCase); // For flat format
 
         foreach (var rawLine in lines)
         {
@@ -378,7 +380,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 if (!string.IsNullOrEmpty(currentSection))
                 {
                     ProcessSection(options, currentSection, currentDict);
-                    currentDict = [];
+                    currentDict = new(StringComparer.OrdinalIgnoreCase);
                 }
 
                 currentSection = line[1..^1].Trim();
@@ -461,10 +463,10 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             "UseCloudMap", "UseDoubleClickAttackMove", "UseLightMap",
         };
 
-        Dictionary<string, string> audioDict = [];
-        Dictionary<string, string> videoDict = [];
-        Dictionary<string, string> networkDict = [];
-        Dictionary<string, string> theSuperHackersDict = [];
+        Dictionary<string, string> audioDict = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> videoDict = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> networkDict = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> theSuperHackersDict = new(StringComparer.OrdinalIgnoreCase);
 
         foreach (var kvp in rootDict)
         {
@@ -518,7 +520,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
         // Store TheSuperHackers settings in AdditionalSections to preserve them
         if (theSuperHackersDict.Count > 0)
-            options.AdditionalSections["TheSuperHackers"] = theSuperHackersDict;
+            options.AdditionalSections["TheSuperHackers"] = new Dictionary<string, string>(theSuperHackersDict, StringComparer.OrdinalIgnoreCase);
     }
 
     private static void ProcessSection(IniOptions options, string sectionName, Dictionary<string, string> values)
@@ -535,7 +537,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 ParseNetworkSection(options.Network, values);
                 break;
             default:
-                options.AdditionalSections[sectionName] = new Dictionary<string, string>(values);
+                options.AdditionalSections[sectionName] = new Dictionary<string, string>(values, StringComparer.OrdinalIgnoreCase);
                 break;
         }
     }
@@ -718,11 +720,12 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         }
 
         // TheSuperHackers settings
-        if (options.AdditionalSections.TryGetValue("TheSuperHackers", out var tshSettings) && tshSettings.Count > 0)
+        var tshKvp = options.AdditionalSections.FirstOrDefault(s => string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+        if (tshKvp.Value != null && tshKvp.Value.Count > 0)
         {
             lines.Add(string.Empty);
             lines.Add("[TheSuperHackers]");
-            foreach (var kvp in tshSettings)
+            foreach (var kvp in tshKvp.Value)
             {
                 lines.Add($"{kvp.Key} = {kvp.Value}");
             }
@@ -741,7 +744,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         }
 
         // Add any other additional sections with section headers (for future extensibility)
-        foreach (var section in options.AdditionalSections.Where(s => s.Key != "TheSuperHackers"))
+        foreach (var section in options.AdditionalSections.Where(s => !string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)))
         {
             lines.Add(string.Empty);
             lines.Add($"[{section.Key}]");
@@ -756,51 +759,72 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
     private static string BoolToString(bool value) => value ? "yes" : "no";
 
+    private static bool TryGetCaseInsensitive(Dictionary<string, string> values, string key, out string value)
+    {
+        if (values.TryGetValue(key, out var val))
+        {
+            value = val;
+            return true;
+        }
+
+        foreach (var kvp in values)
+        {
+            if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = kvp.Value;
+                return true;
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
     private static void ParseTheSuperHackersSection(TheSuperHackersSettings settings, Dictionary<string, string> values)
     {
-        if (values.TryGetValue("ArchiveReplays", out var archiveReplays))
+        if (TryGetCaseInsensitive(values, "ArchiveReplays", out var archiveReplays))
             settings.ArchiveReplays = ParseBool(archiveReplays);
 
-        if (values.TryGetValue("CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
+        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
             settings.CursorCaptureEnabledInFullscreenGame = ParseBool(cursorFullscreenGame);
 
-        if (values.TryGetValue("CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
+        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
             settings.CursorCaptureEnabledInFullscreenMenu = ParseBool(cursorFullscreenMenu);
 
-        if (values.TryGetValue("CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
+        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
             settings.CursorCaptureEnabledInWindowedGame = ParseBool(cursorWindowedGame);
 
-        if (values.TryGetValue("CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
+        if (TryGetCaseInsensitive(values, "CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
             settings.CursorCaptureEnabledInWindowedMenu = ParseBool(cursorWindowedMenu);
 
-        if (values.TryGetValue("MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, out var mv))
+        if (TryGetCaseInsensitive(values, "MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
             settings.MoneyTransactionVolume = mv;
 
-        if (values.TryGetValue("NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, out var nlf))
+        if (TryGetCaseInsensitive(values, "NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
             settings.NetworkLatencyFontSize = nlf;
 
-        if (values.TryGetValue("PlayerObserverEnabled", out var playerObserver))
+        if (TryGetCaseInsensitive(values, "PlayerObserverEnabled", out var playerObserver))
             settings.PlayerObserverEnabled = ParseBool(playerObserver);
 
-        if (values.TryGetValue("RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, out var ff))
+        if (TryGetCaseInsensitive(values, "RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
             settings.RenderFpsFontSize = ff;
 
-        if (values.TryGetValue("ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, out var rfa))
+        if (TryGetCaseInsensitive(values, "ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
             settings.ResolutionFontAdjustment = rfa;
 
-        if (values.TryGetValue("ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
+        if (TryGetCaseInsensitive(values, "ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
             settings.ScreenEdgeScrollEnabledInFullscreenApp = ParseBool(scrollFullscreen);
 
-        if (values.TryGetValue("ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
+        if (TryGetCaseInsensitive(values, "ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
             settings.ScreenEdgeScrollEnabledInWindowedApp = ParseBool(scrollWindowed);
 
-        if (values.TryGetValue("ShowMoneyPerMinute", out var showMoney))
+        if (TryGetCaseInsensitive(values, "ShowMoneyPerMinute", out var showMoney))
             settings.ShowMoneyPerMinute = ParseBool(showMoney);
 
-        if (values.TryGetValue("SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, out var stf))
+        if (TryGetCaseInsensitive(values, "SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
             settings.SystemTimeFontSize = stf;
 
-        if (values.TryGetValue(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedMult))
+        if (TryGetCaseInsensitive(values, GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedMult))
         {
             var parsed = GameSettingsMapper.ParseTransitionSpeedMultiplier(speedMult);
             if (parsed.HasValue)
@@ -812,7 +836,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
     private static Dictionary<string, string> SerializeTheSuperHackersSettings(TheSuperHackersSettings settings)
     {
-        return new Dictionary<string, string>
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["ArchiveReplays"] = BoolToString(settings.ArchiveReplays),
             ["CursorCaptureEnabledInFullscreenGame"] = BoolToString(settings.CursorCaptureEnabledInFullscreenGame),

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -557,12 +557,9 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
             if (tshKey != null && options.AdditionalSections.TryGetValue(tshKey, out var existingTshDict) && existingTshDict != null)
             {
                 // Merge flat root settings; existing section values win on conflict
-                foreach (var kvp in theSuperHackersDict)
+                foreach (var kvp in theSuperHackersDict.Where(kvp => !existingTshDict.ContainsKey(kvp.Key)))
                 {
-                    if (!existingTshDict.ContainsKey(kvp.Key))
-                    {
-                        existingTshDict[kvp.Key] = kvp.Value;
-                    }
+                    existingTshDict[kvp.Key] = kvp.Value;
                 }
             }
             else

--- a/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
+++ b/GenHub/GenHub/Features/GameSettings/GameSettingsService.cs
@@ -166,7 +166,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     /// <inheritdoc/>
     public async Task<OperationResult<TheSuperHackersSettings>> LoadTheSuperHackersSettingsAsync(GameType gameType)
     {
-        using (_logger.BeginScope(new Dictionary<string, object> { ["GameType"] = gameType, ["Section"] = "TheSuperHackers" }))
+        using (_logger.BeginScope(new Dictionary<string, object> { ["GameType"] = gameType, ["Section"] = GameSettingsTheSuperHackersConstants.SectionName }))
         {
             try
             {
@@ -179,7 +179,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 var settings = new TheSuperHackersSettings();
                 var options = optionsResult.Data;
 
-                var tshKvp = options.AdditionalSections.FirstOrDefault(s => string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+                var tshKvp = options.AdditionalSections.FirstOrDefault(s => string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
                 if (tshKvp.Value != null)
                 {
                     ParseTheSuperHackersSection(settings, tshKvp.Value);
@@ -199,7 +199,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     /// <inheritdoc/>
     public async Task<OperationResult<bool>> SaveTheSuperHackersSettingsAsync(GameType gameType, TheSuperHackersSettings settings)
     {
-        using (_logger.BeginScope(new Dictionary<string, object> { ["GameType"] = gameType, ["Section"] = "TheSuperHackers" }))
+        using (_logger.BeginScope(new Dictionary<string, object> { ["GameType"] = gameType, ["Section"] = GameSettingsTheSuperHackersConstants.SectionName }))
         {
             try
             {
@@ -210,7 +210,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
                 }
 
                 var options = optionsResult.Data;
-                var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k => string.Equals(k, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)) ?? "TheSuperHackers";
+                var tshKey = options.AdditionalSections.Keys.FirstOrDefault(k => string.Equals(k, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase)) ?? GameSettingsTheSuperHackersConstants.SectionName;
                 Dictionary<string, string> tshSection = [];
                 if (options.AdditionalSections.TryGetValue(tshKey, out var existingTsh) && existingTsh != null)
                 {
@@ -454,14 +454,32 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         // TheSuperHackers / GeneralsOnline specific keys that appear in flat format
         var theSuperHackersKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "CursorCaptureEnabledInWindowedMenu", "CursorCaptureEnabledInWindowedGame", "DrawScrollAnchor", "DynamicLOD",
-            "GameTimeFontSize", GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, "LanguageFilter", "MaxParticleCount",
-            "MoneyTransactionVolume", "MoveScrollAnchor", "NetworkLatencyFontSize",
-            "PlayerObserverEnabled", "RenderFpsFontSize", "ResolutionFontAdjustment",
-            "Retaliation", "ScreenEdgeScrollEnabledInFullscreenApp",
-            "ScreenEdgeScrollEnabledInWindowedApp", "ScrollFactor", "SendDelay",
-            "ShowMoneyPerMinute", "ShowSoftWaterEdge", "ShowTrees", "SystemTimeFontSize",
-            "UseCloudMap", "UseDoubleClickAttackMove", "UseLightMap",
+            GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey,
+            GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey,
+            "DrawScrollAnchor",
+            GameSettingsTheSuperHackersConstants.DynamicLODKey,
+            "GameTimeFontSize",
+            GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey,
+            "LanguageFilter",
+            GameSettingsTheSuperHackersConstants.MaxParticleCountKey,
+            GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey,
+            "MoveScrollAnchor",
+            GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey,
+            GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey,
+            GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey,
+            GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey,
+            GameSettingsTheSuperHackersConstants.RetaliationKey,
+            GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey,
+            GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey,
+            GameSettingsTheSuperHackersConstants.ScrollFactorKey,
+            "SendDelay",
+            GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey,
+            "ShowSoftWaterEdge",
+            "ShowTrees",
+            GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey,
+            "UseCloudMap",
+            GameSettingsTheSuperHackersConstants.UseDoubleClickAttackMoveKey,
+            "UseLightMap",
         };
 
         Dictionary<string, string> audioDict = new(StringComparer.OrdinalIgnoreCase);
@@ -521,7 +539,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
         // Store TheSuperHackers settings in AdditionalSections to preserve them
         if (theSuperHackersDict.Count > 0)
-            options.AdditionalSections["TheSuperHackers"] = new Dictionary<string, string>(theSuperHackersDict, StringComparer.OrdinalIgnoreCase);
+            options.AdditionalSections[GameSettingsTheSuperHackersConstants.SectionName] = new Dictionary<string, string>(theSuperHackersDict, StringComparer.OrdinalIgnoreCase);
     }
 
     private static void ProcessSection(IniOptions options, string sectionName, Dictionary<string, string> values)
@@ -721,11 +739,11 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         }
 
         // TheSuperHackers settings
-        var tshKvp = options.AdditionalSections.FirstOrDefault(s => string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase));
+        var tshKvp = options.AdditionalSections.FirstOrDefault(s => string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase));
         if (tshKvp.Value is { Count: > 0 })
         {
             lines.Add(string.Empty);
-            lines.Add("[TheSuperHackers]");
+            lines.Add($"[{GameSettingsTheSuperHackersConstants.SectionName}]");
             foreach (var kvp in tshKvp.Value)
             {
                 lines.Add($"{kvp.Key} = {kvp.Value}");
@@ -745,7 +763,7 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
         }
 
         // Add any other additional sections with section headers (for future extensibility)
-        foreach (var section in options.AdditionalSections.Where(s => !string.Equals(s.Key, "TheSuperHackers", StringComparison.OrdinalIgnoreCase)))
+        foreach (var section in options.AdditionalSections.Where(s => !string.Equals(s.Key, GameSettingsTheSuperHackersConstants.SectionName, StringComparison.OrdinalIgnoreCase)))
         {
             lines.Add(string.Empty);
             lines.Add($"[{section.Key}]");
@@ -762,46 +780,46 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
 
     private static void ParseTheSuperHackersSection(TheSuperHackersSettings settings, Dictionary<string, string> values)
     {
-        if (values.TryGetCaseInsensitive("ArchiveReplays", out var archiveReplays))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ArchiveReplaysKey, out var archiveReplays))
             settings.ArchiveReplays = ParseBool(archiveReplays);
 
-        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenGame", out var cursorFullscreenGame))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey, out var cursorFullscreenGame))
             settings.CursorCaptureEnabledInFullscreenGame = ParseBool(cursorFullscreenGame);
 
-        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInFullscreenMenu", out var cursorFullscreenMenu))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey, out var cursorFullscreenMenu))
             settings.CursorCaptureEnabledInFullscreenMenu = ParseBool(cursorFullscreenMenu);
 
-        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedGame", out var cursorWindowedGame))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey, out var cursorWindowedGame))
             settings.CursorCaptureEnabledInWindowedGame = ParseBool(cursorWindowedGame);
 
-        if (values.TryGetCaseInsensitive("CursorCaptureEnabledInWindowedMenu", out var cursorWindowedMenu))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey, out var cursorWindowedMenu))
             settings.CursorCaptureEnabledInWindowedMenu = ParseBool(cursorWindowedMenu);
 
-        if (values.TryGetCaseInsensitive("MoneyTransactionVolume", out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey, out var moneyVolume) && int.TryParse(moneyVolume, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mv))
             settings.MoneyTransactionVolume = mv;
 
-        if (values.TryGetCaseInsensitive("NetworkLatencyFontSize", out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey, out var netLatencyFont) && int.TryParse(netLatencyFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nlf))
             settings.NetworkLatencyFontSize = nlf;
 
-        if (values.TryGetCaseInsensitive("PlayerObserverEnabled", out var playerObserver))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey, out var playerObserver))
             settings.PlayerObserverEnabled = ParseBool(playerObserver);
 
-        if (values.TryGetCaseInsensitive("RenderFpsFontSize", out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey, out var fpsFont) && int.TryParse(fpsFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
             settings.RenderFpsFontSize = ff;
 
-        if (values.TryGetCaseInsensitive("ResolutionFontAdjustment", out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey, out var resFontAdj) && int.TryParse(resFontAdj, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rfa))
             settings.ResolutionFontAdjustment = rfa;
 
-        if (values.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInFullscreenApp", out var scrollFullscreen))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey, out var scrollFullscreen))
             settings.ScreenEdgeScrollEnabledInFullscreenApp = ParseBool(scrollFullscreen);
 
-        if (values.TryGetCaseInsensitive("ScreenEdgeScrollEnabledInWindowedApp", out var scrollWindowed))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey, out var scrollWindowed))
             settings.ScreenEdgeScrollEnabledInWindowedApp = ParseBool(scrollWindowed);
 
-        if (values.TryGetCaseInsensitive("ShowMoneyPerMinute", out var showMoney))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey, out var showMoney))
             settings.ShowMoneyPerMinute = ParseBool(showMoney);
 
-        if (values.TryGetCaseInsensitive("SystemTimeFontSize", out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
+        if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey, out var sysTimeFont) && int.TryParse(sysTimeFont, NumberStyles.Integer, CultureInfo.InvariantCulture, out var stf))
             settings.SystemTimeFontSize = stf;
 
         if (values.TryGetCaseInsensitive(GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey, out var speedMult))
@@ -818,21 +836,21 @@ public class GameSettingsService(ILogger<GameSettingsService> logger, IGamePathP
     {
         return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["ArchiveReplays"] = BoolToString(settings.ArchiveReplays),
-            ["CursorCaptureEnabledInFullscreenGame"] = BoolToString(settings.CursorCaptureEnabledInFullscreenGame),
-            ["CursorCaptureEnabledInFullscreenMenu"] = BoolToString(settings.CursorCaptureEnabledInFullscreenMenu),
-            ["CursorCaptureEnabledInWindowedGame"] = BoolToString(settings.CursorCaptureEnabledInWindowedGame),
-            ["CursorCaptureEnabledInWindowedMenu"] = BoolToString(settings.CursorCaptureEnabledInWindowedMenu),
+            [GameSettingsTheSuperHackersConstants.ArchiveReplaysKey] = BoolToString(settings.ArchiveReplays),
+            [GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenGameKey] = BoolToString(settings.CursorCaptureEnabledInFullscreenGame),
+            [GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInFullscreenMenuKey] = BoolToString(settings.CursorCaptureEnabledInFullscreenMenu),
+            [GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedGameKey] = BoolToString(settings.CursorCaptureEnabledInWindowedGame),
+            [GameSettingsTheSuperHackersConstants.CursorCaptureEnabledInWindowedMenuKey] = BoolToString(settings.CursorCaptureEnabledInWindowedMenu),
             [GameSettingsTheSuperHackersConstants.GameWindowTransitionSpeedMultiplierKey] = (GameSettingsMapper.NormalizeTransitionSpeedMultiplier(settings.GameWindowTransitionSpeedMultiplier) ?? GameSettingsTheSuperHackersConstants.DefaultGameWindowTransitionSpeedMultiplier).ToString(CultureInfo.InvariantCulture),
-            ["MoneyTransactionVolume"] = settings.MoneyTransactionVolume.ToString(),
-            ["NetworkLatencyFontSize"] = settings.NetworkLatencyFontSize.ToString(),
-            ["PlayerObserverEnabled"] = BoolToString(settings.PlayerObserverEnabled),
-            ["RenderFpsFontSize"] = settings.RenderFpsFontSize.ToString(),
-            ["ResolutionFontAdjustment"] = settings.ResolutionFontAdjustment.ToString(),
-            ["ScreenEdgeScrollEnabledInFullscreenApp"] = BoolToString(settings.ScreenEdgeScrollEnabledInFullscreenApp),
-            ["ScreenEdgeScrollEnabledInWindowedApp"] = BoolToString(settings.ScreenEdgeScrollEnabledInWindowedApp),
-            ["ShowMoneyPerMinute"] = BoolToString(settings.ShowMoneyPerMinute),
-            ["SystemTimeFontSize"] = settings.SystemTimeFontSize.ToString(),
+            [GameSettingsTheSuperHackersConstants.MoneyTransactionVolumeKey] = settings.MoneyTransactionVolume.ToString(),
+            [GameSettingsTheSuperHackersConstants.NetworkLatencyFontSizeKey] = settings.NetworkLatencyFontSize.ToString(),
+            [GameSettingsTheSuperHackersConstants.PlayerObserverEnabledKey] = BoolToString(settings.PlayerObserverEnabled),
+            [GameSettingsTheSuperHackersConstants.RenderFpsFontSizeKey] = settings.RenderFpsFontSize.ToString(),
+            [GameSettingsTheSuperHackersConstants.ResolutionFontAdjustmentKey] = settings.ResolutionFontAdjustment.ToString(),
+            [GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInFullscreenAppKey] = BoolToString(settings.ScreenEdgeScrollEnabledInFullscreenApp),
+            [GameSettingsTheSuperHackersConstants.ScreenEdgeScrollEnabledInWindowedAppKey] = BoolToString(settings.ScreenEdgeScrollEnabledInWindowedApp),
+            [GameSettingsTheSuperHackersConstants.ShowMoneyPerMinuteKey] = BoolToString(settings.ShowMoneyPerMinute),
+            [GameSettingsTheSuperHackersConstants.SystemTimeFontSizeKey] = settings.SystemTimeFontSize.ToString(),
         };
     }
 

--- a/GenHub/GenHub/Features/Info/Services/MockGameSettingsService.cs
+++ b/GenHub/GenHub/Features/Info/Services/MockGameSettingsService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Interfaces.GameSettings;
 using GenHub.Core.Models.Enums;
@@ -17,6 +18,12 @@ public class MockGameSettingsService : IGameSettingsService
 
     /// <inheritdoc/>
     public Task<OperationResult<GeneralsOnlineSettings>> LoadGeneralsOnlineSettingsAsync()
+    {
+        return LoadGeneralsOnlineSettingsAsync(CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public Task<OperationResult<GeneralsOnlineSettings>> LoadGeneralsOnlineSettingsAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult(OperationResult<GeneralsOnlineSettings>.CreateSuccess(new GeneralsOnlineSettings
         {
@@ -56,6 +63,12 @@ public class MockGameSettingsService : IGameSettingsService
 
     /// <inheritdoc/>
     public Task<OperationResult<bool>> SaveGeneralsOnlineSettingsAsync(GeneralsOnlineSettings settings)
+    {
+        return SaveGeneralsOnlineSettingsAsync(settings, CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public Task<OperationResult<bool>> SaveGeneralsOnlineSettingsAsync(GeneralsOnlineSettings settings, CancellationToken cancellationToken)
     {
         return Task.FromResult(OperationResult<bool>.CreateSuccess(true));
     }

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -1809,12 +1809,43 @@ Constants for TheSuperHackers (TSH) client settings in `Options.ini`.
 | Constant | Value | Description |
 | --- | --- | --- |
 | `SectionName` | `"TheSuperHackers"` | Section name in `Options.ini` for TSH configuration |
+| `UseDoubleClickAttackMoveKey` | `"UseDoubleClickAttackMove"` | Key for double-click attack move toggle |
+| `UseDoubleClickKey` | `"UseDoubleClick"` | Fallback key for double-click setting |
+| `ScrollFactorKey` | `"ScrollFactor"` | Key for scroll speed factor |
+| `RetaliationKey` | `"Retaliation"` | Key for retaliation behavior |
+| `DynamicLODKey` | `"DynamicLOD"` | Key for dynamic level-of-detail toggle |
+| `MaxParticleCountKey` | `"MaxParticleCount"` | Key for maximum particle count |
+| `ArchiveReplaysKey` | `"ArchiveReplays"` | Key for automatic replay archiving |
+| `ShowMoneyPerMinuteKey` | `"ShowMoneyPerMinute"` | Key for displaying income rate |
+| `PlayerObserverEnabledKey` | `"PlayerObserverEnabled"` | Key for observer mode toggle |
+| `SystemTimeFontSizeKey` | `"SystemTimeFontSize"` | Key for system time overlay font size |
+| `NetworkLatencyFontSizeKey` | `"NetworkLatencyFontSize"` | Key for network latency overlay font size |
+| `RenderFpsFontSizeKey` | `"RenderFpsFontSize"` | Key for render FPS overlay font size |
+| `ResolutionFontAdjustmentKey` | `"ResolutionFontAdjustment"` | Key for resolution font adjustment |
+| `CursorCaptureEnabledInFullscreenGameKey` | `"CursorCaptureEnabledInFullscreenGame"` | Key for cursor capture in fullscreen game |
+| `CursorCaptureEnabledInFullscreenMenuKey` | `"CursorCaptureEnabledInFullscreenMenu"` | Key for cursor capture in fullscreen menu |
+| `CursorCaptureEnabledInWindowedGameKey` | `"CursorCaptureEnabledInWindowedGame"` | Key for cursor capture in windowed game |
+| `CursorCaptureEnabledInWindowedMenuKey` | `"CursorCaptureEnabledInWindowedMenu"` | Key for cursor capture in windowed menu |
+| `ScreenEdgeScrollEnabledInFullscreenAppKey` | `"ScreenEdgeScrollEnabledInFullscreenApp"` | Key for screen edge scroll in fullscreen app |
+| `ScreenEdgeScrollEnabledInWindowedAppKey` | `"ScreenEdgeScrollEnabledInWindowedApp"` | Key for screen edge scroll in windowed app |
+| `MoneyTransactionVolumeKey` | `"MoneyTransactionVolume"` | Key for transaction sound volume |
+| `MinFontSize` | `0` | Minimum font size value |
+| `MaxFontSize` | `72` | Maximum font size value |
+| `MinResolutionFontAdjustment` | `-100` | Minimum resolution font adjustment |
+| `MaxResolutionFontAdjustment` | `100` | Maximum resolution font adjustment |
+| `DefaultResolutionFontAdjustment` | `-100` | Default resolution font adjustment |
+| `DefaultNetworkLatencyFontSize` | `8` | Default font size for network latency display |
+| `DefaultRenderFpsFontSize` | `8` | Default font size for FPS display |
+| `DefaultSystemTimeFontSize` | `8` | Default font size for system time display |
+| `DefaultMoneyTransactionVolume` | `50` | Default transaction audio volume (0-100 scale) |
+| `DefaultPlayerObserverEnabled` | `true` | Default observer mode toggle |
+| `DefaultCursorCaptureEnabledInFullscreenGame` | `true` | Default cursor capture in fullscreen game |
+| `DefaultCursorCaptureEnabledInFullscreenMenu` | `true` | Default cursor capture in fullscreen menu |
+| `DefaultCursorCaptureEnabledInWindowedGame` | `true` | Default cursor capture in windowed game |
+| `DefaultCursorCaptureEnabledInWindowedMenu` | `false` | Default cursor capture in windowed menu |
+| `DefaultScreenEdgeScrollEnabledInFullscreenApp` | `true` | Default screen edge scrolling in fullscreen app |
+| `DefaultScreenEdgeScrollEnabledInWindowedApp` | `false` | Default screen edge scrolling in windowed app |
 | `GameWindowTransitionSpeedMultiplierKey` | `"GameWindowTransitionSpeedMultiplier"` | Key for window transition animation speed multiplier |
 | `DefaultGameWindowTransitionSpeedMultiplier` | `1.0f` | Default transition speed multiplier |
 | `MinGameWindowTransitionSpeedMultiplier` | `1.0f` | Minimum allowed transition speed multiplier |
 | `MaxGameWindowTransitionSpeedMultiplier` | `4.0f` | Maximum allowed transition speed multiplier |
-| `ScrollFactorKey` | `"ScrollFactor"` | Key for scroll speed factor |
-| `MoneyTransactionVolumeKey` | `"MoneyTransactionVolume"` | Key for transaction sound volume |
-| `ArchiveReplaysKey` | `"ArchiveReplays"` | Key for automatic replay archiving |
-| `ShowMoneyPerMinuteKey` | `"ShowMoneyPerMinute"` | Key for displaying income rate |
-| `PlayerObserverEnabledKey` | `"PlayerObserverEnabled"` | Key for observer mode toggle |

--- a/docs/dev/constants.md
+++ b/docs/dev/constants.md
@@ -1799,3 +1799,22 @@ folder under `Documents`.
 
 - [Manifest ID System](manifest-id-system.md)
 - [Complete System Architecture](../architecture.md)
+
+---
+
+## GameSettingsTheSuperHackersConstants Class
+
+Constants for TheSuperHackers (TSH) client settings in `Options.ini`.
+
+| Constant | Value | Description |
+| --- | --- | --- |
+| `SectionName` | `"TheSuperHackers"` | Section name in `Options.ini` for TSH configuration |
+| `GameWindowTransitionSpeedMultiplierKey` | `"GameWindowTransitionSpeedMultiplier"` | Key for window transition animation speed multiplier |
+| `DefaultGameWindowTransitionSpeedMultiplier` | `1.0f` | Default transition speed multiplier |
+| `MinGameWindowTransitionSpeedMultiplier` | `1.0f` | Minimum allowed transition speed multiplier |
+| `MaxGameWindowTransitionSpeedMultiplier` | `4.0f` | Maximum allowed transition speed multiplier |
+| `ScrollFactorKey` | `"ScrollFactor"` | Key for scroll speed factor |
+| `MoneyTransactionVolumeKey` | `"MoneyTransactionVolume"` | Key for transaction sound volume |
+| `ArchiveReplaysKey` | `"ArchiveReplays"` | Key for automatic replay archiving |
+| `ShowMoneyPerMinuteKey` | `"ShowMoneyPerMinute"` | Key for displaying income rate |
+| `PlayerObserverEnabledKey` | `"PlayerObserverEnabled"` | Key for observer mode toggle |


### PR DESCRIPTION
﻿## Summary

Fixes an issue where scanning and adding Generals Online (or Zero Hour profiles) causes the user's custom `GameWindowTransitionSpeedMultiplier` (e.g. `1.5`) and other `[TheSuperHackers]` settings in `Options.ini` to be overwritten/reset to defaults.

### Root Causes
1. **Dictionary replacement in `ApplyTshToOptions`**: When writing `[TheSuperHackers]` section back into `Options.ini`, `ApplyTshToOptions` previously instantiated a new empty dictionary and reassigned `options.AdditionalSections["TheSuperHackers"]`, wiping existing/unmanaged keys.
2. **GeneralsOnlineSettings inheritance bug**: `GeneralsOnlineSettings` was inheriting from `TheSuperHackersSettings`. Because Generals Online client's `settings.json` has no TSH settings, deserializing `settings.json` initialized default TSH values (with unset/default fields) which then overwrote profile TSH settings.
3. **Partial `ApplyFromOptions` mapping**: `GameSettingsMapper.ApplyFromOptions` previously mapped only a subset of TSH keys and completely omitted `GameWindowTransitionSpeedMultiplier` and 14 other TSH properties.
4. **Missing `settings.json` inheritance on profile creation**: `GameProfileManager.LoadExistingSettingsIntoProfileAsync` loaded `Options.ini` but did not load existing GeneralsOnline `settings.json`.
5. **Case sensitivity**: `Options.ini` section and key lookups were case-sensitive, which caused lookups like `thesuperhackers` to miss existing entries.

### Changes
- **Preserve existing TSH keys**: Mutate the existing `[TheSuperHackers]` dictionary in `ApplyTshToOptions` and `GameSettingsService` so unmanaged/pre-existing keys are preserved.
- **Decouple `GeneralsOnlineSettings`**: Removed `: TheSuperHackersSettings` inheritance so that client `settings.json` only controls Generals Online-specific options.
- **Case-insensitive section & key lookups**: Added case-insensitive matching (`StringComparer.OrdinalIgnoreCase` and helper `TryGetCaseInsensitive`) across `GameSettingsMapper`, `GameSettingsService`, and `GameSettingsViewModel`.
- **Complete TSH mapping in `ApplyFromOptions`**: Mapped all 15 TSH properties case-insensitively, including culture-resilient float parsing for `GameWindowTransitionSpeedMultiplier`.
- **Inherit GO settings on profile scan/creation**: Added `LoadGeneralsOnlineSettingsAsync` call in `GameProfileManager.LoadExistingSettingsIntoProfileAsync` for Generals Online profiles.
- **Unit tests**: Added and updated unit tests covering TSH mapping, Options.ini preservation, case-insensitivity, and float culture parsing.

## Test Verification
- Ran `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj`
- Passed: 3450 tests, 0 failed, 1 skipped.
