### PR TITLE
fix(downloads): prevent update-available loop for Generals Online releases

### DIFF
--- a/GenHub/GenHub.Core/Constants/ContentConstants.cs
+++ b/GenHub/GenHub.Core/Constants/ContentConstants.cs
@@ -270,6 +270,16 @@ public static class ContentConstants
     public const string DownloadFailedStatusMessage = "Download failed";
 
     /// <summary>
+    /// Status message displayed when content update failed.
+    /// </summary>
+    public const string UpdateFailedStatusMessage = "Failed to update content";
+
+    /// <summary>
+    /// Status message displayed when content update was cancelled or failed.
+    /// </summary>
+    public const string UpdateCancelledOrFailedStatusMessage = "Update was canceled or failed.";
+
+    /// <summary>
     /// Status message displayed while selecting a profile.
     /// </summary>
     public const string SelectingProfileStatusMessage = "Selecting profile...";

--- a/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
+++ b/GenHub/GenHub.Core/Constants/GeneralsOnlineConstants.cs
@@ -16,6 +16,9 @@ public static class GeneralsOnlineConstants
     /// <summary>Content name for manifests.</summary>
     public const string ContentName = "Generals Online";
 
+    /// <summary>Client name and identifier prefix for GeneralsOnline.</summary>
+    public const string ClientName = "GeneralsOnline";
+
     /// <summary>Full content description.</summary>
     public const string Description = "Community-driven multiplayer service for C&C Generals Zero Hour. Features 60Hz tick rate, automatic updates, and improved stability.";
 
@@ -83,6 +86,9 @@ public static class GeneralsOnlineConstants
     public const int UpdateCheckIntervalHours = 24;
 
     // ===== Manifest Generation =====
+
+    /// <summary>Prefix for GeneralsOnline catalog content identifiers.</summary>
+    public const string ContentIdPrefix = "GeneralsOnline_";
 
     /// <summary>Publisher ID for the Generals Online service.</summary>
     public const string PublisherId = PublisherType;

--- a/GenHub/GenHub.Core/Constants/PublisherInfoConstants.cs
+++ b/GenHub/GenHub.Core/Constants/PublisherInfoConstants.cs
@@ -30,6 +30,13 @@ public static class PublisherInfoConstants
         (["github"], GitHub.LogoSource),
     ];
 
+    private static readonly (string[] Keywords, string CoverSource)[] CoverRules =
+    [
+        (["communityoutpost", "community outpost", "community-outpost"], CommunityOutpostConstants.CoverSource),
+        (["superhacker"], SuperHackersConstants.ZeroHourCoverSource),
+        (["generalsonline", "generals online", "generals-online"], GeneralsOnlineConstants.CoverSource),
+    ];
+
     /// <summary>
     /// Publisher information for Steam.
     /// </summary>
@@ -371,6 +378,20 @@ public static class PublisherInfoConstants
         return primary ?? secondary;
     }
 
+    /// <summary>
+    /// Gets the cover source URI for a publisher or content item based on publisher ID, provider name, or title.
+    /// </summary>
+    /// <param name="publisherIdOrName">The publisher ID or provider display name.</param>
+    /// <param name="contentIdOrName">The content ID, title, or manifest ID context.</param>
+    /// <returns>A cover image path string, or null if unmapped.</returns>
+    public static string? GetPublisherCover(string? publisherIdOrName, string? contentIdOrName = null)
+    {
+        var primary = MatchCover(publisherIdOrName);
+        var secondary = MatchCover(contentIdOrName);
+
+        return primary ?? secondary;
+    }
+
     private static string? MatchLogo(string? input)
     {
         if (string.IsNullOrWhiteSpace(input))
@@ -383,6 +404,24 @@ public static class PublisherInfoConstants
             if (keywords.Any(keyword => input.Contains(keyword, StringComparison.OrdinalIgnoreCase)))
             {
                 return logoSource;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? MatchCover(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return null;
+        }
+
+        foreach (var (keywords, coverSource) in CoverRules)
+        {
+            if (keywords.Any(keyword => input.Contains(keyword, StringComparison.OrdinalIgnoreCase)))
+            {
+                return coverSource;
             }
         }
 

--- a/GenHub/GenHub.Core/Constants/UriConstants.cs
+++ b/GenHub/GenHub.Core/Constants/UriConstants.cs
@@ -71,9 +71,19 @@ public static class UriConstants
     public const string ZeroHourIconFilename = "zerohour-icon.png";
 
     /// <summary>
+    /// Substring marker for Zero Hour icon asset.
+    /// </summary>
+    public const string ZeroHourIconMarker = "zerohour-icon";
+
+    /// <summary>
     /// Filename for GenHub default icon.
     /// </summary>
     public const string GenHubIconFilename = "generalshub-icon.png";
+
+    /// <summary>
+    /// Substring marker for GenHub default icon asset.
+    /// </summary>
+    public const string GenHubIconMarker = "generalshub-icon";
 
     /// <summary>
     /// Filename for Steam platform icon.
@@ -116,6 +126,11 @@ public static class UriConstants
     /// Filename for Zero Hour cover.
     /// </summary>
     public const string ZeroHourCoverFilename = "zerohour-cover.png";
+
+    /// <summary>
+    /// Substring marker for Zero Hour cover asset.
+    /// </summary>
+    public const string ZeroHourCoverMarker = "zerohour-cover";
 
     // Logo Path Constants
 

--- a/GenHub/GenHub.Core/Interfaces/Common/IDialogService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Common/IDialogService.cs
@@ -45,5 +45,5 @@ public interface IDialogService
     /// <param name="message">The dialog message.</param>
     /// <param name="initialDeleteOldVersions">The initial delete old versions checkbox state.</param>
     /// <returns>The result of the dialog interaction.</returns>
-    Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message, bool initialDeleteOldVersions = true);
+    Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message, bool initialDeleteOldVersions);
 }

--- a/GenHub/GenHub.Core/Interfaces/Common/IDialogService.cs
+++ b/GenHub/GenHub.Core/Interfaces/Common/IDialogService.cs
@@ -43,6 +43,7 @@ public interface IDialogService
     /// </summary>
     /// <param name="title">The dialog title.</param>
     /// <param name="message">The dialog message.</param>
+    /// <param name="initialDeleteOldVersions">The initial delete old versions checkbox state.</param>
     /// <returns>The result of the dialog interaction.</returns>
-    Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message);
+    Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message, bool initialDeleteOldVersions = true);
 }

--- a/GenHub/GenHub.Core/Models/Content/ContentCardBadgeHelper.cs
+++ b/GenHub/GenHub.Core/Models/Content/ContentCardBadgeHelper.cs
@@ -459,7 +459,7 @@ public static partial class ContentCardBadgeHelper
                (result.ProviderName?.Equals("Generals Online", StringComparison.OrdinalIgnoreCase) == true) ||
                (result.Id?.StartsWith("generalsonline.", StringComparison.OrdinalIgnoreCase) == true) ||
                (result.Id?.StartsWith("1.generalsonline.", StringComparison.OrdinalIgnoreCase) == true) ||
-               (result.Id?.StartsWith("GeneralsOnline_", StringComparison.OrdinalIgnoreCase) == true) ||
+               (result.Id?.StartsWith(GeneralsOnlineConstants.ContentIdPrefix, StringComparison.OrdinalIgnoreCase) == true) ||
                (result.AuthorName?.Equals("Generals Online", StringComparison.OrdinalIgnoreCase) == true) ||
                (result.ResolverMetadata?.TryGetValue(GitHubConstants.OwnerMetadataKey, out var goOwner) == true &&
                 (goOwner.Equals(PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) ||

--- a/GenHub/GenHub.Core/Models/Dialogs/UpdateDialogResult.cs
+++ b/GenHub/GenHub.Core/Models/Dialogs/UpdateDialogResult.cs
@@ -18,6 +18,11 @@ public class UpdateDialogResult
     public UpdateStrategy Strategy { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether superseded version files should be deleted from storage.
+    /// </summary>
+    public bool DeleteOldVersions { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to apply this choice for future updates.
     /// </summary>
     public bool IsDoNotAskAgain { get; set; }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/ViewModels/Dialogs/UpdateOptionDialogViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/ViewModels/Dialogs/UpdateOptionDialogViewModelTests.cs
@@ -1,0 +1,136 @@
+using GenHub.Common.ViewModels.Dialogs;
+using GenHub.Core.Models.Enums;
+using Xunit;
+
+namespace GenHub.Tests.Core.Common.ViewModels.Dialogs;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateOptionDialogViewModel"/>.
+/// </summary>
+public class UpdateOptionDialogViewModelTests
+{
+    /// <summary>
+    /// Verifies that the default constructor initializes with ReplaceCurrent and DeleteOldVersions set to true.
+    /// </summary>
+    [Fact]
+    public void Constructor_DefaultsToReplaceCurrentWithDeleteOldVersionsTrue()
+    {
+        var vm = new UpdateOptionDialogViewModel();
+
+        Assert.Equal(UpdateStrategy.ReplaceCurrent, vm.Strategy);
+        Assert.True(vm.IsReplaceCurrentVersion);
+        Assert.False(vm.IsCreateNewProfile);
+        Assert.True(vm.DeleteOldVersions);
+        Assert.True(vm.CanDeleteOldVersions);
+    }
+
+    /// <summary>
+    /// Verifies that selecting CreateNewProfile disables and unchecks DeleteOldVersions.
+    /// </summary>
+    [Fact]
+    public void SetIsCreateNewProfile_DisablesAndUnchecksDeleteOldVersions()
+    {
+        var vm = new UpdateOptionDialogViewModel
+        {
+            IsCreateNewProfile = true,
+        };
+
+        Assert.Equal(UpdateStrategy.CreateNewProfile, vm.Strategy);
+        Assert.False(vm.IsReplaceCurrentVersion);
+        Assert.True(vm.IsCreateNewProfile);
+        Assert.False(vm.DeleteOldVersions);
+        Assert.False(vm.CanDeleteOldVersions);
+    }
+
+    /// <summary>
+    /// Verifies that switching back to ReplaceCurrentVersion re-enables and checks DeleteOldVersions.
+    /// </summary>
+    [Fact]
+    public void SetIsReplaceCurrentVersion_EnablesAndChecksDeleteOldVersions()
+    {
+        var vm = new UpdateOptionDialogViewModel
+        {
+            IsCreateNewProfile = true,
+        };
+
+        Assert.False(vm.CanDeleteOldVersions);
+        Assert.False(vm.DeleteOldVersions);
+
+        vm.IsReplaceCurrentVersion = true;
+
+        Assert.Equal(UpdateStrategy.ReplaceCurrent, vm.Strategy);
+        Assert.True(vm.IsReplaceCurrentVersion);
+        Assert.False(vm.IsCreateNewProfile);
+        Assert.True(vm.DeleteOldVersions);
+        Assert.True(vm.CanDeleteOldVersions);
+    }
+
+    /// <summary>
+    /// Verifies that executing UpdateCommand with ReplaceCurrent preserves DeleteOldVersions.
+    /// </summary>
+    [Fact]
+    public void UpdateCommand_WithReplaceCurrent_PopulatesResultWithDeleteOldVersions()
+    {
+        var closed = false;
+        var vm = new UpdateOptionDialogViewModel
+        {
+            IsReplaceCurrentVersion = true,
+            DeleteOldVersions = true,
+            IsDoNotAskAgain = true,
+            CloseAction = _ => closed = true,
+        };
+
+        vm.UpdateCommand.Execute(null);
+
+        Assert.True(closed);
+        Assert.NotNull(vm.Result);
+        Assert.Equal("Update", vm.Result.Action);
+        Assert.Equal(UpdateStrategy.ReplaceCurrent, vm.Result.Strategy);
+        Assert.True(vm.Result.DeleteOldVersions);
+        Assert.True(vm.Result.IsDoNotAskAgain);
+    }
+
+    /// <summary>
+    /// Verifies that executing UpdateCommand with CreateNewProfile forces DeleteOldVersions to false.
+    /// </summary>
+    [Fact]
+    public void UpdateCommand_WithCreateNewProfile_ForcesDeleteOldVersionsFalse()
+    {
+        var closed = false;
+        var vm = new UpdateOptionDialogViewModel
+        {
+            IsCreateNewProfile = true,
+            CloseAction = _ => closed = true,
+        };
+
+        vm.UpdateCommand.Execute(null);
+
+        Assert.True(closed);
+        Assert.NotNull(vm.Result);
+        Assert.Equal("Update", vm.Result.Action);
+        Assert.Equal(UpdateStrategy.CreateNewProfile, vm.Result.Strategy);
+        Assert.False(vm.Result.DeleteOldVersions);
+    }
+
+    /// <summary>
+    /// Verifies that executing SkipCommand populates result with Skip action and DeleteOldVersions as false.
+    /// </summary>
+    [Fact]
+    public void SkipCommand_PopulatesResultWithSkipActionAndDeleteOldVersionsFalse()
+    {
+        var closed = false;
+        var vm = new UpdateOptionDialogViewModel
+        {
+            IsDoNotAskAgain = true,
+            CloseAction = _ => closed = true,
+        };
+
+        vm.SkipCommand.Execute(null);
+
+        Assert.True(closed);
+        Assert.NotNull(vm.Result);
+        Assert.Equal("Skip", vm.Result.Action);
+        Assert.False(vm.Result.DeleteOldVersions);
+        Assert.True(vm.Result.IsDoNotAskAgain);
+    }
+}

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
@@ -145,7 +145,7 @@ public class CommunityOutpostProfileReconcilerTests
         _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
 
         _dialogServiceMock
-            .Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
             .ReturnsAsync(new UpdateDialogResult { Action = "Skip" });
 
         _userSettingsServiceMock

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconcilerTests.cs
@@ -240,4 +240,36 @@ public class CommunityOutpostProfileReconcilerTests
             x => x.ShowError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Never);
     }
+
+    /// <summary>
+    /// Verifies that the reconciler forwards the persisted DeleteOldVersions preference to the update dialog.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_WhenPromptingUser_ForwardsPersistedDeleteOldVersionsPreferenceAsync()
+    {
+        _updateServiceMock
+            .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable("2.0.0", "1.0.0"));
+
+        var settings = new UserSettings();
+        var subscription = settings.GetOrCreateSubscription(CommunityOutpostConstants.PublisherType);
+        subscription.DeleteOldVersions = false;
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _dialogServiceMock
+            .Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), false))
+            .ReturnsAsync(new UpdateDialogResult { Action = "Skip" });
+
+        _userSettingsServiceMock
+            .Setup(x => x.TryUpdateAndSaveAsync(It.IsAny<Func<UserSettings, bool>>()))
+            .ReturnsAsync(true);
+
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync("profile1");
+
+        Assert.True(result.Success);
+        _dialogServiceMock.Verify(
+            x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), false),
+            Times.Once);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactoryTests.cs
@@ -68,6 +68,28 @@ public class GeneralsOnlineManifestFactoryTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that <see cref="GeneralsOnlineManifestFactory.CreateManifests"/> throws <see cref="ArgumentException"/>
+    /// when the QFE value in the version string exceeds 9, preventing ambiguous legacy manifest IDs.
+    /// </summary>
+    [Fact]
+    public void CreateManifests_WithQfeExceedingNine_ThrowsArgumentException()
+    {
+        // Arrange
+        var release = new GeneralsOnlineRelease
+        {
+            Version = "101525_QFE10",
+            ReleaseDate = DateTime.UtcNow,
+            PortableUrl = "https://example.com/GeneralsOnline_portable_101525_QFE10.zip",
+            PortableSize = 1048576,
+            Changelog = "https://example.com/changelog",
+        };
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => _factory.CreateManifests(release));
+        Assert.Contains("exceeding 9", ex.Message);
+    }
+
+    /// <summary>
     /// Verifies that <see cref="GeneralsOnlineManifestFactory.CreateManifests"/> generates 3 manifests:
     /// 60Hz GameClient, QuickMatch MapPack, and GeneralsOnlineGameData data patch.
     /// </summary>

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -9,6 +9,7 @@ using GenHub.Core.Models.Common;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Dialogs;
 using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameClients;
 using GenHub.Core.Models.GameProfile;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Results;
@@ -64,6 +65,8 @@ public class GeneralsOnlineProfileReconcilerTests
 
         _profileManagerMock.Setup(x => x.GetAllProfilesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(ProfileOperationResult<IReadOnlyList<GameProfile>>.CreateSuccess([])));
