### PR TITLE
fix(build): accept supported .NET 8 SDK patch versions in global.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ jobs:
               - '**/*.sln'
               - '**/*.props'
               - '**/*.targets'
+              - '**/*.ruleset'
+              - '**/.editorconfig'
+              - '**/NuGet.config'
+              - 'global.json'
+              - 'stylecop.json'
               - '.github/workflows/**'
 
       - name: Changes Summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,9 @@ you agree to uphold a welcoming and inclusive environment for all contributors.
 
 ## Development Environment
 
-- **.NET Version**: GenHub targets **.NET 8**. Ensure you have the latest SDK installed.
+- **.NET Version**: GenHub targets **.NET 8**. `global.json` pins the SDK to the 8.0.4xx feature
+  band with `rollForward: latestFeature`, so install a **8.0.4xx SDK** (8.0.400 or newer). A later
+  major SDK such as .NET 9 will not satisfy it, and an older 8.0.x band will not either.
 - **IDE**: Visual Studio 2022 is recommended. The Community Edition is free and sufficient.
 - **Dependencies**: Restore NuGet packages before building.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -220,7 +220,7 @@ public async Task ShouldDownloadContent()
 
 ### Prerequisites
 
-- **.NET 8 SDK** or later
+- **.NET 8 SDK**, version **8.0.400 or newer** in the 8.0.4xx band (pinned by `global.json`; .NET 9 will not work)
 - **Visual Studio 2022** / **JetBrains Rider** / **VS Code**
 - **Git** for version control
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.424",
-    "rollForward": "latestMajor",
+    "version": "8.0.400",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Closes #461.

## Problem

`global.json` requested SDK `8.0.424` with `rollForward: latestMajor`. A machine with only `8.0.423` cannot resolve an SDK at all, so `dotnet build` and `dotnet test` fail before the solution loads. `latestMajor` also permits a later major SDK, which is broader than intended.

## Change

Request `8.0.400` with `rollForward: latestFeature`. That accepts any 8.0.4xx patch, including 8.0.423 and 8.0.424, and refuses to roll forward to a later major.

Also widen the CI change filter. `global.json` controls SDK resolution for every project, but it was not in the `any` filter, so a change to it skipped the Windows, Linux and macOS build jobs entirely. That is how this pin reached `development` without CI noticing. The filter now also covers `stylecop.json`, which is a real file in the tree today. It additionally lists `*.ruleset`, `.editorconfig` and `NuGet.config`, which match nothing at present and are there so that adding one later cannot reintroduce this same silent skip.

## Verification

Reproduced and fixed on a machine with only 8.0.423 installed.

Before:

```
A compatible .NET SDK was not found.
Requested SDK version: 8.0.424
```

After, on the Windows box, building the full solution:

```
$ dotnet build GenHub.sln -c Release
    21 Warning(s)
    0 Error(s)
```

The SDK resolves and the solution builds. The remaining warnings are 21 pre-existing SA1648
occurrences in `GenHub.Windows` and `GenHub.Linux`, unrelated to this change and fixed by #476.

The CI filter change is self-demonstrating: this PR previously ran no build jobs, and now runs the full matrix.

