### PR TITLE
fix(gameprofiles): prevent removing game installation with active dependent clients

### DIFF
--- a/GenHub/GenHub.Core/Constants/ProfileValidationConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ProfileValidationConstants.cs
@@ -89,4 +89,39 @@ public static class ProfileValidationConstants
     /// Notification title when tool launch fails.
     /// </summary>
     public const string ToolLaunchFailedTitle = "Tool Launch Failed";
+
+    /// <summary>
+    /// Notification title when removing a game installation is blocked by active dependent clients.
+    /// </summary>
+    public const string CannotRemoveInstallationTitle = "Cannot Remove Installation";
+
+    /// <summary>
+    /// Notification title when deleting a game installation is blocked by active dependent clients.
+    /// </summary>
+    public const string CannotDeleteInstallationTitle = "Cannot Delete Installation";
+
+    /// <summary>
+    /// Notification title when saving without a required game installation.
+    /// </summary>
+    public const string MissingGameInstallationTitle = "Missing Game Installation";
+
+    /// <summary>
+    /// Notification message when saving without a required game installation.
+    /// </summary>
+    public const string SelectGameInstallationBeforeSaving = "Please select a game installation before saving.";
+
+    /// <summary>
+    /// Notification title when saving without a profile name.
+    /// </summary>
+    public const string MissingProfileNameTitle = "Missing Name";
+
+    /// <summary>
+    /// Notification message when saving without a profile name.
+    /// </summary>
+    public const string EnterProfileNameBeforeSaving = "Please enter a profile name before saving.";
+
+    /// <summary>
+    /// Notification title when content cannot be modified in the current mode.
+    /// </summary>
+    public const string CannotModifyContentTitle = "Cannot Modify Content";
 }

--- a/GenHub/GenHub.Core/Constants/ProfileValidationConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ProfileValidationConstants.cs
@@ -101,6 +101,18 @@ public static class ProfileValidationConstants
     public const string CannotDeleteInstallationTitle = "Cannot Delete Installation";
 
     /// <summary>
