### PR TITLE
fix(catalog): exclude Launcher.txt from Generals registry

### DIFF
--- a/GenHub/GenHub.Core/Assets/Registries/Generals-1.08.csv
+++ b/GenHub/GenHub.Core/Assets/Registries/Generals-1.08.csv
@@ -137,7 +137,6 @@ INI.big,7607479,ecdd6e48060398b207f70a6d40917e97,bff8d621088b25fd8b041c8acca020a
 Install_Final.bmp,1440056,ff426b5b7fb72dcb3e0d38846f7ac128,05fe660e4794ce97752e15074ad61f0ef5508484a776be97bd1f0d46f4786baa,Generals,All,False,"{""category"":""other""}",
 langdata.dat,25398,2e7d20210b21b5fe40e1bb44af63c1c2,b964985085af30ff170d25cdbf97a000db1f52d99e9e4cda293a7761cc5a2616,Generals,All,False,"{""category"":""other""}",
 launcher.bmp,39608,4ad9b62f4ab1fababf35c616b6e7285f,4d61a1b74377b4a42353d17b10b72a1757f6da4efae3b79a355f38a500051922,Generals,All,False,"{""category"":""other""}",
-Launcher.txt,22690,9df9e806744c78e0d860c2cc0e6ec1f6,0065e33171eac7670d506b1c2b3c1bfdb5c4ab121fb3b5e465d3481376d37f13,Generals,All,False,"{""category"":""other""}",
 maps.big,23554152,728bf83395aa64dce52d8d27b5f88a30,8a241df0c87ea47f6ad992984ea73dabf4f2ac5f96f8924f30bb0bf5fc4ac4d1,Generals,All,False,"{""category"":""other""}",
 MSS/mssa3d.m3d,83456,e089ce52b0617a6530069f22e0bdba2a,41ccd5e30475ef7b40e68aa8c5c0ce18e804179fcaa77ba42e6ffa4f438d9a24,Generals,All,False,"{""category"":""other""}",
 MSS/mssds3d.m3d,70656,85267776d45dbf5475c7d9882f08117c,a2926f4e2a094a99508c05adaf86c5710ad3cff8bbcf247821feb0e6977f547c,Generals,All,False,"{""category"":""other""}",