+        _profileManagerMock.Setup(x => x.CreateProfileAsync(It.IsAny<CreateProfileRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(new GameProfile { Id = "default-created-id", Name = "Default Created Profile" }));
 
         _reconciler = new GeneralsOnlineProfileReconciler(
             NullLogger<GeneralsOnlineProfileReconciler>.Instance,
@@ -315,11 +318,337 @@ public class GeneralsOnlineProfileReconcilerTests
         Assert.False(result.Data);
 
         _dialogServiceMock.Verify(
-            x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>()),
+            x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()),
             Times.Never);
 
         _contentOrchestratorMock.Verify(
             x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that when the user skips the update dialog, the reconciler returns false and does not acquire content.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_WhenUserSkipsDialog_ReturnsSuccessFalseAndDoesNotAcquireAsync()
+    {
+        // Arrange
+        string latestVersion = "0.0.99";
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "0.0.1"));
+
+        var settings = new UserSettings();
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _dialogServiceMock.Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new UpdateDialogResult { Action = "Skip", IsDoNotAskAgain = false });
+
+        // Act
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync("profile1", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.False(result.Data);
+
+        _contentOrchestratorMock.Verify(
+            x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that when the user specifies DeleteOldVersions is false, old manifests are not removed.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_WhenUserDisablesDeleteOldVersions_DoesNotDeleteOldManifestsAsync()
+    {
+        // Arrange
+        string latestVersion = "0.0.99";
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "0.0.1"));
+
+        var settings = new UserSettings();
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _dialogServiceMock.Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new UpdateDialogResult
+            {
+                Action = "Update",
+                Strategy = UpdateStrategy.ReplaceCurrent,
+                DeleteOldVersions = false,
+            });
+
+        var oldManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.82826.generalsonline.gameclient.30hz"),
+            Name = "Generals Online Client (30Hz)",
+            Version = "0.0.1",
+        };
+        var newManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.82827.generalsonline.gameclient.30hz"),
+            Name = "Generals Online Client (30Hz)",
+            Version = latestVersion,
+        };
+
+        _manifestPoolMock.SetupSequence(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldManifest, newManifest]));
+
+        _contentOrchestratorMock.Setup(
+                x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new() { Name = "New GO Version", Version = latestVersion },
+            ]));
+
+        _contentOrchestratorMock.Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(newManifest));
+
+        _reconciliationServiceMock
+            .Setup(x => x.OrchestrateBulkUpdateAsync(
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ReconciliationResult>.CreateSuccess(new ReconciliationResult(1, 0)));
+
+        // Act
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync("profile1", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.True(result.Data);
+
+        _reconciliationServiceMock.Verify(
+            x => x.OrchestrateBulkRemovalAsync(It.IsAny<IEnumerable<ManifestId>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// When zero profiles exist and CreateNewProfile is selected, should create a fresh profile.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CheckAndReconcile_WhenZeroProfilesExist_AndCreateNewProfileSelected_ShouldCreateFreshProfileAsync()
+    {
+        // Arrange
+        string latestVersion = "1.101525";
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "1.101524"));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(GeneralsOnlineConstants.PublisherType, true);
+        var sub = settings.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType);
+        sub.PreferredUpdateStrategy = UpdateStrategy.CreateNewProfile;
+        sub.DeleteOldVersions = false;
+
+        _userSettingsServiceMock.Setup(x => x.Get())
+            .Returns(settings);
+
+        var newClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101525.generalsonline.gameclient.60hz"),
+            Name = "GeneralsOnline",
+            Version = latestVersion,
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        _manifestPoolMock.SetupSequence(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([newClientManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([newClientManifest]));
+
+        _contentOrchestratorMock.Setup(
+                x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new() { Name = "New GO Version", Version = latestVersion },
+            ]));
+
+        _contentOrchestratorMock.Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(newClientManifest));
+
+        _profileManagerMock.Setup(x => x.GetAllProfilesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<IReadOnlyList<GameProfile>>.CreateSuccess([]));
+
+        CreateProfileRequest? capturedRequest = null;
+        _profileManagerMock.Setup(x => x.CreateProfileAsync(It.IsAny<CreateProfileRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateProfileRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(new GameProfile { Id = "fresh-1", Name = "GeneralsOnline" }));
+
+        // Act
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync(string.Empty, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal($"GeneralsOnline v{latestVersion}", capturedRequest.Name);
+        Assert.Equal(GeneralsOnlineConstants.LogoSource, capturedRequest.IconPath);
+        Assert.Equal(GeneralsOnlineConstants.CoverSource, capturedRequest.CoverPath);
+        Assert.Equal(GeneralsOnlineConstants.ThemeColor, capturedRequest.ThemeColor);
+    }
+
+    /// <summary>
+    /// When a profile has an existing messy version suffix, formatting for CreateNewProfile strips redundant suffixes cleanly.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CheckAndReconcile_WhenProfileHasMessyVersionSuffix_ShouldFormatNameCleanlyAsync()
+    {
+        // Arrange
+        string latestVersion = "1.101525";
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "1.101524"));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(GeneralsOnlineConstants.PublisherType, true);
+        var sub = settings.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType);
+        sub.PreferredUpdateStrategy = UpdateStrategy.CreateNewProfile;
+        sub.DeleteOldVersions = false;
+
+        _userSettingsServiceMock.Setup(x => x.Get())
+            .Returns(settings);
+
+        var oldClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101524.generalsonline.gameclient.60hz"),
+            Version = "1.101524",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        var newClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101525.generalsonline.gameclient.60hz"),
+            Name = "GeneralsOnline",
+            Version = latestVersion,
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        _manifestPoolMock.SetupSequence(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, newClientManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, newClientManifest]));
+
+        _contentOrchestratorMock.Setup(
+                x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new() { Name = "New GO Version", Version = latestVersion },
+            ]));
+
+        _contentOrchestratorMock.Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(newClientManifest));
+
+        var messyProfile = new GameProfile
+        {
+            Id = "p1",
+            Name = "GeneralsOnline v032926 (v082826_QFE1)",
+            GameClient = new GameClient { Id = oldClientManifest.Id.Value, PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        _profileManagerMock.Setup(x => x.GetAllProfilesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<IReadOnlyList<GameProfile>>.CreateSuccess([messyProfile]));
+
+        CreateProfileRequest? capturedRequest = null;
+        _profileManagerMock.Setup(x => x.CreateProfileAsync(It.IsAny<CreateProfileRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateProfileRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(new GameProfile { Id = "p2", Name = "GeneralsOnline v1.101525" }));
+
+        // Act
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync(string.Empty, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal($"GeneralsOnline v{latestVersion}", capturedRequest.Name);
+    }
+
+    /// <summary>
+    /// When CreateNewProfile is selected, old preserved profiles should not be mutated or renamed by EnforceMapPackDependency.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task CheckAndReconcile_WhenCreateNewProfileSelected_ShouldNotMutatePreservedOldProfilesAsync()
+    {
+        // Arrange
+        string latestVersion = "1.101525";
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "1.101524"));
+
+        var settings = new UserSettings();
+        settings.SetAutoUpdatePreference(GeneralsOnlineConstants.PublisherType, true);
+        var sub = settings.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType);
+        sub.PreferredUpdateStrategy = UpdateStrategy.CreateNewProfile;
+        sub.DeleteOldVersions = false;
+
+        _userSettingsServiceMock.Setup(x => x.Get())
+            .Returns(settings);
+
+        var oldClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101524.generalsonline.gameclient.60hz"),
+            Version = "1.101524",
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        var newClientManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101525.generalsonline.gameclient.60hz"),
+            Name = "GeneralsOnline",
+            Version = latestVersion,
+            ContentType = ContentType.GameClient,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        var newMapPackManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.101525.generalsonline.mappack.quickmatch-maps"),
+            Version = latestVersion,
+            ContentType = ContentType.MapPack,
+            Publisher = new PublisherInfo { PublisherType = GeneralsOnlineConstants.PublisherType },
+        };
+
+        _manifestPoolMock.SetupSequence(x => x.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, newClientManifest, newMapPackManifest]))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([oldClientManifest, newClientManifest, newMapPackManifest]));
+
+        _contentOrchestratorMock.Setup(
+                x => x.SearchAsync(It.IsAny<ContentSearchQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentSearchResult>>.CreateSuccess(
+            [
+                new() { Name = "New GO Version", Version = latestVersion },
+            ]));
+
+        _contentOrchestratorMock.Setup(x => x.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(newClientManifest));
+
+        var oldProfile = new GameProfile
+        {
+            Id = "old-profile-id",
+            Name = "GeneralsOnline v1.101524",
+            GameClient = new GameClient { Id = oldClientManifest.Id.Value, PublisherType = GeneralsOnlineConstants.PublisherType },
+            EnabledContentIds = ["1.101524.generalsonline.mappack.quickmatch-maps"],
+        };
+
+        _profileManagerMock.Setup(x => x.GetAllProfilesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<IReadOnlyList<GameProfile>>.CreateSuccess([oldProfile]));
+
+        _profileManagerMock.Setup(x => x.CreateProfileAsync(It.IsAny<CreateProfileRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(new GameProfile { Id = "new-profile-id", Name = $"GeneralsOnline v{latestVersion}" }));
+
+        // Act
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync(string.Empty, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        _profileManagerMock.Verify(
+            x => x.UpdateProfileAsync("old-profile-id", It.IsAny<UpdateProfileRequest>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconcilerTests.cs
@@ -651,4 +651,34 @@ public class GeneralsOnlineProfileReconcilerTests
             x => x.UpdateProfileAsync("old-profile-id", It.IsAny<UpdateProfileRequest>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    /// <summary>
+    /// Verifies that the reconciler forwards the persisted DeleteOldVersions preference to the update dialog.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_WhenPromptingUser_ForwardsPersistedDeleteOldVersionsPreferenceAsync()
+    {
+        // Arrange
+        string latestVersion = "0.0.99";
+        _updateServiceMock.Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable(latestVersion, "0.0.1"));
+
+        var settings = new UserSettings();
+        var subscription = settings.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType);
+        subscription.DeleteOldVersions = false;
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _dialogServiceMock.Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), false))
+            .ReturnsAsync(new UpdateDialogResult { Action = "Skip", IsDoNotAskAgain = false });
+
+        // Act
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync("profile1", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        _dialogServiceMock.Verify(
+            x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), false),
+            Times.Once);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
@@ -147,7 +147,7 @@ public class SuperHackersProfileReconcilerTests
         _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
 
         _dialogServiceMock
-            .Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
             .ReturnsAsync(new UpdateDialogResult { Action = "Skip" });
 
         _userSettingsServiceMock

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Content/Services/SuperHackers/SuperHackersProfileReconcilerTests.cs
@@ -356,4 +356,36 @@ public class SuperHackersProfileReconcilerTests
             x => x.ShowSuccess("SuperHackers Updated", It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()),
             Times.Once);
     }
+
+    /// <summary>
+    /// Verifies that the reconciler forwards the persisted DeleteOldVersions preference to the update dialog.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CheckAndReconcileIfNeededAsync_WhenPromptingUser_ForwardsPersistedDeleteOldVersionsPreferenceAsync()
+    {
+        _updateServiceMock
+            .Setup(x => x.CheckForUpdatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentUpdateCheckResult.CreateUpdateAvailable("2.0.0", "1.0.0"));
+
+        var settings = new UserSettings();
+        var subscription = settings.GetOrCreateSubscription(PublisherTypeConstants.TheSuperHackers);
+        subscription.DeleteOldVersions = false;
+        _userSettingsServiceMock.Setup(x => x.Get()).Returns(settings);
+
+        _dialogServiceMock
+            .Setup(x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), false))
+            .ReturnsAsync(new UpdateDialogResult { Action = "Skip" });
+
+        _userSettingsServiceMock
+            .Setup(x => x.TryUpdateAndSaveAsync(It.IsAny<Func<UserSettings, bool>>()))
+            .ReturnsAsync(true);
+
+        var result = await _reconciler.CheckAndReconcileIfNeededAsync("profile1");
+
+        Assert.True(result.Success);
+        _dialogServiceMock.Verify(
+            x => x.ShowUpdateOptionDialogAsync(It.IsAny<string>(), It.IsAny<string>(), false),
+            Times.Once);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ContentStateServiceTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ContentStateServiceTests.cs
@@ -1727,6 +1727,109 @@ public class ContentStateServiceTests
         Assert.True(ContentStateService.IsCompatiblePublisherAlias(p1, p2));
     }
 
+    /// <summary>
+    /// Verifies that when both an older Generals Online release (e.g. 032926) and the current release (082826_QFE1)
+    /// exist in the manifest pool, ContentStateService correctly matches the current release, returns Downloaded,
+    /// and does not spuriously report UpdateAvailable due to selecting the older manifest.
+    /// </summary>
+    /// <returns>A completed task.</returns>
+    [Fact]
+    public async Task GetStateAsync_GeneralsOnlineWithOlderAndCurrentInstalledManifests_ReturnsDownloadedAsync()
+    {
+        var olderManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.329260.generalsonline.gameclient.60hz"),
+            Name = "Generals Online 60Hz",
+            Version = "032926",
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            Publisher = new PublisherInfo
+            {
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+                Website = "https://www.playgenerals.online",
+            },
+        };
+
+        var currentManifest = new ContentManifest
+        {
+            Id = ManifestId.Create("1.828261.generalsonline.gameclient.60hz"),
+            Name = "Generals Online 60Hz",
+            Version = "082826_QFE1",
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            Publisher = new PublisherInfo
+            {
+                PublisherType = PublisherTypeConstants.GeneralsOnline,
+                Website = "https://www.playgenerals.online",
+            },
+        };
+
+        var item = new ContentSearchResult
+        {
+            Id = "GeneralsOnline_082826_QFE1",
+            Name = "Generals Online",
+            ProviderName = PublisherTypeConstants.GeneralsOnline,
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+            Version = "082826_QFE1",
+            SourceUrl = "https://www.playgenerals.online",
+        };
+
+        var pool = new Mock<IContentManifestPool>();
+        pool.Setup(p => p.GetAllManifestsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IEnumerable<ContentManifest>>.CreateSuccess([olderManifest, currentManifest]));
+        pool.Setup(p => p.IsManifestAcquiredAsync(It.IsAny<ManifestId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManifestId id, CancellationToken _) => OperationResult<bool>.CreateSuccess(id == olderManifest.Id || id == currentManifest.Id));
+
+        var service = new ContentStateService(pool.Object, NullLogger<ContentStateService>.Instance);
+
+        var state = await service.GetStateAsync(item);
+        var localManifestId = await service.GetLocalManifestIdAsync(item);
+
+        Assert.Equal(ContentState.Downloaded, state);
+        Assert.Equal(currentManifest.Id.Value, localManifestId);
+    }
+
+    /// <summary>
+    /// Verifies that CompareVersions correctly evaluates Generals Online MMddyy[_QFE#] versions.
+    /// </summary>
+    [Fact]
+    public void CompareVersions_GeneralsOnlineVersionScheme_OrdersChronologicallyAndByQfe()
+    {
+        Assert.True(ContentStateService.CompareVersions("082826_QFE1", "082826", isGeneralsOnline: true) > 0);
+        Assert.True(ContentStateService.CompareVersions("082826_QFE2", "082826_QFE1", isGeneralsOnline: true) > 0);
+        Assert.True(ContentStateService.CompareVersions("090126", "082826_QFE1", isGeneralsOnline: true) > 0);
+        Assert.True(ContentStateService.CompareVersions("032926", "082826_QFE1", isGeneralsOnline: true) < 0);
+        Assert.Equal(0, ContentStateService.CompareVersions("082826_QFE1", "082826_QFE1", isGeneralsOnline: true));
+    }
+
+    /// <summary>
+    /// Verifies that non-Generals Online publisher content IDs retain standard integer comparisons
+    /// without falling into date-based sorting semantics.
+    /// </summary>
+    [Fact]
+    public void IsNewerVersion_NonGeneralsOnlinePublisher_RetainsIntegerSemantics()
+    {
+        // Under integer semantics: prospective 101099 < local 901010, so IsNewer is false.
+        // Under date semantics: 101099 (2009) > 901010 (2001), so without the publisher gate it would erroneously be true.
+        Assert.False(ContentStateService.IsNewerVersion("1.101099.communityoutpost.patch.name", "1.901010.communityoutpost.patch.name"));
+        Assert.True(ContentStateService.IsNewerVersion("1.901010.communityoutpost.patch.name", "1.101099.communityoutpost.patch.name"));
+    }
+
+    /// <summary>
+    /// Verifies that explicit non-Generals Online version strings like 123125 and 010126
+    /// are not parsed as MMDDYY dates and retain numeric/string ordering.
+    /// </summary>
+    [Fact]
+    public void CompareVersions_NonGeneralsOnlineNumericStrings_DoesNotApplyDateSemantics()
+    {
+        // 123125 should be greater than 010126 when evaluated without Generals Online scheme
+        Assert.True(ContentStateService.CompareVersions("123125", "010126", isGeneralsOnline: false) > 0);
+
+        // Under Generals Online scheme (MMddyy), 010126 (2026-01-01) is newer than 123125 (2025-12-31)
+        Assert.True(ContentStateService.CompareVersions("123125", "010126", isGeneralsOnline: true) < 0);
+    }
+
     private static ContentSearchResult CreateSuperHackersCard(GameType gameType)
     {
         var item = new ContentSearchResult

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/ContentDetailViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/ContentDetailViewModelTests.cs
@@ -2101,4 +2101,54 @@ public sealed class ContentDetailViewModelTests
         Assert.Equal(ContentConstants.Md5ChecksumTitle, item.ChecksumTitle);
         Assert.Equal("098f6bcd4621d373cade4e832627b4f6", item.ChecksumDisplay);
     }
+
+    /// <summary>
+    /// Verifies that when content has an update available and its search result ID is not a valid manifest ID
+    /// (e.g. Generals Online uninstalled prospective update "GeneralsOnline_082826_QFE1"),
+    /// LoadInitialStateAsync does not rewrite SearchResult.Id to the older local manifest ID,
+    /// preserving the prospective release's identity and update state.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task Initialize_WhenUpdateAvailableAndSearchResultIdInvalidManifest_DoesNotRewriteSearchResultIdAsync()
+    {
+        // Arrange
+        const string prospectiveCatalogId = "GeneralsOnline_082826_QFE1";
+        const string oldLocalManifestId = "1.329260.generalsonline.gameclient.60hz";
+
+        var searchResult = new ContentSearchResult
+        {
+            Id = prospectiveCatalogId,
+            Name = "Generals Online",
+            ProviderName = PublisherTypeConstants.GeneralsOnline,
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+        };
+
+        var stateService = new Mock<IContentStateService>();
+        stateService
+            .Setup(s => s.GetStateAsync(searchResult, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentState.UpdateAvailable);
+        stateService
+            .Setup(s => s.GetLocalManifestIdAsync(searchResult, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(oldLocalManifestId);
+
+        var coordinator = new Mock<IContentDownloadCoordinator>();
+        var viewModel = CreateViewModel(
+            searchResult,
+            coordinator.Object,
+            contentStateService: stateService.Object,
+            isUpdateAvailable: true);
+
+        // Act
+        viewModel.Initialize();
+        await viewModel.WaitForInitializationAsync();
+
+        // Assert
+        Assert.Equal(prospectiveCatalogId, searchResult.Id);
+        Assert.True(viewModel.IsUpdateAvailable);
+        Assert.True(viewModel.IsDownloaded);
+        Assert.True(viewModel.ShowUpdateButton);
+        Assert.True(viewModel.ShowAddToProfileButton);
+    }
 }

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/DownloadsBrowserViewModelTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/Downloads/ViewModels/DownloadsBrowserViewModelTests.cs
@@ -1294,11 +1294,11 @@ public class DownloadsBrowserViewModelTests
     }
 
     /// <summary>
-    /// Verifies that UpdateContentCommand falls back to downloading the target item when publisher reconciler reports no reconciliation.
+    /// Verifies that UpdateContentCommand does not download the target item when publisher reconciler reports no reconciliation or user skips.
     /// </summary>
     /// <returns>A task representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task UpdateContentCommand_WhenPublisherReconcilerReturnsNoReconciliation_FallsBackToDownloadAsync()
+    public async Task UpdateContentCommand_WhenPublisherReconcilerReturnsNoReconciliation_DoesNotDownloadAsync()
     {
         // Arrange
         var orchestratorMock = new Mock<IContentOrchestrator>();
@@ -1308,10 +1308,8 @@ public class DownloadsBrowserViewModelTests
             Name = "Custom Mod",
             Version = "2.0.0",
         };
-        string? acquiredId = null;
         orchestratorMock
             .Setup(o => o.AcquireContentAsync(It.IsAny<ContentSearchResult>(), It.IsAny<IProgress<ContentAcquisitionProgress>?>(), It.IsAny<CancellationToken>()))
-            .Callback<ContentSearchResult, IProgress<ContentAcquisitionProgress>?, CancellationToken>((sr, _, _) => acquiredId = sr.Id)
             .ReturnsAsync(OperationResult<ContentManifest>.CreateSuccess(manifest));
 
         var reconcilerMock = new Mock<IPublisherReconciler>();
@@ -1354,17 +1352,16 @@ public class DownloadsBrowserViewModelTests
         // Act
         await viewModel.UpdateContentCommand.ExecuteAsync(currentVm);
 
-        // Assert: Reconciler was invoked but returned false, so fallback downloaded target VM
+        // Assert: Reconciler was invoked and handled the update; since it returned false, no download was performed
         reconcilerMock.Verify(
             r => r.CheckAndReconcileIfNeededAsync(string.Empty, It.IsAny<CancellationToken>()),
             Times.Once);
-        Assert.Equal("custom.mod.v2", acquiredId);
         orchestratorMock.Verify(
             o => o.AcquireContentAsync(
                 It.IsAny<ContentSearchResult>(),
                 It.IsAny<IProgress<ContentAcquisitionProgress>?>(),
                 It.IsAny<CancellationToken>()),
-            Times.Once);
+            Times.Never);
     }
 
     /// <summary>
