### PR TITLE
fix(content): normalize .ctr files by content during local content import

### DIFF
--- a/GenHub/GenHub.Core/Constants/GenLauncherConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GenLauncherConstants.cs
@@ -36,6 +36,11 @@ public static class GenLauncherConstants
     public const string BigExtension = ".big";
 
     /// <summary>
+    /// Standard executable file extension.
+    /// </summary>
+    public const string ExeExtension = ".exe";
+
+    /// <summary>
     /// Session key for "do not ask again" preference for normalization dialog.
     /// </summary>
     public const string NormalizationDialogSessionKey = "genlauncher.normalization.skip";

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherDetectionResult.cs
@@ -19,6 +19,11 @@ public class GenLauncherDetectionResult
     public List<string> GibFiles { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the list of .ctr files found.
+    /// </summary>
+    public List<string> CtrFiles { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the list of files with .GLR suffix.
     /// </summary>
     public List<string> GlrFiles { get; set; } = [];
@@ -42,7 +47,7 @@ public class GenLauncherDetectionResult
     /// Gets the total count of affected files.
     /// </summary>
     public int TotalAffectedFiles =>
-        GibFiles.Count + GlrFiles.Count + GofFiles.Count + GltcFiles.Count + SymbolicLinks.Count;
+        GibFiles.Count + CtrFiles.Count + GlrFiles.Count + GofFiles.Count + GltcFiles.Count + SymbolicLinks.Count;
 
     /// <summary>
     /// Gets a user-friendly summary of detected files.
@@ -54,6 +59,11 @@ public class GenLauncherDetectionResult
         if (GibFiles.Count > 0)
         {
             parts.Add($"{GibFiles.Count} {GenLauncherConstants.GibExtension} file(s)");
+        }
+
+        if (CtrFiles.Count > 0)
+        {
+            parts.Add($"{CtrFiles.Count} {GenLauncherConstants.CtrExtension} file(s)");
         }
 
         if (GlrFiles.Count > 0)

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
@@ -23,6 +23,11 @@ public class GenLauncherNormalizationResult
     public List<string> FailedFiles { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the list of files left untouched because their format was not recognized.
+    /// </summary>
+    public List<string> SkippedFiles { get; set; } = [];
+
+    /// <summary>
     /// Gets a value indicating whether normalization was fully successful.
     /// </summary>
     public bool IsFullySuccessful => FailedFiles.Count == 0;

--- a/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
+++ b/GenHub/GenHub.Core/Interfaces/Content/GenLauncherNormalizationResult.cs
@@ -8,7 +8,7 @@ namespace GenHub.Core.Interfaces.Content;
 public class GenLauncherNormalizationResult
 {
     /// <summary>
-    /// Gets or sets the number of files successfully normalized.
+    /// Gets or sets the number of normalization operations successfully completed (each stage, such as suffix stripping and subsequent .gib/.ctr format conversion, counts as an operation).
     /// </summary>
     public int NormalizedCount { get; set; }
 

--- a/GenHub/GenHub.Core/Utilities/BigArchiveClassifier.cs
+++ b/GenHub/GenHub.Core/Utilities/BigArchiveClassifier.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+
+namespace GenHub.Core.Utilities;
+
+/// <summary>
+/// Provides utility methods for detecting and validating BIG format archives based on file headers.
+/// </summary>
+public static class BigArchiveClassifier
+{
+    /// <summary>
+    /// Magic header length required to inspect BIG format signature (4 bytes).
+    /// </summary>
+    public const int MagicHeaderLength = 4;
+
+    /// <summary>
+    /// Minimum valid BIG archive file size in bytes (16 bytes for header fields).
+    /// </summary>
+    public const int MinimumBigFileSize = 16;
+
+    /// <summary>
+    /// Determines whether the file at <paramref name="filePath"/> starts with the magic bytes
+    /// of a BIG archive format (BIG4, BIGF, BIGE, or BIG null byte) and meets minimum size requirements.
+    /// </summary>
+    /// <param name="filePath">The path of the file to inspect.</param>
+    /// <returns>
+    /// <c>true</c> if the file exists and its header matches a known BIG archive signature;
+    /// otherwise <c>false</c>. Missing, short, or unreadable files safely return <c>false</c>.
+    /// </returns>
+    public static bool IsBigArchiveFile(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var stream = new FileStream(
+                filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            if (stream.Length < MinimumBigFileSize)
+            {
+                return false;
+            }
+
+            Span<byte> header = stackalloc byte[MagicHeaderLength];
+            if (stream.Read(header) < MagicHeaderLength)
+            {
+                return false;
+            }
+
+            return HasBigArchiveMagicBytes(header);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="header"/> starts with the magic bytes of a BIG archive.
+    /// Accepted signatures start with 'B', 'I', 'G' followed by '4', 'F', 'E', or 0x00.
+    /// </summary>
+    /// <param name="header">The byte span containing at least <see cref="MagicHeaderLength"/> bytes.</param>
+    /// <returns><c>true</c> if the header matches a BIG signature; otherwise <c>false</c>.</returns>
+    public static bool HasBigArchiveMagicBytes(ReadOnlySpan<byte> header)
+    {
+        if (header.Length < MagicHeaderLength)
+        {
+            return false;
+        }
+
+        return header[0] == (byte)'B' &&
+               header[1] == (byte)'I' &&
+               header[2] == (byte)'G' &&
+               (header[3] == (byte)'4' || header[3] == (byte)'F' || header[3] == (byte)'E' || header[3] == 0);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Content;
@@ -763,6 +764,162 @@ public class AddLocalContentViewModelTests : IDisposable
         await vm.AddContentCommand.ExecuteAsync(null);
 
         Assert.Null(capturedEntryPoint);
+    }
+
+    /// <summary>
+    /// Verifies that when GenLauncher files including .ctr files are detected, the confirmation prompt includes .ctr conversion details, and confirming invokes normalization.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WhenCtrFilesDetected_PromptsWithCtrDetails_AndNormalizesOnConfirmationAsync()
+    {
+        var tempDir = CreateTempDirectory();
+        var ctrFile = Path.Combine(tempDir, "!Contra009.ctr");
+        File.WriteAllText(ctrFile, "dummy");
+
+        var detectionResult = new GenLauncherDetectionResult
+        {
+            HasGenLauncherFiles = true,
+            CtrFiles = [ctrFile],
+        };
+
+        _normalizationServiceMock
+            .Setup(x => x.DetectGenLauncherFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(detectionResult);
+
+        string? capturedPrompt = null;
+        _dialogServiceMock
+            .Setup(x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey))
+            .Callback<string, string, string, string, string?>((_, prompt, _, _, _) => capturedPrompt = prompt)
+            .ReturnsAsync(true);
+
+        _normalizationServiceMock
+            .Setup(x => x.NormalizeFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GenLauncherNormalizationResult>.CreateSuccess(new GenLauncherNormalizationResult
+            {
+                NormalizedCount = 1,
+            }));
+
+        var vm = CreateViewModel();
+        await vm.ImportContentAsync(tempDir);
+
+        _dialogServiceMock.Verify(
+            x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey),
+            Times.Once);
+
+        Assert.NotNull(capturedPrompt);
+        Assert.Contains(GenLauncherConstants.CtrExtension, capturedPrompt);
+        Assert.Contains(GenLauncherConstants.BigExtension, capturedPrompt);
+        Assert.Contains(GenLauncherConstants.ExeExtension, capturedPrompt);
+
+        _normalizationServiceMock.Verify(x => x.NormalizeFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains("Normalized 1 file(s)", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Verifies that when the user skips GenLauncher normalization, NormalizeFilesAsync is not called.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WhenNormalizationSkipped_DoesNotCallNormalizeFilesAsync()
+    {
+        var tempDir = CreateTempDirectory();
+        var ctrFile = Path.Combine(tempDir, "!Contra009.ctr");
+        File.WriteAllText(ctrFile, "dummy");
+
+        var detectionResult = new GenLauncherDetectionResult
+        {
+            HasGenLauncherFiles = true,
+            CtrFiles = [ctrFile],
+        };
+
+        _normalizationServiceMock
+            .Setup(x => x.DetectGenLauncherFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(detectionResult);
+
+        _dialogServiceMock
+            .Setup(x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey))
+            .ReturnsAsync(false);
+
+        var vm = CreateViewModel();
+        await vm.ImportContentAsync(tempDir);
+
+        _normalizationServiceMock.Verify(x => x.NormalizeFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Contains("GenLauncher files not normalized", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Verifies that importing a folder containing Contra .ctr archives and executables with the real normalization service converts them to .big and .exe and auto-selects the resulting executable for GameClient.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WithRealNormalizationService_NormalizesContraFilesAndAutoSelectsExecutableAsync()
+    {
+        var tempDir = CreateTempDirectory();
+
+        // Write Contra BIG archive file (.ctr)
+        var bigCtrPath = Path.Combine(tempDir, "!Contra009.ctr");
+        var bigBytes = new byte[16];
+        bigBytes[0] = (byte)'B';
+        bigBytes[1] = (byte)'I';
+        bigBytes[2] = (byte)'G';
+        bigBytes[3] = (byte)'F';
+        await File.WriteAllBytesAsync(bigCtrPath, bigBytes);
+
+        // Write Contra executable file (.ctr)
+        var exeCtrPath = Path.Combine(tempDir, "generals.ctr");
+        var exeBytes = new byte[16];
+        exeBytes[0] = 0x4D; // 'M'
+        exeBytes[1] = 0x5A; // 'Z'
+        exeBytes[2] = 0x90;
+        exeBytes[3] = 0x00;
+        await File.WriteAllBytesAsync(exeCtrPath, exeBytes);
+
+        _dialogServiceMock
+            .Setup(x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey))
+            .ReturnsAsync(true);
+
+        var realNormalizationService = new GenHub.Infrastructure.Services.GenLauncherNormalizationService(
+            NullLogger<GenHub.Infrastructure.Services.GenLauncherNormalizationService>.Instance);
+
+        var vm = new AddLocalContentViewModel(
+            _localContentServiceMock.Object,
+            _contentStorageServiceMock.Object,
+            realNormalizationService,
+            _dialogServiceMock.Object,
+            NullLogger<AddLocalContentViewModel>.Instance);
+        _viewModels.Add(vm);
+
+        vm.SelectedContentType = ContentType.GameClient;
+        vm.ContentName = "Contra 009";
+
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Equal(1, vm.ExecutableCount);
+        Assert.NotNull(vm.SelectedExecutableItem);
+        Assert.Equal("generals.exe", vm.SelectedExecutableItem.Name);
+        Assert.True(vm.CanAdd);
+        Assert.Contains("Normalized 2 file(s)", vm.StatusMessage);
     }
 
     private static FileTreeItem? FindInTree(IEnumerable<FileTreeItem> items, Func<FileTreeItem, bool> predicate)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
@@ -922,6 +922,50 @@ public class AddLocalContentViewModelTests : IDisposable
         Assert.Contains("Normalized 2 file(s)", vm.StatusMessage);
     }
 
+    /// <summary>
+    /// Verifies that when normalization succeeds with skipped files, the status message reports the skipped count.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WhenNormalizationHasSkippedFiles_ReportsSkippedCountInStatusMessageAsync()
+    {
+        var tempDir = CreateTempDirectory();
+        var ctrFile = Path.Combine(tempDir, "unknown.ctr");
+        await File.WriteAllTextAsync(ctrFile, "dummy");
+
+        var detectionResult = new GenLauncherDetectionResult
+        {
+            HasGenLauncherFiles = true,
+            CtrFiles = [ctrFile],
+        };
+
+        _normalizationServiceMock
+            .Setup(x => x.DetectGenLauncherFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(detectionResult);
+
+        _dialogServiceMock
+            .Setup(x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey))
+            .ReturnsAsync(true);
+
+        _normalizationServiceMock
+            .Setup(x => x.NormalizeFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GenLauncherNormalizationResult>.CreateSuccess(new GenLauncherNormalizationResult
+            {
+                NormalizedCount = 0,
+                SkippedFiles = [ctrFile],
+            }));
+
+        var vm = CreateViewModel();
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Contains("0 file(s); 1 skipped. Import successful.", vm.StatusMessage);
+    }
+
     private static FileTreeItem? FindInTree(IEnumerable<FileTreeItem> items, Func<FileTreeItem, bool> predicate)
     {
         foreach (var item in items)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/ViewModels/AddLocalContentViewModelTests.cs
@@ -963,7 +963,118 @@ public class AddLocalContentViewModelTests : IDisposable
         var vm = CreateViewModel();
         await vm.ImportContentAsync(tempDir);
 
-        Assert.Contains("0 file(s); 1 skipped. Import successful.", vm.StatusMessage);
+        Assert.Contains("0 file(s); 1 skipped. Import completed.", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Verifies that when normalization produces both skipped and failed files, the status message reports both and ends with 'Import completed.'.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WhenNormalizationHasFailedAndSkippedFiles_ReportsCombinedStatusMessageAsync()
+    {
+        var tempDir = CreateTempDirectory();
+        var ctrFile = Path.Combine(tempDir, "test.ctr");
+        File.WriteAllText(ctrFile, "dummy");
+
+        _normalizationServiceMock
+            .Setup(x => x.DetectGenLauncherFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GenLauncherDetectionResult { HasGenLauncherFiles = true, CtrFiles = [ctrFile] });
+
+        _dialogServiceMock
+            .Setup(x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey))
+            .ReturnsAsync(true);
+
+        _normalizationServiceMock
+            .Setup(x => x.NormalizeFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GenLauncherNormalizationResult>.CreateSuccess(new GenLauncherNormalizationResult
+            {
+                NormalizedCount = 0,
+                SkippedFiles = ["skipped.ctr"],
+                FailedFiles = ["failed.ctr"],
+            }));
+
+        var vm = CreateViewModel();
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Contains("0 file(s); 1 skipped, 1 failed. Import completed.", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Verifies that when normalization produces failed files only, the status message reports the failed count and ends with 'Import completed.'.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WhenNormalizationHasFailedFilesOnly_ReportsFailedCountInStatusMessageAsync()
+    {
+        var tempDir = CreateTempDirectory();
+        var ctrFile = Path.Combine(tempDir, "test.ctr");
+        File.WriteAllText(ctrFile, "dummy");
+
+        _normalizationServiceMock
+            .Setup(x => x.DetectGenLauncherFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GenLauncherDetectionResult { HasGenLauncherFiles = true, CtrFiles = [ctrFile] });
+
+        _dialogServiceMock
+            .Setup(x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey))
+            .ReturnsAsync(true);
+
+        _normalizationServiceMock
+            .Setup(x => x.NormalizeFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GenLauncherNormalizationResult>.CreateSuccess(new GenLauncherNormalizationResult
+            {
+                NormalizedCount = 0,
+                FailedFiles = ["failed.ctr"],
+            }));
+
+        var vm = CreateViewModel();
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Contains("0 file(s); 1 failed. Import completed.", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Verifies that when normalization fails with an operation error, a warning is set and import continues.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task ImportContentAsync_WhenNormalizeFilesFails_ReportsWarningAndContinuesImportAsync()
+    {
+        var tempDir = CreateTempDirectory();
+        var ctrFile = Path.Combine(tempDir, "test.ctr");
+        File.WriteAllText(ctrFile, "dummy");
+
+        _normalizationServiceMock
+            .Setup(x => x.DetectGenLauncherFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GenLauncherDetectionResult { HasGenLauncherFiles = true, CtrFiles = [ctrFile] });
+
+        _dialogServiceMock
+            .Setup(x => x.ShowConfirmationAsync(
+                "GenLauncher Files Detected",
+                It.IsAny<string>(),
+                "Normalize",
+                "Skip",
+                GenLauncherConstants.NormalizationDialogSessionKey))
+            .ReturnsAsync(true);
+
+        _normalizationServiceMock
+            .Setup(x => x.NormalizeFilesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<GenLauncherNormalizationResult>.CreateFailure("Disk I/O error"));
+
+        var vm = CreateViewModel();
+        await vm.ImportContentAsync(tempDir);
+
+        Assert.Contains("Normalization warning: Disk I/O error. Import will continue.", vm.StatusMessage);
     }
 
     private static FileTreeItem? FindInTree(IEnumerable<FileTreeItem> items, Func<FileTreeItem, bool> predicate)

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
@@ -322,6 +322,175 @@ public class GenLauncherNormalizationServiceTests : IDisposable
         Assert.True(ExecutableFileClassifier.IsLegacyLaunchCandidate("generals", normalizedPath));
     }
 
+    /// <summary>
+    /// Tests that a .ctr file with BIG archive magic bytes is normalized to .big.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_ConvertsBigCtrToBigAsync()
+    {
+        var ctrPath = Path.Combine(_tempDir, "!Contra.ctr");
+        var bytes = new byte[16];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'I';
+        bytes[2] = (byte)'G';
+        bytes[3] = (byte)'F';
+        await File.WriteAllBytesAsync(ctrPath, bytes);
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.NormalizedCount);
+        Assert.False(File.Exists(ctrPath));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "!Contra.big")));
+    }
+
+    /// <summary>
+    /// Tests that a .ctr file with MZ executable magic bytes is normalized to .exe and never to .big.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_ConvertsExecutableCtrToExeAsync()
+    {
+        var ctrPath = Path.Combine(_tempDir, "generals.ctr");
+        var bytes = new byte[16];
+        bytes[0] = 0x4D; // 'M'
+        bytes[1] = 0x5A; // 'Z'
+        bytes[2] = 0x90;
+        bytes[3] = 0x00;
+        await File.WriteAllBytesAsync(ctrPath, bytes);
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.NormalizedCount);
+        Assert.False(File.Exists(ctrPath));
+        Assert.False(File.Exists(Path.Combine(_tempDir, "generals.big")));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "generals.exe")));
+    }
+
+    /// <summary>
+    /// Tests that a .ctr file with unknown format is left untouched and reported in SkippedFiles.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_LeavesUnknownCtrUntouchedAndReportsSkippedAsync()
+    {
+        var ctrPath = Path.Combine(_tempDir, "unknown.ctr");
+        await File.WriteAllTextAsync(ctrPath, "plain text content that is neither BIG nor MZ");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.Data.NormalizedCount);
+        Assert.True(result.Data.IsFullySuccessful);
+        Assert.Contains(ctrPath, result.Data.SkippedFiles);
+        Assert.DoesNotContain(ctrPath, result.Data.FailedFiles);
+        Assert.True(File.Exists(ctrPath));
+    }
+
+    /// <summary>
+    /// Tests that .ctr normalization skips and marks failed when destination file already exists.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_SkipsWhenCtrDestinationExistsAsync()
+    {
+        var ctrPath = Path.Combine(_tempDir, "!Contra.ctr");
+        var bigPath = Path.Combine(_tempDir, "!Contra.big");
+        var bytes = new byte[16];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'I';
+        bytes[2] = (byte)'G';
+        bytes[3] = (byte)'F';
+        await File.WriteAllBytesAsync(ctrPath, bytes);
+        await File.WriteAllTextAsync(bigPath, "existing-big-content");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.Data.NormalizedCount);
+        Assert.False(result.Data.IsFullySuccessful);
+        Assert.Contains(ctrPath, result.Data.FailedFiles);
+        Assert.True(File.Exists(ctrPath));
+        Assert.Equal("existing-big-content", await File.ReadAllTextAsync(bigPath));
+    }
+
+    /// <summary>
+    /// Tests that a suffixed .ctr file whose final normalized destination already exists is preserved without creating intermediate files.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_SkipsWhenSuffixedCtrFinalDestinationExistsAsync()
+    {
+        var suffixedCtrPath = Path.Combine(_tempDir, "generals.ctr" + GenLauncherConstants.OriginalFileSuffix);
+        var existingExePath = Path.Combine(_tempDir, "generals.exe");
+        var intermediateCtrPath = Path.Combine(_tempDir, "generals.ctr");
+
+        var bytes = new byte[16];
+        bytes[0] = 0x4D; // 'M'
+        bytes[1] = 0x5A; // 'Z'
+        bytes[2] = 0x90;
+        bytes[3] = 0x00;
+        await File.WriteAllBytesAsync(suffixedCtrPath, bytes);
+        await File.WriteAllTextAsync(existingExePath, "existing-exe-content");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.Data.NormalizedCount);
+        Assert.False(result.Data.IsFullySuccessful);
+        Assert.Contains(suffixedCtrPath, result.Data.FailedFiles);
+        Assert.True(File.Exists(suffixedCtrPath));
+        Assert.False(File.Exists(intermediateCtrPath));
+        Assert.Equal("existing-exe-content", await File.ReadAllTextAsync(existingExePath));
+    }
+
+    /// <summary>
+    /// Tests that a suffixed .gib file whose final .big destination already exists is preserved without creating intermediate files.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_SkipsWhenSuffixedGibFinalDestinationExistsAsync()
+    {
+        var suffixedGibPath = Path.Combine(_tempDir, "sound.gib" + GenLauncherConstants.ReplaceSuffix);
+        var existingBigPath = Path.Combine(_tempDir, "sound.big");
+        var intermediateGibPath = Path.Combine(_tempDir, "sound.gib");
+
+        await File.WriteAllTextAsync(suffixedGibPath, "new-gib-content");
+        await File.WriteAllTextAsync(existingBigPath, "existing-big-content");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.Data.NormalizedCount);
+        Assert.False(result.Data.IsFullySuccessful);
+        Assert.Contains(suffixedGibPath, result.Data.FailedFiles);
+        Assert.True(File.Exists(suffixedGibPath));
+        Assert.False(File.Exists(intermediateGibPath));
+        Assert.Equal("existing-big-content", await File.ReadAllTextAsync(existingBigPath));
+    }
+
+    /// <summary>
+    /// Tests that detection finds .ctr files in nested subdirectories and includes them in summary.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task DetectGenLauncherFilesAsync_FindsNestedCtrFilesAsync()
+    {
+        var nestedDir = Path.Combine(_tempDir, "mods", "contra");
+        Directory.CreateDirectory(nestedDir);
+        var ctrPath = Path.Combine(nestedDir, "patch.ctr");
+        await File.WriteAllTextAsync(ctrPath, "dummy");
+
+        var detection = await _service.DetectGenLauncherFilesAsync(_tempDir);
+
+        Assert.True(detection.HasGenLauncherFiles);
+        Assert.Single(detection.CtrFiles);
+        Assert.Equal(ctrPath, detection.CtrFiles[0]);
+        Assert.Contains(".ctr", detection.GetSummary());
+    }
+
     private bool TryCreateFileSymlink(out string? skipReason)
     {
         skipReason = null;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Infrastructure/Services/GenLauncherNormalizationServiceTests.cs
@@ -491,6 +491,78 @@ public class GenLauncherNormalizationServiceTests : IDisposable
         Assert.Contains(".ctr", detection.GetSummary());
     }
 
+    /// <summary>
+    /// Tests that a suffixed .ctr file with unrecognized content has its suffix removed and is recorded in SkippedFiles.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_SuffixedCtrWithUnrecognizedContent_StripsSuffixAndReportsSkippedAsync()
+    {
+        var suffixedCtrPath = Path.Combine(_tempDir, "patch.ctr" + GenLauncherConstants.OriginalFileSuffix);
+        await File.WriteAllTextAsync(suffixedCtrPath, "plain text content that is neither BIG nor executable");
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.NormalizedCount);
+        var strippedCtrPath = Path.Combine(_tempDir, "patch.ctr");
+        Assert.False(File.Exists(suffixedCtrPath));
+        Assert.True(File.Exists(strippedCtrPath));
+        Assert.Contains(strippedCtrPath, result.Data.SkippedFiles);
+        Assert.DoesNotContain(strippedCtrPath, result.Data.FailedFiles);
+    }
+
+    /// <summary>
+    /// Tests that a .ctr file with ELF or Mach-O executable magic bytes is normalized to .exe.
+    /// </summary>
+    /// <param name="header">Executable magic bytes to write to the file.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [InlineData(new byte[] { 0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00 })]
+    [InlineData(new byte[] { 0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01 })]
+    public async Task NormalizeFilesAsync_ConvertsExecutableCtrWithElfOrMachOToExeAsync(byte[] header)
+    {
+        var ctrPath = Path.Combine(_tempDir, "generals.ctr");
+        var payload = new byte[16];
+        Array.Copy(header, payload, header.Length);
+        await File.WriteAllBytesAsync(ctrPath, payload);
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.Data.NormalizedCount);
+        Assert.False(File.Exists(ctrPath));
+        Assert.False(File.Exists(Path.Combine(_tempDir, "generals.big")));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "generals.exe")));
+    }
+
+    /// <summary>
+    /// Tests that a .ctr file inside a suffixed directory is normalized to .big and the directory suffix is subsequently stripped.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task NormalizeFilesAsync_DetectsAndRenamesSuffixDirectory_NormalizingContainedCtrAsync()
+    {
+        var gltcDir = Path.Combine(_tempDir, "Maps.GLTC");
+        Directory.CreateDirectory(gltcDir);
+        var ctrPath = Path.Combine(gltcDir, "map1.ctr");
+        var bytes = new byte[16];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'I';
+        bytes[2] = (byte)'G';
+        bytes[3] = (byte)'F';
+        await File.WriteAllBytesAsync(ctrPath, bytes);
+
+        var result = await _service.NormalizeFilesAsync(_tempDir);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Data.NormalizedCount);
+        var targetDir = Path.Combine(_tempDir, "Maps");
+        Assert.True(Directory.Exists(targetDir));
+        Assert.False(Directory.Exists(gltcDir));
+        Assert.True(File.Exists(Path.Combine(targetDir, "map1.big")));
+    }
+
     private bool TryCreateFileSymlink(out string? skipReason)
     {
         skipReason = null;

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BigArchiveClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BigArchiveClassifierTests.cs
@@ -1,9 +1,9 @@
-namespace GenHub.Tests.Core.Utilities;
-
 using System;
 using System.IO;
 using GenHub.Core.Utilities;
 using Xunit;
+
+namespace GenHub.Tests.Core.Utilities;
 
 /// <summary>
 /// Unit tests for <see cref="BigArchiveClassifier"/>.

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BigArchiveClassifierTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Utilities/BigArchiveClassifierTests.cs
@@ -1,0 +1,124 @@
+namespace GenHub.Tests.Core.Utilities;
+
+using System;
+using System.IO;
+using GenHub.Core.Utilities;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="BigArchiveClassifier"/>.
+/// </summary>
+public class BigArchiveClassifierTests : IDisposable
+{
+    private readonly string _tempDirectory = Directory.CreateTempSubdirectory("big-classifier-tests").FullName;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Allowed to fail during cleanup
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Tests that valid BIG magic byte headers return true.
+    /// </summary>
+    /// <param name="fourthByte">The fourth magic byte variant.</param>
+    [Theory]
+    [InlineData((byte)'4')]
+    [InlineData((byte)'F')]
+    [InlineData((byte)'E')]
+    [InlineData((byte)0)]
+    public void HasBigArchiveMagicBytes_ValidSignatures_ReturnsTrue(byte fourthByte)
+    {
+        ReadOnlySpan<byte> header = [(byte)'B', (byte)'I', (byte)'G', fourthByte];
+        Assert.True(BigArchiveClassifier.HasBigArchiveMagicBytes(header));
+    }
+
+    /// <summary>
+    /// Tests that headers shorter than 4 bytes return false.
+    /// </summary>
+    [Fact]
+    public void HasBigArchiveMagicBytes_TooShort_ReturnsFalse()
+    {
+        ReadOnlySpan<byte> header = [(byte)'B', (byte)'I', (byte)'G'];
+        Assert.False(BigArchiveClassifier.HasBigArchiveMagicBytes(header));
+    }
+
+    /// <summary>
+    /// Tests that headers with non-BIG signatures return false.
+    /// </summary>
+    [Fact]
+    public void HasBigArchiveMagicBytes_InvalidSignature_ReturnsFalse()
+    {
+        ReadOnlySpan<byte> header = [(byte)'M', (byte)'Z', 0x90, 0x00];
+        Assert.False(BigArchiveClassifier.HasBigArchiveMagicBytes(header));
+    }
+
+    /// <summary>
+    /// Tests that valid BIG archive files on disk are detected as true.
+    /// </summary>
+    /// <param name="fourthByte">The fourth magic byte variant.</param>
+    [Theory]
+    [InlineData((byte)'4')]
+    [InlineData((byte)'F')]
+    [InlineData((byte)'E')]
+    [InlineData((byte)0)]
+    public void IsBigArchiveFile_ValidBigFile_ReturnsTrue(byte fourthByte)
+    {
+        var filePath = Path.Combine(_tempDirectory, $"test_{fourthByte}.big");
+        var bytes = new byte[16];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'I';
+        bytes[2] = (byte)'G';
+        bytes[3] = fourthByte;
+        File.WriteAllBytes(filePath, bytes);
+
+        Assert.True(BigArchiveClassifier.IsBigArchiveFile(filePath));
+    }
+
+    /// <summary>
+    /// Tests that files smaller than 16 bytes return false.
+    /// </summary>
+    [Fact]
+    public void IsBigArchiveFile_FileTooShort_ReturnsFalse()
+    {
+        var filePath = Path.Combine(_tempDirectory, "short.big");
+        File.WriteAllBytes(filePath, [(byte)'B', (byte)'I', (byte)'G', (byte)'4']);
+
+        Assert.False(BigArchiveClassifier.IsBigArchiveFile(filePath));
+    }
+
+    /// <summary>
+    /// Tests that non-existent files return false.
+    /// </summary>
+    [Fact]
+    public void IsBigArchiveFile_NonExistentFile_ReturnsFalse()
+    {
+        var filePath = Path.Combine(_tempDirectory, "nonexistent.big");
+        Assert.False(BigArchiveClassifier.IsBigArchiveFile(filePath));
+    }
+
+    /// <summary>
+    /// Tests that null, empty, or whitespace paths return false.
+    /// </summary>
+    /// <param name="path">The file path to test.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsBigArchiveFile_NullOrWhiteSpace_ReturnsFalse(string? path)
+    {
+        Assert.False(BigArchiveClassifier.IsBigArchiveFile(path!));
+    }
+}

--- a/GenHub/GenHub/Features/Content/Services/Common/ArchivePayloadProcessor.cs
+++ b/GenHub/GenHub/Features/Content/Services/Common/ArchivePayloadProcessor.cs
@@ -184,6 +184,14 @@ public class ArchivePayloadProcessor(ILogger<ArchivePayloadProcessor> logger) : 
         await NormalizeDirectoryStructureAsync(extractedDirectory, contentType, targetGame, normalizeInactiveArchives, cancellationToken);
     }
 