--- a/GenHub/GenHub.Core/Assets/Registries/index.json
+++ b/GenHub/GenHub.Core/Assets/Registries/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-08-30T17:40:00Z",
+  "lastUpdated": "2026-09-12T14:51:04Z",
   "description": "Index of CSV registries for Command & Conquer Generals and Zero Hour validation",
   "registries": [
     {
@@ -8,8 +8,8 @@
       "gameType": "Generals",
       "version": "1.08",
       "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
-      "fileCount": 164,
-      "totalSizeBytes": 28977,
+      "fileCount": 163,
+      "totalSizeBytes": 28813,
       "languages": [
         "All",
         "EN",
@@ -24,10 +24,10 @@
         "ZH-TW"
       ],
       "checksum": {
-        "md5": "4b77bce0b4dd0301478e0e341757491f",
-        "sha256": "0fba15bb0a0db434b5edce0475615d4f84c4f2a02b01610f42dc23b9f491099d"
+        "md5": "7f599b8c81ef300692c944c7419bf968",
+        "sha256": "0b2578095af96028bc9be32e5cecc2e10070290e9a6b923ac1eb5dd43c9af114"
       },
-      "generatedAt": "2025-09-17T09:15:00Z",
+      "generatedAt": "2026-09-12T14:51:04Z",
       "generatorVersion": "1.0.0",
       "isActive": true
     },

--- a/GenHub/GenHub.Core/Constants/CsvConstants.cs
+++ b/GenHub/GenHub.Core/Constants/CsvConstants.cs
@@ -207,7 +207,7 @@ public static class CsvConstants
     /// <summary>
     /// Trusted SHA-256 checksum for Generals 1.08 authoritative CSV registry.
     /// </summary>
-    public const string Generals108Sha256 = "0fba15bb0a0db434b5edce0475615d4f84c4f2a02b01610f42dc23b9f491099d";
+    public const string Generals108Sha256 = "0b2578095af96028bc9be32e5cecc2e10070290e9a6b923ac1eb5dd43c9af114";
 
     /// <summary>
     /// Trusted SHA-256 checksum for Zero Hour 1.04 authoritative CSV registry.

--- a/docs/GameInstallationFilesRegistry/Generals-1.08.csv
+++ b/docs/GameInstallationFilesRegistry/Generals-1.08.csv
@@ -137,7 +137,6 @@ INI.big,7607479,ecdd6e48060398b207f70a6d40917e97,bff8d621088b25fd8b041c8acca020a
 Install_Final.bmp,1440056,ff426b5b7fb72dcb3e0d38846f7ac128,05fe660e4794ce97752e15074ad61f0ef5508484a776be97bd1f0d46f4786baa,Generals,All,False,"{""category"":""other""}",
 langdata.dat,25398,2e7d20210b21b5fe40e1bb44af63c1c2,b964985085af30ff170d25cdbf97a000db1f52d99e9e4cda293a7761cc5a2616,Generals,All,False,"{""category"":""other""}",
 launcher.bmp,39608,4ad9b62f4ab1fababf35c616b6e7285f,4d61a1b74377b4a42353d17b10b72a1757f6da4efae3b79a355f38a500051922,Generals,All,False,"{""category"":""other""}",
-Launcher.txt,22690,9df9e806744c78e0d860c2cc0e6ec1f6,0065e33171eac7670d506b1c2b3c1bfdb5c4ab121fb3b5e465d3481376d37f13,Generals,All,False,"{""category"":""other""}",
 maps.big,23554152,728bf83395aa64dce52d8d27b5f88a30,8a241df0c87ea47f6ad992984ea73dabf4f2ac5f96f8924f30bb0bf5fc4ac4d1,Generals,All,False,"{""category"":""other""}",
 MSS/mssa3d.m3d,83456,e089ce52b0617a6530069f22e0bdba2a,41ccd5e30475ef7b40e68aa8c5c0ce18e804179fcaa77ba42e6ffa4f438d9a24,Generals,All,False,"{""category"":""other""}",
 MSS/mssds3d.m3d,70656,85267776d45dbf5475c7d9882f08117c,a2926f4e2a094a99508c05adaf86c5710ad3cff8bbcf247821feb0e6977f547c,Generals,All,False,"{""category"":""other""}",

--- a/docs/GameInstallationFilesRegistry/README.md
+++ b/docs/GameInstallationFilesRegistry/README.md
@@ -36,7 +36,7 @@ The `index.json` manifest acts as the root index queried by `CsvDiscoverer` duri
 ```json
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-08-30T17:40:00Z",
+  "lastUpdated": "2026-09-12T14:51:04Z",
   "description": "Index of CSV registries for Command & Conquer Generals and Zero Hour validation",
   "registries": [
     {
@@ -44,14 +44,14 @@ The `index.json` manifest acts as the root index queried by `CsvDiscoverer` duri
       "gameType": "Generals",
       "version": "1.08",
       "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
-      "fileCount": 164,
-      "totalSizeBytes": 28977,
+      "fileCount": 163,
+      "totalSizeBytes": 28813,
       "languages": ["All", "EN", "DE", "FR", "ES", "IT", "KO", "PL", "PT-BR", "ZH-CN", "ZH-TW"],
       "checksum": {
-        "md5": "4b77bce0b4dd0301478e0e341757491f",
-        "sha256": "0fba15bb0a0db434b5edce0475615d4f84c4f2a02b01610f42dc23b9f491099d"
+        "md5": "7f599b8c81ef300692c944c7419bf968",
+        "sha256": "0b2578095af96028bc9be32e5cecc2e10070290e9a6b923ac1eb5dd43c9af114"
       },
-      "generatedAt": "2025-09-17T09:15:00Z",
+      "generatedAt": "2026-09-12T14:51:04Z",
       "generatorVersion": "1.0.0",
       "isActive": true
     }

--- a/docs/GameInstallationFilesRegistry/index.json
+++ b/docs/GameInstallationFilesRegistry/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-08-30T17:40:00Z",
+  "lastUpdated": "2026-09-12T14:51:04Z",
   "description": "Index of CSV registries for Command & Conquer Generals and Zero Hour validation",
   "registries": [
     {
@@ -8,8 +8,8 @@
       "gameType": "Generals",
       "version": "1.08",
       "url": "https://raw.githubusercontent.com/community-outpost/GenHub/development/docs/GameInstallationFilesRegistry/Generals-1.08.csv",
-      "fileCount": 164,
-      "totalSizeBytes": 28977,
+      "fileCount": 163,
+      "totalSizeBytes": 28813,
       "languages": [
         "All",
         "EN",
@@ -24,10 +24,10 @@
         "ZH-TW"
       ],
       "checksum": {
-        "md5": "4b77bce0b4dd0301478e0e341757491f",
-        "sha256": "0fba15bb0a0db434b5edce0475615d4f84c4f2a02b01610f42dc23b9f491099d"
+        "md5": "7f599b8c81ef300692c944c7419bf968",
+        "sha256": "0b2578095af96028bc9be32e5cecc2e10070290e9a6b923ac1eb5dd43c9af114"
       },
-      "generatedAt": "2025-09-17T09:15:00Z",
+      "generatedAt": "2026-09-12T14:51:04Z",
       "generatorVersion": "1.0.0",
       "isActive": true
     },


### PR DESCRIPTION
Remove the optional `Launcher.txt` documentation file from the Generals catalog and refresh the catalog metadata and pinned checksum.

**Testing:** Catalog and CSV resolver tests pass.