@@ -1587,6 +1584,94 @@ public class DownloadsBrowserViewModelTests
         Assert.Equal("1.0.cnclabs.map.defcon8", item.SearchResult.Id);
         Assert.True(item.ShowAddToProfileButton);
         Assert.False(item.ShowDownloadButton);
+    }
+
+    /// <summary>
+    /// Verifies that closing the detail view for content with an available update preserves
+    /// the grid item's UpdateAvailable state and ShowUpdateButton visibility.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task CloseDetailCommand_WhenContentHasUpdateAvailable_PreservesUpdateAvailableStateAsync()
+    {
+        // Arrange
+        const string prospectiveCatalogId = "GeneralsOnline_082826_QFE1";
+        const string oldLocalManifestId = "1.329260.generalsonline.gameclient.60hz";
+
+        var stateServiceMock = new Mock<IContentStateService>();
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+
+        var serviceProviderMock = new Mock<IServiceProvider>();
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(ILogger<ContentDetailViewModel>)))
+            .Returns(new Mock<ILogger<ContentDetailViewModel>>().Object);
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(ITabProviderRegistry)))
+            .Returns(new Mock<ITabProviderRegistry>().Object);
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(IContentDownloadCoordinator)))
+            .Returns(new Mock<IContentDownloadCoordinator>().Object);
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(IContentManifestPool)))
+            .Returns(new Mock<IContentManifestPool>().Object);
+
+        var subscriptionStore = new Mock<IPublisherSubscriptionStore>();
+        subscriptionStore
+            .Setup(store => store.GetSubscriptionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OperationResult<IReadOnlyList<PublisherSubscription>>.CreateSuccess([]));
+
+        using var viewModel = new DownloadsBrowserViewModel(
+            serviceProviderMock.Object,
+            new Mock<ILogger<DownloadsBrowserViewModel>>().Object,
+            [],
+            stateServiceMock.Object,
+            new Mock<IContentOrchestrator>().Object,
+            new Mock<IProfileContentService>().Object,
+            new Mock<IGameProfileManager>().Object,
+            new Mock<INotificationService>().Object,
+            loggerFactoryMock.Object,
+            subscriptionStore.Object);
+
+        var sr = new ContentSearchResult
+        {
+            Id = prospectiveCatalogId,
+            Name = "Generals Online",
+            ProviderName = PublisherTypeConstants.GeneralsOnline,
+            ContentType = ContentType.GameClient,
+            TargetGame = GameType.ZeroHour,
+        };
+
+        stateServiceMock
+            .Setup(s => s.GetStateAsync(sr, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ContentState.UpdateAvailable);
+        stateServiceMock
+            .Setup(s => s.GetLocalManifestIdAsync(sr, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(oldLocalManifestId);
+
+        var item = new ContentGridItemViewModel(sr, stateServiceMock.Object, new Mock<ILogger<ContentGridItemViewModel>>().Object)
+        {
+            CurrentState = ContentState.UpdateAvailable,
+        };
+        viewModel.ContentItems.Add(item);
+
+        Assert.True(item.ShowUpdateButton);
+
+        // Act 1: open detail
+        viewModel.ViewContentCommand.Execute(item);
+        Assert.NotNull(viewModel.SelectedContent);
+        await viewModel.SelectedContent.WaitForInitializationAsync();
+
+        // SearchResult.Id must remain the prospective catalog ID, not overwritten with oldLocalManifestId
+        Assert.Equal(prospectiveCatalogId, sr.Id);
+        Assert.True(viewModel.SelectedContent.IsUpdateAvailable);
+
+        // Act 2: close detail
+        viewModel.CloseDetailCommand.Execute(null);
+
+        // Allow background refresh task to complete
+        await Task.Delay(100);
+
+        // Assert: detail is closed, grid item remains UpdateAvailable with ShowUpdateButton true
+        Assert.Null(viewModel.SelectedContent);
+        Assert.Equal(ContentState.UpdateAvailable, item.CurrentState);
+        Assert.True(item.ShowUpdateButton);
     }
 
     private static DownloadsBrowserViewModel CreateViewModel(

--- a/GenHub/GenHub/Common/Services/DialogService.cs
+++ b/GenHub/GenHub/Common/Services/DialogService.cs
@@ -104,7 +104,7 @@ public class DialogService(ISessionPreferenceService sessionPreferenceService) :
     }
 
     /// <inheritdoc/>
-    public async Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message, bool initialDeleteOldVersions = true)
+    public async Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message, bool initialDeleteOldVersions)
     {
         var viewModel = new UpdateOptionDialogViewModel
         {

--- a/GenHub/GenHub/Common/Services/DialogService.cs
+++ b/GenHub/GenHub/Common/Services/DialogService.cs
@@ -104,12 +104,13 @@ public class DialogService(ISessionPreferenceService sessionPreferenceService) :
     }
 
     /// <inheritdoc/>
-    public async Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message)
+    public async Task<UpdateDialogResult?> ShowUpdateOptionDialogAsync(string title, string message, bool initialDeleteOldVersions = true)
     {
         var viewModel = new UpdateOptionDialogViewModel
         {
             Title = title,
             Message = message,
+            DeleteOldVersions = initialDeleteOldVersions,
         };
 
         var window = new UpdateOptionDialogWindow

--- a/GenHub/GenHub/Common/ViewModels/Dialogs/UpdateOptionDialogViewModel.cs
+++ b/GenHub/GenHub/Common/ViewModels/Dialogs/UpdateOptionDialogViewModel.cs
@@ -30,6 +30,12 @@ public partial class UpdateOptionDialogViewModel : ViewModelBase
     private UpdateStrategy _strategy = UpdateStrategy.ReplaceCurrent;
 
     /// <summary>
+    /// Gets or sets a value indicating whether superseded version files should be deleted from storage.
+    /// </summary>
+    [ObservableProperty]
+    private bool _deleteOldVersions = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether the user selected "Replace Current Version".
     /// </summary>
     public bool IsReplaceCurrentVersion
@@ -40,9 +46,11 @@ public partial class UpdateOptionDialogViewModel : ViewModelBase
             if (value)
             {
                 Strategy = UpdateStrategy.ReplaceCurrent;
+                DeleteOldVersions = true;
             }
 
             OnPropertyChanged(nameof(IsReplaceCurrentVersion));
+            OnPropertyChanged(nameof(CanDeleteOldVersions));
         }
     }
 
@@ -57,11 +65,19 @@ public partial class UpdateOptionDialogViewModel : ViewModelBase
             if (value)
             {
                 Strategy = UpdateStrategy.CreateNewProfile;
+                DeleteOldVersions = false;
             }
 
             OnPropertyChanged(nameof(IsCreateNewProfile));
+            OnPropertyChanged(nameof(CanDeleteOldVersions));
         }
     }
+
+    /// <summary>
+    /// Gets a value indicating whether the delete old versions option can be toggled.
+    /// Superseded versions can only be deleted when replacing in existing profiles.
+    /// </summary>
+    public bool CanDeleteOldVersions => IsReplaceCurrentVersion;
 
     /// <summary>
     /// Gets or sets a value indicating whether the "Do not ask again" checkbox is checked.
@@ -87,6 +103,7 @@ public partial class UpdateOptionDialogViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(IsReplaceCurrentVersion));
         OnPropertyChanged(nameof(IsCreateNewProfile));
+        OnPropertyChanged(nameof(CanDeleteOldVersions));
     }
 
     /// <summary>
@@ -99,6 +116,7 @@ public partial class UpdateOptionDialogViewModel : ViewModelBase
         {
             Action = "Update",
             Strategy = Strategy,
+            DeleteOldVersions = IsReplaceCurrentVersion && DeleteOldVersions,
             IsDoNotAskAgain = IsDoNotAskAgain,
         };
         CloseAction?.Invoke(Result);
@@ -114,6 +132,7 @@ public partial class UpdateOptionDialogViewModel : ViewModelBase
         {
             Action = "Skip",
             Strategy = Strategy,
+            DeleteOldVersions = false,
             IsDoNotAskAgain = IsDoNotAskAgain,
         };
         CloseAction?.Invoke(Result);

--- a/GenHub/GenHub/Common/Views/Dialogs/UpdateOptionDialogWindow.axaml
+++ b/GenHub/GenHub/Common/Views/Dialogs/UpdateOptionDialogWindow.axaml
@@ -62,15 +62,21 @@
                                          Content="Replace (Update current version)"
                                          Foreground="White" FontWeight="Medium"/>
 
-                            <TextBlock Text="Updates the current version in existing profiles. This will replace the files in your current installation."
-                                       FontSize="12" Foreground="#A0A0A0" Margin="28,-8,0,4"
+                            <TextBlock Text="Updates the current version in existing profiles. Superseded version files (old game client, map pack, data patch) will be deleted to save disk space."
+                                       FontSize="12" Foreground="#A0A0A0" Margin="28,-8,0,0"
                                        TextWrapping="Wrap"/>
+
+                            <CheckBox IsChecked="{Binding DeleteOldVersions}"
+                                      IsEnabled="{Binding CanDeleteOldVersions}"
+                                      Content="Delete superseded version files from storage"
+                                      ToolTip.Tip="Removes previous version files from local storage to prevent accumulating unused versions"
+                                      Foreground="#B0B0B0" FontSize="12" Margin="28,-4,0,4"/>
 
                             <RadioButton IsChecked="{Binding IsCreateNewProfile}"
                                          Content="Create New Profile"
                                          Foreground="White" FontWeight="Medium"/>
 
-                            <TextBlock Text="Creates a new companion profile for the new version, keeping your current version and profile intact."
+                            <TextBlock Text="Creates a new companion profile for the new version, keeping your current version, files, and profile intact."
                                        FontSize="12" Foreground="#A0A0A0" Margin="28,-8,0,0"
                                        TextWrapping="Wrap"/>
                         </StackPanel>
@@ -82,13 +88,14 @@
                     <CheckBox Grid.Column="0"
                               IsChecked="{Binding IsDoNotAskAgain}"
                               Content="Don't ask again"
+                              ToolTip.Tip="Remember this choice for future updates"
                               Foreground="#C0C0C0" VerticalAlignment="Center"/>
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="16">
-                        <Button Command="{Binding SkipCommand}" Content="Skip"
+                        <Button Command="{Binding SkipCommand}" Content="Cancel"
                                 Background="Transparent" BorderBrush="#40FFFFFF" BorderThickness="1"
                                 Foreground="White" Padding="20,10" CornerRadius="4"
-                                ToolTip.Tip="Skip this update (you'll be notified again for newer versions)"/>
+                                ToolTip.Tip="Cancel this update (no files will be downloaded or modified)"/>
 
                         <Button Command="{Binding UpdateCommand}" Content="Update"
                                 Background="{DynamicResource PrimaryGradientBrush}"

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
@@ -508,6 +508,7 @@ public class CommunityOutpostProfileReconciler(
         }
 
         strategy = dialogResult.Strategy;
