### PR TITLE
fix(wizard): show downloaded content with missing profiles as create profile

### DIFF
--- a/GenHub/GenHub.Core/Constants/GameClientConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameClientConstants.cs
@@ -175,7 +175,8 @@ public static class GameClientConstants
     public const string Direct3D8WrapperDll = "d3d8.dll";
 
     /// <summary>
-    /// DLLs required for standard game installations.</summary>
+    /// DLLs required for standard game installations.
+    /// </summary>
     public static readonly string[] RequiredDlls =
     [
         "steam_api.dll",      // Steam integration

--- a/GenHub/GenHub.Core/Constants/GameClientConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GameClientConstants.cs
@@ -175,8 +175,7 @@ public static class GameClientConstants
     public const string Direct3D8WrapperDll = "d3d8.dll";
 
     /// <summary>
-    /// DLLs required for standard game installations.
-    /// </summary>
+    /// DLLs required for standard game installations.</summary>
     public static readonly string[] RequiredDlls =
     [
         "steam_api.dll",      // Steam integration
@@ -276,6 +275,54 @@ public static class GameClientConstants
 
         /// <summary>No action taken.</summary>
         public const string None = "None";
+    }
+
+    /// <summary>
+    /// Status strings displayed in the Setup Wizard.
+    /// </summary>
+    public static class WizardStatuses
+    {
+        /// <summary>Installed status.</summary>
+        public const string Installed = "Installed";
+
+        /// <summary>Downloaded status.</summary>
+        public const string Downloaded = "Downloaded";
+
+        /// <summary>Detected status.</summary>
+        public const string Detected = "Detected";
+
+        /// <summary>Missing status.</summary>
+        public const string Missing = "Missing";
+    }
+
+    /// <summary>
+    /// Action button and toggle labels displayed in the Setup Wizard.
+    /// </summary>
+    public static class WizardActionLabels
+    {
+        /// <summary>Update or reinstall action label.</summary>
+        public const string UpdateReinstall = "Update / Reinstall";
+
+        /// <summary>Create profile action label.</summary>
+        public const string CreateProfile = "Create Profile";
+
+        /// <summary>Download and install action label.</summary>
+        public const string DownloadAndInstall = "Download & Install";
+    }
+
+    /// <summary>
+    /// Description format templates used in the Setup Wizard.
+    /// </summary>
+    public static class WizardDescriptionTemplates
+    {
+        /// <summary>Format string for creating a game profile: "Create game profile for {0} {1}.".</summary>
+        public const string CreateProfileFormat = "Create game profile for {0} {1}.";
+
+        /// <summary>Format string for updating existing profiles: "Update existing {0} profiles to {1}.".</summary>
+        public const string UpdateProfileFormat = "Update existing {0} profiles to {1}.";
+
+        /// <summary>Format string for detected installed component: "Detected installed {0}. Install managed {1} and create profiles?".</summary>
+        public const string DetectedInstallFormat = "Detected installed {0}. Install managed {1} and create profiles?";
     }
 
     /// <summary>

--- a/GenHub/GenHub.Core/Interfaces/GameProfiles/IPublisherProfileOrchestrator.cs
+++ b/GenHub/GenHub.Core/Interfaces/GameProfiles/IPublisherProfileOrchestrator.cs
@@ -17,11 +17,13 @@ public interface IPublisherProfileOrchestrator
     /// <param name="installation">The parent game installation.</param>
     /// <param name="gameClient">The detected publisher game client.</param>
     /// <param name="forceReacquireContent">True to bypass cache and re-acquire content from the provider.</param>
+    /// <param name="skipAcquisition">True to skip downloading/acquiring content and only create profiles from existing pool manifests.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Result containing the number of profiles created.</returns>
     Task<OperationResult<int>> CreateProfilesForPublisherClientAsync(
         GameInstallation installation,
         GameClient gameClient,
         bool forceReacquireContent = false,
+        bool skipAcquisition = false,
         CancellationToken cancellationToken = default);
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/PublisherProfileOrchestratorTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/PublisherProfileOrchestratorTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GenHub.Core.Constants;
+using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.GameInstallations;
+using GenHub.Core.Interfaces.GameProfiles;
+using GenHub.Core.Interfaces.Manifest;
+using GenHub.Core.Interfaces.Notifications;
+using GenHub.Core.Interfaces.Providers;
+using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameClients;
+using GenHub.Core.Models.GameInstallations;
+using GenHub.Core.Models.GameProfile;
+using GenHub.Core.Models.Manifest;
+using GenHub.Core.Models.Results;
+using GenHub.Core.Models.Results.Content;
+using GenHub.Features.GameProfiles.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using ContentType = GenHub.Core.Models.Enums.ContentType;
+
+namespace GenHub.Tests.Core.Features.GameProfiles.Services;
+
+/// <summary>
+/// Unit tests for <see cref="PublisherProfileOrchestrator"/>.
+/// </summary>
+public sealed class PublisherProfileOrchestratorTests
+{
+    private readonly Mock<IContentOrchestrator> _contentOrchestratorMock;
+    private readonly Mock<IContentManifestPool> _manifestPoolMock;
+    private readonly Mock<IGameClientProfileService> _gameClientProfileServiceMock;
+    private readonly Mock<INotificationService> _notificationServiceMock;
+    private readonly Mock<IContentVersionComparer> _versionComparerMock;
+    private readonly PublisherProfileOrchestrator _orchestrator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublisherProfileOrchestratorTests"/> class.
+    /// </summary>
+    public PublisherProfileOrchestratorTests()
+    {
+        _contentOrchestratorMock = new Mock<IContentOrchestrator>();
+        _manifestPoolMock = new Mock<IContentManifestPool>();
+        _gameClientProfileServiceMock = new Mock<IGameClientProfileService>();
+        _notificationServiceMock = new Mock<INotificationService>();
+        _versionComparerMock = new Mock<IContentVersionComparer>();
+
+        _orchestrator = new PublisherProfileOrchestrator(
+            _contentOrchestratorMock.Object,
+            _manifestPoolMock.Object,
+            _gameClientProfileServiceMock.Object,
+            _notificationServiceMock.Object,
+            _versionComparerMock.Object,
+            NullLogger<PublisherProfileOrchestrator>.Instance);
+    }
+
+    /// <summary>
+    /// Verifies that passing a null client returns a failure result.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CreateProfilesForPublisherClientAsync_WhenClientNull_ReturnsFailureAsync()
+    {
+        // Arrange
+        var installation = CreateInstallation();
+
+        // Act
+        var result = await _orchestrator.CreateProfilesForPublisherClientAsync(installation, null!);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Game client cannot be null", string.Join(" ", result.Errors));
+    }
+
+    /// <summary>
+    /// Verifies that passing a client without a publisher type returns a failure result.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CreateProfilesForPublisherClientAsync_WhenPublisherTypeNullOrEmpty_ReturnsFailureAsync()
+    {
+        // Arrange
+        var installation = CreateInstallation();
+        var client = new GameClient { Id = "test-client", PublisherType = null };
+
+        // Act
+        var result = await _orchestrator.CreateProfilesForPublisherClientAsync(installation, client);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Publisher type unknown", string.Join(" ", result.Errors));
+    }
+
+    /// <summary>
+    /// Verifies that when skipAcquisition is true and manifests exist in the pool,
+    /// acquisition is skipped and profiles are created directly from the pool manifests.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CreateProfilesForPublisherClientAsync_WhenSkipAcquisitionTrueAndPoolHasManifests_DoesNotAcquireContentAndCreatesProfilesAsync()
+    {
+        // Arrange
+        var installation = CreateInstallation();
+        var client = CreateGameClient();
+        var manifest = CreateDownloadedManifest();
+
+        _manifestPoolMock
+            .Setup(p => p.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([manifest]));
+
+        _gameClientProfileServiceMock
+            .Setup(s => s.CreateProfileFromManifestAsync(manifest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(new GameProfile { Id = "p1", Name = "Profile 1" }));
+
+        // Act
+        var result = await _orchestrator.CreateProfilesForPublisherClientAsync(
+            installation,
+            client,
+            skipAcquisition: true);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data);
+
+        _contentOrchestratorMock.Verify(
+            o => o.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contentOrchestratorMock.Verify(
+            o => o.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _gameClientProfileServiceMock.Verify(
+            s => s.CreateProfileFromManifestAsync(manifest, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that when skipAcquisition is true but the pool is empty,
+    /// the orchestrator falls back to acquisition so profiles can be created.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CreateProfilesForPublisherClientAsync_WhenSkipAcquisitionTrueAndPoolIsEmpty_FallsBackToAcquisitionAsync()
+    {
+        // Arrange
+        var installation = CreateInstallation();
+        var client = CreateGameClient();
+        var manifest = CreateDownloadedManifest();
+
+        var searchResultItem = new ContentSearchResult
+        {
+            Id = "search-go",
+            Name = "GeneralsOnline 60Hz",
+            Version = "060526_QFE1",
+            ContentType = ContentType.GameClient,
+            ProviderName = PublisherTypeConstants.GeneralsOnline,
+        };
+
+        // First call returns empty pool, second call (after acquisition) returns the acquired manifest
+        var invocationCount = 0;
+        _manifestPoolMock
+            .Setup(p => p.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                invocationCount++;
+                return OperationResult<IEnumerable<ContentManifest>>.CreateSuccess(
+                    invocationCount == 1 ? [] : [manifest]);
+            });
+
+        _contentOrchestratorMock
+            .Setup(o => o.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess([searchResultItem]));
+
+        _contentOrchestratorMock
+            .Setup(o => o.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
+
+        _gameClientProfileServiceMock
+            .Setup(s => s.CreateProfileFromManifestAsync(manifest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(new GameProfile { Id = "p1", Name = "Profile 1" }));
+
+        // Act
+        var result = await _orchestrator.CreateProfilesForPublisherClientAsync(
+            installation,
+            client,
+            skipAcquisition: true);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data);
+
+        _contentOrchestratorMock.Verify(
+            o => o.SearchAsync(
+                It.Is<ContentSearchQuery>(q => q.ProviderName == PublisherTypeConstants.GeneralsOnline && q.ContentType == ContentType.GameClient),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _contentOrchestratorMock.Verify(
+            o => o.AcquireContentAsync(
+                searchResultItem,
+                It.IsAny<IProgress<ContentAcquisitionProgress>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _gameClientProfileServiceMock.Verify(
+            s => s.CreateProfileFromManifestAsync(manifest, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static GameInstallation CreateInstallation() => new("C:\\Games\\ZeroHour", GameInstallationType.Steam, null);
+
+    private static GameClient CreateGameClient() => new()
+    {
+        Id = "test-client",
+        Name = "GeneralsOnline",
+        PublisherType = PublisherTypeConstants.GeneralsOnline,
+        ExecutablePath = @"C:\Games\ZeroHour\GeneralsOnlineZH_60.exe",
+    };
+
+    private static ContentManifest CreateDownloadedManifest() => new()
+    {
+        Id = ManifestId.Create("1.0.generalsonline.gameclient.zerohour-generalsonline-60hz"),
+        Name = "GeneralsOnline 60Hz",
+        Version = "060526_QFE1",
+        ContentType = ContentType.GameClient,
+        Publisher = new PublisherInfo
+        {
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+            Name = "Generals Online",
+        },
+        Files =
+        [
+            new ManifestFile
+            {
+                RelativePath = "GeneralsOnlineZH_60.exe",
+                SourceType = ContentSourceType.ContentAddressable,
+                Hash = "hash123",
+            },
+        ],
+    };
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/SetupWizardServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/SetupWizardServiceTests.cs
@@ -14,6 +14,7 @@ using GenHub.Features.Content.Services.CommunityOutpost;
 using GenHub.Features.Content.Services.GeneralsOnline;
 using GenHub.Features.Content.Services.Publishers;
 using GenHub.Features.GameProfiles.Services;
+using GenHub.Features.GameProfiles.ViewModels.Wizard;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -100,11 +101,11 @@ public class SetupWizardServiceTests
 
     /// <summary>
     /// Verifies that when a managed client manifest is up-to-date in the pool but its profile is missing,
-    /// the setup wizard auto-accepts CreateProfile without prompting the user.
+    /// the setup wizard displays it as Downloaded with action Create Profile, and confirms profile creation.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Fact]
-    public async Task RunSetupWizardAsync_WhenManagedClientUpToDateAndProfileMissing_AutoAcceptsCreateProfileAsync()
+    public async Task RunSetupWizardAsync_WhenManagedClientUpToDateAndProfileMissing_ShowsInWizardAsCreateProfileAsync()
     {
         // Arrange
         const string latestVersion = "082826_QFE1";
@@ -140,10 +141,25 @@ public class SetupWizardServiceTests
 
         var service = CreateService();
 
+        SetupWizardViewModel? capturedVm = null;
+        service.DialogShower = vm =>
+        {
+            capturedVm = vm;
+            vm.ConfirmCommand.Execute(null);
+            return Task.FromResult(true);
+        };
+
         // Act
         var result = await service.RunSetupWizardAsync([], CancellationToken.None);
 
-        // Assert: Up-to-date manifest found in pool, profile missing -> auto-accept CreateProfile
+        // Assert: Generals Online was shown in wizard with Create Profile action
+        Assert.NotNull(capturedVm);
+        var goItem = capturedVm.Items.FirstOrDefault(i => i.Title == "Generals Online");
+        Assert.NotNull(goItem);
+        Assert.Equal("Downloaded", goItem.Status);
+        Assert.Equal("Create Profile", goItem.ActionLabel);
+        Assert.Equal(GameClientConstants.WizardActionTypes.CreateProfile, goItem.ActionType);
+        Assert.True(goItem.IsSelected);
         Assert.Equal(GameClientConstants.WizardActionTypes.CreateProfile, result.GeneralsOnlineAction);
     }
 

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/SetupWizardServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/SetupWizardServiceTests.cs
@@ -6,6 +6,8 @@ using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Models.Content;
+using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameClients;
 using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
@@ -156,8 +158,75 @@ public class SetupWizardServiceTests
         Assert.NotNull(capturedVm);
         var goItem = capturedVm.Items.FirstOrDefault(i => i.Title == "Generals Online");
         Assert.NotNull(goItem);
-        Assert.Equal("Downloaded", goItem.Status);
-        Assert.Equal("Create Profile", goItem.ActionLabel);
+        Assert.Equal(GameClientConstants.WizardStatuses.Downloaded, goItem.Status);
+        Assert.Equal(GameClientConstants.WizardActionLabels.CreateProfile, goItem.ActionLabel);
+        Assert.Equal(GameClientConstants.WizardActionTypes.CreateProfile, goItem.ActionType);
+        Assert.True(goItem.IsSelected);
+        Assert.Equal(GameClientConstants.WizardActionTypes.CreateProfile, result.GeneralsOnlineAction);
+    }
+
+    /// <summary>
+    /// Verifies that when an up-to-date client is found in an installation but its profile is missing,
+    /// the setup wizard displays it as Detected with action Create Profile, and confirms profile creation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task RunSetupWizardAsync_WhenInstalledClientUpToDateAndProfileMissing_ShowsInWizardAsCreateProfileAsync()
+    {
+        // Arrange
+        const string latestVersion = "082826_QFE1";
+        const string clientId = "installed.generalsonline.client";
+
+        _goDiscovererMock
+            .Setup(d => d.DiscoverAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentDiscoveryResult>.CreateSuccess(new ContentDiscoveryResult
+            {
+                Items = [new ContentSearchResult { Version = latestVersion }],
+            }));
+
+        _cpDiscovererMock
+            .Setup(d => d.DiscoverAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentDiscoveryResult>.CreateSuccess(new ContentDiscoveryResult { Items = [] }));
+
+        // Manifest pool has no up-to-date manifests
+        _manifestPoolMock
+            .Setup(p => p.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([]));
+
+        var installation = new GameInstallation("C:\\Games\\Generals", GameInstallationType.Retail, null);
+        var client = new GameClient
+        {
+            Id = clientId,
+            InstallationId = installation.Id,
+            Name = "Generals Online",
+            PublisherType = PublisherTypeConstants.GeneralsOnline,
+            Version = latestVersion,
+        };
+        installation.AvailableGameClients = [client];
+
+        _profileServiceMock
+            .Setup(s => s.ProfileExistsForGameClientAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var service = CreateService();
+
+        SetupWizardViewModel? capturedVm = null;
+        service.DialogShower = vm =>
+        {
+            capturedVm = vm;
+            vm.ConfirmCommand.Execute(null);
+            return Task.FromResult(true);
+        };
+
+        // Act
+        var result = await service.RunSetupWizardAsync([installation], CancellationToken.None);
+
+        // Assert: Generals Online was shown in wizard with Status "Detected" and "Create Profile" action
+        Assert.NotNull(capturedVm);
+        var goItem = capturedVm.Items.FirstOrDefault(i => i.Title == "Generals Online");
+        Assert.NotNull(goItem);
+        Assert.Equal(GameClientConstants.WizardStatuses.Detected, goItem.Status);
+        Assert.Equal(GameClientConstants.WizardActionLabels.CreateProfile, goItem.ActionLabel);
         Assert.Equal(GameClientConstants.WizardActionTypes.CreateProfile, goItem.ActionType);
         Assert.True(goItem.IsSelected);
         Assert.Equal(GameClientConstants.WizardActionTypes.CreateProfile, result.GeneralsOnlineAction);

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileLauncherViewModelTests.cs
@@ -417,11 +417,88 @@ public class GameProfileLauncherViewModelTests
 
         Assert.Equal("Scan complete. Found 1 installations, created 0 profiles", vm.StatusMessage);
         publisherOrchestrator.Verify(
-            x => x.CreateProfilesForPublisherClientAsync(It.IsAny<GameInstallation>(), It.IsAny<GameClient>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            x => x.CreateProfilesForPublisherClientAsync(It.IsAny<GameInstallation>(), It.IsAny<GameClient>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Never);
         profileManager.Verify(
             x => x.CreateProfileAsync(It.IsAny<CreateProfileRequest>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that when the wizard returns CreateProfile for Generals Online, the publisher orchestrator is invoked with skipAcquisition true.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ScanForGamesCommand_WhenWizardReturnsCreateProfileForGeneralsOnline_CallsOrchestratorWithSkipAcquisitionAsync()
+    {
+        var installationService = new Mock<IGameInstallationService>();
+        var installation = new GameInstallation(Path.Combine("C:", "Steam", "Games"), GameInstallationType.Steam, new Mock<ILogger<GameInstallation>>().Object);
+        installation.PopulateGameClients([
+            new GameClient
+            {
+                Id = "base-zh",
+                Name = "Zero Hour",
+                GameType = GameType.ZeroHour,
+                InstallationId = installation.Id,
+            },
+        ]);
+        var installations = new List<GameInstallation> { installation };
+
+        installationService.Setup(x => x.GetAllInstallationsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IReadOnlyList<GameInstallation>>.CreateSuccess(installations));
+
+        var shortcutService = new Mock<IShortcutService>();
+        var notificationService = new Mock<INotificationService>();
+        var publisherOrchestrator = new Mock<IPublisherProfileOrchestrator>();
+        publisherOrchestrator
+            .Setup(x => x.CreateProfilesForPublisherClientAsync(
+                It.IsAny<GameInstallation>(),
+                It.IsAny<GameClient>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<int>.CreateSuccess(1));
+
+        var profileManager = new Mock<IGameProfileManager>();
+        var editorFacade = new Mock<IProfileEditorFacade>();
+
+        var setupWizardService = new Mock<ISetupWizardService>();
+        setupWizardService.Setup(x => x.RunSetupWizardAsync(It.IsAny<IEnumerable<GameInstallation>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SetupWizardResult
+            {
+                Confirmed = true,
+                GeneralsOnlineAction = GameClientConstants.WizardActionTypes.CreateProfile,
+            });
+
+        var vm = new GameProfileLauncherViewModel(
+            installationService.Object,
+            profileManager.Object,
+            null!,
+            null!,
+            editorFacade.Object,
+            null!,
+            null!,
+            shortcutService.Object,
+            publisherOrchestrator.Object,
+            new Mock<ISteamManifestPatcher>().Object,
+            CreateProfileResourceService(),
+            new Mock<IGameClientDetector>().Object,
+            notificationService.Object,
+            setupWizardService.Object,
+            new Mock<IDialogService>().Object,
+            NullLogger<GameProfileLauncherViewModel>.Instance);
+
+        await vm.ScanForGamesCommand.ExecuteAsync(null);
+
+        Assert.Equal("Scan complete. Found 1 installations, created 1 profiles", vm.StatusMessage);
+        publisherOrchestrator.Verify(
+            x => x.CreateProfilesForPublisherClientAsync(
+                It.Is<GameInstallation>(inst => inst == installation),
+                It.Is<GameClient>(c => c.PublisherType == PublisherTypeConstants.GeneralsOnline),
+                false,
+                true,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     /// <summary>

--- a/GenHub/GenHub/Features/GameProfiles/Services/PublisherProfileOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/PublisherProfileOrchestrator.cs
@@ -37,6 +37,7 @@ public class PublisherProfileOrchestrator(
         GameInstallation installation,
         GameClient gameClient,
         bool forceReacquireContent = false,
+        bool skipAcquisition = false,
         CancellationToken cancellationToken = default)
     {
         try
@@ -60,7 +61,14 @@ public class PublisherProfileOrchestrator(
             var existingManifests = await GetPublisherManifestsFromPoolAsync(publisherType, cancellationToken);
 
             bool shouldAcquire = false;
-            if (existingManifests.Count == 0)
+            if (skipAcquisition && existingManifests.Count > 0)
+            {
+                logger.LogInformation(
+                    "Skip acquisition requested for {PublisherType}, creating profiles from {Count} existing manifests",
+                    publisherType,
+                    existingManifests.Count);
+            }
+            else if (existingManifests.Count == 0)
             {
                 // No manifests in pool - need to acquire
                 shouldAcquire = true;

--- a/GenHub/GenHub/Features/GameProfiles/Services/PublisherProfileOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/PublisherProfileOrchestrator.cs
@@ -61,7 +61,7 @@ public class PublisherProfileOrchestrator(
             var existingManifests = await GetPublisherManifestsFromPoolAsync(publisherType, cancellationToken);
 
             bool shouldAcquire = false;
-            if (skipAcquisition)
+            if (skipAcquisition && existingManifests.Count > 0)
             {
                 logger.LogInformation(
                     "Skip acquisition requested for {PublisherType}, creating profiles from {Count} existing manifests",

--- a/GenHub/GenHub/Features/GameProfiles/Services/PublisherProfileOrchestrator.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/PublisherProfileOrchestrator.cs
@@ -61,7 +61,7 @@ public class PublisherProfileOrchestrator(
             var existingManifests = await GetPublisherManifestsFromPoolAsync(publisherType, cancellationToken);
 
             bool shouldAcquire = false;
-            if (skipAcquisition && existingManifests.Count > 0)
+            if (skipAcquisition)
             {
                 logger.LogInformation(
                     "Skip acquisition requested for {PublisherType}, creating profiles from {Count} existing manifests",

--- a/GenHub/GenHub/Features/GameProfiles/Services/SetupWizardService.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/SetupWizardService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,9 +105,9 @@ public class SetupWizardService(
                 var downloadedItem = new SetupWizardItemViewModel
                 {
                     Title = title,
-                    Status = "Downloaded",
-                    Description = $"Create game profile for {title} {latestVersion}.",
-                    ActionLabel = "Create Profile",
+                    Status = GameClientConstants.WizardStatuses.Downloaded,
+                    Description = FormatCreateProfileDescription(title, latestVersion),
+                    ActionLabel = GameClientConstants.WizardActionLabels.CreateProfile,
                     ActionType = GameClientConstants.WizardActionTypes.CreateProfile,
                     IsSelected = true,
                     IconPath = iconPath,
@@ -138,9 +139,9 @@ public class SetupWizardService(
                 var detectedItem = new SetupWizardItemViewModel
                 {
                     Title = title,
-                    Status = "Detected",
-                    Description = $"Create game profile for {title} {latestVersion}.",
-                    ActionLabel = "Create Profile",
+                    Status = GameClientConstants.WizardStatuses.Detected,
+                    Description = FormatCreateProfileDescription(title, latestVersion),
+                    ActionLabel = GameClientConstants.WizardActionLabels.CreateProfile,
                     ActionType = GameClientConstants.WizardActionTypes.CreateProfile,
                     IsSelected = true,
                     IconPath = iconPath,
@@ -193,36 +194,36 @@ public class SetupWizardService(
             if (anyProfileExists)
             {
                 // Profile exists, but it is not the latest managed version
-                item.Status = "Installed";
-                item.Description = $"Update existing {title} profiles to {displayVersion}.";
-                item.ActionLabel = "Update / Reinstall";
+                item.Status = GameClientConstants.WizardStatuses.Installed;
+                item.Description = FormatUpdateProfileDescription(title, displayVersion);
+                item.ActionLabel = GameClientConstants.WizardActionLabels.UpdateReinstall;
                 item.ActionType = GameClientConstants.WizardActionTypes.Update;
                 item.IsSelected = false;
             }
             else if (managedManifests.Count > 0)
             {
                 // Content downloaded in pool, but no profile exists
-                item.Status = "Downloaded";
-                item.Description = $"Create game profile for {title} {displayVersion}.";
-                item.ActionLabel = "Create Profile";
+                item.Status = GameClientConstants.WizardStatuses.Downloaded;
+                item.Description = FormatCreateProfileDescription(title, displayVersion);
+                item.ActionLabel = GameClientConstants.WizardActionLabels.CreateProfile;
                 item.ActionType = GameClientConstants.WizardActionTypes.CreateProfile;
                 item.IsSelected = true;
             }
             else if (isDetected)
             {
                 // Unmanaged files detected but no profile
-                item.Status = "Detected";
-                item.Description = $"Detected installed {title}. Create game profile?";
-                item.ActionLabel = "Create Profile";
-                item.ActionType = GameClientConstants.WizardActionTypes.CreateProfile;
+                item.Status = GameClientConstants.WizardStatuses.Detected;
+                item.Description = FormatDetectedInstallDescription(title, latestVersion);
+                item.ActionLabel = GameClientConstants.WizardActionLabels.DownloadAndInstall;
+                item.ActionType = GameClientConstants.WizardActionTypes.Install;
                 item.IsSelected = true;
             }
             else
             {
                 // Nothing found at all
-                item.Status = "Missing";
+                item.Status = GameClientConstants.WizardStatuses.Missing;
                 item.Description = missingDescription;
-                item.ActionLabel = "Download & Install";
+                item.ActionLabel = GameClientConstants.WizardActionLabels.DownloadAndInstall;
                 item.ActionType = GameClientConstants.WizardActionTypes.Install;
                 item.IsSelected = title == "Community Patch"; // Defaults
             }
@@ -319,6 +320,15 @@ public class SetupWizardService(
 
         return result;
     }
+
+    private static string FormatCreateProfileDescription(string title, string version) =>
+        string.Format(CultureInfo.InvariantCulture, GameClientConstants.WizardDescriptionTemplates.CreateProfileFormat, title, version);
+
+    private static string FormatUpdateProfileDescription(string title, string version) =>
+        string.Format(CultureInfo.InvariantCulture, GameClientConstants.WizardDescriptionTemplates.UpdateProfileFormat, title, version);
+
+    private static string FormatDetectedInstallDescription(string title, string version) =>
+        string.Format(CultureInfo.InvariantCulture, GameClientConstants.WizardDescriptionTemplates.DetectedInstallFormat, title, version);
 
     private static Window? GetMainWindow()
     {

--- a/GenHub/GenHub/Features/GameProfiles/Services/SetupWizardService.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/SetupWizardService.cs
@@ -33,6 +33,11 @@ public class SetupWizardService(
     IContentManifestPool manifestPool,
     ILogger<SetupWizardService> logger) : ISetupWizardService
 {
+    /// <summary>
+    /// Gets or sets an optional hook for showing the wizard dialog, primarily used in unit tests to simulate user interaction.
+    /// </summary>
+    internal Func<SetupWizardViewModel, Task<bool>>? DialogShower { get; set; }
+
     /// <inheritdoc/>
     public async Task<SetupWizardResult> RunSetupWizardAsync(IEnumerable<GameInstallation> installations, CancellationToken cancellationToken = default)
     {
@@ -95,8 +100,21 @@ public class SetupWizardService(
                     return (true, GameClientConstants.WizardActionTypes.Decline);
                 }
 
-                logger.LogInformation("[SetupWizard] Managed up-to-date manifest found for {Title} ({Version}), but profile missing. Creating profile.", title, latestVersion);
-                return (true, GameClientConstants.WizardActionTypes.CreateProfile);
+                logger.LogInformation("[SetupWizard] Managed up-to-date manifest found for {Title} ({Version}), but profile missing. Showing in wizard to create profile.", title, latestVersion);
+                var downloadedItem = new SetupWizardItemViewModel
+                {
+                    Title = title,
+                    Status = "Downloaded",
+                    Description = $"Create game profile for {title} {latestVersion}.",
+                    ActionLabel = "Create Profile",
+                    ActionType = GameClientConstants.WizardActionTypes.CreateProfile,
+                    IsSelected = true,
+                    IconPath = iconPath,
+                    Metadata = metadata,
+                    Version = latestVersion,
+                };
+                wizardItems.Add(downloadedItem);
+                return (false, downloadedItem.ActionType);
             }
 
             // Also check unmanaged clients from installations in case an unmanaged client is managed/has ID
@@ -116,8 +134,21 @@ public class SetupWizardService(
                     return (true, GameClientConstants.WizardActionTypes.Decline);
                 }
 
-                logger.LogInformation("[SetupWizard] Up-to-date client found in installations for {Title} ({Version}), profile missing. Creating profile.", title, latestVersion);
-                return (true, GameClientConstants.WizardActionTypes.CreateProfile);
+                logger.LogInformation("[SetupWizard] Up-to-date client found in installations for {Title} ({Version}), profile missing. Showing in wizard to create profile.", title, latestVersion);
+                var detectedItem = new SetupWizardItemViewModel
+                {
+                    Title = title,
+                    Status = "Detected",
+                    Description = $"Create game profile for {title} {latestVersion}.",
+                    ActionLabel = "Create Profile",
+                    ActionType = GameClientConstants.WizardActionTypes.CreateProfile,
+                    IsSelected = true,
+                    IconPath = iconPath,
+                    Metadata = metadata,
+                    Version = latestVersion,
+                };
+                wizardItems.Add(detectedItem);
+                return (false, detectedItem.ActionType);
             }
 
             // 3. Check if any profiles exist for this component (managed or unmanaged)
@@ -145,7 +176,9 @@ public class SetupWizardService(
             }
 
             var isDetected = componentGlobal.Count > 0;
-            var isInstalled = managedManifests.Count > 0 || anyProfileExists;
+            var displayVersion = !string.IsNullOrEmpty(latestVersion) && latestVersion != GameClientConstants.UnknownVersion
+                ? latestVersion
+                : (managedManifests.FirstOrDefault()?.Version ?? latestVersion);
 
             // Construct Wizard Item
             var item = new SetupWizardItemViewModel
@@ -154,25 +187,35 @@ public class SetupWizardService(
                 IsSelected = true,
                 IconPath = iconPath,
                 Metadata = metadata,
-                Version = latestVersion,
+                Version = displayVersion,
             };
 
-            if (isInstalled)
+            if (anyProfileExists)
             {
-                // Profile or older managed manifest exists, but it is not the latest managed version
+                // Profile exists, but it is not the latest managed version
                 item.Status = "Installed";
-                item.Description = $"Update existing {title} profiles to {latestVersion}.";
+                item.Description = $"Update existing {title} profiles to {displayVersion}.";
                 item.ActionLabel = "Update / Reinstall";
                 item.ActionType = GameClientConstants.WizardActionTypes.Update;
                 item.IsSelected = false;
+            }
+            else if (managedManifests.Count > 0)
+            {
+                // Content downloaded in pool, but no profile exists
+                item.Status = "Downloaded";
+                item.Description = $"Create game profile for {title} {displayVersion}.";
+                item.ActionLabel = "Create Profile";
+                item.ActionType = GameClientConstants.WizardActionTypes.CreateProfile;
+                item.IsSelected = true;
             }
             else if (isDetected)
             {
                 // Unmanaged files detected but no profile
                 item.Status = "Detected";
-                item.Description = $"Detected installed {title}. Install managed {latestVersion} and create profiles?";
-                item.ActionLabel = "Download & Install";
+                item.Description = $"Detected installed {title}. Create game profile?";
+                item.ActionLabel = "Create Profile";
                 item.ActionType = GameClientConstants.WizardActionTypes.CreateProfile;
+                item.IsSelected = true;
             }
             else
             {
@@ -227,22 +270,29 @@ public class SetupWizardService(
         if (wizardItems.Count > 0)
         {
             var wizardVm = new SetupWizardViewModel(wizardItems);
-            var mainWindow = GetMainWindow();
-            if (mainWindow != null)
+            if (DialogShower != null)
             {
-                var wizardView = new SetupWizardView
-                {
-                    DataContext = wizardVm,
-                };
-
-                await wizardView.ShowDialog(mainWindow);
-
-                result.Confirmed = wizardVm.Confirmed;
+                result.Confirmed = await DialogShower(wizardVm);
             }
             else
             {
-                logger.LogWarning("Could not resolve MainWindow for Setup Wizard.");
-                result.Confirmed = false;
+                var mainWindow = GetMainWindow();
+                if (mainWindow != null)
+                {
+                    var wizardView = new SetupWizardView
+                    {
+                        DataContext = wizardVm,
+                    };
+
+                    await wizardView.ShowDialog(mainWindow);
+
+                    result.Confirmed = wizardVm.Confirmed;
+                }
+                else
+                {
+                    logger.LogWarning("Could not resolve MainWindow for Setup Wizard.");
+                    result.Confirmed = false;
+                }
             }
         }
         else

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
@@ -654,6 +654,12 @@ public partial class GameProfileLauncherViewModel(
         }
 
         var client = installation.AvailableGameClients?.FirstOrDefault(c => string.Equals(c.PublisherType, publisherType, StringComparison.OrdinalIgnoreCase));
+        if (client == null &&
+            decision != GameClientConstants.WizardActionTypes.Install &&
+            decision != GameClientConstants.WizardActionTypes.CreateProfile)
+        {
+            return (false, 0);
+        }
 
         var clientToUse = client ?? new GameClient
         {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
@@ -654,10 +654,6 @@ public partial class GameProfileLauncherViewModel(
         }
 
         var client = installation.AvailableGameClients?.FirstOrDefault(c => string.Equals(c.PublisherType, publisherType, StringComparison.OrdinalIgnoreCase));
-        if (client == null && decision != GameClientConstants.WizardActionTypes.Install)
-        {
-            return (false, 0);
-        }
 
         var clientToUse = client ?? new GameClient
         {
@@ -669,7 +665,12 @@ public partial class GameProfileLauncherViewModel(
         };
 
         bool forceAttr = decision == GameClientConstants.WizardActionTypes.Update;
-        var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(installation, clientToUse, forceReacquireContent: forceAttr);
+        bool skipAcquire = decision == GameClientConstants.WizardActionTypes.CreateProfile;
+        var result = await publisherProfileOrchestrator.CreateProfilesForPublisherClientAsync(
+            installation,
+            clientToUse,
+            forceReacquireContent: forceAttr,
+            skipAcquisition: skipAcquire);
         int profiles = (result.Success && result.Data > 0) ? result.Data : 0;
 
         return (true, profiles);


### PR DESCRIPTION
## Summary

When components like Generals Online are downloaded to the manifest pool and the user later deletes the profile, re-scanning would previously skip displaying the item in the Setup Wizard. This PR ensures that downloaded components with missing profiles are always presented in the Setup Wizard with status **Downloaded** and action **Create Profile** (selected by default), allowing users to create the profile directly without re-downloading content.

## Root Cause

1. `SetupWizardService.ProcessComponentAsync` identified that a managed client manifest was up to date in the manifest pool but its profile was missing, returning `(true, GameClientConstants.WizardActionTypes.CreateProfile)`. Because `skipWizard: true` was returned, the item was never added to `wizardItems` for user interaction.
2. If `CreateProfile` was returned for a publisher client not yet registered on `GameInstallation.AvailableGameClients`, `GameProfileLauncherViewModel.TryProcessPublisherDecisionAsync` rejected profile creation because `client == null && decision != Install`.
3. Even when profile creation was initiated, `IPublisherProfileOrchestrator` had no way to indicate that acquisition/downloading should be bypassed when content was already in the manifest pool, potentially triggering redundant content downloads.

## Changes

- **Setup Wizard Display (`SetupWizardService.cs`)**:
  - For components where managed manifests are present in the pool but the profile is missing, construct a `SetupWizardItemViewModel` with `Status = "Downloaded"`, `ActionLabel = "Create Profile"`, `ActionType = CreateProfile`, and `IsSelected = true`, and add it to `wizardItems` instead of skipping the wizard.
  - Corrected display version resolution and detection descriptions.
  - Added an internal `DialogShower` delegate to allow unit test verification of dialog content and user interaction.
- **Launcher Pipeline (`GameProfileLauncherViewModel.cs`)**:
  - Allowed `TryProcessPublisherDecisionAsync` to proceed when `decision == CreateProfile` even if `client == null`.
  - Pass `skipAcquisition: decision == CreateProfile` to `IPublisherProfileOrchestrator.CreateProfilesForPublisherClientAsync`.
- **Publisher Profile Orchestrator (`IPublisherProfileOrchestrator.cs` & `PublisherProfileOrchestrator.cs`)**:
  - Added optional `skipAcquisition = false` parameter.
  - When `skipAcquisition` is true and existing manifests are in the pool, skips network content re-acquisition and creates profiles directly from existing manifests.
- **Automated Tests**:
  - `SetupWizardServiceTests.RunSetupWizardAsync_WhenManagedClientUpToDateAndProfileMissing_ShowsInWizardAsCreateProfileAsync`: verifies item displays as "Downloaded" with "Create Profile" action and confirms profile creation.
  - `GameProfileLauncherViewModelTests.ScanForGamesCommand_WhenWizardReturnsCreateProfileForGeneralsOnline_CallsOrchestratorWithSkipAcquisitionAsync`: verifies launcher triggers orchestrator with `skipAcquisition: true`.

## Verification

- Built solution: 0 Errors, 0 Warnings.
- Unit tests executed:
  - `dotnet test GenHub/GenHub.Tests/GenHub.Tests.Core/GenHub.Tests.Core.csproj --filter "FullyQualifiedName~SetupWizardServiceTests|FullyQualifiedName~ScanForGamesCommand"`: 9/9 passed.