+    /// <summary>
+    /// Determines whether the specified file is a valid BIG archive based on its header magic bytes.
+    /// </summary>
+    /// <param name="filePath">The absolute path to the file.</param>
+    /// <returns><c>true</c> if the file contains BIG archive magic bytes; otherwise, <c>false</c>.</returns>
+    internal static bool IsBigArchiveFile(string filePath) =>
+        BigArchiveClassifier.IsBigArchiveFile(filePath);
+
     private static bool ShouldAttemptExecutableExtraction(ContentType? contentType)
     {
         if (!contentType.HasValue)
@@ -651,64 +659,8 @@ public class ArchivePayloadProcessor(ILogger<ArchivePayloadProcessor> logger) : 
         }
     }
 
-    private static bool IsBigArchiveFile(string filePath)
-    {
-        if (!File.Exists(filePath))
-        {
-            return false;
-        }
-
-        try
-        {
-            using var stream = File.OpenRead(filePath);
-            if (stream.Length < 16)
-            {
-                return false;
-            }
-
-            Span<byte> header = stackalloc byte[4];
-            if (stream.Read(header) < 4)
-            {
-                return false;
-            }
-
-            return header[0] == (byte)'B' && header[1] == (byte)'I' && header[2] == (byte)'G' &&
-                   (header[3] == (byte)'4' || header[3] == (byte)'F' || header[3] == (byte)'E' || header[3] == 0);
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static bool IsExecutableFile(string filePath)
-    {
-        if (!File.Exists(filePath))
-        {
-            return false;
-        }
-
-        try
-        {
-            using var stream = File.OpenRead(filePath);
-            if (stream.Length < 2)
-            {
-                return false;
-            }
-
-            Span<byte> header = stackalloc byte[2];
-            if (stream.Read(header) < 2)
-            {
-                return false;
-            }
-
-            return header[0] == (byte)'M' && header[1] == (byte)'Z';
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    private static bool IsExecutableFile(string filePath) =>
+        ExecutableFileClassifier.HasExecutableMagicBytes(filePath);
 
     private static void CopyEntryWithCap(
         Stream source,

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -417,6 +417,7 @@ public partial class AddLocalContentViewModel(
                             $"This content contains GenLauncher-modified files:\n\n{detectionResult.GetSummary()}\n\nWould you like to normalize these files to standard format?\n\n" +
                             "This will:\n" +
                             $"• Convert {GenLauncherConstants.GibExtension} files to {GenLauncherConstants.BigExtension}\n" +
+                            $"• Convert {GenLauncherConstants.CtrExtension} files to {GenLauncherConstants.BigExtension} or {GenLauncherConstants.ExeExtension} based on content\n" +
                             $"• Remove {string.Join(", ", GenLauncherConstants.AllSuffixes)} suffixes\n" +
                             "• Remove symbolic links";
 

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -331,22 +331,7 @@ public partial class AddLocalContentViewModel(
             return;
         }
 
-        // Only set SourcePath if not already set or empty (support multiple imports)
-        if (string.IsNullOrEmpty(SourcePath))
-        {
-            SourcePath = path;
-        }
-
-        if (string.IsNullOrWhiteSpace(ContentName) && string.IsNullOrEmpty(SourcePath))
-        {
-            // Use the folder name or first file name as default content name if not set
-            ContentName = Path.GetFileNameWithoutExtension(path);
-        }
-        else if (string.IsNullOrWhiteSpace(ContentName))
-        {
-            // If adding more files, don't overwrite name unless empty
-            ContentName = Path.GetFileNameWithoutExtension(path);
-        }
+        SetDefaultContentName(path);
 
         try
         {
@@ -354,46 +339,6 @@ public partial class AddLocalContentViewModel(
             StatusMessage = $"Importing {Path.GetFileName(path)}...";
             logger?.LogInformation("Importing content from {Path} to staging {Staging}", path, _stagingPath);
 
-            if (!Directory.Exists(_stagingPath))
-            {
-                Directory.CreateDirectory(_stagingPath);
-            }
-
-            if (File.Exists(path))
-            {
-                var extension = Path.GetExtension(path);
-                if (extension.Equals(".zip", StringComparison.OrdinalIgnoreCase))
-                {
-                    await Task.Run(() => ZipFile.ExtractToDirectory(path, _stagingPath, true), _cts?.Token ?? CancellationToken.None);
-                }
-                else
-                {
-                    var destFile = Path.Combine(_stagingPath, Path.GetFileName(path));
-                    File.Copy(path, destFile, true);
-                }
-            }
-            else if (Directory.Exists(path))
-            {
-                // Preserve directory structure by copying the folder itself into staging
-                var dirInfo = new DirectoryInfo(path);
-                var dirName = dirInfo.Name;
-
-                // Ensure we don't try to copy to the staging root itself if Name is somehow empty
-                if (string.IsNullOrWhiteSpace(dirName))
-                {
-                    dirName = "Imported_Folder";
-                }
-
-                var targetSubDir = Path.Combine(_stagingPath, dirName);
-                logger?.LogDebug("ImportContentAsync: Preserving directory structure. Source: {Source}, Target: {Target}", path, targetSubDir);
-
-                await Task.Run(() => CopyDirectory(dirInfo, new DirectoryInfo(targetSubDir)), _cts?.Token ?? CancellationToken.None);
-            }
-
-            // Auto-organization: If we have .map files at the root level, move them into subdirectories
-            CreateMapFoldersIfNeeded();
-
-            // Detect and normalize GenLauncher files
             _cts ??= new CancellationTokenSource();
             if (_cts.IsCancellationRequested)
             {
@@ -402,98 +347,15 @@ public partial class AddLocalContentViewModel(
             }
 
             var cancellationToken = _cts.Token;
+            await StageContentSourceAsync(path, cancellationToken);
+
+            // Auto-organization: If we have .map files at the root level, move them into subdirectories
+            CreateMapFoldersIfNeeded();
+
             var normalizationSetStatus = false;
             try
             {
-                if (genLauncherNormalizationService != null && dialogService != null)
-                {
-                    var detectionResult = await genLauncherNormalizationService.DetectGenLauncherFilesAsync(_stagingPath, cancellationToken);
-
-                    if (detectionResult.HasGenLauncherFiles)
-                    {
-                        logger?.LogInformation("GenLauncher files detected: {Summary}", detectionResult.GetSummary());
-
-                        var normalizationPrompt =
-                            $"This content contains GenLauncher-modified files:\n\n{detectionResult.GetSummary()}\n\nWould you like to normalize these files to standard format?\n\n" +
-                            "This will:\n" +
-                            $"• Convert {GenLauncherConstants.GibExtension} files to {GenLauncherConstants.BigExtension}\n" +
-                            $"• Convert {GenLauncherConstants.CtrExtension} files to {GenLauncherConstants.BigExtension} or {GenLauncherConstants.ExeExtension} based on content\n" +
-                            $"• Remove {string.Join(", ", GenLauncherConstants.AllSuffixes)} suffixes\n" +
-                            "• Remove symbolic links";
-
-                        var shouldNormalize = await dialogService.ShowConfirmationAsync(
-                            "GenLauncher Files Detected",
-                            normalizationPrompt,
-                            "Normalize",
-                            "Skip",
-                            sessionKey: GenLauncherConstants.NormalizationDialogSessionKey);
-
-                        if (shouldNormalize)
-                        {
-                            StatusMessage = "Normalizing GenLauncher files...";
-                            logger?.LogInformation("User confirmed normalization");
-
-                            var normalizationResult = await genLauncherNormalizationService.NormalizeFilesAsync(
-                                _stagingPath,
-                                cancellationToken);
-
-                            if (normalizationResult.Success)
-                            {
-                                var result = normalizationResult.Data;
-                                if (result.FailedFiles.Count > 0 && result.SkippedFiles.Count > 0)
-                                {
-                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped, {result.FailedFiles.Count} failed. Import successful.";
-                                }
-                                else if (result.FailedFiles.Count > 0)
-                                {
-                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
-                                }
-                                else if (result.SkippedFiles.Count > 0)
-                                {
-                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped. Import successful.";
-                                }
-                                else
-                                {
-                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s). Import successful.";
-                                }
-
-                                normalizationSetStatus = true;
-                                logger?.LogInformation(
-                                    "Normalization completed: {NormalizedCount} files, {SymlinksRemoved} symlinks removed, {SkippedCount} skipped, {FailedCount} failed",
-                                    result.NormalizedCount,
-                                    result.SymbolicLinksRemoved,
-                                    result.SkippedFiles.Count,
-                                    result.FailedFiles.Count);
-
-                                if (!result.IsFullySuccessful)
-                                {
-                                    logger?.LogWarning(
-                                        "Some files failed to normalize: {FailedFiles}",
-                                        string.Join(", ", result.FailedFiles));
-                                }
-
-                                if (result.SkippedFiles.Count > 0)
-                                {
-                                    logger?.LogInformation(
-                                        "Some files were skipped during normalization: {SkippedFiles}",
-                                        string.Join(", ", result.SkippedFiles));
-                                }
-                            }
-                            else
-                            {
-                                StatusMessage = $"Normalization warning: {normalizationResult.FirstError}. Import will continue.";
-                                normalizationSetStatus = true;
-                                logger?.LogWarning("Normalization failed: {Error}", normalizationResult.FirstError);
-                            }
-                        }
-                        else
-                        {
-                            logger?.LogInformation("User skipped normalization");
-                            StatusMessage = "Import successful (GenLauncher files not normalized).";
-                            normalizationSetStatus = true;
-                        }
-                    }
-                }
+                normalizationSetStatus = await ProcessGenLauncherNormalizationAsync(cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -898,6 +760,155 @@ public partial class AddLocalContentViewModel(
         {
             logger?.LogWarning(ex, "Failed to auto-organize map files");
         }
+    }
+
+    private void SetDefaultContentName(string path)
+    {
+        // Only set SourcePath if not already set or empty (support multiple imports)
+        if (string.IsNullOrEmpty(SourcePath))
+        {
+            SourcePath = path;
+        }
+
+        if (string.IsNullOrWhiteSpace(ContentName))
+        {
+            // Use the folder name or first file name as default content name if not set
+            ContentName = Path.GetFileNameWithoutExtension(path);
+        }
+    }
+
+    private async Task StageContentSourceAsync(string path, CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(_stagingPath))
+        {
+            Directory.CreateDirectory(_stagingPath);
+        }
+
+        if (File.Exists(path))
+        {
+            var extension = Path.GetExtension(path);
+            if (extension.Equals(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                await Task.Run(() => ZipFile.ExtractToDirectory(path, _stagingPath, true), cancellationToken);
+            }
+            else
+            {
+                var destFile = Path.Combine(_stagingPath, Path.GetFileName(path));
+                File.Copy(path, destFile, true);
+            }
+        }
+        else if (Directory.Exists(path))
+        {
+            // Preserve directory structure by copying the folder itself into staging
+            var dirInfo = new DirectoryInfo(path);
+            var dirName = dirInfo.Name;
+
+            // Ensure we don't try to copy to the staging root itself if Name is somehow empty
+            if (string.IsNullOrWhiteSpace(dirName))
+            {
+                dirName = "Imported_Folder";
+            }
+
+            var targetSubDir = Path.Combine(_stagingPath, dirName);
+            logger?.LogDebug("ImportContentAsync: Preserving directory structure. Source: {Source}, Target: {Target}", path, targetSubDir);
+
+            await Task.Run(() => CopyDirectory(dirInfo, new DirectoryInfo(targetSubDir)), cancellationToken);
+        }
+    }
+
+    private async Task<bool> ProcessGenLauncherNormalizationAsync(CancellationToken cancellationToken)
+    {
+        if (genLauncherNormalizationService == null || dialogService == null)
+        {
+            return false;
+        }
+
+        var detectionResult = await genLauncherNormalizationService.DetectGenLauncherFilesAsync(_stagingPath, cancellationToken);
+        if (!detectionResult.HasGenLauncherFiles)
+        {
+            return false;
+        }
+
+        logger?.LogInformation("GenLauncher files detected: {Summary}", detectionResult.GetSummary());
+
+        var normalizationPrompt =
+            $"This content contains GenLauncher-modified files:\n\n{detectionResult.GetSummary()}\n\nWould you like to normalize these files to standard format?\n\n" +
+            "This will:\n" +
+            $"• Convert {GenLauncherConstants.GibExtension} files to {GenLauncherConstants.BigExtension}\n" +
+            $"• Convert {GenLauncherConstants.CtrExtension} files to {GenLauncherConstants.BigExtension} or {GenLauncherConstants.ExeExtension} based on content\n" +
+            $"• Remove {string.Join(", ", GenLauncherConstants.AllSuffixes)} suffixes\n" +
+            "• Remove symbolic links";
+
+        var shouldNormalize = await dialogService.ShowConfirmationAsync(
+            "GenLauncher Files Detected",
+            normalizationPrompt,
+            "Normalize",
+            "Skip",
+            sessionKey: GenLauncherConstants.NormalizationDialogSessionKey);
+
+        if (!shouldNormalize)
+        {
+            logger?.LogInformation("User skipped normalization");
+            StatusMessage = "Import successful (GenLauncher files not normalized).";
+            return true;
+        }
+
+        StatusMessage = "Normalizing GenLauncher files...";
+        logger?.LogInformation("User confirmed normalization");
+
+        var normalizationResult = await genLauncherNormalizationService.NormalizeFilesAsync(_stagingPath, cancellationToken);
+        if (normalizationResult.Success)
+        {
+            var result = normalizationResult.Data;
+            StatusMessage = FormatNormalizationSuccessMessage(result);
+            logger?.LogInformation(
+                "Normalization completed: {NormalizedCount} files, {SymlinksRemoved} symlinks removed, {SkippedCount} skipped, {FailedCount} failed",
+                result.NormalizedCount,
+                result.SymbolicLinksRemoved,
+                result.SkippedFiles.Count,
+                result.FailedFiles.Count);
+
+            if (!result.IsFullySuccessful)
+            {
+                logger?.LogWarning(
+                    "Some files failed to normalize: {FailedFiles}",
+                    string.Join(", ", result.FailedFiles));
+            }
+
+            if (result.SkippedFiles.Count > 0)
+            {
+                logger?.LogInformation(
+                    "Some files were skipped during normalization: {SkippedFiles}",
+                    string.Join(", ", result.SkippedFiles));
+            }
+        }
+        else
+        {
+            StatusMessage = $"Normalization warning: {normalizationResult.FirstError}. Import will continue.";
+            logger?.LogWarning("Normalization failed: {Error}", normalizationResult.FirstError);
+        }
+
+        return true;
+    }
+
+    private string FormatNormalizationSuccessMessage(GenLauncherNormalizationResult result)
+    {
+        if (result.FailedFiles.Count > 0 && result.SkippedFiles.Count > 0)
+        {
+            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped, {result.FailedFiles.Count} failed. Import successful.";
+        }
+
+        if (result.FailedFiles.Count > 0)
+        {
+            return $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
+        }
+
+        if (result.SkippedFiles.Count > 0)
+        {
+            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped. Import successful.";
+        }
+
+        return $"Normalized {result.NormalizedCount} file(s). Import successful.";
     }
 
     private FileTreeItem? FindFileItemByRelativePath(IEnumerable<FileTreeItem> items, string relativePath)

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -390,6 +390,11 @@ public partial class AddLocalContentViewModel(
 
             Validate();
         }
+        catch (OperationCanceledException) when (_cts?.IsCancellationRequested == true)
+        {
+            logger?.LogInformation("Import was cancelled");
+            StatusMessage = "Import cancelled.";
+        }
         catch (Exception ex)
         {
             StatusMessage = $"Import Error: {ex.Message}";
@@ -506,17 +511,17 @@ public partial class AddLocalContentViewModel(
     {
         if (result.FailedFiles.Count > 0 && result.SkippedFiles.Count > 0)
         {
-            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped, {result.FailedFiles.Count} failed. Import successful.";
+            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped, {result.FailedFiles.Count} failed. Import completed.";
         }
 
         if (result.FailedFiles.Count > 0)
         {
-            return $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
+            return $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import completed.";
         }
 
         if (result.SkippedFiles.Count > 0)
         {
-            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped. Import successful.";
+            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped. Import completed.";
         }
 
         return $"Normalized {result.NormalizedCount} file(s). Import successful.";
@@ -802,7 +807,7 @@ public partial class AddLocalContentViewModel(
         if (File.Exists(path))
         {
             var extension = Path.GetExtension(path);
-            if (extension.Equals(".zip", StringComparison.OrdinalIgnoreCase))
+            if (extension.Equals(FileTypes.ZipFileExtension, StringComparison.OrdinalIgnoreCase))
             {
                 await Task.Run(() => ZipFile.ExtractToDirectory(path, _stagingPath, true), cancellationToken);
             }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -440,20 +440,43 @@ public partial class AddLocalContentViewModel(
                             if (normalizationResult.Success)
                             {
                                 var result = normalizationResult.Data;
-                                StatusMessage = result.IsFullySuccessful
-                                    ? $"Normalized {result.NormalizedCount} file(s). Import successful."
-                                    : $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
+                                if (result.FailedFiles.Count > 0 && result.SkippedFiles.Count > 0)
+                                {
+                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped, {result.FailedFiles.Count} failed. Import successful.";
+                                }
+                                else if (result.FailedFiles.Count > 0)
+                                {
+                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
+                                }
+                                else if (result.SkippedFiles.Count > 0)
+                                {
+                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped. Import successful.";
+                                }
+                                else
+                                {
+                                    StatusMessage = $"Normalized {result.NormalizedCount} file(s). Import successful.";
+                                }
+
                                 normalizationSetStatus = true;
                                 logger?.LogInformation(
-                                    "Normalization completed: {NormalizedCount} files, {SymlinksRemoved} symlinks removed",
+                                    "Normalization completed: {NormalizedCount} files, {SymlinksRemoved} symlinks removed, {SkippedCount} skipped, {FailedCount} failed",
                                     result.NormalizedCount,
-                                    result.SymbolicLinksRemoved);
+                                    result.SymbolicLinksRemoved,
+                                    result.SkippedFiles.Count,
+                                    result.FailedFiles.Count);
 
                                 if (!result.IsFullySuccessful)
                                 {
                                     logger?.LogWarning(
                                         "Some files failed to normalize: {FailedFiles}",
                                         string.Join(", ", result.FailedFiles));
+                                }
+
+                                if (result.SkippedFiles.Count > 0)
+                                {
+                                    logger?.LogInformation(
+                                        "Some files were skipped during normalization: {SkippedFiles}",
+                                        string.Join(", ", result.SkippedFiles));
                                 }
                             }
                             else

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/AddLocalContentViewModel.cs
@@ -331,7 +331,17 @@ public partial class AddLocalContentViewModel(
             return;
         }
 
-        SetDefaultContentName(path);
+        // Only set SourcePath if not already set or empty (support multiple imports)
+        if (string.IsNullOrEmpty(SourcePath))
+        {
+            SourcePath = path;
+        }
+
+        if (string.IsNullOrWhiteSpace(ContentName))
+        {
+            // Use the folder name or first file name as default content name if not set
+            ContentName = Path.GetFileNameWithoutExtension(path);
+        }
 
         try
         {
@@ -490,6 +500,26 @@ public partial class AddLocalContentViewModel(
             var nextTargetSubDir = target.CreateSubdirectory(subDirectory.Name);
             CopyDirectory(subDirectory, nextTargetSubDir);
         }
+    }
+
+    private static string FormatNormalizationSuccessMessage(GenLauncherNormalizationResult result)
+    {
+        if (result.FailedFiles.Count > 0 && result.SkippedFiles.Count > 0)
+        {
+            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped, {result.FailedFiles.Count} failed. Import successful.";
+        }
+
+        if (result.FailedFiles.Count > 0)
+        {
+            return $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
+        }
+
+        if (result.SkippedFiles.Count > 0)
+        {
+            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped. Import successful.";
+        }
+
+        return $"Normalized {result.NormalizedCount} file(s). Import successful.";
     }
 
     [RelayCommand]
@@ -762,21 +792,6 @@ public partial class AddLocalContentViewModel(
         }
     }
 
-    private void SetDefaultContentName(string path)
-    {
-        // Only set SourcePath if not already set or empty (support multiple imports)
-        if (string.IsNullOrEmpty(SourcePath))
-        {
-            SourcePath = path;
-        }
-
-        if (string.IsNullOrWhiteSpace(ContentName))
-        {
-            // Use the folder name or first file name as default content name if not set
-            ContentName = Path.GetFileNameWithoutExtension(path);
-        }
-    }
-
     private async Task StageContentSourceAsync(string path, CancellationToken cancellationToken)
     {
         if (!Directory.Exists(_stagingPath))
@@ -889,26 +904,6 @@ public partial class AddLocalContentViewModel(
         }
 
         return true;
-    }
-
-    private string FormatNormalizationSuccessMessage(GenLauncherNormalizationResult result)
-    {
-        if (result.FailedFiles.Count > 0 && result.SkippedFiles.Count > 0)
-        {
-            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped, {result.FailedFiles.Count} failed. Import successful.";
-        }
-
-        if (result.FailedFiles.Count > 0)
-        {
-            return $"Normalized {result.NormalizedCount} file(s); {result.FailedFiles.Count} failed. Import successful.";
-        }
-
-        if (result.SkippedFiles.Count > 0)
-        {
-            return $"Normalized {result.NormalizedCount} file(s); {result.SkippedFiles.Count} skipped. Import successful.";
-        }
-
-        return $"Normalized {result.NormalizedCount} file(s). Import successful.";
     }
 
     private FileTreeItem? FindFileItemByRelativePath(IEnumerable<FileTreeItem> items, string relativePath)

--- a/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
+++ b/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
@@ -96,34 +96,7 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
             }
 
             // Remove symbolic links (both files and directories, including dangling links)
-            foreach (var symlink in detection.SymbolicLinks)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    var attributes = File.GetAttributes(symlink);
-
-                    // Check if it's a directory symlink using reparse-point metadata rather than target existence
-                    if (attributes.HasFlag(FileAttributes.Directory))
-                    {
-                        Directory.Delete(symlink);
-                        result.SymbolicLinksRemoved++;
-                        logger.LogInformation("Removed directory symbolic link: {DirectoryPath}", symlink);
-                    }
-                    else
-                    {
-                        File.Delete(symlink);
-                        result.SymbolicLinksRemoved++;
-                        logger.LogInformation("Removed file symbolic link: {FilePath}", symlink);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to remove symbolic link: {FilePath}", symlink);
-                    result.FailedFiles.Add(symlink);
-                }
-            }
+            RemoveSymbolicLinks(detection.SymbolicLinks, result, cancellationToken);
 
             // Remove suffixes from .GLR, .GOF, .GLTC files and directories.
             var suffixItems = detection.GlrFiles
@@ -135,130 +108,16 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
             var suffixFiles = suffixItems.Where(File.Exists).ToList();
             var suffixDirectories = suffixItems.Where(Directory.Exists).OrderByDescending(d => d.Length).ToList();
 
-            foreach (var suffixFile in suffixFiles)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    var normalizedName = RemoveSuffix(suffixFile);
-                    if (normalizedName != suffixFile)
-                    {
-                        var ext = Path.GetExtension(normalizedName);
-                        if (ext.Equals(GenLauncherConstants.CtrExtension, StringComparison.OrdinalIgnoreCase))
-                        {
-                            string? targetDestination = null;
-                            if (ExecutableFileClassifier.HasExecutableMagicBytes(suffixFile))
-                            {
-                                targetDestination = Path.ChangeExtension(normalizedName, GenLauncherConstants.ExeExtension);
-                            }
-                            else if (BigArchiveClassifier.IsBigArchiveFile(suffixFile))
-                            {
-                                targetDestination = Path.ChangeExtension(normalizedName, GenLauncherConstants.BigExtension);
-                            }
-
-                            if (targetDestination != null && (File.Exists(targetDestination) || Directory.Exists(targetDestination)))
-                            {
-                                logger.LogWarning(
-                                    "Skipping .ctr normalization for {OriginalFile}: target {Destination} already exists. Manual resolution required.",
-                                    suffixFile,
-                                    targetDestination);
-                                result.FailedFiles.Add(suffixFile);
-                                continue;
-                            }
-                        }
-                        else if (ext.Equals(GenLauncherConstants.GibExtension, StringComparison.OrdinalIgnoreCase))
-                        {
-                            var targetBig = Path.ChangeExtension(normalizedName, GenLauncherConstants.BigExtension);
-                            if (File.Exists(targetBig) || Directory.Exists(targetBig))
-                            {
-                                logger.LogWarning(
-                                    "Skipping .gib → .big conversion for {OriginalFile}: target {BigFile} already exists. Manual resolution required.",
-                                    suffixFile,
-                                    targetBig);
-                                result.FailedFiles.Add(suffixFile);
-                                continue;
-                            }
-                        }
-
-                        // Check if destination exists (file or directory) - skip to avoid data loss
-                        if (File.Exists(normalizedName) || Directory.Exists(normalizedName))
-                        {
-                            logger.LogWarning(
-                                "Skipping suffix removal for {OriginalFile}: target {NormalizedFile} already exists. Manual resolution required.",
-                                suffixFile,
-                                normalizedName);
-                            result.FailedFiles.Add(suffixFile);
-                            continue;
-                        }
-
-                        File.Move(suffixFile, normalizedName);
-                        result.NormalizedCount++;
-                        logger.LogInformation("Normalized {OriginalFile} to {NormalizedFile}", suffixFile, normalizedName);
-
-                        if (Path.GetExtension(normalizedName).Equals(GenLauncherConstants.GibExtension, StringComparison.OrdinalIgnoreCase))
-                        {
-                            TryConvertGibToBig(normalizedName, result);
-                        }
-                        else if (Path.GetExtension(normalizedName).Equals(GenLauncherConstants.CtrExtension, StringComparison.OrdinalIgnoreCase))
-                        {
-                            TryNormalizeCtr(normalizedName, result);
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to normalize file: {FilePath}", suffixFile);
-                    result.FailedFiles.Add(suffixFile);
-                }
-            }
+            NormalizeSuffixFiles(suffixFiles, result, cancellationToken);
 
             // Convert standalone .gib files to .big before directory moves so file paths remain valid during conversion
-            foreach (var gibFile in detection.GibFiles)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                TryConvertGibToBig(gibFile, result);
-            }
+            ConvertGibFiles(detection.GibFiles, result, cancellationToken);
 
             // Normalize .ctr files by content before directory moves so file paths remain valid during conversion
-            foreach (var ctrFile in detection.CtrFiles)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                TryNormalizeCtr(ctrFile, result);
-            }
+            NormalizeCtrFiles(detection.CtrFiles, result, cancellationToken);
 
             // Normalize matching directories after file conversions
-            foreach (var suffixDir in suffixDirectories)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    var normalizedName = RemoveSuffix(suffixDir);
-                    if (normalizedName != suffixDir)
-                    {
-                        // Check if destination exists (directory or file) - skip to avoid data loss
-                        if (Directory.Exists(normalizedName) || File.Exists(normalizedName))
-                        {
-                            logger.LogWarning(
-                                "Skipping suffix removal for directory {OriginalDir}: target {NormalizedDir} already exists. Manual resolution required.",
-                                suffixDir,
-                                normalizedName);
-                            result.FailedFiles.Add(suffixDir);
-                            continue;
-                        }
-
-                        Directory.Move(suffixDir, normalizedName);
-                        result.NormalizedCount++;
-                        logger.LogInformation("Normalized directory {OriginalDir} to {NormalizedDir}", suffixDir, normalizedName);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to normalize directory: {DirectoryPath}", suffixDir);
-                    result.FailedFiles.Add(suffixDir);
-                }
-            }
+            NormalizeSuffixDirectories(suffixDirectories, result, cancellationToken);
 
             logger.LogInformation(
                 "Normalization complete. Normalized: {NormalizedCount}, Symlinks removed: {SymlinksRemoved}, Failed: {FailedCount}",
@@ -295,6 +154,204 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
         }
 
         return filePath;
+    }
+
+    private void RemoveSymbolicLinks(
+        IEnumerable<string> symbolicLinks,
+        GenLauncherNormalizationResult result,
+        CancellationToken cancellationToken)
+    {
+        foreach (var symlink in symbolicLinks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var attributes = File.GetAttributes(symlink);
+
+                // Check if it's a directory symlink using reparse-point metadata rather than target existence
+                if (attributes.HasFlag(FileAttributes.Directory))
+                {
+                    Directory.Delete(symlink);
+                    result.SymbolicLinksRemoved++;
+                    logger.LogInformation("Removed directory symbolic link: {DirectoryPath}", symlink);
+                }
+                else
+                {
+                    File.Delete(symlink);
+                    result.SymbolicLinksRemoved++;
+                    logger.LogInformation("Removed file symbolic link: {FilePath}", symlink);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to remove symbolic link: {FilePath}", symlink);
+                result.FailedFiles.Add(symlink);
+            }
+        }
+    }
+
+    private void NormalizeSuffixFiles(
+        IEnumerable<string> suffixFiles,
+        GenLauncherNormalizationResult result,
+        CancellationToken cancellationToken)
+    {
+        foreach (var suffixFile in suffixFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var normalizedName = RemoveSuffix(suffixFile);
+                if (normalizedName == suffixFile)
+                {
+                    continue;
+                }
+
+                if (HasSuffixedDestinationCollision(suffixFile, normalizedName, result))
+                {
+                    continue;
+                }
+
+                File.Move(suffixFile, normalizedName);
+                result.NormalizedCount++;
+                logger.LogInformation("Normalized {OriginalFile} to {NormalizedFile}", suffixFile, normalizedName);
+
+                if (Path.GetExtension(normalizedName).Equals(GenLauncherConstants.GibExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    TryConvertGibToBig(normalizedName, result);
+                }
+                else if (Path.GetExtension(normalizedName).Equals(GenLauncherConstants.CtrExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    TryNormalizeCtr(normalizedName, result);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to normalize file: {FilePath}", suffixFile);
+                result.FailedFiles.Add(suffixFile);
+            }
+        }
+    }
+
+    private bool HasSuffixedDestinationCollision(
+        string suffixFile,
+        string normalizedName,
+        GenLauncherNormalizationResult result)
+    {
+        var ext = Path.GetExtension(normalizedName);
+        if (ext.Equals(GenLauncherConstants.CtrExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            string? targetDestination = null;
+            if (ExecutableFileClassifier.HasExecutableMagicBytes(suffixFile))
+            {
+                targetDestination = Path.ChangeExtension(normalizedName, GenLauncherConstants.ExeExtension);
+            }
+            else if (BigArchiveClassifier.IsBigArchiveFile(suffixFile))
+            {
+                targetDestination = Path.ChangeExtension(normalizedName, GenLauncherConstants.BigExtension);
+            }
+
+            if (targetDestination != null && (File.Exists(targetDestination) || Directory.Exists(targetDestination)))
+            {
+                logger.LogWarning(
+                    "Skipping .ctr normalization for {OriginalFile}: target {Destination} already exists. Manual resolution required.",
+                    suffixFile,
+                    targetDestination);
+                result.FailedFiles.Add(suffixFile);
+                return true;
+            }
+        }
+        else if (ext.Equals(GenLauncherConstants.GibExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            var targetBig = Path.ChangeExtension(normalizedName, GenLauncherConstants.BigExtension);
+            if (File.Exists(targetBig) || Directory.Exists(targetBig))
+            {
+                logger.LogWarning(
+                    "Skipping .gib → .big conversion for {OriginalFile}: target {BigFile} already exists. Manual resolution required.",
+                    suffixFile,
+                    targetBig);
+                result.FailedFiles.Add(suffixFile);
+                return true;
+            }
+        }
+
+        // Check if destination exists (file or directory) - skip to avoid data loss
+        if (File.Exists(normalizedName) || Directory.Exists(normalizedName))
+        {
+            logger.LogWarning(
+                "Skipping suffix removal for {OriginalFile}: target {NormalizedFile} already exists. Manual resolution required.",
+                suffixFile,
+                normalizedName);
+            result.FailedFiles.Add(suffixFile);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void ConvertGibFiles(
+        IEnumerable<string> gibFiles,
+        GenLauncherNormalizationResult result,
+        CancellationToken cancellationToken)
+    {
+        foreach (var gibFile in gibFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TryConvertGibToBig(gibFile, result);
+        }
+    }
+
+    private void NormalizeCtrFiles(
+        IEnumerable<string> ctrFiles,
+        GenLauncherNormalizationResult result,
+        CancellationToken cancellationToken)
+    {
+        foreach (var ctrFile in ctrFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TryNormalizeCtr(ctrFile, result);
+        }
+    }
+
+    private void NormalizeSuffixDirectories(
+        IEnumerable<string> suffixDirectories,
+        GenLauncherNormalizationResult result,
+        CancellationToken cancellationToken)
+    {
+        foreach (var suffixDir in suffixDirectories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var normalizedName = RemoveSuffix(suffixDir);
+                if (normalizedName == suffixDir)
+                {
+                    continue;
+                }
+
+                // Check if destination exists (directory or file) - skip to avoid data loss
+                if (Directory.Exists(normalizedName) || File.Exists(normalizedName))
+                {
+                    logger.LogWarning(
+                        "Skipping suffix removal for directory {OriginalDir}: target {NormalizedDir} already exists. Manual resolution required.",
+                        suffixDir,
+                        normalizedName);
+                    result.FailedFiles.Add(suffixDir);
+                    continue;
+                }
+
+                Directory.Move(suffixDir, normalizedName);
+                result.NormalizedCount++;
+                logger.LogInformation("Normalized directory {OriginalDir} to {NormalizedDir}", suffixDir, normalizedName);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to normalize directory: {DirectoryPath}", suffixDir);
+                result.FailedFiles.Add(suffixDir);
+            }
+        }
     }
 
     private void ScanDirectory(string directoryPath, GenLauncherDetectionResult result, CancellationToken cancellationToken)

--- a/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
+++ b/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
@@ -217,6 +217,8 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
                 result.NormalizedCount++;
                 logger.LogInformation("Normalized {OriginalFile} to {NormalizedFile}", suffixFile, normalizedName);
 
+                // Note: If this suffixed file is further converted (e.g. .gib -> .big or .ctr -> .exe/.big),
+                // the subsequent conversion operation also increments NormalizedCount.
                 if (Path.GetExtension(normalizedName).Equals(GenLauncherConstants.GibExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     TryConvertGibToBig(normalizedName, result);
@@ -532,6 +534,9 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
         try
         {
             string destination;
+
+            // Content-based classification: executables (Windows PE/MZ, Linux ELF, macOS Mach-O) convert to .exe,
+            // BIG archives convert to .big, and unrecognized formats remain untouched in SkippedFiles.
             if (ExecutableFileClassifier.HasExecutableMagicBytes(ctrFile))
             {
                 destination = Path.ChangeExtension(ctrFile, GenLauncherConstants.ExeExtension);

--- a/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
+++ b/GenHub/GenHub/Infrastructure/Services/GenLauncherNormalizationService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Models.Results;
+using GenHub.Core.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace GenHub.Infrastructure.Services;
@@ -143,6 +144,43 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
                     var normalizedName = RemoveSuffix(suffixFile);
                     if (normalizedName != suffixFile)
                     {
+                        var ext = Path.GetExtension(normalizedName);
+                        if (ext.Equals(GenLauncherConstants.CtrExtension, StringComparison.OrdinalIgnoreCase))
+                        {
+                            string? targetDestination = null;
+                            if (ExecutableFileClassifier.HasExecutableMagicBytes(suffixFile))
+                            {
+                                targetDestination = Path.ChangeExtension(normalizedName, GenLauncherConstants.ExeExtension);
+                            }
+                            else if (BigArchiveClassifier.IsBigArchiveFile(suffixFile))
+                            {
+                                targetDestination = Path.ChangeExtension(normalizedName, GenLauncherConstants.BigExtension);
+                            }
+
+                            if (targetDestination != null && (File.Exists(targetDestination) || Directory.Exists(targetDestination)))
+                            {
+                                logger.LogWarning(
+                                    "Skipping .ctr normalization for {OriginalFile}: target {Destination} already exists. Manual resolution required.",
+                                    suffixFile,
+                                    targetDestination);
+                                result.FailedFiles.Add(suffixFile);
+                                continue;
+                            }
+                        }
+                        else if (ext.Equals(GenLauncherConstants.GibExtension, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var targetBig = Path.ChangeExtension(normalizedName, GenLauncherConstants.BigExtension);
+                            if (File.Exists(targetBig) || Directory.Exists(targetBig))
+                            {
+                                logger.LogWarning(
+                                    "Skipping .gib → .big conversion for {OriginalFile}: target {BigFile} already exists. Manual resolution required.",
+                                    suffixFile,
+                                    targetBig);
+                                result.FailedFiles.Add(suffixFile);
+                                continue;
+                            }
+                        }
+
                         // Check if destination exists (file or directory) - skip to avoid data loss
                         if (File.Exists(normalizedName) || Directory.Exists(normalizedName))
                         {
@@ -162,6 +200,10 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
                         {
                             TryConvertGibToBig(normalizedName, result);
                         }
+                        else if (Path.GetExtension(normalizedName).Equals(GenLauncherConstants.CtrExtension, StringComparison.OrdinalIgnoreCase))
+                        {
+                            TryNormalizeCtr(normalizedName, result);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -176,6 +218,13 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 TryConvertGibToBig(gibFile, result);
+            }
+
+            // Normalize .ctr files by content before directory moves so file paths remain valid during conversion
+            foreach (var ctrFile in detection.CtrFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                TryNormalizeCtr(ctrFile, result);
             }
 
             // Normalize matching directories after file conversions
@@ -279,6 +328,11 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
                     {
                         result.GibFiles.Add(file);
                         logger.LogDebug("Detected .gib file: {FilePath}", file);
+                    }
+                    else if (extension.Equals(GenLauncherConstants.CtrExtension, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.CtrFiles.Add(file);
+                        logger.LogDebug("Detected .ctr file: {FilePath}", file);
                     }
 
                     // Check for suffix files
@@ -408,6 +462,53 @@ public class GenLauncherNormalizationService(ILogger<GenLauncherNormalizationSer
         {
             logger.LogError(ex, "Failed to convert .gib file: {FilePath}", gibFile);
             result.FailedFiles.Add(gibFile);
+        }
+    }
+
+    private void TryNormalizeCtr(string ctrFile, GenLauncherNormalizationResult result)
+    {
+        if (!File.Exists(ctrFile))
+        {
+            return;
+        }
+
+        try
+        {
+            string destination;
+            if (ExecutableFileClassifier.HasExecutableMagicBytes(ctrFile))
+            {
+                destination = Path.ChangeExtension(ctrFile, GenLauncherConstants.ExeExtension);
+            }
+            else if (BigArchiveClassifier.IsBigArchiveFile(ctrFile))
+            {
+                destination = Path.ChangeExtension(ctrFile, GenLauncherConstants.BigExtension);
+            }
+            else
+            {
+                logger.LogInformation("Skipping .ctr file with unrecognized format: {CtrFile}", ctrFile);
+                result.SkippedFiles.Add(ctrFile);
+                return;
+            }
+
+            // Check if destination exists (file or directory) - skip to avoid data loss
+            if (File.Exists(destination) || Directory.Exists(destination))
+            {
+                logger.LogWarning(
+                    "Skipping .ctr normalization for {CtrFile}: target {Destination} already exists. Manual resolution required.",
+                    ctrFile,
+                    destination);
+                result.FailedFiles.Add(ctrFile);
+                return;
+            }
+
+            File.Move(ctrFile, destination);
+            result.NormalizedCount++;
+            logger.LogInformation("Normalized {CtrFile} to {Destination}", ctrFile, destination);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to normalize .ctr file: {FilePath}", ctrFile);
+            result.FailedFiles.Add(ctrFile);
         }
     }
 }


### PR DESCRIPTION
## Summary
Resolves #459 by implementing content-based normalization for GenLauncher `.ctr` files during local content import. Instead of blindly mapping `.ctr` files to `.big`, GenHub now inspects the file magic bytes: BIG archives (`BIG4`, `BIGF`, `BIGE`, `BIG\0`) are converted to `.big`, while Windows executables (`MZ`) are converted to `.exe`, ensuring Contra mod archives and executables can be imported without binary corruption.

### Root Cause
GenLauncher generates `.ctr` files for both BIG archive packages (such as `!Contra009.ctr`) and executable binaries (such as `generals.ctr`). A naive extension rename to `.big` without byte-level inspection risks corrupting executable files and leaves GameClient profiles unable to detect or launch their game entry points.

### Changes
- **Core / Classifiers**:
  - Added `BigArchiveClassifier` in `GenHub.Core/Utilities/` to inspect BIG header magic bytes (`BIG4`, `BIGF`, `BIGE`, `BIG\0`) with span and file path overloads.
  - Added `ExeExtension = ".exe"` to `GenLauncherConstants`.
  - Extended `GenLauncherDetectionResult` with `CtrFiles`, updated `TotalAffectedFiles`, and included `.ctr` counts in `GetSummary()`.
  - Extended `GenLauncherNormalizationResult` with `SkippedFiles` for graceful handling of unrecognized formats.
- **Normalization Service**:
  - Updated `GenLauncherNormalizationService` to scan for `.ctr` files during detection.
  - In `NormalizeFilesAsync`, inspects `.ctr` files using `ExecutableFileClassifier` and `BigArchiveClassifier`, renaming executables to `.exe` and archives to `.big`.
  - Added collision detection: if the target `.exe` or `.big` already exists, normalization aborts for that file and records to `FailedFiles` to avoid overwriting files.
  - Handles any `.ctr` files uncovered after removing GenLauncher suffixes.
- **UI / ViewModel**:
  - Updated `AddLocalContentViewModel` confirmation prompt to describe `.ctr` conversion to `.big` or `.exe` based on file content.
- **Tests**:
  - Added `BigArchiveClassifierTests` covering all signature variants, file length boundaries, and error cases.
  - Added regression test suite in `GenLauncherNormalizationServiceTests` for BIG archives, MZ executables, unrecognized formats, and destination collision guards.
  - Added unit and end-to-end integration tests in `AddLocalContentViewModelTests` verifying the prompt display, skip flow, and successful Contra import auto-selecting `generals.exe` as the entry point.

### Verification
- [x] Targeted unit and integration tests executed and passing (55/55 in `AddLocalContentViewModelTests`, full suite 3,490 passed).
- [x] Solution builds cleanly with 0 warnings or lint errors.
- [x] Verified cross-platform compatibility and file stream disposal.