+        shouldDeleteOldVersions = dialogResult.DeleteOldVersions;
 
         if (dialogResult.IsDoNotAskAgain)
         {
@@ -519,6 +520,7 @@ public class CommunityOutpostProfileReconciler(
                 if (sub != null)
                 {
                     sub.PreferredUpdateStrategy = strategy;
+                    sub.DeleteOldVersions = shouldDeleteOldVersions;
                 }
 
                 return true;

--- a/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/CommunityOutpost/CommunityOutpostProfileReconciler.cs
@@ -484,7 +484,8 @@ public class CommunityOutpostProfileReconciler(
 
         var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
             "Community Patch Update Available",
-            $"A new version of the **Community Patch** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
+            $"A new version of the **Community Patch** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?",
+            shouldDeleteOldVersions);
 
         if (dialogResult == null)
         {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineJsonCatalogParser.cs
@@ -314,7 +314,7 @@ public class GeneralsOnlineJsonCatalogParser(
 
         var searchResult = new ContentSearchResult
         {
-            Id = $"GeneralsOnline_{release.Version}",
+            Id = $"{GeneralsOnlineConstants.ContentIdPrefix}{release.Version}",
             Name = GeneralsOnlineConstants.ContentName,
             Description = release.Changelog ?? provider.Description,
             Version = release.Version,

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineManifestFactory.cs
@@ -5,6 +5,7 @@ using GenHub.Core.Interfaces.Providers;
 using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.GeneralsOnline;
 using GenHub.Core.Models.Manifest;
+using GenHub.Core.Services.Providers.VersionSchemes;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -84,6 +85,8 @@ public class GeneralsOnlineManifestFactory(
             Version = release.Version,
             ContentType = ContentType.GameClient,
             TargetGame = GameType.ZeroHour,
+            OriginalProviderName = PublisherTypeConstants.GeneralsOnline,
+            OriginalContentId = $"{GeneralsOnlineConstants.ContentIdPrefix}{release.Version}",
             Publisher = new PublisherInfo
             {
                 Name = GeneralsOnlineConstants.PublisherName,
@@ -234,7 +237,18 @@ public class GeneralsOnlineManifestFactory(
         return await UpdateManifestsWithExtractedFiles(manifests, installationPath, cancellationToken);
     }
 
-    private static int ParseVersionForManifestId(string version) => GameVersionHelper.GetGeneralsOnlineManifestIdComponent(version);
+    private static int ParseVersionForManifestId(string version)
+    {
+        var scheme = new MmddyyQfeVersionScheme();
+        if (scheme.TryParse(version, out var parsed) && parsed.Components.Count > 3 && parsed.Components[3] > 9)
+        {
+            throw new ArgumentException(
+                $"Generals Online version '{version}' has a QFE value ({parsed.Components[3]}) exceeding 9, which cannot be encoded into a 7-digit legacy manifest ID without year collision.",
+                nameof(version));
+        }
+
+        return GameVersionHelper.GetGeneralsOnlineManifestIdComponent(version);
+    }
 
     /// <summary>
     /// Determines whether a manifest-relative path is the named file at the archive root.
@@ -335,6 +349,8 @@ public class GeneralsOnlineManifestFactory(
             Version = release.Version,
             ContentType = ContentType.Patch,
             TargetGame = GameType.ZeroHour,
+            OriginalProviderName = PublisherTypeConstants.GeneralsOnline,
+            OriginalContentId = $"{GeneralsOnlineConstants.ContentIdPrefix}{release.Version}",
             Publisher = new PublisherInfo
             {
                 Name = GeneralsOnlineConstants.PublisherName,
@@ -388,6 +404,8 @@ public class GeneralsOnlineManifestFactory(
             Version = release.Version,
             ContentType = ContentType.MapPack,
             TargetGame = GameType.ZeroHour,
+            OriginalProviderName = PublisherTypeConstants.GeneralsOnline,
+            OriginalContentId = $"{GeneralsOnlineConstants.ContentIdPrefix}{release.Version}",
             Publisher = new PublisherInfo
             {
                 Name = GeneralsOnlineConstants.PublisherName,
@@ -429,6 +447,13 @@ public class GeneralsOnlineManifestFactory(
         var version = originalManifest.Version ?? GeneralsOnlineConstants.UnknownVersion;
         var userVersion = ParseVersionForManifestId(version);
 
+        var originalProviderName = !string.IsNullOrEmpty(originalManifest.OriginalProviderName)
+            ? originalManifest.OriginalProviderName
+            : PublisherTypeConstants.GeneralsOnline;
+        var originalContentId = !string.IsNullOrEmpty(originalManifest.OriginalContentId)
+            ? originalManifest.OriginalContentId
+            : $"{GeneralsOnlineConstants.ContentIdPrefix}{version}";
+
         // Get URLs from provider definition (prefer original manifest metadata if available)
         var provider = providerLoader.GetProvider(PublisherTypeConstants.GeneralsOnline);
         var websiteUrl = provider?.Endpoints.WebsiteUrl ?? GeneralsOnlineConstants.WebsiteUrl;
@@ -463,6 +488,8 @@ public class GeneralsOnlineManifestFactory(
             Version = version,
             ContentType = ContentType.GameClient,
             TargetGame = GameType.ZeroHour,
+            OriginalProviderName = originalProviderName,
+            OriginalContentId = originalContentId,
             Publisher = publisherInfo,
             Metadata = new ContentMetadata
             {
@@ -494,6 +521,8 @@ public class GeneralsOnlineManifestFactory(
             Version = version,
             ContentType = ContentType.MapPack,
             TargetGame = GameType.ZeroHour,
+            OriginalProviderName = originalProviderName,
+            OriginalContentId = originalContentId,
             Publisher = publisherInfo,
             Metadata = new ContentMetadata
             {
@@ -524,6 +553,8 @@ public class GeneralsOnlineManifestFactory(
             Version = version,
             ContentType = ContentType.Patch,
             TargetGame = GameType.ZeroHour,
+            OriginalProviderName = originalProviderName,
+            OriginalContentId = originalContentId,
             Publisher = publisherInfo,
             Metadata = new ContentMetadata
             {
@@ -598,6 +629,8 @@ public class GeneralsOnlineManifestFactory(
                 Version = manifest.Version,
                 ContentType = manifest.ContentType,
                 TargetGame = manifest.TargetGame,
+                OriginalProviderName = manifest.OriginalProviderName,
+                OriginalContentId = manifest.OriginalContentId,
                 Publisher = manifest.Publisher,
                 Metadata = manifest.Metadata,
                 Files = manifestFiles,

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -1,13 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
 using GenHub.Core.Extensions;
 using GenHub.Core.Interfaces.Common;
 using GenHub.Core.Interfaces.Content;
+using GenHub.Core.Interfaces.GameInstallations;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Interfaces.Notifications;
@@ -15,6 +19,7 @@ using GenHub.Core.Interfaces.Providers;
 using GenHub.Core.Interfaces.Storage;
 using GenHub.Core.Models.Content;
 using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameInstallations;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Notifications;
 using GenHub.Core.Models.Results;
@@ -28,7 +33,8 @@ namespace GenHub.Features.Content.Services.GeneralsOnline;
 /// When an update is found, this service updates all profiles using GeneralsOnline,
 /// removes old manifests and CAS content, and prepares profiles for the new version.
 /// </summary>
-public class GeneralsOnlineProfileReconciler(
+[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Primary constructor injects required dependencies for Generals Online reconciliation.")]
+public partial class GeneralsOnlineProfileReconciler(
     ILogger<GeneralsOnlineProfileReconciler> logger,
     IGeneralsOnlineUpdateService updateService,
     IContentManifestPool manifestPool,
@@ -38,7 +44,8 @@ public class GeneralsOnlineProfileReconciler(
     IDialogService dialogService,
     IUserSettingsService userSettingsService,
     IGameProfileManager profileManager,
-    IContentVersionComparer versionComparer)
+    IContentVersionComparer versionComparer,
+    IGameInstallationService? installationService = null)
     : IGeneralsOnlineProfileReconciler, IPublisherReconciler
 {
     private readonly SemaphoreSlim _reconcileLock = new(1, 1);
@@ -64,7 +71,7 @@ public class GeneralsOnlineProfileReconciler(
                 return OperationResult<bool>.CreateFailure(checkResult.FirstError ?? "Failed to check update availability");
             }
 
-            var (proceed, updateResult, strategy, subscription) = checkResult.Data;
+            var (proceed, updateResult, strategy, _, shouldDeleteOldVersions) = checkResult.Data;
             if (!proceed || updateResult == null)
             {
                 return OperationResult<bool>.CreateSuccess(false);
@@ -129,8 +136,8 @@ public class GeneralsOnlineProfileReconciler(
                     anyFailure = true;
                 }
 
-                bool shouldDeleteOldVersions = (strategy != UpdateStrategy.CreateNewProfile) && (subscription?.DeleteOldVersions ?? true);
-                await HandleOldManifestsAndCleanupAsync(shouldDeleteOldVersions, anyFailure, manifestMapping, oldManifests, cancellationToken);
+                bool deleteOldVersions = (strategy != UpdateStrategy.CreateNewProfile) && shouldDeleteOldVersions;
+                await HandleOldManifestsAndCleanupAsync(deleteOldVersions, anyFailure, manifestMapping, oldManifests, cancellationToken);
 
                 if (anyFailure)
                 {
@@ -167,6 +174,46 @@ public class GeneralsOnlineProfileReconciler(
         {
             _reconcileLock.Release();
         }
+    }
+
+    [GeneratedRegex(@"\s*(?:\([vV]?[\w\.\-]+(?:\s*QFE\d+)?\)|\b[vV]\d+[\w\.\-]*)\s*$", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 2000)]
+    private static partial Regex VersionSuffixRegex();
+
+    /// <summary>
+    /// Formats an updated profile name by stripping existing version suffixes and appending the new version.
+    /// </summary>
+    /// <param name="originalName">The existing profile name.</param>
+    /// <param name="newVersion">The new version string.</param>
+    /// <param name="existingNames">Set of already existing profile names to prevent collisions.</param>
+    /// <returns>A formatted, unique profile name.</returns>
+    private static string FormatUpdatedProfileName(string originalName, string newVersion, HashSet<string> existingNames)
+    {
+        var baseName = originalName.Trim();
+        while (true)
+        {
+            var stripped = VersionSuffixRegex().Replace(baseName, string.Empty).Trim();
+            if (stripped.Length == 0 || stripped == baseName)
+            {
+                break;
+            }
+
+            baseName = stripped;
+        }
+
+        var candidate = $"{baseName} v{newVersion}";
+        if (string.Equals(candidate, originalName, StringComparison.OrdinalIgnoreCase))
+        {
+            return originalName;
+        }
+
+        var finalName = candidate;
+        int suffix = 2;
+        while (existingNames.Contains(finalName))
+        {
+            finalName = $"{candidate} ({suffix++})";
+        }
+
+        return finalName;
     }
 
     /// <summary>
@@ -314,6 +361,169 @@ public class GeneralsOnlineProfileReconciler(
     }
 
     /// <summary>
+    /// Builds an updated GameClient model based on the new client manifest and the existing profile's client settings.
+    /// </summary>
+    private static Core.Models.GameClients.GameClient BuildUpdatedGameClient(
+        Core.Models.GameProfile.GameProfile profile,
+        ContentManifest? newClientManifest,
+        string newVersion)
+    {
+        var workingDir = !string.IsNullOrEmpty(profile.GameClient?.WorkingDirectory)
+            ? profile.GameClient.WorkingDirectory
+            : string.Empty;
+
+        var executableFile = newClientManifest?.Files?.FirstOrDefault(f =>
+            f.RelativePath?.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) == true);
+        var relativeExe = executableFile?.RelativePath ?? "GeneralsOnline.exe";
+        var exePath = !string.IsNullOrEmpty(workingDir)
+            ? Path.Combine(workingDir, relativeExe)
+            : (profile.GameClient?.ExecutablePath ?? relativeExe);
+
+        return new Core.Models.GameClients.GameClient
+        {
+            Id = newClientManifest?.Id.Value ?? profile.GameClient?.Id ?? string.Empty,
+            Name = newClientManifest?.Name ?? profile.GameClient?.Name ?? GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = newClientManifest?.Version ?? newVersion,
+            GameType = newClientManifest?.TargetGame ?? profile.GameClient?.GameType ?? GameType.ZeroHour,
+            SourceType = newClientManifest?.ContentType ?? profile.GameClient?.SourceType ?? ContentType.GameClient,
+            PublisherType = newClientManifest?.Publisher?.PublisherType ?? profile.GameClient?.PublisherType ?? GeneralsOnlineConstants.PublisherType,
+            InstallationId = profile.GameInstallationId ?? profile.GameClient?.InstallationId ?? string.Empty,
+            ExecutablePath = exePath,
+            WorkingDirectory = workingDir,
+            CommandLineArgs = profile.GameClient?.CommandLineArgs ?? string.Empty,
+        };
+    }
+
+    /// <summary>
+    /// Resolves updated enabled content IDs mapping old manifests to new ones and preserving non-GeneralsOnline content.
+    /// </summary>
+    private static List<string> ResolveUpdatedEnabledContent(
+        Core.Models.GameProfile.GameProfile profile,
+        Dictionary<string, string> manifestMapping,
+        List<ContentManifest> newManifests)
+    {
+        var newEnabledContent = new List<string>();
+        if (profile.EnabledContentIds != null)
+        {
+            foreach (var id in profile.EnabledContentIds)
+            {
+                if (manifestMapping.TryGetValue(id, out var newId))
+                {
+                    newEnabledContent.Add(newId);
+                }
+                else
+                {
+                    // Keep non-GO content
+                    newEnabledContent.Add(id);
+                }
+            }
+        }
+
+        // Ensure all new GO manifests (e.g. MapPack) are included
+        newEnabledContent.AddRange(
+            newManifests
+                .Select(m => m.Id.Value)
+                .Where(id => !newEnabledContent.Contains(id, StringComparer.OrdinalIgnoreCase)));
+
+        return newEnabledContent;
+    }
+
+    /// <summary>
+    /// Builds a CreateProfileRequest cloning the existing profile's settings with the updated client and content.
+    /// </summary>
+    private static Core.Models.GameProfile.CreateProfileRequest BuildCloneProfileRequest(
+        Core.Models.GameProfile.GameProfile profile,
+        string targetProfileName,
+        Core.Models.GameClients.GameClient updatedGameClient,
+        List<string> newEnabledContent,
+        ContentManifest? newClientManifest)
+    {
+        var iconPath = !string.IsNullOrEmpty(profile.IconPath) &&
+                       !profile.IconPath.Contains(UriConstants.GenHubIconMarker) &&
+                       !profile.IconPath.Contains(UriConstants.ZeroHourIconMarker)
+            ? profile.IconPath
+            : (newClientManifest?.Metadata?.IconUrl ?? GeneralsOnlineConstants.LogoSource);
+
+        var coverPath = !string.IsNullOrEmpty(profile.CoverPath) &&
+                        !profile.CoverPath.Contains(UriConstants.ZeroHourCoverMarker)
+            ? profile.CoverPath
+            : (newClientManifest?.Metadata?.CoverUrl ?? GeneralsOnlineConstants.CoverSource);
+
+        var themeColor = !string.IsNullOrEmpty(profile.ThemeColor)
+            ? profile.ThemeColor
+            : (newClientManifest?.Metadata?.ThemeColor ?? GeneralsOnlineConstants.ThemeColor);
+
+        var description = !string.IsNullOrEmpty(profile.Description)
+            ? profile.Description
+            : (newClientManifest?.Metadata?.Description ?? GeneralsOnlineConstants.ShortDescription);
+
+        return new Core.Models.GameProfile.CreateProfileRequest
+        {
+            Name = targetProfileName,
+            Description = description,
+            GameInstallationId = profile.GameInstallationId,
+            GameClientId = updatedGameClient.Id,
+            GameClient = updatedGameClient,
+            WorkspaceStrategy = profile.WorkspaceStrategy,
+            EnabledContentIds = newEnabledContent,
+            ThemeColor = themeColor,
+            IconPath = iconPath,
+            CoverPath = coverPath,
+            CommandLineArguments = profile.CommandLineArguments,
+            GameSpyIPAddress = profile.GameSpyIPAddress,
+            UseSteamLaunch = profile.UseSteamLaunch,
+
+            // Video Settings
+            VideoResolutionWidth = profile.VideoResolutionWidth,
+            VideoResolutionHeight = profile.VideoResolutionHeight,
+            VideoWindowed = profile.VideoWindowed,
+            VideoTextureQuality = profile.VideoTextureQuality,
+            EnableVideoShadows = profile.EnableVideoShadows,
+            VideoParticleEffects = profile.VideoParticleEffects,
+            VideoExtraAnimations = profile.VideoExtraAnimations,
+            VideoBuildingAnimations = profile.VideoBuildingAnimations,
+            VideoGamma = profile.VideoGamma,
+            VideoAlternateMouseSetup = profile.VideoAlternateMouseSetup,
+            VideoHeatEffects = profile.VideoHeatEffects,
+            VideoStaticGameLOD = profile.VideoStaticGameLOD,
+            VideoIdealStaticGameLOD = profile.VideoIdealStaticGameLOD,
+            VideoUseDoubleClickAttackMove = profile.VideoUseDoubleClickAttackMove,
+            VideoScrollFactor = profile.VideoScrollFactor,
+            VideoRetaliation = profile.VideoRetaliation,
+            VideoDynamicLOD = profile.VideoDynamicLOD,
+            VideoMaxParticleCount = profile.VideoMaxParticleCount,
+            VideoAntiAliasing = profile.VideoAntiAliasing,
+            VideoSkipEALogo = profile.VideoSkipEALogo,
+
+            // Audio Settings
+            AudioSoundVolume = profile.AudioSoundVolume,
+            AudioThreeDSoundVolume = profile.AudioThreeDSoundVolume,
+            AudioSpeechVolume = profile.AudioSpeechVolume,
+            AudioMusicVolume = profile.AudioMusicVolume,
+            AudioNumSounds = profile.AudioNumSounds,
+            AudioEnabled = profile.AudioEnabled,
+
+            // GeneralsOnline Settings
+            GoShowFps = profile.GoShowFps,
+            GoShowPing = profile.GoShowPing,
+            GoAutoLogin = profile.GoAutoLogin,
+            GoRememberUsername = profile.GoRememberUsername,
+            GoEnableNotifications = profile.GoEnableNotifications,
+            GoChatFontSize = profile.GoChatFontSize,
+            GoEnableSoundNotifications = profile.GoEnableSoundNotifications,
+            GoShowPlayerRanks = profile.GoShowPlayerRanks,
+            GoCameraMaxHeightOnlyWhenLobbyHost = profile.GoCameraMaxHeightOnlyWhenLobbyHost,
+            GoCameraMinHeight = profile.GoCameraMinHeight,
+            GoCameraMoveSpeedRatio = profile.GoCameraMoveSpeedRatio,
+            GoChatDurationSecondsUntilFadeOut = profile.GoChatDurationSecondsUntilFadeOut,
+            GoDebugVerboseLogging = profile.GoDebugVerboseLogging,
+            GoRenderFpsLimit = profile.GoRenderFpsLimit,
+            GoRenderLimitFramerate = profile.GoRenderLimitFramerate,
+            GoRenderStatsOverlay = profile.GoRenderStatsOverlay,
+        };
+    }
+
+    /// <summary>
     /// Builds a mapping from old manifest IDs to new manifest IDs based on variant matching.
     /// Handles 30hz, 60hz, quickmatch-maps, and gamedata variants.
     /// </summary>
@@ -364,58 +574,61 @@ public class GeneralsOnlineProfileReconciler(
         return mapping;
     }
 
-    private async Task<OperationResult<(bool Proceed, ContentUpdateCheckResult? UpdateResult, UpdateStrategy Strategy, PublisherSubscription? Subscription)>>
+    private async Task<OperationResult<(bool Proceed, ContentUpdateCheckResult? UpdateResult, UpdateStrategy Strategy, PublisherSubscription? Subscription, bool ShouldDeleteOldVersions)>>
         CheckUpdateAvailabilityAndStrategyAsync(string? triggeringProfileId, CancellationToken cancellationToken)
     {
         var updateResult = await updateService.CheckForUpdatesAsync(cancellationToken);
         if (!updateResult.Success)
         {
             logger.LogWarning("[GO Reconciler] Update check failed: {Error}", updateResult.FirstError);
-            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateFailure(
+            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?, bool)>.CreateFailure(
                 $"Failed to check for GeneralsOnline updates: {updateResult.FirstError}");
         }
 
         if (!updateResult.IsUpdateAvailable)
         {
             logger.LogInformation("[GO Reconciler] No update available. Current version: {Version}", updateResult.CurrentVersion);
-            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess((false, null, UpdateStrategy.ReplaceCurrent, null));
+            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?, bool)>.CreateSuccess((false, null, UpdateStrategy.ReplaceCurrent, null, true));
         }
 
         if (!string.IsNullOrEmpty(triggeringProfileId) &&
             await IsTriggeringProfileUpToDateAsync(triggeringProfileId, updateResult.LatestVersion, cancellationToken))
         {
-            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess(
-                (false, null, UpdateStrategy.ReplaceCurrent, null));
+            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?, bool)>.CreateSuccess(
+                (false, null, UpdateStrategy.ReplaceCurrent, null, true));
         }
 
         var settings = userSettingsService.Get();
         if (settings.IsVersionSkipped(GeneralsOnlineConstants.PublisherType, updateResult.LatestVersion ?? string.Empty))
         {
             logger.LogInformation("[GO Reconciler] User opted to skip version {Version}. Skipping.", updateResult.LatestVersion);
-            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess((false, null, UpdateStrategy.ReplaceCurrent, null));
+            return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?, bool)>.CreateSuccess((false, null, UpdateStrategy.ReplaceCurrent, null, true));
         }
 
         var subscription = settings.GetSubscription(GeneralsOnlineConstants.PublisherType);
         var strategy = subscription?.PreferredUpdateStrategy ?? settings.PreferredUpdateStrategy ?? UpdateStrategy.ReplaceCurrent;
         var autoUpdate = subscription is { AutoUpdateEnabled: true };
+        var shouldDeleteOldVersions = subscription?.DeleteOldVersions ?? true;
 
         if (!autoUpdate)
         {
             var promptResult = await PromptUserForUpdateStrategyAsync(
                 updateResult.LatestVersion ?? string.Empty,
-                strategy);
+                strategy,
+                shouldDeleteOldVersions);
 
             if (!promptResult.Proceed)
             {
-                return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess(
-                    (false, null, promptResult.Strategy, subscription));
+                return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?, bool)>.CreateSuccess(
+                    (false, null, promptResult.Strategy, subscription, promptResult.ShouldDeleteOldVersions));
             }
 
             strategy = promptResult.Strategy;
+            shouldDeleteOldVersions = promptResult.ShouldDeleteOldVersions;
         }
 
-        return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?)>.CreateSuccess(
-            (true, updateResult, strategy, subscription));
+        return OperationResult<(bool, ContentUpdateCheckResult?, UpdateStrategy, PublisherSubscription?, bool)>.CreateSuccess(
+            (true, updateResult, strategy, subscription, shouldDeleteOldVersions));
     }
 
     /// <summary>
@@ -481,10 +694,12 @@ public class GeneralsOnlineProfileReconciler(
     /// </summary>
     /// <param name="latestVersion">The latest version string.</param>
     /// <param name="fallbackStrategy">The default update strategy to use if not specified.</param>
-    /// <returns>A tuple indicating whether to proceed and the chosen strategy.</returns>
-    private async Task<(bool Proceed, UpdateStrategy Strategy)> PromptUserForUpdateStrategyAsync(
+    /// <param name="fallbackDeleteOldVersions">The default setting for deleting old versions.</param>
+    /// <returns>A tuple indicating whether to proceed, the chosen strategy, and whether to delete old versions.</returns>
+    private async Task<(bool Proceed, UpdateStrategy Strategy, bool ShouldDeleteOldVersions)> PromptUserForUpdateStrategyAsync(
         string latestVersion,
-        UpdateStrategy fallbackStrategy)
+        UpdateStrategy fallbackStrategy,
+        bool fallbackDeleteOldVersions = true)
     {
         var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
             "Generals Online Update Available",
@@ -492,7 +707,7 @@ public class GeneralsOnlineProfileReconciler(
 
         if (dialogResult == null)
         {
-            return (false, fallbackStrategy);
+            return (false, fallbackStrategy, fallbackDeleteOldVersions);
         }
 
         if (dialogResult.Action == "Skip")
@@ -507,10 +722,12 @@ public class GeneralsOnlineProfileReconciler(
                 });
             }
 
-            return (false, fallbackStrategy);
+            return (false, fallbackStrategy, fallbackDeleteOldVersions);
         }
 
         var strategy = dialogResult.Strategy;
+        var shouldDeleteOldVersions = dialogResult.DeleteOldVersions;
+
         if (dialogResult.IsDoNotAskAgain)
         {
             logger.LogInformation("[GO Reconciler] Saving user preference for GeneralsOnline updates");
@@ -519,11 +736,12 @@ public class GeneralsOnlineProfileReconciler(
                 var sub = s.GetOrCreateSubscription(GeneralsOnlineConstants.PublisherType, isSubscribed: true);
                 sub.AutoUpdateEnabled = true;
                 sub.PreferredUpdateStrategy = strategy;
+                sub.DeleteOldVersions = shouldDeleteOldVersions;
                 return true;
             });
         }
 
-        return (true, strategy);
+        return (true, strategy, shouldDeleteOldVersions);
     }
 
     private async Task<OperationResult<(int ProfilesUpdated, bool AnyFailure, Dictionary<string, string>? ManifestMapping)>>
@@ -556,6 +774,31 @@ public class GeneralsOnlineProfileReconciler(
         }
 
         int profilesUpdated = bulkUpdateResult.Data?.ProfilesUpdated ?? 0;
+
+        // If no profiles were updated because none existed, create a fresh profile
+        if (profilesUpdated == 0)
+        {
+            var allProfiles = await profileManager.GetAllProfilesAsync(cancellationToken);
+            var hasAnyRelevant = allProfiles.Data?.Any(p =>
+                (p.GameClient != null && string.Equals(p.GameClient.PublisherType, GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase)) ||
+                (p.GameClient != null && p.GameClient.Id.Contains($".{GeneralsOnlineConstants.PublisherType}.", StringComparison.OrdinalIgnoreCase)) ||
+                (p.EnabledContentIds is { } enabled && enabled.Any(id => id.Contains($".{GeneralsOnlineConstants.PublisherType}.", StringComparison.OrdinalIgnoreCase)))) == true;
+
+            if (!hasAnyRelevant)
+            {
+                logger.LogInformation("[GO Reconciler] No relevant profiles found during replace update. Creating fresh profile.");
+                var freshResult = await CreateFreshGeneralsOnlineProfileAsync(newManifests, newVersion, cancellationToken);
+                if (freshResult.Success)
+                {
+                    profilesUpdated = freshResult.Data;
+                }
+                else
+                {
+                    return OperationResult<(int, bool, Dictionary<string, string>?)>.CreateFailure(freshResult.FirstError ?? "Failed to create fresh GeneralsOnline profile");
+                }
+            }
+        }
+
         bool anyFailure = (bulkUpdateResult.Data?.FailedProfilesCount ?? 0) > 0;
         if (anyFailure)
         {
@@ -613,8 +856,8 @@ public class GeneralsOnlineProfileReconciler(
             .Where(m =>
                 !m.Id.Value.Contains(".local.", StringComparison.OrdinalIgnoreCase) && // Exclude local content
                 (string.Equals(m.Publisher?.PublisherType, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase) ||
-                  m.Id.Value.Contains(".generalsonline.", StringComparison.OrdinalIgnoreCase) ||
-                  (m.Name is { } name && name.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase))))];
+                  m.Id.Value.Contains($".{GeneralsOnlineConstants.PublisherType}.", StringComparison.OrdinalIgnoreCase) ||
+                  (m.Name is { } name && name.Contains(GeneralsOnlineConstants.ClientName, StringComparison.OrdinalIgnoreCase))))];
     }
 
     private IProgress<ContentAcquisitionProgress>? CreateAcquisitionProgress(
@@ -779,6 +1022,8 @@ public class GeneralsOnlineProfileReconciler(
     {
         // 1. Identify the new MapPack ID and GameClient IDs
         var newMapPack = newManifests.FirstOrDefault(m => m.ContentType == ContentType.MapPack);
+        var newGameClient = newManifests.FirstOrDefault(m => m.ContentType == ContentType.GameClient);
+        var newVersion = newGameClient?.Version ?? string.Empty;
         var newGameClientIds = newManifests
             .Where(m => m.ContentType == ContentType.GameClient)
             .Select(m => m.Id.Value)
@@ -802,30 +1047,68 @@ public class GeneralsOnlineProfileReconciler(
 
         // 3. Iterate profiles and patch if needed
         var errors = new List<string>();
+        var existingProfileNames = allProfilesResult.Data.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         foreach (var profile in allProfilesResult.Data)
         {
-            // Check if profile uses one of the new GameClients
-            bool isGeneralsOnline = profile.GameClient != null &&
-                                    newGameClientIds.Contains(profile.GameClient.Id);
+            // Only update profiles that use one of the new GameClients (preserving old profiles when CreateNewProfile was selected)
+            if (profile.GameClient == null || !newGameClientIds.Contains(profile.GameClient.Id))
+            {
+                continue;
+            }
 
             // Check if profile already has the new MapPack
             bool hasMapPack = profile.EnabledContentIds is { } contentIds &&
                               contentIds.Contains(newMapPackId, StringComparer.OrdinalIgnoreCase);
 
-            if (isGeneralsOnline && !hasMapPack)
+            var newEnabledContent = profile.EnabledContentIds != null
+                ? [.. profile.EnabledContentIds]
+                : new List<string>();
+
+            bool needsUpdate = false;
+            if (!hasMapPack)
             {
                 logger.LogInformation("[GO Reconciler] Adding required MapPack {MapPackId} to profile {ProfileName}", newMapPackId, profile.Name);
-
-                var newEnabledContent = profile.EnabledContentIds != null
-                    ? [.. profile.EnabledContentIds]
-                    : new List<string>();
                 newEnabledContent.Add(newMapPackId);
+                needsUpdate = true;
+            }
 
-                var updateRequest = new Core.Models.GameProfile.UpdateProfileRequest
-                {
-                    EnabledContentIds = newEnabledContent,
-                };
+            var updateRequest = new Core.Models.GameProfile.UpdateProfileRequest();
+            if (needsUpdate)
+            {
+                updateRequest.EnabledContentIds = newEnabledContent;
+            }
 
+            // If profile name had an old version, update it to the new version
+            var updatedName = FormatUpdatedProfileName(profile.Name, newVersion, existingProfileNames);
+            if (!string.Equals(updatedName, profile.Name, StringComparison.Ordinal))
+            {
+                updateRequest.Name = updatedName;
+                existingProfileNames.Add(updatedName);
+                needsUpdate = true;
+            }
+
+            // Ensure branding paths are populated if missing or defaulted
+            if (string.IsNullOrEmpty(profile.IconPath) || profile.IconPath.Contains(UriConstants.GenHubIconMarker) || profile.IconPath.Contains(UriConstants.ZeroHourIconMarker))
+            {
+                updateRequest.IconPath = GeneralsOnlineConstants.LogoSource;
+                needsUpdate = true;
+            }
+
+            if (string.IsNullOrEmpty(profile.CoverPath) || profile.CoverPath.Contains(UriConstants.ZeroHourCoverMarker))
+            {
+                updateRequest.CoverPath = GeneralsOnlineConstants.CoverSource;
+                needsUpdate = true;
+            }
+
+            if (string.IsNullOrEmpty(profile.ThemeColor))
+            {
+                updateRequest.ThemeColor = GeneralsOnlineConstants.ThemeColor;
+                needsUpdate = true;
+            }
+
+            if (needsUpdate)
+            {
                 var updateResult = await profileManager.UpdateProfileAsync(profile.Id, updateRequest, cancellationToken);
                 if (!updateResult.Success)
                 {
@@ -842,6 +1125,105 @@ public class GeneralsOnlineProfileReconciler(
         }
 
         return OperationResult.CreateSuccess();
+    }
+
+    /// <summary>
+    /// Creates a fresh GeneralsOnline profile when no existing relevant profiles are present.
+    /// </summary>
+    private async Task<OperationResult<int>> CreateFreshGeneralsOnlineProfileAsync(
+        List<ContentManifest> newManifests,
+        string newVersion,
+        CancellationToken cancellationToken)
+    {
+        var newClientManifest = newManifests.FirstOrDefault(m => m.ContentType == ContentType.GameClient);
+        GameInstallation? installation = null;
+
+        if (installationService != null)
+        {
+            var installationsResult = await installationService.GetAllInstallationsAsync(cancellationToken);
+            if (installationsResult.Success && installationsResult.Data != null)
+            {
+                installation = installationsResult.Data.FirstOrDefault(i => i.HasZeroHour);
+            }
+        }
+
+        var installationPath = installation?.ZeroHourPath ?? string.Empty;
+        var executableFile = newClientManifest?.Files?.FirstOrDefault(f =>
+            f.RelativePath?.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) == true);
+        var relativeExe = executableFile?.RelativePath ?? "GeneralsOnline.exe";
+        var exePath = !string.IsNullOrEmpty(installationPath)
+            ? Path.Combine(installationPath, relativeExe)
+            : relativeExe;
+
+        var gameClient = new Core.Models.GameClients.GameClient
+        {
+            Id = newClientManifest?.Id.Value ?? string.Empty,
+            Name = newClientManifest?.Name ?? GameClientConstants.GeneralsOnline60HzDisplayName,
+            Version = newClientManifest?.Version ?? newVersion,
+            GameType = GameType.ZeroHour,
+            SourceType = ContentType.GameClient,
+            PublisherType = GeneralsOnlineConstants.PublisherType,
+            InstallationId = installation?.Id ?? string.Empty,
+            ExecutablePath = exePath,
+            WorkingDirectory = installationPath,
+        };
+
+        var enabledContentIds = new List<string>();
+        var allPoolManifestsResult = await manifestPool.GetAllManifestsAsync(cancellationToken);
+        var installManifest = allPoolManifestsResult.Data?.FirstOrDefault(m =>
+            m.ContentType == ContentType.GameInstallation && m.TargetGame == GameType.ZeroHour);
+        if (installManifest != null)
+        {
+            enabledContentIds.Add(installManifest.Id.Value);
+        }
+
+        enabledContentIds.AddRange(
+            newManifests
+                .Select(m => m.Id.Value)
+                .Where(id => !enabledContentIds.Contains(id, StringComparer.OrdinalIgnoreCase)));
+
+        var baseName = !string.IsNullOrWhiteSpace(newClientManifest?.Name) ? newClientManifest.Name : GeneralsOnlineConstants.ClientName;
+        var profileName = $"{baseName} v{newVersion}";
+
+        var allProfiles = await profileManager.GetAllProfilesAsync(cancellationToken);
+        var existingProfileNames = allProfiles.Data?.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase)
+            ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var finalProfileName = profileName;
+        int suffix = 2;
+        while (existingProfileNames.Contains(finalProfileName))
+        {
+            finalProfileName = $"{profileName} ({suffix++})";
+        }
+
+        var iconPath = newClientManifest?.Metadata?.IconUrl ?? GeneralsOnlineConstants.LogoSource;
+        var coverPath = newClientManifest?.Metadata?.CoverUrl ?? GeneralsOnlineConstants.CoverSource;
+        var themeColor = newClientManifest?.Metadata?.ThemeColor ?? GeneralsOnlineConstants.ThemeColor;
+
+        var createRequest = new Core.Models.GameProfile.CreateProfileRequest
+        {
+            Name = finalProfileName,
+            Description = newClientManifest?.Metadata?.Description ?? GeneralsOnlineConstants.ShortDescription,
+            GameInstallationId = installation?.Id,
+            GameClientId = gameClient.Id,
+            GameClient = gameClient,
+            WorkspaceStrategy = WorkspaceStrategy.SymlinkOnly,
+            EnabledContentIds = enabledContentIds,
+            ThemeColor = themeColor,
+            IconPath = iconPath,
+            CoverPath = coverPath,
+            UseSteamLaunch = installation?.InstallationType == GameInstallationType.Steam,
+        };
+
+        var createResult = await profileManager.CreateProfileAsync(createRequest, cancellationToken);
+        if (createResult != null && createResult.Success)
+        {
+            logger.LogInformation("[GO Reconciler] Successfully created fresh profile '{Name}' for update", createRequest.Name);
+            return OperationResult<int>.CreateSuccess(1);
+        }
+
+        logger.LogError("[GO Reconciler] Failed to create fresh profile for update: {Error}", createResult?.FirstError);
+        return OperationResult<int>.CreateFailure(createResult?.FirstError ?? "Failed to create fresh GeneralsOnline profile");
     }
 
     /// <summary>
@@ -865,76 +1247,32 @@ public class GeneralsOnlineProfileReconciler(
 
         var existingProfileNames = allProfiles.Data.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var profile in allProfiles.Data)
+        var relevantProfiles = allProfiles.Data.Where(p =>
+            (p.GameClient != null && oldIds.Contains(p.GameClient.Id)) ||
+            (p.EnabledContentIds is { } enabled && enabled.Any(oldIds.Contains)) ||
+            (p.GameClient != null && string.Equals(p.GameClient.PublisherType, GeneralsOnlineConstants.PublisherType, StringComparison.OrdinalIgnoreCase)) ||
+            (p.GameClient != null && p.GameClient.Id.Contains($".{GeneralsOnlineConstants.PublisherType}.", StringComparison.OrdinalIgnoreCase))).ToList();
+
+        if (relevantProfiles.Count == 0)
         {
-            // Check if profile is relevant (uses any Old GeneralsOnline manifest)
-            bool isRelevant = (profile.GameClient != null && oldIds.Contains(profile.GameClient.Id)) ||
-                              (profile.EnabledContentIds is { } enabledIds && enabledIds.Any(oldIds.Contains));
+            logger.LogInformation("[GO Reconciler] No existing relevant profiles found. Creating a fresh profile.");
+            return await CreateFreshGeneralsOnlineProfileAsync(newManifests, newVersion, cancellationToken);
+        }
 
-            if (!isRelevant) continue;
+        var newClientManifest = newManifests.FirstOrDefault(m => m.ContentType == ContentType.GameClient);
 
-            var targetProfileName = $"{profile.Name} (v{newVersion})";
-            if (existingProfileNames.Contains(targetProfileName))
-            {
-                logger.LogInformation("[GO Reconciler] Profile '{Name}' already exists, skipping clone", targetProfileName);
-                continue;
-            }
+        foreach (var profile in relevantProfiles)
+        {
+            var targetProfileName = FormatUpdatedProfileName(profile.Name, newVersion, existingProfileNames);
 
             try
             {
-                // Resolve updated game client reference if applicable
-                var updatedGameClient = profile.GameClient;
-                if (profile.GameClient != null && manifestMapping.TryGetValue(profile.GameClient.Id, out var newGameClientId))
-                {
-                    var newManifest = newManifests.FirstOrDefault(m => string.Equals(m.Id.Value, newGameClientId, StringComparison.OrdinalIgnoreCase));
-                    if (newManifest != null)
-                    {
-                        updatedGameClient = new Core.Models.GameClients.GameClient
-                        {
-                            Id = newManifest.Id.Value,
-                            Name = newManifest.Name,
-                            Version = newManifest.Version ?? string.Empty,
-                            GameType = newManifest.TargetGame,
-                            SourceType = newManifest.ContentType,
-                            PublisherType = newManifest.Publisher?.PublisherType ?? profile.GameClient.PublisherType,
-                            InstallationId = profile.GameClient.InstallationId,
-                            ExecutablePath = profile.GameClient.ExecutablePath,
-                            WorkingDirectory = profile.GameClient.WorkingDirectory,
-                        };
-                    }
-                }
-
-                // Clone the profile
-                var cloneRequest = new Core.Models.GameProfile.CreateProfileRequest
-                {
-                   Name = targetProfileName,
-                   GameInstallationId = profile.GameInstallationId,
-                   WorkspaceStrategy = profile.WorkspaceStrategy,
-                   GameClient = updatedGameClient,
-                };
-
-                // Calculate new content IDs
-                var newEnabledContent = new List<string>();
-                if (profile.EnabledContentIds != null)
-                {
-                    foreach (var id in profile.EnabledContentIds)
-                    {
-                        if (manifestMapping.TryGetValue(id, out var newId))
-                        {
-                            newEnabledContent.Add(newId);
-                        }
-                        else
-                        {
-                            // Keep non-GO content
-                            newEnabledContent.Add(id);
-                        }
-                    }
-                }
-
-                cloneRequest.EnabledContentIds = newEnabledContent;
+                var updatedGameClient = BuildUpdatedGameClient(profile, newClientManifest, newVersion);
+                var newEnabledContent = ResolveUpdatedEnabledContent(profile, manifestMapping, newManifests);
+                var cloneRequest = BuildCloneProfileRequest(profile, targetProfileName, updatedGameClient, newEnabledContent, newClientManifest);
 
                 var createResult = await profileManager.CreateProfileAsync(cloneRequest, cancellationToken);
-                if (createResult.Success)
+                if (createResult != null && createResult.Success)
                 {
                     createdCount++;
                     existingProfileNames.Add(targetProfileName);
@@ -942,7 +1280,7 @@ public class GeneralsOnlineProfileReconciler(
                 }
                 else
                 {
-                    logger.LogError("[GO Reconciler] Failed to create new profile for update: {Error}", createResult.FirstError);
+                    logger.LogError("[GO Reconciler] Failed to create new profile for update: {Error}", createResult?.FirstError);
                 }
             }
             catch (OperationCanceledException)
@@ -953,6 +1291,12 @@ public class GeneralsOnlineProfileReconciler(
             {
                 logger.LogError(ex, "[GO Reconciler] Error creating profile for update");
             }
+        }
+
+        if (createdCount == 0)
+        {
+            logger.LogInformation("[GO Reconciler] No profiles were cloned. Creating fresh profile as fallback.");
+            return await CreateFreshGeneralsOnlineProfileAsync(newManifests, newVersion, cancellationToken);
         }
 
         return OperationResult<int>.CreateSuccess(createdCount);

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProfileReconciler.cs
@@ -699,11 +699,12 @@ public partial class GeneralsOnlineProfileReconciler(
     private async Task<(bool Proceed, UpdateStrategy Strategy, bool ShouldDeleteOldVersions)> PromptUserForUpdateStrategyAsync(
         string latestVersion,
         UpdateStrategy fallbackStrategy,
-        bool fallbackDeleteOldVersions = true)
+        bool fallbackDeleteOldVersions)
     {
         var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
             "Generals Online Update Available",
-            $"A new version of **Generals Online** is available ({latestVersion}).\n\nHow do you want to apply this update?");
+            $"A new version of **Generals Online** is available ({latestVersion}).\n\nHow do you want to apply this update?",
+            fallbackDeleteOldVersions);
 
         if (dialogResult == null)
         {

--- a/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
+++ b/GenHub/GenHub/Features/Content/Services/GeneralsOnline/GeneralsOnlineProvider.cs
@@ -67,13 +67,13 @@ public class GeneralsOnlineProvider(
         {
             // ContentId format from discoverer: "GeneralsOnline_{Version}" (e.g., "GeneralsOnline_101525_QFE5")
             // Manifest IDs in pool: "1.1015255.generalsonline.gameclient.30hz" or "1.1015255.generalsonline.gameclient.60hz"
-            if (!contentId.StartsWith("GeneralsOnline_", StringComparison.OrdinalIgnoreCase))
+            if (!contentId.StartsWith(GeneralsOnlineConstants.ContentIdPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return OperationResult<ContentManifest>.CreateFailure(
                     $"Invalid contentId format: '{contentId}'. Expected format: 'GeneralsOnline_{{version}}'");
             }
 
-            var version = contentId.Substring("GeneralsOnline_".Length);
+            var version = contentId.Substring(GeneralsOnlineConstants.ContentIdPrefix.Length);
 
             if (string.IsNullOrWhiteSpace(version))
             {

--- a/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
@@ -529,6 +529,7 @@ public class SuperHackersProfileReconciler(
         }
 
         strategy = dialogResult.Strategy;
+        shouldDeleteOldVersions = dialogResult.DeleteOldVersions;
 
         if (dialogResult.IsDoNotAskAgain)
         {
@@ -540,6 +541,7 @@ public class SuperHackersProfileReconciler(
                 if (sub != null)
                 {
                     sub.PreferredUpdateStrategy = strategy;
+                    sub.DeleteOldVersions = shouldDeleteOldVersions;
                 }
 
                 return true;

--- a/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
+++ b/GenHub/GenHub/Features/Content/Services/SuperHackers/SuperHackersProfileReconciler.cs
@@ -505,7 +505,8 @@ public class SuperHackersProfileReconciler(
 
         var dialogResult = await dialogService.ShowUpdateOptionDialogAsync(
             "SuperHackers Update Available",
-            $"A new version of **The Super Hackers** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?");
+            $"A new version of **The Super Hackers** is available ({updateResult.LatestVersion}).\n\nHow do you want to apply this update?",
+            shouldDeleteOldVersions);
 
         if (dialogResult == null)
         {

--- a/GenHub/GenHub/Features/Downloads/Services/ContentStateService.cs
+++ b/GenHub/GenHub/Features/Downloads/Services/ContentStateService.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using GenHub.Core.Constants;
+using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.Content;
 using GenHub.Core.Interfaces.Manifest;
 using GenHub.Core.Models.CommunityOutpost;
@@ -14,6 +15,7 @@ using GenHub.Core.Models.Enums;
 using GenHub.Core.Models.Manifest;
 using GenHub.Core.Models.Providers;
 using GenHub.Core.Models.Results.Content;
+using GenHub.Core.Services.Providers.VersionSchemes;
 using GenHub.Features.Content.Services.ContentDiscoverers;
 using Microsoft.Extensions.Logging;
 
@@ -468,28 +470,33 @@ public sealed partial class ContentStateService(
     }
 
     /// <summary>
-    /// Compares two manifest IDs and optional version strings to determine if the prospective version is newer.
+    /// Compares two manifest IDs (or explicit human-readable versions) to determine if prospective is newer than local.
+    /// Returns true ONLY if prospective is strictly newer.
+    /// If versions are equal, or prospective is older, or comparison is inconclusive, returns false.
     /// </summary>
-    /// <param name="prospectiveId">The prospective manifest ID.</param>
-    /// <param name="localId">The local installed manifest ID.</param>
-    /// <param name="prospectiveVersionStr">Optional human-readable prospective version string.</param>
-    /// <param name="localVersionStr">Optional human-readable local version string.</param>
-    /// <returns>True if the prospective version is newer; otherwise false.</returns>
+    /// <param name="prospectiveId">The prospective manifest ID (e.g. 1.20260228.publisher.type.name).</param>
+    /// <param name="localId">The local manifest ID (e.g. 1.20251114.publisher.type.name).</param>
+    /// <param name="prospectiveVersionStr">Optional human-readable prospective version (e.g. "v1.2.3").</param>
+    /// <param name="localVersionStr">Optional human-readable local version (e.g. "v1.2.0").</param>
+    /// <returns>True if prospective is strictly newer than local; otherwise false.</returns>
     internal static bool IsNewerVersion(
         string prospectiveId,
         string localId,
         string? prospectiveVersionStr = null,
         string? localVersionStr = null)
     {
+        var prospectiveSegments = prospectiveId.Split('.');
+        var localSegments = localId.Split('.');
+        bool isGoPublisher = (prospectiveSegments.Length == 5 && IsCompatiblePublisherAlias(prospectiveSegments[2], PublisherTypeConstants.GeneralsOnline)) ||
+                             (localSegments.Length == 5 && IsCompatiblePublisherAlias(localSegments[2], PublisherTypeConstants.GeneralsOnline));
+
         // 1. If human-readable version strings are available on both sides, compare them first.
-        if (CompareVersionStrings(prospectiveVersionStr, localVersionStr, out var stringCompareResult))
+        if (CompareVersionStrings(prospectiveVersionStr, localVersionStr, out var stringCompareResult, isGoPublisher))
         {
             return stringCompareResult;
         }
 
         // 2. Parse 5-segment manifest IDs.
-        var prospectiveSegments = prospectiveId.Split('.');
-        var localSegments = localId.Split('.');
         if (prospectiveSegments.Length != 5 || localSegments.Length != 5)
         {
             return false;
@@ -497,6 +504,14 @@ public sealed partial class ContentStateService(
 
         var prospectiveVersion = prospectiveSegments[1];
         var localVersion = localSegments[1];
+
+        if (isGoPublisher &&
+            TryDecodeGeneralsOnlineNumericVersion(prospectiveVersion, out var pDate, out var pQfe) &&
+            TryDecodeGeneralsOnlineNumericVersion(localVersion, out var lDate, out var lQfe))
+        {
+            var dateCmp = pDate.CompareTo(lDate);
+            return dateCmp != 0 ? dateCmp > 0 : pQfe > lQfe;
+        }
 
         if (int.TryParse(prospectiveVersion, out var pInt) && int.TryParse(localVersion, out var lInt))
         {
@@ -522,13 +537,15 @@ public sealed partial class ContentStateService(
     }
 
     /// <summary>
-    /// Compares two version strings, returning positive if versionA is newer than versionB,
-    /// negative if older, or zero if equivalent.
+    /// Compares two version strings. Returns a negative integer if versionA is older than versionB,
+    /// zero if equal, or a positive integer if versionA is newer than versionB.
+    /// Handles semver, "v" prefixes, prefixed numeric strings (e.g. "genpatcher103"), Generals Online MMddyy[_QFE#], and dates.
     /// </summary>
     /// <param name="versionA">First version string.</param>
     /// <param name="versionB">Second version string.</param>
+    /// <param name="isGeneralsOnline">Whether the version strings belong to Generals Online content.</param>
     /// <returns>A signed integer indicating the relative order.</returns>
-    internal static int CompareVersions(string? versionA, string? versionB)
+    internal static int CompareVersions(string? versionA, string? versionB, bool isGeneralsOnline = false)
     {
         if (string.IsNullOrWhiteSpace(versionA) && string.IsNullOrWhiteSpace(versionB))
         {
@@ -550,6 +567,15 @@ public sealed partial class ContentStateService(
         if (string.Equals(cleanedA, cleanedB, StringComparison.OrdinalIgnoreCase))
         {
             return 0;
+        }
+
+        if (isGeneralsOnline)
+        {
+            var goScheme = new MmddyyQfeVersionScheme();
+            if (goScheme.TryParse(cleanedA, out var cvA) && goScheme.TryParse(cleanedB, out var cvB))
+            {
+                return cvA.CompareTo(cvB);
+            }
         }
 
         if (Version.TryParse(cleanedA, out var vA) && Version.TryParse(cleanedB, out var vB))
@@ -589,7 +615,8 @@ public sealed partial class ContentStateService(
     private static bool CompareVersionStrings(
         string? prospectiveVersionStr,
         string? localVersionStr,
-        out bool isNewer)
+        out bool isNewer,
+        bool isGeneralsOnline = false)
     {
         isNewer = false;
         if (string.IsNullOrWhiteSpace(prospectiveVersionStr) || string.IsNullOrWhiteSpace(localVersionStr))
@@ -602,6 +629,16 @@ public sealed partial class ContentStateService(
         if (string.Equals(cleanedP, cleanedL, StringComparison.OrdinalIgnoreCase))
         {
             return true;
+        }
+
+        if (isGeneralsOnline)
+        {
+            var goScheme = new MmddyyQfeVersionScheme();
+            if (goScheme.TryParse(cleanedP, out var cvP) && goScheme.TryParse(cleanedL, out var cvL))
+            {
+                isNewer = cvP > cvL;
+                return true;
+            }
         }
 
         if (Version.TryParse(cleanedP, out var vP) && Version.TryParse(cleanedL, out var vL))
@@ -639,6 +676,62 @@ public sealed partial class ContentStateService(
         }
 
         return false;
+    }
+
+    private static bool TryDecodeGeneralsOnlineNumericVersion(string raw, out DateTime date, out int qfe)
+    {
+        date = default;
+        qfe = 0;
+        if (string.IsNullOrWhiteSpace(raw) || !long.TryParse(raw, NumberStyles.None, CultureInfo.InvariantCulture, out _))
+        {
+            return false;
+        }
+
+        if (raw.Length != 6 && raw.Length != 7)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(raw.AsSpan(raw.Length - 1, 1), NumberStyles.None, CultureInfo.InvariantCulture, out qfe))
+        {
+            return false;
+        }
+
+        var datePart = raw[..^1];
+        int month = 0, day = 0, year = 0;
+        if (datePart.Length == 5)
+        {
+            if (!int.TryParse(datePart.AsSpan(0, 1), NumberStyles.None, CultureInfo.InvariantCulture, out month) ||
+                !int.TryParse(datePart.AsSpan(1, 2), NumberStyles.None, CultureInfo.InvariantCulture, out day) ||
+                !int.TryParse(datePart.AsSpan(3, 2), NumberStyles.None, CultureInfo.InvariantCulture, out year))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (!int.TryParse(datePart.AsSpan(0, 2), NumberStyles.None, CultureInfo.InvariantCulture, out month) ||
+                !int.TryParse(datePart.AsSpan(2, 2), NumberStyles.None, CultureInfo.InvariantCulture, out day) ||
+                !int.TryParse(datePart.AsSpan(4, 2), NumberStyles.None, CultureInfo.InvariantCulture, out year))
+            {
+                return false;
+            }
+        }
+
+        if (month < 1 || month > 12 || day < 1 || day > 31)
+        {
+            return false;
+        }
+
+        try
+        {
+            date = new DateTime(2000, month, day, 0, 0, 0, DateTimeKind.Utc).AddYears(year);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
     }
 
     // Architecture note: Extrapolate publisher-specific variant state matching heuristics (e.g. IsSuperHackersVariant
@@ -692,43 +785,17 @@ public sealed partial class ContentStateService(
             return false;
         }
 
-        var version = ManifestIdGenerator.ExtractVersionFromTag(tag);
-        expectedVersion = version.ToString();
+        var versionNum = SuperHackersConstants.ExtractVersionFromReleaseTag(tag);
+        if (versionNum <= 0)
+        {
+            return false;
+        }
+
+        expectedVersion = versionNum.ToString(CultureInfo.InvariantCulture);
         return true;
     }
 
-    /// <summary>
-    /// Publisher-agnostic backstop that correlates a catalog card to an installed manifest by
-    /// the manifest ID's publisher + content-type + content-name segments, with variant
-    /// suffixes stripped symmetrically. This is the path that keeps working across restarts
-    /// once a manifest is on disk, since it relies only on the stable manifest ID rather than
-    /// in-memory provenance (which publishers do not persist today).
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// A card may carry its content identity in several places, of varying reliability. The
-    /// display <see cref="ContentSearchResult.Name"/> drifts with variant/resolution labels
-    /// (e.g. "Community Patch (TheSuperHackers Build)"), so it is the weakest key. The card's
-    /// manifest-style <see cref="ContentSearchResult.Id"/> content-name segment and the
-    /// explicit <c>contentCode</c> resolver metadata are the stable keys, so they are tried
-    /// first. A manifest is accepted when any candidate key matches the manifest's content-name
-    /// segment, with a <c>-suffix</c> variant stripped off whichever side carries one.
-    /// </para>
-    /// <para>
-    /// Some publishers expose a single parent card whose actual on-disk manifests are variant
-    /// siblings with no shared content-name token (e.g. the Generals Online game-client card
-    /// resolves to <c>60hz</c>/<c>144hz</c> variants). Such a card carries no stable content
-    /// key at all — its Id is a non-manifest string and it has no content code — so for those
-    /// cards only, a publisher-family fallback marks the card as downloaded when at least one
-    /// sibling manifest shares the publisher, content type, and target game. The fallback is
-    /// deliberately gated on "no stable key was available": a card that DID carry a stable key
-    /// but failed to match is a genuinely distinct release (e.g. two CommunityOutpost addons)
-    /// and must not be conflated with an installed sibling.
-    /// </para>
-    /// </remarks>
-    private static ContentManifest? FindByPublisherTypeAndGame(
-        List<ContentManifest> manifests,
-        ContentSearchResult item)
+    private static ContentManifest? FindByPublisherTypeAndGame(IReadOnlyList<ContentManifest> manifests, ContentSearchResult item)
     {
         var candidatePublishers = CollectCandidatePublishers(item);
         if (candidatePublishers.Count == 0)
@@ -739,6 +806,7 @@ public sealed partial class ContentStateService(
         var expectedContentType = item.ContentType.ToString().ToLowerInvariant();
         var candidateNames = CollectCandidateNames(item);
 
+        var matches = new List<ContentManifest>();
         foreach (var expectedPublisher in candidatePublishers)
         {
             foreach (var candidate in candidateNames)
@@ -748,13 +816,15 @@ public sealed partial class ContentStateService(
                     continue;
                 }
 
-                var match = manifests.FirstOrDefault(manifest =>
-                    ContentNameMatches(manifest, expectedPublisher, expectedContentType, item.TargetGame, candidate));
-                if (match != null)
-                {
-                    return match;
-                }
+                matches.AddRange(manifests.Where(manifest =>
+                    ContentNameMatches(manifest, expectedPublisher, expectedContentType, item.TargetGame, candidate)));
             }
+        }
+
+        var bestMatch = SelectBestMatchingManifest(matches, item);
+        if (bestMatch != null)
+        {
+            return bestMatch;
         }
 
         if (item.ContentType == ContentType.GameClient &&
@@ -898,12 +968,12 @@ public sealed partial class ContentStateService(
     }
 
     private static ContentManifest? FindGeneralsOnlineFallback(
-        List<ContentManifest> manifests,
+        IReadOnlyList<ContentManifest> manifests,
         List<string> candidatePublishers,
         string expectedContentType,
         ContentSearchResult item)
     {
-        return manifests.FirstOrDefault(manifest =>
+        var matches = manifests.Where(manifest =>
         {
             var segments = manifest.Id.Value.Split('.');
             if (segments.Length != 5)
@@ -924,6 +994,135 @@ public sealed partial class ContentStateService(
                 && string.Equals(segments[3], expectedContentType, StringComparison.OrdinalIgnoreCase)
                 && manifest.TargetGame == item.TargetGame;
         });
+
+        return SelectBestMatchingManifest(matches, item);
+    }
+
+    /// <summary>
+    /// Selects the best matching manifest from a collection of candidates.
+    /// Prioritizes exact matches (matching ID, version, or session download), then falls back to newest candidate.
+    /// </summary>
+    private static ContentManifest? SelectBestMatchingManifest(
+        IEnumerable<ContentManifest> matches,
+        ContentSearchResult item)
+    {
+        var candidates = matches.DistinctBy(m => m.Id.Value).ToList();
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0];
+        }
+
+        var exactMatch = candidates.FirstOrDefault(m => IsExactManifestMatch(m, item));
+        if (exactMatch != null)
+        {
+            return exactMatch;
+        }
+
+        var best = candidates[0];
+        for (int i = 1; i < candidates.Count; i++)
+        {
+            var current = candidates[i];
+            if (CompareCandidateManifests(current, best) > 0)
+            {
+                best = current;
+            }
+        }
+
+        return best;
+    }
+
+    private static bool IsExactManifestMatch(ContentManifest manifest, ContentSearchResult item)
+    {
+        if (IsSameContentSource(manifest, item))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(item.Id) &&
+            (string.Equals(manifest.Id.Value, item.Id, StringComparison.OrdinalIgnoreCase) ||
+             (!string.IsNullOrWhiteSpace(manifest.OriginalContentId) &&
+              string.Equals(manifest.OriginalContentId, item.Id, StringComparison.OrdinalIgnoreCase))))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(item.Version) && !string.IsNullOrWhiteSpace(manifest.Version))
+        {
+            var cleanedItemVer = item.Version.Trim().TrimStart('v', 'V');
+            var cleanedManVer = manifest.Version.Trim().TrimStart('v', 'V');
+            if (string.Equals(cleanedItemVer, cleanedManVer, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(item.Version))
+        {
+            var segments = manifest.Id.Value.Split('.');
+            if (segments.Length == 5)
+            {
+                var goVer = GameVersionHelper.GetGeneralsOnlineManifestIdComponent(item.Version);
+                if (goVer > 0 && string.Equals(segments[1], goVer.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                var extVer = CatalogManifestIdentity.ExtractVersionNumber(item.Version);
+                if (extVer > 0 && string.Equals(segments[1], extVer.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static int CompareCandidateManifests(ContentManifest a, ContentManifest b)
+    {
+        var segA = a.Id.Value.Split('.');
+        var segB = b.Id.Value.Split('.');
+        bool isGeneralsOnline = (segA.Length == 5 && IsCompatiblePublisherAlias(segA[2], PublisherTypeConstants.GeneralsOnline)) ||
+                                (segB.Length == 5 && IsCompatiblePublisherAlias(segB[2], PublisherTypeConstants.GeneralsOnline)) ||
+                                IsCompatiblePublisherAlias(a.Publisher?.PublisherType ?? string.Empty, PublisherTypeConstants.GeneralsOnline) ||
+                                IsCompatiblePublisherAlias(b.Publisher?.PublisherType ?? string.Empty, PublisherTypeConstants.GeneralsOnline) ||
+                                IsCompatiblePublisherAlias(a.OriginalProviderName ?? string.Empty, PublisherTypeConstants.GeneralsOnline) ||
+                                IsCompatiblePublisherAlias(b.OriginalProviderName ?? string.Empty, PublisherTypeConstants.GeneralsOnline);
+
+        if (!string.IsNullOrWhiteSpace(a.Version) && !string.IsNullOrWhiteSpace(b.Version))
+        {
+            var verCmp = CompareVersions(a.Version, b.Version, isGeneralsOnline);
+            if (verCmp != 0)
+            {
+                return verCmp;
+            }
+        }
+
+        if (segA.Length == 5 && segB.Length == 5)
+        {
+            var idCmp = CompareManifestVersions(segA[1], segB[1], isGeneralsOnline);
+            if (idCmp != 0)
+            {
+                return idCmp;
+            }
+        }
+
+        if (a.Metadata?.ReleaseDate is { } aDate && b.Metadata?.ReleaseDate is { } bDate &&
+            aDate > DateTime.MinValue && bDate > DateTime.MinValue)
+        {
+            var dateCmp = aDate.CompareTo(bDate);
+            if (dateCmp != 0)
+            {
+                return dateCmp;
+            }
+        }
+
+        return 0;
     }
 
     /// <summary>
@@ -1191,11 +1390,19 @@ public sealed partial class ContentStateService(
             rawManifestName.StartsWith(contentName + "-", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static int CompareManifestVersions(string existingVersion, string? bestMatchVersion)
+    private static int CompareManifestVersions(string existingVersion, string? bestMatchVersion, bool isGeneralsOnline = false)
     {
         if (bestMatchVersion == null)
         {
             return 1;
+        }
+
+        if (isGeneralsOnline &&
+            TryDecodeGeneralsOnlineNumericVersion(existingVersion, out var dateE, out var qfeE) &&
+            TryDecodeGeneralsOnlineNumericVersion(bestMatchVersion, out var dateB, out var qfeB))
+        {
+            var dateCmp = dateE.CompareTo(dateB);
+            return dateCmp != 0 ? dateCmp : qfeE.CompareTo(qfeB);
         }
 
         if (int.TryParse(existingVersion, out var existingInt) && int.TryParse(bestMatchVersion, out var bestInt))
@@ -1335,7 +1542,7 @@ public sealed partial class ContentStateService(
 
     private static ContentManifest? FindDirectFileMatch(IReadOnlyList<ContentManifest> manifests, ContentSearchResult item)
     {
-        return manifests.FirstOrDefault(manifest =>
+        var matches = manifests.Where(manifest =>
             (!string.IsNullOrEmpty(manifest.OriginalContentId) && (
                 string.Equals(manifest.OriginalContentId, item.Id, StringComparison.OrdinalIgnoreCase) ||
                 (item.ResolverMetadata?.TryGetValue(ContentConstants.ParentContentIdMetadataKey, out var parentId) == true &&
@@ -1346,13 +1553,15 @@ public sealed partial class ContentStateService(
                     string.Equals(file.DownloadUrl, item.SelectedDownloadUrl, StringComparison.OrdinalIgnoreCase)) == true) ||
                 (!string.IsNullOrWhiteSpace(manifest.Publisher?.ContentIndexUrl) &&
                     string.Equals(manifest.Publisher.ContentIndexUrl, item.SelectedDownloadUrl, StringComparison.OrdinalIgnoreCase)))));
+
+        return SelectBestMatchingManifest(matches, item);
     }
 
     private static ContentManifest? FindOriginMatch(IReadOnlyList<ContentManifest> manifests, ContentSearchResult item)
     {
         bool isGitHub = IsGitHubPublisher(item.ProviderName);
 
-        return manifests.FirstOrDefault(manifest =>
+        var matches = manifests.Where(manifest =>
         {
             var manifestPublisher = manifest.OriginalProviderName;
             if (string.IsNullOrEmpty(manifestPublisher))
@@ -1396,6 +1605,8 @@ public sealed partial class ContentStateService(
 
             return contentIdMatches || (!isGitHub && ContentNameMatches(manifest, item.ProviderName, item.ContentType.ToString(), item.TargetGame, item.Name));
         });
+
+        return SelectBestMatchingManifest(matches, item);
     }
 
     private static ContentManifest? FindGitHubRepoMatch(IReadOnlyList<ContentManifest> manifests, ContentSearchResult item)
@@ -1405,7 +1616,8 @@ public sealed partial class ContentStateService(
             return null;
         }
 
-        return manifests.FirstOrDefault(manifest => IsGitHubManifestMatch(manifest, item));
+        var matches = manifests.Where(manifest => IsGitHubManifestMatch(manifest, item));
+        return SelectBestMatchingManifest(matches, item);
     }
 
     private static bool IsGitHubManifestMatch(ContentManifest manifest, ContentSearchResult item)
@@ -1498,17 +1710,19 @@ public sealed partial class ContentStateService(
         return clean;
     }
 
-    private static ContentManifest? FindDownloadUrlMatch(IReadOnlyList<ContentManifest> manifests, string? selectedDownloadUrl)
+    private static ContentManifest? FindDownloadUrlMatch(IReadOnlyList<ContentManifest> manifests, string? selectedDownloadUrl, ContentSearchResult item)
     {
         if (string.IsNullOrWhiteSpace(selectedDownloadUrl))
         {
             return null;
         }
 
-        return manifests.FirstOrDefault(manifest =>
+        var matches = manifests.Where(manifest =>
             manifest.Files?.Any(file =>
                 !string.IsNullOrWhiteSpace(file.DownloadUrl) &&
                 string.Equals(file.DownloadUrl, selectedDownloadUrl, StringComparison.OrdinalIgnoreCase)) == true);
+
+        return SelectBestMatchingManifest(matches, item);
     }
 
     private static ContentManifest? FindSuperHackersMatch(IReadOnlyList<ContentManifest> manifests, ContentSearchResult item)
@@ -1518,7 +1732,7 @@ public sealed partial class ContentStateService(
             return null;
         }
 
-        return manifests.FirstOrDefault(manifest =>
+        var matches = manifests.Where(manifest =>
         {
             var segments = manifest.Id.Value.Split('.');
             return segments.Length == 5
@@ -1528,6 +1742,8 @@ public sealed partial class ContentStateService(
                 && string.Equals(segments[4], expectedContentName, StringComparison.OrdinalIgnoreCase)
                 && manifest.TargetGame == item.TargetGame;
         });
+
+        return SelectBestMatchingManifest(matches, item);
     }
 
     private async Task<bool> CheckDirectSessionManifestFastPathAsync(ContentSearchResult item, CancellationToken cancellationToken)
@@ -1716,8 +1932,10 @@ public sealed partial class ContentStateService(
             return null;
         }
 
-        if (hasRealDate &&
-            releaseDate > DateTime.MinValue &&
+        bool canCompareVersion = (hasRealDate && releaseDate > DateTime.MinValue) ||
+                                 (!string.IsNullOrWhiteSpace(item.Version) && !string.IsNullOrWhiteSpace(persistedManifest.Version));
+
+        if (canCompareVersion &&
             IsNewerVersion(persistedManifest.Id.Value, prospectiveId, persistedManifest.Version, item.Version))
         {
             var exactResult = await manifestPool.IsManifestAcquiredAsync(prospectiveId, cancellationToken);
@@ -1775,7 +1993,7 @@ public sealed partial class ContentStateService(
 
         return FindOriginMatch(manifests, item)
             ?? FindGitHubRepoMatch(manifests, item)
-            ?? FindDownloadUrlMatch(manifests, item.SelectedDownloadUrl)
+            ?? FindDownloadUrlMatch(manifests, item.SelectedDownloadUrl, item)
             ?? FindSuperHackersMatch(manifests, item)
             ?? FindByPublisherTypeAndGame(manifests, item);
     }
@@ -1823,9 +2041,7 @@ public sealed partial class ContentStateService(
         var contentType = prospectiveSegments[3];
         var contentName = prospectiveSegments[4];
 
-        ContentManifest? bestMatch = null;
-        string? bestMatchVersion = null;
-
+        var candidateManifests = new List<ContentManifest>();
         foreach (var manifest in allManifestsResult.Data)
         {
             var manifestSegments = manifest.Id.Value.Split('.');
@@ -1836,20 +2052,28 @@ public sealed partial class ContentStateService(
 
             if (IsProspectiveManifestCandidate(manifest, manifestSegments, publisher, contentType, contentName, targetGame))
             {
-                var existingVersion = manifestSegments[1];
-                if (bestMatch == null || CompareManifestVersions(existingVersion, bestMatchVersion) > 0)
-                {
-                    bestMatch = manifest;
-                    bestMatchVersion = existingVersion;
-                }
+                candidateManifests.Add(manifest);
             }
         }
 
+        if (candidateManifests.Count == 0)
+        {
+            return (null, false, false);
+        }
+
+        var prospectiveItem = new ContentSearchResult
+        {
+            Id = prospectiveId,
+            Version = itemVersion ?? string.Empty,
+            TargetGame = targetGame,
+        };
+        var bestMatch = SelectBestMatchingManifest(candidateManifests, prospectiveItem);
         if (bestMatch == null)
         {
             return (null, false, false);
         }
 
+        var bestMatchVersion = bestMatch.Id.Value.Split('.')[1];
         var prospectiveVersion = prospectiveSegments[1];
         bool isNewerAvailable = false;
         bool isOlderAvailable = false;

--- a/GenHub/GenHub/Features/Downloads/ViewModels/ContentDetailViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/ContentDetailViewModel.cs
@@ -2278,15 +2278,21 @@ public partial class ContentDetailViewModel(
             var state = await contentStateService.GetStateAsync(searchResult, _cts.Token);
 
             var idRewritten = false;
-            if ((state == ContentState.Downloaded || state == ContentState.UpdateAvailable) &&
-                (string.IsNullOrEmpty(searchResult.Id) || !ManifestIdValidator.IsValid(searchResult.Id, out _)))
+            string? localManifestId = null;
+            if (state is ContentState.Downloaded or ContentState.UpdateAvailable)
             {
-                var manifestId = await contentStateService.GetLocalManifestIdAsync(searchResult, _cts.Token);
-                if (!string.IsNullOrEmpty(manifestId))
-                {
-                    searchResult.UpdateId(manifestId);
-                    idRewritten = true;
-                }
+                localManifestId = await contentStateService.GetLocalManifestIdAsync(searchResult, _cts.Token);
+            }
+
+            // Only rewrite the search result ID when the content is already downloaded and does NOT have an update available.
+            // If an update is available, the search result represents the newer prospective release; rewriting its ID
+            // to the older locally installed manifest would corrupt the prospective item's identity and break update detection.
+            if (state == ContentState.Downloaded &&
+                (string.IsNullOrEmpty(searchResult.Id) || !ManifestIdValidator.IsValid(searchResult.Id, out _)) &&
+                !string.IsNullOrEmpty(localManifestId))
+            {
+                searchResult.UpdateId(localManifestId);
+                idRewritten = true;
             }
 
             await RunOnUiThreadAsync(() =>
@@ -2308,9 +2314,19 @@ public partial class ContentDetailViewModel(
                 {
                     Releases[0].IsDownloaded = true;
                     Releases[0].IsUpdateAvailable = IsUpdateAvailable;
-                    if (!string.IsNullOrEmpty(searchResult.Id) && ManifestIdValidator.IsValid(searchResult.Id, out _))
+                    string? manifestIdForRelease = null;
+                    if (!string.IsNullOrEmpty(localManifestId) && ManifestIdValidator.IsValid(localManifestId, out _))
                     {
-                        Releases[0].DownloadedManifestId = searchResult.Id;
+                        manifestIdForRelease = localManifestId;
+                    }
+                    else if (!string.IsNullOrEmpty(searchResult.Id) && ManifestIdValidator.IsValid(searchResult.Id, out _))
+                    {
+                        manifestIdForRelease = searchResult.Id;
+                    }
+
+                    if (!string.IsNullOrEmpty(manifestIdForRelease))
+                    {
+                        Releases[0].DownloadedManifestId = manifestIdForRelease;
                     }
 
                     RefreshSelectedTargetProperties();
@@ -2323,9 +2339,13 @@ public partial class ContentDetailViewModel(
                 }
             });
 
-            if ((state == ContentState.Downloaded || state == ContentState.UpdateAvailable) && !string.IsNullOrEmpty(searchResult.Id))
+            var dependencyManifestId = !string.IsNullOrEmpty(localManifestId)
+                ? localManifestId
+                : searchResult.Id;
+
+            if ((state == ContentState.Downloaded || state == ContentState.UpdateAvailable) && !string.IsNullOrEmpty(dependencyManifestId) && ManifestIdValidator.IsValid(dependencyManifestId, out _))
             {
-                await LoadDependencySummaryAsync(searchResult.Id);
+                await LoadDependencySummaryAsync(dependencyManifestId);
             }
         }
         catch (Exception ex)
@@ -3389,6 +3409,11 @@ public partial class ContentDetailViewModel(
 
             if (_disposed || !success)
             {
+                if (!success && !_disposed)
+                {
+                    DownloadStatusMessage = ContentConstants.UpdateCancelledOrFailedStatusMessage;
+                }
+
                 return;
             }
 
@@ -3410,6 +3435,11 @@ public partial class ContentDetailViewModel(
             var success = await ExecuteDownloadFlowAsync(_updateTargetSearchResult, cancellationToken);
             if (_disposed || !success)
             {
+                if (!success && !_disposed)
+                {
+                    DownloadStatusMessage = ContentConstants.UpdateCancelledOrFailedStatusMessage;
+                }
+
                 return;
             }
 
@@ -4133,6 +4163,11 @@ public partial class ContentDetailViewModel(
 
     private async Task LoadDependencySummaryAsync(string manifestId)
     {
+        if (!ManifestIdValidator.IsValid(manifestId, out _))
+        {
+            return;
+        }
+
         var manifestResult = await manifestPool.GetManifestAsync(ManifestId.Create(manifestId), _cts.Token);
         if (manifestResult.Success && manifestResult.Data != null)
         {

--- a/GenHub/GenHub/Features/Downloads/ViewModels/DownloadsBrowserViewModel.cs
+++ b/GenHub/GenHub/Features/Downloads/ViewModels/DownloadsBrowserViewModel.cs
@@ -391,7 +391,7 @@ public sealed partial class DownloadsBrowserViewModel(
 
             var familyItems = family
                 .OrderByDescending(it => it.SearchResult.LastUpdated ?? DateTime.MinValue)
-                .ThenByDescending(it => it.SearchResult.Version, Comparer<string?>.Create(ContentStateService.CompareVersions))
+                .ThenByDescending(it => it.SearchResult.Version, Comparer<string?>.Create((a, b) => ContentStateService.CompareVersions(a, b, family.Any(f => string.Equals(f.SearchResult.ProviderName, PublisherTypeConstants.GeneralsOnline, StringComparison.OrdinalIgnoreCase)))))
                 .ToList();
             if (familyItems.Count <= 1)
             {
@@ -1725,7 +1725,10 @@ public sealed partial class DownloadsBrowserViewModel(
             if (!result.Success)
             {
                 logger.LogWarning("Reconciler failed for {PublisherId}: {Error}", publisherId, result.FirstError);
+                targetItem.DownloadStatus = $"{ContentConstants.ErrorStatusPrefix}{result.FirstError ?? ContentConstants.UpdateFailedStatusMessage}";
             }
+
+            return false;
         }
 
         return await DownloadContentAsync(targetItem, ct);
@@ -1944,7 +1947,7 @@ public sealed partial class DownloadsBrowserViewModel(
                         {
                             var state = await contentStateService.GetStateAsync(match.SearchResult, _vmCts.Token);
                             var isDownloaded = state is ContentState.Downloaded or ContentState.UpdateAvailable;
-                            if (isDownloaded && (string.IsNullOrEmpty(match.SearchResult.Id) || !ManifestIdValidator.IsValid(match.SearchResult.Id, out _)))
+                            if (state == ContentState.Downloaded && (string.IsNullOrEmpty(match.SearchResult.Id) || !ManifestIdValidator.IsValid(match.SearchResult.Id, out _)))
                             {
                                 var manifestId = await contentStateService.GetLocalManifestIdAsync(match.SearchResult, _vmCts.Token);
                                 if (!string.IsNullOrEmpty(manifestId))
@@ -1953,11 +1956,13 @@ public sealed partial class DownloadsBrowserViewModel(
                                 }
                             }
 
+                            await match.RefreshVariantStatesAsync().ConfigureAwait(false);
                             RunOnUi(() =>
                             {
                                 match.CurrentState = state;
                                 match.IsDownloaded = isDownloaded;
                                 match.NotifyStateChanged();
+                                ReconcileReleaseUpdateStates(ContentItems);
                             });
                         }
                     }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileItemViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileItemViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -8,6 +9,7 @@ using GenHub.Core.Constants;
 using GenHub.Core.Helpers;
 using GenHub.Core.Interfaces.GameProfiles;
 using GenHub.Core.Models.Enums;
+using GenHub.Core.Models.GameClients;
 using GenHub.Core.Models.GameProfile;
 
 namespace GenHub.Features.GameProfiles.ViewModels;
@@ -452,6 +454,21 @@ public partial class GameProfileItemViewModel : ViewModelBase
             {
                 ExtractManifestInfo(gameProfile.GameClient.Id);
 
+                if (string.IsNullOrEmpty(_publisher))
+                {
+                    if (!string.IsNullOrEmpty(gameProfile.GameClient.PublisherType))
+                    {
+                        var pub = gameProfile.GameClient.PublisherType.ToLowerInvariant();
+                        _publisher = MapPublisherName(pub, gameProfile.GameClient.PublisherType);
+                        ApplyPublisherBranding(pub);
+                    }
+                    else if (gameProfile.GameClient.Name.Contains("GeneralsOnline", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _publisher = PublisherInfoConstants.GeneralsOnline.Name;
+                        ApplyPublisherBranding(PublisherTypeConstants.GeneralsOnline);
+                    }
+                }
+
                 // Fallback: use GameClient.Version directly if we couldn't extract from manifest
                 // But SKIP if the publisher is "Local" - we want NO version for local content
                 if (string.IsNullOrEmpty(_gameVersion) &&
@@ -577,52 +594,69 @@ public partial class GameProfileItemViewModel : ViewModelBase
         Version = updatedProfile.Version;
         ExecutablePath = updatedProfile.ExecutablePath;
 
-        // Re-extract version and publisher info from updated profile
+        // Re-extract version, branding and publisher info from updated profile
         if (updatedProfile is GameProfile gameProfile)
         {
-            // Reset version info before re-extracting
-            GameVersion = string.Empty;
-            Publisher = string.Empty;
+            ColorValue = GetDefaultColorForGameType(gameProfile.GameClient?.GameType);
 
-            // First try to get info from enabled GameInstallation manifests
-            var installationManifestId = gameProfile.EnabledContentIds?.FirstOrDefault(id => id.Contains("-installation"));
-            if (!string.IsNullOrEmpty(installationManifestId))
+            if (!string.IsNullOrEmpty(gameProfile.IconPath))
             {
-                ExtractManifestInfo(installationManifestId);
+                IconPath = gameProfile.IconPath;
             }
 
-            // Fallback to GameClient manifest
-            else if (gameProfile.GameClient != null)
+            if (!string.IsNullOrEmpty(gameProfile.CoverPath))
             {
-                ExtractManifestInfo(gameProfile.GameClient.Id);
-
-                // Fallback: use GameClient.Version directly
-                // But SKIP if the publisher is "Local"
-                if (string.IsNullOrEmpty(GameVersion) &&
-                    !string.IsNullOrEmpty(gameProfile.GameClient.Version) &&
-                    !string.Equals(Publisher, "Local", StringComparison.OrdinalIgnoreCase))
-                {
-                    var version = gameProfile.GameClient.Version;
-                    GameVersion = IsZeroOrPlaceholderVersion(version) ? string.Empty : version;
-                }
+                CoverPath = gameProfile.CoverPath;
+                CoverImagePath = NormalizeCoverPath(gameProfile.CoverPath);
             }
 
-            // Update description
-            // Update description layout
+            ResolveProfileVersionAndPublisher(gameProfile);
+
+            if (!string.IsNullOrEmpty(gameProfile.ThemeColor))
+            {
+                ColorValue = gameProfile.ThemeColor;
+            }
+
             UpdateDescription(gameProfile);
         }
 
         // Notify UI of all property changes
-        OnPropertyChanged(nameof(Name));
-        OnPropertyChanged(nameof(Version));
-        OnPropertyChanged(nameof(GameVersion));
-        OnPropertyChanged(nameof(Publisher));
-        OnPropertyChanged(nameof(Description));
-        OnPropertyChanged(nameof(ColorValue));
-        OnPropertyChanged(nameof(IconPath));
-        OnPropertyChanged(nameof(CoverPath));
-        OnPropertyChanged(nameof(CoverImagePath));
-        OnPropertyChanged(nameof(CommandLineArguments));
+        NotifyAllPropertiesChanged();
+    }
+
+    /// <summary>
+    /// Normalizes old cover paths to new paths for backward compatibility.
+    /// Handles migration from Assets/Images/*.png to Assets/Covers/*.png.
+    /// </summary>
+    /// <param name="coverPath">The cover path to normalize.</param>
+    /// <returns>The normalized cover path.</returns>
+    internal static string NormalizeCoverPath(string coverPath)
+    {
+        if (string.IsNullOrEmpty(coverPath))
+        {
+            return coverPath;
+        }
+
+        // Map old paths to new paths for backward compatibility
+        // Images were renamed/moved: Assets/Images/china-poster.png → Assets/Covers/china-cover.png
+        return coverPath switch
+        {
+            var p when p.Contains("china-poster.png", StringComparison.OrdinalIgnoreCase) =>
+                p.Replace("china-poster.png", "china-cover.png", StringComparison.OrdinalIgnoreCase)
+                 .Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
+            var p when p.Contains("usa-poster.png", StringComparison.OrdinalIgnoreCase) =>
+                p.Replace("usa-poster.png", "usa-cover.png", StringComparison.OrdinalIgnoreCase)
+                 .Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
+            var p when p.Contains("gla-poster.png", StringComparison.OrdinalIgnoreCase) =>
+                p.Replace("gla-poster.png", "gla-cover.png", StringComparison.OrdinalIgnoreCase)
+                 .Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
+
+            // Also handle just the directory change for any other files in Images/ that might reference covers
+            var p when p.Contains("/Assets/Images/", StringComparison.OrdinalIgnoreCase) &&
+                       (p.Contains("cover", StringComparison.OrdinalIgnoreCase) || p.Contains("poster", StringComparison.OrdinalIgnoreCase)) =>
+                p.Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
+            _ => coverPath,
+        };
     }
 
     private static string MapPublisherName(string publisherSegment, string fallback) =>
@@ -703,41 +737,6 @@ public partial class GameProfileItemViewModel : ViewModelBase
             GameType.Generals => "#BD5A0F", // Orange/yellow for Generals
             GameType.ZeroHour => "#1B6575", // Teal/blue for Zero Hour
             _ => "#2A2A2A", // Default dark gray
-        };
-    }
-
-    /// <summary>
-    /// Normalizes old cover paths to new paths for backward compatibility.
-    /// Handles migration from Assets/Images/*.png to Assets/Covers/*.png.
-    /// </summary>
-    /// <param name="coverPath">The cover path to normalize.</param>
-    /// <returns>The normalized cover path.</returns>
-    private static string NormalizeCoverPath(string coverPath)
-    {
-        if (string.IsNullOrEmpty(coverPath))
-        {
-            return coverPath;
-        }
-
-        // Map old paths to new paths for backward compatibility
-        // Images were renamed/moved: Assets/Images/china-poster.png → Assets/Covers/china-cover.png
-        return coverPath switch
-        {
-            var p when p.Contains("china-poster.png", StringComparison.OrdinalIgnoreCase) =>
-                p.Replace("china-poster.png", "china-cover.png", StringComparison.OrdinalIgnoreCase)
-                 .Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
-            var p when p.Contains("usa-poster.png", StringComparison.OrdinalIgnoreCase) =>
-                p.Replace("usa-poster.png", "usa-cover.png", StringComparison.OrdinalIgnoreCase)
-                 .Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
-            var p when p.Contains("gla-poster.png", StringComparison.OrdinalIgnoreCase) =>
-                p.Replace("gla-poster.png", "gla-cover.png", StringComparison.OrdinalIgnoreCase)
-                 .Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
-
-            // Also handle just the directory change for any other files in Images/ that might reference covers
-            var p when p.Contains("/Assets/Images/", StringComparison.OrdinalIgnoreCase) &&
-                       (p.Contains("cover", StringComparison.OrdinalIgnoreCase) || p.Contains("poster", StringComparison.OrdinalIgnoreCase)) =>
-                p.Replace("/Assets/Images/", "/Assets/Covers/", StringComparison.OrdinalIgnoreCase),
-            _ => coverPath,
         };
     }
 
@@ -920,5 +919,78 @@ public partial class GameProfileItemViewModel : ViewModelBase
             ColorValue = CommunityOutpostConstants.ThemeColor;
             CoverImagePath = CommunityOutpostConstants.CoverSource;
         }
+    }
+
+    private void ResolveProfileVersionAndPublisher(GameProfile gameProfile)
+    {
+        GameVersion = string.Empty;
+        Publisher = string.Empty;
+
+        if (gameProfile.GameClient != null)
+        {
+            ResolveFromGameClient(gameProfile.GameClient);
+        }
+        else
+        {
+            ResolveFromInstallationManifest(gameProfile.EnabledContentIds);
+        }
+    }
+
+    private void ResolveFromGameClient(GameClient gameClient)
+    {
+        ExtractManifestInfo(gameClient.Id);
+
+        if (string.IsNullOrEmpty(Publisher))
+        {
+            ResolvePublisherFromGameClient(gameClient);
+        }
+
+        // Fallback: use GameClient.Version directly
+        // But SKIP if the publisher is "Local"
+        if (string.IsNullOrEmpty(GameVersion) &&
+            !string.IsNullOrEmpty(gameClient.Version) &&
+            !string.Equals(Publisher, "Local", StringComparison.OrdinalIgnoreCase))
+        {
+            var version = gameClient.Version;
+            GameVersion = IsZeroOrPlaceholderVersion(version) ? string.Empty : version;
+        }
+    }
+
+    private void ResolvePublisherFromGameClient(GameClient gameClient)
+    {
+        if (!string.IsNullOrEmpty(gameClient.PublisherType))
+        {
+            var pub = gameClient.PublisherType.ToLowerInvariant();
+            Publisher = MapPublisherName(pub, gameClient.PublisherType);
+            ApplyPublisherBranding(pub);
+        }
+        else if (gameClient.Name.Contains(GeneralsOnlineConstants.ClientName, StringComparison.OrdinalIgnoreCase))
+        {
+            Publisher = PublisherInfoConstants.GeneralsOnline.Name;
+            ApplyPublisherBranding(PublisherTypeConstants.GeneralsOnline);
+        }
+    }
+
+    private void ResolveFromInstallationManifest(IReadOnlyList<string>? enabledContentIds)
+    {
+        var installationManifestId = enabledContentIds?.FirstOrDefault(id => id.Contains("-installation"));
+        if (!string.IsNullOrEmpty(installationManifestId))
+        {
+            ExtractManifestInfo(installationManifestId);
+        }
+    }
+
+    private void NotifyAllPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(Name));
+        OnPropertyChanged(nameof(Version));
+        OnPropertyChanged(nameof(GameVersion));
+        OnPropertyChanged(nameof(Publisher));
+        OnPropertyChanged(nameof(Description));
+        OnPropertyChanged(nameof(ColorValue));
+        OnPropertyChanged(nameof(IconPath));
+        OnPropertyChanged(nameof(CoverPath));
+        OnPropertyChanged(nameof(CoverImagePath));
+        OnPropertyChanged(nameof(CommandLineArguments));
     }
 }

--- a/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
+++ b/GenHub/GenHub/Features/GameProfiles/ViewModels/GameProfileLauncherViewModel.cs
@@ -165,16 +165,9 @@ public partial class GameProfileLauncherViewModel(
                 {
                     if (profile == null) continue;
 
-                    // Use ProfileResourceService to get default paths based on game type if profile paths are missing
+                    // Resolve display icon and cover, prioritizing publisher branding before generic game defaults
                     var gameTypeStr = profile.GameClient?.GameType.ToString() ?? "ZeroHour";
-
-                    var iconPath = !string.IsNullOrEmpty(profile.IconPath)
-                        ? profile.IconPath
-                        : UriConstants.DefaultIconUri;
-
-                    var coverPath = !string.IsNullOrEmpty(profile.CoverPath)
-                        ? profile.CoverPath
-                        : profileResourceService.GetDefaultCoverPath(gameTypeStr);
+                    var (iconPath, coverPath) = ResolveProfileDisplayPaths(profile, gameTypeStr);
 
                     var item = new GameProfileItemViewModel(
                         profile.Id,
@@ -426,12 +419,10 @@ public partial class GameProfileLauncherViewModel(
                     existingItem.UpdateFromProfile(profile);
 
                     var gameType = profile.GameClient?.GameType.ToString() ?? "ZeroHour";
-                    existingItem.IconPath = !string.IsNullOrEmpty(profile.IconPath)
-                        ? profile.IconPath
-                        : UriConstants.DefaultIconUri;
-                    existingItem.CoverPath = !string.IsNullOrEmpty(profile.CoverPath)
-                        ? profile.CoverPath
-                        : profileResourceService.GetDefaultCoverPath(gameType);
+                    var (iconPath, coverPath) = ResolveProfileDisplayPaths(profile, gameType);
+                    existingItem.IconPath = iconPath;
+                    existingItem.CoverPath = coverPath;
+                    existingItem.CoverImagePath = GameProfileItemViewModel.NormalizeCoverPath(coverPath);
 
                     logger.LogInformation("Refreshed profile {ProfileId} in-place (Running: {IsRunning})", profileId, existingItem.IsProcessRunning);
                 }
@@ -931,6 +922,63 @@ public partial class GameProfileLauncherViewModel(
     }
 
     /// <summary>
+    /// Resolves display icon and cover image paths for a profile, checking publisher branding before falling back to generic defaults.
+    /// </summary>
+    private (string IconPath, string CoverPath) ResolveProfileDisplayPaths(Core.Models.GameProfile.GameProfile profile, string fallbackGameType)
+    {
+        var publisherKey = profile.GameClient?.PublisherType ?? profile.GameClient?.Name ?? profile.Name;
+
+        string iconPath;
+        if (!string.IsNullOrEmpty(profile.IconPath) &&
+            !profile.IconPath.Contains(UriConstants.GenHubIconMarker) &&
+            !profile.IconPath.Contains(UriConstants.ZeroHourIconMarker))
+        {
+            iconPath = profile.IconPath;
+        }
+        else
+        {
+            var publisherLogo = PublisherInfoConstants.GetPublisherLogo(publisherKey, profile.GameClient?.Id);
+            if (publisherLogo != null)
+            {
+                iconPath = publisherLogo;
+            }
+            else if (!string.IsNullOrEmpty(profile.IconPath))
+            {
+                iconPath = profile.IconPath;
+            }
+            else
+            {
+                iconPath = UriConstants.DefaultIconUri;
+            }
+        }
+
+        string coverPath;
+        if (!string.IsNullOrEmpty(profile.CoverPath) &&
+            !profile.CoverPath.Contains(UriConstants.ZeroHourCoverMarker))
+        {
+            coverPath = profile.CoverPath;
+        }
+        else
+        {
+            var publisherCover = PublisherInfoConstants.GetPublisherCover(publisherKey, profile.GameClient?.Id);
+            if (publisherCover != null)
+            {
+                coverPath = publisherCover;
+            }
+            else if (!string.IsNullOrEmpty(profile.CoverPath))
+            {
+                coverPath = profile.CoverPath;
+            }
+            else
+            {
+                coverPath = profileResourceService.GetDefaultCoverPath(fallbackGameType);
+            }
+        }
+
+        return (iconPath, coverPath);
+    }
+
+    /// <summary>
     /// Adds a newly created profile to the UI immediately (without waiting for full refresh).
     /// </summary>
     private void AddProfileToUI(Core.Models.GameProfile.GameProfile profile)
@@ -944,13 +992,8 @@ public partial class GameProfileLauncherViewModel(
                 return;
             }
 
-            var iconPath = !string.IsNullOrEmpty(profile.IconPath)
-                ? profile.IconPath
-                : UriConstants.DefaultIconUri;
-
-            var coverPath = !string.IsNullOrEmpty(profile.CoverPath)
-                ? profile.CoverPath
-                : iconPath;
+            var gameTypeStr = profile.GameClient?.GameType.ToString() ?? "ZeroHour";
+            var (iconPath, coverPath) = ResolveProfileDisplayPaths(profile, gameTypeStr);
 
             var item = new GameProfileItemViewModel(
                 profile.Id,


### PR DESCRIPTION
## Summary
Fixes an issue where ContentStateService repeatedly reported UpdateAvailable for Generals Online even after updating to newer QFE releases, caused by older manifests remaining in the pool and arbitrary selection via FirstOrDefault. Also improves update prompt interaction flow, cancellation behavior, and superseded file cleanup UX.

### Approvals Checklist
- [x] Self-review completed
- [x] CI tests passing
- [x] UI and Reconciler flow verified

### Root Cause
1. **Manifest Selection Arbitrariness**: ContentStateService used FirstOrDefault when scanning the manifest pool across matcher routines (FindOriginMatch, FindByPublisherTypeAndGame, etc.). When a user downloaded a newer release (e.g. 082826_QFE1), the older release (032926) remained in the pool. FirstOrDefault picked the older manifest, causing EvaluatePersistedManifestStateAsync to compare the prospective version against the old installed version and continuously report UpdateAvailable.
2. **Missing Original Content Metadata**: GeneralsOnlineManifestFactory omitted OriginalProviderName and OriginalContentId when generating variant manifests and discarded them during zip extraction updates. This prevented exact origin matching from resolving the downloaded release directly.
3. **Generals Online Version Comparison**: ContentStateService did not use MmddyyQfeVersionScheme and compared numeric manifest ID components as raw integers without chronological month/year semantics.
4. **Update Dialog Cancellation Fallthrough**: DownloadsBrowserViewModel.UpdateContentAsync fell through to DownloadContentAsync when the publisher reconciler returned false, ignoring user cancellation.

### Changes
- **Core / Downloads**:
  - Replaced FirstOrDefault across candidate searches with SelectBestMatchingManifest.
  - Added SelectBestMatchingManifest and IsExactManifestMatch to prioritize exact matches and fall back to the highest versioned manifest.
  - Publisher-gated 6/7-digit version decoding for Generals Online aliases.
  - Replaced ambiguous 'Skip' with 'Cancel' in update options dialog and stopped falling through to downloading when reconciliation returns false.
  - Added 'Delete superseded version files from storage' toggle (defaults to true for Replace) to remove obsolete version files and reclaim disk space.
- **Tests**:
  - Added UpdateOptionDialogViewModelTests.
  - Added GeneralsOnlineProfileReconcilerTests for cancellation and old version deletion toggling.
  - Updated DownloadsBrowserViewModelTests to verify never downloading when reconciler returns false.

---
*Created with Gemini 3.8 Flash High via T3 Code*