+    /// Status message format when removing or deleting a game installation is blocked by active dependent clients.
+    /// Format arguments: {0} action verb (remove/delete), {1} installation display name, {2} comma-separated client names.
+    /// </summary>
+    public const string InstallationActionBlockedStatusFormat = "Cannot {0} {1} while dependent game client {2} is active";
+
+    /// <summary>
+    /// Notification message format when removing or deleting a game installation is blocked by active dependent clients.
+    /// Format arguments: {0} action verb (remove/delete), {1} installation display name, {2} comma-separated client names.
+    /// </summary>
+    public const string InstallationActionBlockedNotificationFormat = "Cannot {0} game installation '{1}' while dependent game client {2} is active. Please remove the game client first.";
+
+    /// <summary>
     /// Notification title when saving without a required game installation.
     /// </summary>
     public const string MissingGameInstallationTitle = "Missing Game Installation";

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Interfaces.GameSettings;
@@ -1059,7 +1060,7 @@ public class GameProfileSettingsViewModelDependencyTests
         Assert.True(zeroHourInstall.IsEnabled);
         Assert.Contains("Cannot remove", _viewModel.StatusMessage);
         _mockNotificationService.Verify(
-            x => x.ShowWarning("Cannot Remove Installation", It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            x => x.ShowWarning(ProfileValidationConstants.CannotRemoveInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
     }
 
@@ -1142,10 +1143,127 @@ public class GameProfileSettingsViewModelDependencyTests
         // Assert
         Assert.Equal("Please select a game installation", _viewModel.StatusMessage);
         _mockNotificationService.Verify(
-            x => x.ShowError("Missing Game Installation", "Please select a game installation before saving.", It.IsAny<int?>(), It.IsAny<bool>()),
+            x => x.ShowError(ProfileValidationConstants.MissingGameInstallationTitle, ProfileValidationConstants.SelectGameInstallationBeforeSaving, It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
         _mockGameProfileManager.Verify(
             x => x.CreateProfileAsync(It.IsAny<CreateProfileRequest>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is blocked when a publisher-agnostic GameClient
+    /// (e.g. StrictPublisher = false) depends on the installation's GameType.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_BlocksGameInstallationRemoval_WhenPublisherAgnosticClientDependsOnInstallationAsync()
+    {
+        // Arrange
+        var agnosticClientId = new ManifestId("1.104.genhub.gameclient.zerohour");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientManifest = new ContentManifest
+        {
+            Id = agnosticClientId,
+            Name = "SuperHackers ZH Client",
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            Dependencies =
+            [
+                new ContentDependency
+                {
+                    Id = new ManifestId("1.104.genhub.gameinstallation.zerohour"),
+                    DependencyType = ContentType.GameInstallation,
+                    StrictPublisher = false,
+                    CompatibleGameTypes = [GameType.ZeroHour],
+                    IsOptional = false,
+                },
+            ],
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = agnosticClientId,
+            DisplayName = "SuperHackers ZH Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.Unknown,
+            Manifest = clientManifest,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert
+        Assert.Equal(zeroHourInstall, _viewModel.SelectedGameInstallation);
+        Assert.Contains(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.True(zeroHourInstall.IsEnabled);
+        Assert.Contains("Cannot remove", _viewModel.StatusMessage);
+        _mockNotificationService.Verify(
+            x => x.ShowWarning(ProfileValidationConstants.CannotRemoveInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that deleting a GameInstallation is blocked when an active GameClient depends on it.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DeleteContent_BlocksGameInstallationDeletion_WhenDependentGameClientIsActiveAsync()
+    {
+        // Arrange
+        var standardClientId = new ManifestId("1.04.eaapp.gameclient.zerohour");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = standardClientId,
+            DisplayName = "Zero Hour 1.04 Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            SourceId = zeroHourInstallId.Value,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DeleteContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert
+        Assert.Contains("Cannot delete", _viewModel.StatusMessage);
+        _mockNotificationService.Verify(
+            x => x.ShowWarning(ProfileValidationConstants.CannotDeleteInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -1464,4 +1464,165 @@ public class GameProfileSettingsViewModelDependencyTests
         Assert.DoesNotContain(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
         Assert.False(zeroHourInstall.IsEnabled);
     }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is blocked by the fallback heuristic when an active GameClient
+    /// has no manifest or dependencies and an empty SourceId, but matches the installation's GameType.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_BlocksGameInstallationRemoval_WhenActiveClientHasNoDependenciesOrManifest_AndMatchesGameTypeAsync()
+    {
+        // Arrange
+        var clientId = new ManifestId("1.104.community.gameclient.zhclient");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = clientId,
+            DisplayName = "ZH Fallback Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.Unknown,
+            SourceId = string.Empty,
+            Manifest = null,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert - blocked by fallback heuristic (same GameType)
+        Assert.Equal(zeroHourInstall, _viewModel.SelectedGameInstallation);
+        Assert.Contains(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.True(zeroHourInstall.IsEnabled);
+        _mockNotificationService.Verify(
+            x => x.ShowWarning(ProfileValidationConstants.CannotRemoveInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is blocked by the fallback heuristic when an active GameClient
+    /// has a different GameType, but the installation matches SelectedGameInstallation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_BlocksGameInstallationRemoval_WhenActiveClientHasNoDependenciesOrManifest_AndMatchesSelectedGameInstallationAsync()
+    {
+        // Arrange
+        var clientId = new ManifestId("1.104.community.gameclient.otherclient");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = clientId,
+            DisplayName = "Other Fallback Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.Generals,
+            InstallationType = GameInstallationType.Unknown,
+            SourceId = string.Empty,
+            Manifest = null,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert - blocked because zeroHourInstall matches SelectedGameInstallation
+        Assert.Equal(zeroHourInstall, _viewModel.SelectedGameInstallation);
+        Assert.Contains(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.True(zeroHourInstall.IsEnabled);
+        _mockNotificationService.Verify(
+            x => x.ShowWarning(ProfileValidationConstants.CannotRemoveInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that deleting a GameInstallation is allowed by the fallback heuristic when an active GameClient
+    /// has no manifest or dependencies and an empty SourceId, but differs in GameType and is not the SelectedGameInstallation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DeleteContent_AllowsGameInstallationDeletion_WhenActiveClientHasNoDependenciesOrManifest_AndDiffersInGameTypeAsync()
+    {
+        // Arrange
+        var clientId = new ManifestId("1.104.community.gameclient.generalsclient");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+        var generalsInstallId = new ManifestId("1.04.eaapp.gameinstallation.generals");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = false,
+        };
+
+        var generalsInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = generalsInstallId,
+            DisplayName = "Generals 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.Generals,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = clientId,
+            DisplayName = "Generals Fallback Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.Generals,
+            InstallationType = GameInstallationType.Unknown,
+            SourceId = string.Empty,
+            Manifest = null,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall, generalsInstall];
+        _viewModel.SelectedGameInstallation = generalsInstall;
+        _viewModel.EnabledContent.Add(generalsInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DeleteContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert - deletion is not blocked by the Generals client
+        _mockNotificationService.Verify(
+            x => x.ShowWarning(ProfileValidationConstants.CannotDeleteInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Never);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -1266,4 +1266,202 @@ public class GameProfileSettingsViewModelDependencyTests
             x => x.ShowWarning(ProfileValidationConstants.CannotDeleteInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
     }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is allowed when the client only declares an optional dependency.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_AllowsGameInstallationRemoval_WhenClientInstallationDependencyIsOptionalAsync()
+    {
+        // Arrange
+        var clientId = new ManifestId("1.0.0.gameclient.optionalclient");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientManifest = new ContentManifest
+        {
+            Id = clientId,
+            Name = "Optional Client",
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            Dependencies =
+            [
+                new ContentDependency
+                {
+                    Id = zeroHourInstallId,
+                    DependencyType = ContentType.GameInstallation,
+                    IsOptional = true,
+                },
+            ],
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = clientId,
+            DisplayName = "Optional Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.Unknown,
+            Manifest = clientManifest,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert - allowed because the dependency is optional
+        Assert.Null(_viewModel.SelectedGameInstallation);
+        Assert.DoesNotContain(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.False(zeroHourInstall.IsEnabled);
+    }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is blocked when a publisher-agnostic GameClient
+    /// has empty CompatibleGameTypes but matching content-type and content-name segments.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_BlocksGameInstallationRemoval_WhenPublisherAgnosticClientMatchesEmptyCompatibleGameTypesAsync()
+    {
+        // Arrange
+        var agnosticClientId = new ManifestId("1.104.genhub.gameclient.zerohour");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientManifest = new ContentManifest
+        {
+            Id = agnosticClientId,
+            Name = "SuperHackers ZH Client",
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            Dependencies =
+            [
+                new ContentDependency
+                {
+                    Id = new ManifestId("1.104.genhub.gameinstallation.zerohour"),
+                    DependencyType = ContentType.GameInstallation,
+                    StrictPublisher = false,
+                    CompatibleGameTypes = [],
+                    IsOptional = false,
+                },
+            ],
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = agnosticClientId,
+            DisplayName = "SuperHackers ZH Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.Unknown,
+            Manifest = clientManifest,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert - blocked because segments 3 and 4 match (gameinstallation.zerohour)
+        Assert.Equal(zeroHourInstall, _viewModel.SelectedGameInstallation);
+        Assert.Contains(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.True(zeroHourInstall.IsEnabled);
+        _mockNotificationService.Verify(
+            x => x.ShowWarning(ProfileValidationConstants.CannotRemoveInstallationTitle, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is allowed when a publisher-agnostic GameClient
+    /// has empty CompatibleGameTypes and differing content-name segment.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_AllowsGameInstallationRemoval_WhenPublisherAgnosticClientWithEmptyCompatibleGameTypesDoesNotMatchNameAsync()
+    {
+        // Arrange
+        var agnosticClientId = new ManifestId("1.104.genhub.gameclient.generals");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientManifest = new ContentManifest
+        {
+            Id = agnosticClientId,
+            Name = "Generals Client",
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.Generals,
+            Dependencies =
+            [
+                new ContentDependency
+                {
+                    Id = new ManifestId("1.104.genhub.gameinstallation.generals"),
+                    DependencyType = ContentType.GameInstallation,
+                    StrictPublisher = false,
+                    CompatibleGameTypes = [],
+                    IsOptional = false,
+                },
+            ],
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = agnosticClientId,
+            DisplayName = "Generals Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.Generals,
+            InstallationType = GameInstallationType.Unknown,
+            Manifest = clientManifest,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert - allowed because dependency requires 'generals' installation, not 'zerohour'
+        Assert.Null(_viewModel.SelectedGameInstallation);
+        Assert.DoesNotContain(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.False(zeroHourInstall.IsEnabled);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/GameProfileSettingsViewModelDependencyTests.cs
@@ -1012,4 +1012,140 @@ public class GameProfileSettingsViewModelDependencyTests
         Assert.DoesNotContain(_viewModel.EnabledContent, c => c.ContentType == ContentType.GameInstallation);
         Assert.Equal("Standalone tool profiles do not require or support game installations", _viewModel.StatusMessage);
     }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is blocked when a dependent GameClient is active.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_BlocksGameInstallationRemoval_WhenDependentGameClientIsActiveAsync()
+    {
+        // Arrange
+        var standardClientId = new ManifestId("1.04.eaapp.gameclient.zerohour");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = standardClientId,
+            DisplayName = "Zero Hour 1.04 Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            SourceId = zeroHourInstallId.Value,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+
+        // Act
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert
+        Assert.Equal(zeroHourInstall, _viewModel.SelectedGameInstallation);
+        Assert.Contains(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.True(zeroHourInstall.IsEnabled);
+        Assert.Contains("Cannot remove", _viewModel.StatusMessage);
+        _mockNotificationService.Verify(
+            x => x.ShowWarning("Cannot Remove Installation", It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that disabling a GameInstallation is allowed after the dependent GameClient is removed first.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task DisableContent_AllowsGameInstallationRemoval_AfterDependentGameClientIsRemovedAsync()
+    {
+        // Arrange
+        var standardClientId = new ManifestId("1.04.eaapp.gameclient.zerohour");
+        var zeroHourInstallId = new ManifestId("1.04.eaapp.gameinstallation.zerohour");
+
+        var zeroHourInstall = new ViewModelContentDisplayItem
+        {
+            ManifestId = zeroHourInstallId,
+            DisplayName = "Zero Hour 1.04",
+            ContentType = ContentType.GameInstallation,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            IsEnabled = true,
+        };
+
+        var clientDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = standardClientId,
+            DisplayName = "Zero Hour 1.04 Client",
+            ContentType = ContentType.GameClient,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.EaApp,
+            SourceId = zeroHourInstallId.Value,
+            IsEnabled = true,
+        };
+
+        var modDisplayItem = new ViewModelContentDisplayItem
+        {
+            ManifestId = new ManifestId("1.0.0.mod.test"),
+            DisplayName = "Test Mod",
+            ContentType = ContentType.Mod,
+            GameType = GameType.ZeroHour,
+            InstallationType = GameInstallationType.Unknown,
+            IsEnabled = true,
+        };
+
+        _viewModel.AvailableGameInstallations = [zeroHourInstall];
+        _viewModel.SelectedGameInstallation = zeroHourInstall;
+        _viewModel.EnabledContent.Add(zeroHourInstall);
+        _viewModel.EnabledContent.Add(clientDisplayItem);
+        _viewModel.EnabledContent.Add(modDisplayItem);
+
+        // Act 1: Disable client first
+        await _viewModel.DisableContentCommand.ExecuteAsync(clientDisplayItem);
+        Assert.DoesNotContain(_viewModel.EnabledContent, c => c.ManifestId.Value == standardClientId.Value);
+
+        // Act 2: Disable installation
+        await _viewModel.DisableContentCommand.ExecuteAsync(zeroHourInstall);
+
+        // Assert
+        Assert.Null(_viewModel.SelectedGameInstallation);
+        Assert.DoesNotContain(_viewModel.EnabledContent, c => c.ManifestId.Value == zeroHourInstallId.Value);
+        Assert.False(zeroHourInstall.IsEnabled);
+        Assert.Equal($"Disabled {zeroHourInstall.DisplayName}", _viewModel.StatusMessage);
+    }
+
+    /// <summary>
+    /// Verifies that saving fails with error message and notification when SelectedGameInstallation is null.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task Save_FailsWithNotification_WhenSelectedGameInstallationIsNullAsync()
+    {
+        // Arrange
+        _viewModel.Name = "Test Profile";
+        _viewModel.SelectedGameInstallation = null;
+
+        // Act
+        await _viewModel.SaveCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal("Please select a game installation", _viewModel.StatusMessage);
+        _mockNotificationService.Verify(
+            x => x.ShowError("Missing Game Installation", "Please select a game installation before saving.", It.IsAny<int?>(), It.IsAny<bool>()),
+            Times.Once);
+        _mockGameProfileManager.Verify(
+            x => x.CreateProfileAsync(It.IsAny<CreateProfileRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -180,8 +180,40 @@ public partial class GameProfileSettingsViewModel
         await EnableContentInternal(contentItem, bypassLoadingGuard: false);
     }
 
+    private async Task<bool> ValidateInstallationRemovalAsync(
+        ContentDisplayItem contentItem,
+        string actionVerb,
+        string notificationTitle,
+        CancellationToken cancellationToken = default)
+    {
+        if (contentItem.ContentType != ContentType.GameInstallation)
+        {
+            return true;
+        }
+
+        var installation = EnabledContent.FirstOrDefault(e => e.ManifestId.Value == contentItem.ManifestId.Value) ?? contentItem;
+        var dependentClients = await GetDependentActiveGameClientsAsync(installation, cancellationToken);
+        if (dependentClients.Count == 0)
+        {
+            return true;
+        }
+
+        var clientNames = string.Join(", ", dependentClients.Select(c => $"'{c.DisplayName}'"));
+        StatusMessage = $"Cannot {actionVerb} {contentItem.DisplayName} while dependent game client {clientNames} is active";
+        _logger?.LogWarning(
+            "{Action}Content blocked: Game Installation '{Installation}' is required by active Game Client(s) {Clients}",
+            char.ToUpperInvariant(actionVerb[0]) + actionVerb[1..],
+            contentItem.DisplayName,
+            clientNames);
+
+        var notificationMessage = $"Cannot {actionVerb} game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.";
+        _localNotificationService.ShowWarning(notificationTitle, notificationMessage);
+        _notificationService?.ShowWarning(notificationTitle, notificationMessage);
+        return false;
+    }
+
     [RelayCommand]
-    private async Task DisableContentAsync(ContentDisplayItem? contentItem)
+    private async Task DisableContentAsync(ContentDisplayItem? contentItem, CancellationToken cancellationToken = default)
     {
         if (contentItem == null)
         {
@@ -190,26 +222,13 @@ public partial class GameProfileSettingsViewModel
             return;
         }
 
-        if (contentItem.ContentType == ContentType.GameInstallation)
+        if (!await ValidateInstallationRemovalAsync(
+                contentItem,
+                "remove",
+                ProfileValidationConstants.CannotRemoveInstallationTitle,
+                cancellationToken))
         {
-            var installation = EnabledContent.FirstOrDefault(e => e.ManifestId.Value == contentItem.ManifestId.Value) ?? contentItem;
-            var dependentClients = await GetDependentActiveGameClientsAsync(installation);
-            if (dependentClients.Count > 0)
-            {
-                var clientNames = string.Join(", ", dependentClients.Select(c => $"'{c.DisplayName}'"));
-                StatusMessage = $"Cannot remove {contentItem.DisplayName} while dependent game client {clientNames} is active";
-                _logger?.LogWarning(
-                    "DisableContent blocked: Game Installation '{Installation}' is required by active Game Client(s) {Clients}",
-                    contentItem.DisplayName,
-                    clientNames);
-                _localNotificationService.ShowWarning(
-                    "Cannot Remove Installation",
-                    $"Cannot remove game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
-                _notificationService?.ShowWarning(
-                    "Cannot Remove Installation",
-                    $"Cannot remove game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
-                return;
-            }
+            return;
         }
 
         if (contentItem.IsLocked)
@@ -224,7 +243,7 @@ public partial class GameProfileSettingsViewModel
         {
             StatusMessage = "This content item cannot be toggled";
             _logger?.LogWarning("DisableContent: Cannot disable non-toggleable item {DisplayName}", contentItem.DisplayName);
-            _localNotificationService.ShowWarning("Cannot Modify Content", $"'{contentItem.DisplayName}' cannot be modified in this mode.");
+            _localNotificationService.ShowWarning(ProfileValidationConstants.CannotModifyContentTitle, $"'{contentItem.DisplayName}' cannot be modified in this mode.");
             return;
         }
 
@@ -290,7 +309,7 @@ public partial class GameProfileSettingsViewModel
     }
 
     [RelayCommand]
-    private async Task DeleteContentAsync(ContentDisplayItem? contentItem)
+    private async Task DeleteContentAsync(ContentDisplayItem? contentItem, CancellationToken cancellationToken = default)
     {
         if (contentItem == null)
         {
@@ -299,26 +318,13 @@ public partial class GameProfileSettingsViewModel
             return;
         }
 
-        if (contentItem.ContentType == ContentType.GameInstallation)
+        if (!await ValidateInstallationRemovalAsync(
+                contentItem,
+                "delete",
+                ProfileValidationConstants.CannotDeleteInstallationTitle,
+                cancellationToken))
         {
-            var installation = EnabledContent.FirstOrDefault(e => e.ManifestId.Value == contentItem.ManifestId.Value) ?? contentItem;
-            var dependentClients = await GetDependentActiveGameClientsAsync(installation);
-            if (dependentClients.Count > 0)
-            {
-                var clientNames = string.Join(", ", dependentClients.Select(c => $"'{c.DisplayName}'"));
-                StatusMessage = $"Cannot delete {contentItem.DisplayName} while dependent game client {clientNames} is active";
-                _logger?.LogWarning(
-                    "DeleteContent blocked: Game Installation '{Installation}' is required by active Game Client(s) {Clients}",
-                    contentItem.DisplayName,
-                    clientNames);
-                _localNotificationService.ShowWarning(
-                    "Cannot Delete Installation",
-                    $"Cannot delete game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
-                _notificationService?.ShowWarning(
-                    "Cannot Delete Installation",
-                    $"Cannot delete game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
-                return;
-            }
+            return;
         }
 
         if (contentItem.IsLocked)
@@ -411,11 +417,11 @@ public partial class GameProfileSettingsViewModel
             {
                 StatusMessage = "Please select a game installation";
                 _localNotificationService.ShowError(
-                    "Missing Game Installation",
-                    "Please select a game installation before saving.");
+                    ProfileValidationConstants.MissingGameInstallationTitle,
+                    ProfileValidationConstants.SelectGameInstallationBeforeSaving);
                 _notificationService?.ShowError(
-                    "Missing Game Installation",
-                    "Please select a game installation before saving.");
+                    ProfileValidationConstants.MissingGameInstallationTitle,
+                    ProfileValidationConstants.SelectGameInstallationBeforeSaving);
                 _logger?.LogWarning("Profile save blocked: No game installation selected");
                 return;
             }
@@ -424,8 +430,8 @@ public partial class GameProfileSettingsViewModel
             {
                 StatusMessage = "Please enter a profile name";
                 _localNotificationService.ShowWarning(
-                    "Missing Name",
-                    "Please enter a profile name before saving.");
+                    ProfileValidationConstants.MissingProfileNameTitle,
+                    ProfileValidationConstants.EnterProfileNameBeforeSaving);
                 _logger?.LogWarning("Profile save blocked: Profile name is empty");
                 return;
             }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -182,6 +182,7 @@ public partial class GameProfileSettingsViewModel
 
     private async Task<bool> ValidateInstallationRemovalAsync(
         ContentDisplayItem contentItem,
+        string actionCommand,
         string actionVerb,
         string notificationTitle,
         CancellationToken cancellationToken = default)
@@ -199,14 +200,22 @@ public partial class GameProfileSettingsViewModel
         }
 
         var clientNames = string.Join(", ", dependentClients.Select(c => $"'{c.DisplayName}'"));
-        StatusMessage = $"Cannot {actionVerb} {contentItem.DisplayName} while dependent game client {clientNames} is active";
+        StatusMessage = string.Format(
+            ProfileValidationConstants.InstallationActionBlockedStatusFormat,
+            actionVerb,
+            contentItem.DisplayName,
+            clientNames);
         _logger?.LogWarning(
-            "{Action}Content blocked: Game Installation '{Installation}' is required by active Game Client(s) {Clients}",
-            char.ToUpperInvariant(actionVerb[0]) + actionVerb[1..],
+            "{Action} blocked: Game Installation '{Installation}' is required by active Game Client(s) {Clients}",
+            actionCommand,
             contentItem.DisplayName,
             clientNames);
 
-        var notificationMessage = $"Cannot {actionVerb} game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.";
+        var notificationMessage = string.Format(
+            ProfileValidationConstants.InstallationActionBlockedNotificationFormat,
+            actionVerb,
+            contentItem.DisplayName,
+            clientNames);
         _localNotificationService.ShowWarning(notificationTitle, notificationMessage);
         _notificationService?.ShowWarning(notificationTitle, notificationMessage);
         return false;
@@ -224,6 +233,7 @@ public partial class GameProfileSettingsViewModel
 
         if (!await ValidateInstallationRemovalAsync(
                 contentItem,
+                "DisableContent",
                 "remove",
                 ProfileValidationConstants.CannotRemoveInstallationTitle,
                 cancellationToken))
@@ -320,6 +330,7 @@ public partial class GameProfileSettingsViewModel
 
         if (!await ValidateInstallationRemovalAsync(
                 contentItem,
+                "DeleteContent",
                 "delete",
                 ProfileValidationConstants.CannotDeleteInstallationTitle,
                 cancellationToken))

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -351,7 +351,7 @@ public partial class GameProfileSettingsViewModel
 
             _logger?.LogInformation("Attempting to delete content: {ContentName}", contentItem.DisplayName);
 
-            var result = await _localContentService.DeleteLocalContentAsync(contentItem.ManifestId.Value);
+            var result = await _localContentService.DeleteLocalContentAsync(contentItem.ManifestId.Value, cancellationToken);
 
             if (result.Success)
             {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.Commands.cs
@@ -190,6 +190,28 @@ public partial class GameProfileSettingsViewModel
             return;
         }
 
+        if (contentItem.ContentType == ContentType.GameInstallation)
+        {
+            var installation = EnabledContent.FirstOrDefault(e => e.ManifestId.Value == contentItem.ManifestId.Value) ?? contentItem;
+            var dependentClients = await GetDependentActiveGameClientsAsync(installation);
+            if (dependentClients.Count > 0)
+            {
+                var clientNames = string.Join(", ", dependentClients.Select(c => $"'{c.DisplayName}'"));
+                StatusMessage = $"Cannot remove {contentItem.DisplayName} while dependent game client {clientNames} is active";
+                _logger?.LogWarning(
+                    "DisableContent blocked: Game Installation '{Installation}' is required by active Game Client(s) {Clients}",
+                    contentItem.DisplayName,
+                    clientNames);
+                _localNotificationService.ShowWarning(
+                    "Cannot Remove Installation",
+                    $"Cannot remove game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
+                _notificationService?.ShowWarning(
+                    "Cannot Remove Installation",
+                    $"Cannot remove game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
+                return;
+            }
+        }
+
         if (contentItem.IsLocked)
         {
             StatusMessage = "This content item is locked and cannot be modified";
@@ -202,6 +224,7 @@ public partial class GameProfileSettingsViewModel
         {
             StatusMessage = "This content item cannot be toggled";
             _logger?.LogWarning("DisableContent: Cannot disable non-toggleable item {DisplayName}", contentItem.DisplayName);
+            _localNotificationService.ShowWarning("Cannot Modify Content", $"'{contentItem.DisplayName}' cannot be modified in this mode.");
             return;
         }
 
@@ -274,6 +297,28 @@ public partial class GameProfileSettingsViewModel
             StatusMessage = "No content selected";
             _logger?.LogWarning("DeleteContent: contentItem parameter is null");
             return;
+        }
+
+        if (contentItem.ContentType == ContentType.GameInstallation)
+        {
+            var installation = EnabledContent.FirstOrDefault(e => e.ManifestId.Value == contentItem.ManifestId.Value) ?? contentItem;
+            var dependentClients = await GetDependentActiveGameClientsAsync(installation);
+            if (dependentClients.Count > 0)
+            {
+                var clientNames = string.Join(", ", dependentClients.Select(c => $"'{c.DisplayName}'"));
+                StatusMessage = $"Cannot delete {contentItem.DisplayName} while dependent game client {clientNames} is active";
+                _logger?.LogWarning(
+                    "DeleteContent blocked: Game Installation '{Installation}' is required by active Game Client(s) {Clients}",
+                    contentItem.DisplayName,
+                    clientNames);
+                _localNotificationService.ShowWarning(
+                    "Cannot Delete Installation",
+                    $"Cannot delete game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
+                _notificationService?.ShowWarning(
+                    "Cannot Delete Installation",
+                    $"Cannot delete game installation '{contentItem.DisplayName}' while dependent game client {clientNames} is active. Please remove the game client first.");
+                return;
+            }
         }
 
         if (contentItem.IsLocked)
@@ -365,12 +410,23 @@ public partial class GameProfileSettingsViewModel
             if (SelectedGameInstallation == null && !isStandaloneProfile)
             {
                 StatusMessage = "Please select a game installation";
+                _localNotificationService.ShowError(
+                    "Missing Game Installation",
+                    "Please select a game installation before saving.");
+                _notificationService?.ShowError(
+                    "Missing Game Installation",
+                    "Please select a game installation before saving.");
+                _logger?.LogWarning("Profile save blocked: No game installation selected");
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(Name))
             {
                 StatusMessage = "Please enter a profile name";
+                _localNotificationService.ShowWarning(
+                    "Missing Name",
+                    "Please enter a profile name before saving.");
+                _logger?.LogWarning("Profile save blocked: Profile name is empty");
                 return;
             }
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -959,7 +959,8 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
                 string.Equals(SelectedGameInstallation.ManifestId.Value, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static bool MatchesClientSourceId(ContentDisplayItem client, ContentDisplayItem installation)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2325:Methods and properties that don't access instance data should be static", Justification = "Helper method for instance-level dependency resolution")]
+    private bool MatchesClientSourceId(ContentDisplayItem client, ContentDisplayItem installation)
     {
         if (string.IsNullOrEmpty(client.SourceId))
         {
@@ -970,7 +971,8 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
                string.Equals(client.SourceId, installation.SourceId, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool MatchesDependencyGameType(ContentDependency dep, GameType installationGameType, GameType fallbackGameType)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2325:Methods and properties that don't access instance data should be static", Justification = "Helper method for instance-level dependency resolution")]
+    private bool MatchesDependencyGameType(ContentDependency dep, GameType installationGameType, GameType fallbackGameType)
     {
         if (dep.CompatibleGameTypes is { Count: > 0 })
         {

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -854,20 +854,18 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
 
     private async Task<ContentManifest?> GetOrSynthesizeManifestForContentAsync(ContentDisplayItem contentItem, CancellationToken cancellationToken = default)
     {
+        if (_manifestPool != null)
+        {
+            var manifestResult = await _manifestPool.GetManifestAsync(ManifestId.Create(contentItem.ManifestId.Value), cancellationToken);
+            if (manifestResult.Success && manifestResult.Data != null)
+            {
+                return manifestResult.Data;
+            }
+        }
+
         if (contentItem.Manifest != null)
         {
             return contentItem.Manifest;
-        }
-
-        if (_manifestPool == null)
-        {
-            return null;
-        }
-
-        var manifestResult = await _manifestPool.GetManifestAsync(ManifestId.Create(contentItem.ManifestId.Value), cancellationToken);
-        if (manifestResult.Success && manifestResult.Data != null)
-        {
-            return manifestResult.Data;
         }
 
         if (contentItem.ContentType == ContentType.GameClient && !string.IsNullOrEmpty(contentItem.SourceId))
@@ -944,7 +942,7 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
             return true;
         }
 
-        var manifest = await GetOrSynthesizeManifestForContentAsync(client, cancellationToken);
+        var manifest = client.Manifest ?? await GetOrSynthesizeManifestForContentAsync(client, cancellationToken);
         var installDependencies = manifest?.Dependencies?
             .Where(d => d.DependencyType == ContentType.GameInstallation && !d.IsOptional)
             .ToList();

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -854,6 +854,11 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
 
     private async Task<ContentManifest?> GetOrSynthesizeManifestForContentAsync(ContentDisplayItem contentItem, CancellationToken cancellationToken = default)
     {
+        if (contentItem.Manifest != null)
+        {
+            return contentItem.Manifest;
+        }
+
         if (_manifestPool == null)
         {
             return null;
@@ -888,6 +893,106 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Gets all active game clients in <see cref="EnabledContent"/> that depend on the specified game installation.
+    /// </summary>
+    /// <param name="installation">The game installation item to check.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A list of active game client items that depend on the installation.</returns>
+    private async Task<List<ContentDisplayItem>> GetDependentActiveGameClientsAsync(
+        ContentDisplayItem installation,
+        CancellationToken cancellationToken = default)
+    {
+        var dependentClients = new List<ContentDisplayItem>();
+        var activeClients = EnabledContent
+            .Where(c => c.ContentType == ContentType.GameClient && c.IsEnabled)
+            .ToList();
+
+        if (activeClients.Count == 0)
+        {
+            return dependentClients;
+        }
+
+        foreach (var client in activeClients)
+        {
+            if (await DoesGameClientDependOnInstallationAsync(client, installation, cancellationToken))
+            {
+                dependentClients.Add(client);
+            }
+        }
+
+        return dependentClients;
+    }
+
+    /// <summary>
+    /// Determines whether the specified game client depends on the given game installation.
+    /// </summary>
+    /// <param name="client">The game client content item.</param>
+    /// <param name="installation">The game installation content item.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns><c>true</c> if the game client depends on the game installation; otherwise, <c>false</c>.</returns>
+    private async Task<bool> DoesGameClientDependOnInstallationAsync(
+        ContentDisplayItem client,
+        ContentDisplayItem installation,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Direct SourceId match (standard GameClients point directly to the GameInstallation ID)
+        if (!string.IsNullOrEmpty(client.SourceId) &&
+            (string.Equals(client.SourceId, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(client.SourceId, installation.SourceId, StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        // 2. Check manifest dependencies if available or synthesized
+        var manifest = await GetOrSynthesizeManifestForContentAsync(client, cancellationToken);
+        if (manifest?.Dependencies != null)
+        {
+            var installDependencies = manifest.Dependencies
+                .Where(d => d.DependencyType == ContentType.GameInstallation)
+                .ToList();
+
+            if (installDependencies.Count > 0)
+            {
+                foreach (var dep in installDependencies)
+                {
+                    var depId = dep.Id.ToString();
+                    if (depId != ManifestConstants.DefaultContentDependencyId)
+                    {
+                        if (string.Equals(depId, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(depId, installation.SourceId, StringComparison.OrdinalIgnoreCase) ||
+                            HasCompatibleCatalogMatch(depId, installation.ManifestId.Value))
+                        {
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        if (dep.CompatibleGameTypes is { Count: > 0 })
+                        {
+                            if (dep.CompatibleGameTypes.Contains(installation.GameType))
+                            {
+                                return true;
+                            }
+                        }
+                        else if (client.GameType == installation.GameType)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        // 3. Fallback: Any active GameClient targeting the same GameType depends on this GameInstallation,
+        // or if this installation is the currently selected profile installation.
+        return client.GameType == installation.GameType ||
+               (SelectedGameInstallation != null &&
+                string.Equals(SelectedGameInstallation.ManifestId.Value, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase));
     }
 
     private void ResolveGameInstallationDependency(

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -901,6 +901,7 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
     /// <param name="installation">The game installation item to check.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A list of active game client items that depend on the installation.</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2325:Methods and properties that don't access instance data should be static", Justification = "Operates on observable collection properties defined across partial view model classes")]
     private async Task<List<ContentDisplayItem>> GetDependentActiveGameClientsAsync(
         ContentDisplayItem installation,
         CancellationToken cancellationToken = default)
@@ -938,71 +939,71 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         ContentDisplayItem installation,
         CancellationToken cancellationToken = default)
     {
-        // 1. Direct SourceId match (standard GameClients point directly to the GameInstallation ID)
-        if (!string.IsNullOrEmpty(client.SourceId) &&
-            (string.Equals(client.SourceId, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase) ||
-             string.Equals(client.SourceId, installation.SourceId, StringComparison.OrdinalIgnoreCase)))
+        if (MatchesClientSourceId(client, installation))
         {
             return true;
         }
 
-        // 2. Check manifest dependencies if available or synthesized
         var manifest = await GetOrSynthesizeManifestForContentAsync(client, cancellationToken);
-        if (manifest?.Dependencies != null)
+        var installDependencies = manifest?.Dependencies?
+            .Where(d => d.DependencyType == ContentType.GameInstallation)
+            .ToList();
+
+        if (installDependencies is { Count: > 0 })
         {
-            var installDependencies = manifest.Dependencies
-                .Where(d => d.DependencyType == ContentType.GameInstallation)
-                .ToList();
-
-            if (installDependencies.Count > 0)
-            {
-                foreach (var dep in installDependencies)
-                {
-                    var depId = dep.Id.ToString();
-                    if (depId != ManifestConstants.DefaultContentDependencyId)
-                    {
-                        if (string.Equals(depId, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(depId, installation.SourceId, StringComparison.OrdinalIgnoreCase) ||
-                            HasCompatibleCatalogMatch(depId, installation.ManifestId.Value))
-                        {
-                            return true;
-                        }
-
-                        // Publisher-agnostic dependencies (e.g. "1.104.genhub.gameinstallation.zerohour"
-                        // with StrictPublisher = false) are satisfied by any installation of a
-                        // compatible game type, mirroring FindCompatibleGameInstallation.
-                        if (!dep.StrictPublisher &&
-                            (dep.CompatibleGameTypes is not { Count: > 0 } ||
-                             dep.CompatibleGameTypes.Contains(installation.GameType)))
-                        {
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        if (dep.CompatibleGameTypes is { Count: > 0 })
-                        {
-                            if (dep.CompatibleGameTypes.Contains(installation.GameType))
-                            {
-                                return true;
-                            }
-                        }
-                        else if (client.GameType == installation.GameType)
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
-            }
+            return installDependencies.Any(dep => IsInstallationDependencySatisfiedBy(dep, installation, client.GameType));
         }
 
-        // 3. Fallback: Any active GameClient targeting the same GameType depends on this GameInstallation,
-        // or if this installation is the currently selected profile installation.
         return client.GameType == installation.GameType ||
                (SelectedGameInstallation != null &&
                 string.Equals(SelectedGameInstallation.ManifestId.Value, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool MatchesClientSourceId(ContentDisplayItem client, ContentDisplayItem installation)
+    {
+        if (string.IsNullOrEmpty(client.SourceId))
+        {
+            return false;
+        }
+
+        return string.Equals(client.SourceId, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(client.SourceId, installation.SourceId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool MatchesDependencyGameType(ContentDependency dep, GameType installationGameType, GameType fallbackGameType)
+    {
+        if (dep.CompatibleGameTypes is { Count: > 0 })
+        {
+            return dep.CompatibleGameTypes.Contains(installationGameType);
+        }
+
+        return fallbackGameType == installationGameType;
+    }
+
+    private bool MatchesInstallationDependencyId(string depId, ContentDisplayItem installation)
+    {
+        return string.Equals(depId, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(depId, installation.SourceId, StringComparison.OrdinalIgnoreCase) ||
+               HasCompatibleCatalogMatch(depId, installation.ManifestId.Value);
+    }
+
+    private bool IsInstallationDependencySatisfiedBy(ContentDependency dep, ContentDisplayItem installation, GameType clientGameType)
+    {
+        var depId = dep.Id.ToString();
+        if (depId == ManifestConstants.DefaultContentDependencyId)
+        {
+            return MatchesDependencyGameType(dep, installation.GameType, clientGameType);
+        }
+
+        if (MatchesInstallationDependencyId(depId, installation))
+        {
+            return true;
+        }
+
+        // Publisher-agnostic dependencies (e.g. "1.104.genhub.gameinstallation.zerohour"
+        // with StrictPublisher = false) are satisfied by any installation of a
+        // compatible game type, mirroring FindCompatibleGameInstallation.
+        return !dep.StrictPublisher && MatchesDependencyGameType(dep, installation.GameType, clientGameType);
     }
 
     private void ResolveGameInstallationDependency(

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -946,12 +946,17 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
 
         var manifest = await GetOrSynthesizeManifestForContentAsync(client, cancellationToken);
         var installDependencies = manifest?.Dependencies?
-            .Where(d => d.DependencyType == ContentType.GameInstallation)
+            .Where(d => d.DependencyType == ContentType.GameInstallation && !d.IsOptional)
             .ToList();
 
         if (installDependencies is { Count: > 0 })
         {
             return installDependencies.Any(dep => IsInstallationDependencySatisfiedBy(dep, installation, client.GameType));
+        }
+
+        if (manifest?.Dependencies?.Any(d => d.DependencyType == ContentType.GameInstallation) == true)
+        {
+            return false;
         }
 
         return client.GameType == installation.GameType ||
@@ -982,6 +987,7 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         return fallbackGameType == installationGameType;
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2325:Methods and properties that don't access instance data should be static", Justification = "Helper method for instance-level dependency resolution")]
     private bool MatchesInstallationDependencyId(string depId, ContentDisplayItem installation)
     {
         return string.Equals(depId, installation.ManifestId.Value, StringComparison.OrdinalIgnoreCase) ||
@@ -989,6 +995,7 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
                HasCompatibleCatalogMatch(depId, installation.ManifestId.Value);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S2325:Methods and properties that don't access instance data should be static", Justification = "Helper method for instance-level dependency resolution")]
     private bool IsInstallationDependencySatisfiedBy(ContentDependency dep, ContentDisplayItem installation, GameType clientGameType)
     {
         var depId = dep.Id.ToString();
@@ -1003,9 +1010,25 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
         }
 
         // Publisher-agnostic dependencies (e.g. "1.104.genhub.gameinstallation.zerohour"
-        // with StrictPublisher = false) are satisfied by any installation of a
-        // compatible game type, mirroring FindCompatibleGameInstallation.
-        return !dep.StrictPublisher && MatchesDependencyGameType(dep, installation.GameType, clientGameType);
+        // with StrictPublisher = false) are satisfied by an installation of a compatible game type
+        // when CompatibleGameTypes is specified, or by matching content-type and content-name segments.
+        if (!dep.StrictPublisher)
+        {
+            if (dep.CompatibleGameTypes is { Count: > 0 })
+            {
+                return dep.CompatibleGameTypes.Contains(installation.GameType);
+            }
+
+            var depSegments = depId.Split('.');
+            var instSegments = installation.ManifestId.Value.Split('.');
+            if (depSegments.Length >= 5 && instSegments.Length >= 5)
+            {
+                return string.Equals(depSegments[3], instSegments[3], StringComparison.OrdinalIgnoreCase) &&
+                       string.Equals(depSegments[4], instSegments[4], StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        return false;
     }
 
     private void ResolveGameInstallationDependency(

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileSettingsViewModel.cs
@@ -967,6 +967,16 @@ public partial class GameProfileSettingsViewModel : ViewModelBase,
                         {
                             return true;
                         }
+
+                        // Publisher-agnostic dependencies (e.g. "1.104.genhub.gameinstallation.zerohour"
+                        // with StrictPublisher = false) are satisfied by any installation of a
+                        // compatible game type, mirroring FindCompatibleGameInstallation.
+                        if (!dep.StrictPublisher &&
+                            (dep.CompatibleGameTypes is not { Count: > 0 } ||
+                             dep.CompatibleGameTypes.Contains(installation.GameType)))
+                        {
+                            return true;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
﻿## Summary of Changes

In `GameProfileSettingsViewModel`, users were previously able to disable or delete a `GameInstallation` while a dependent `GameClient` remained active in the profile. When saving, the profile failed or was saved in an invalid state without explicit feedback.

This PR ensures proper UX guarding:
1. **Guarded Removal & Deletion**:
   - In `DisableContentAsync` and `DeleteContentAsync`, blocks removal/deletion of a `GameInstallation` if any active `GameClient` depending on it is still in `EnabledContent`.
   - Emits informative warning notifications via both `_localNotificationService` and `_notificationService` asking the user to remove the dependent game client first.
2. **Explicit Validation on Save**:
   - In `SaveAsync`, when `SelectedGameInstallation` is missing on non-standalone profiles, emits an explicit error notification (`Missing Game Installation: Please select a game installation before saving.`) rather than silently failing.
   - Also warns when a profile name is empty.
3. **Dependency Resolution Helpers**:
   - Added `GetDependentActiveGameClientsAsync` and `DoesGameClientDependOnInstallationAsync` with fast-path manifest inspection to determine installation dependencies.
4. **Unit Tests**:
   - Added unit tests in `GameProfileSettingsViewModelDependencyTests.cs` covering:
     - Blocking installation removal when a dependent client is active.
     - Allowing installation removal after the dependent client is removed.
     - Save failure notification when `SelectedGameInstallation` is null.

## Verification
- Built solution with `dotnet build` (`0 Warning(s), 0 Error(s)`).
- Ran xUnit test suite `GameProfileSettingsViewModelDependencyTests` and all related profile tests (`33 Passed, 0 Failed`).
