### PR TITLE
fix(ui): name the Avalonia application so macOS shows GenHub in the menu bar

### DIFF
--- a/GenHub/GenHub/App.axaml
+++ b/GenHub/GenHub/App.axaml
@@ -2,7 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:GenHub.Infrastructure.Converters"
              xmlns:material="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
-             x:Class="GenHub.App">
+             x:Class="GenHub.App"
+             Name="GenHub">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
Closes #472.

## Problem

On macOS the application menu read "Avalonia Application" rather than "GenHub". `Info.plist` was already correct, so the name came from the Avalonia side: `App.axaml` had no `Name` attribute and nothing assigned `Application.Name`, so Avalonia fell back to its default.

## Change

Set `Name="GenHub"` on `<Application>` in `App.axaml`. No `Info.plist` change is needed.

## Verification

Built and ran `GenHub.MacOS` on macOS arm64.

Before, on the packaged 0.0.2832 artifact, the menu bar read "Avalonia Application".

After:

```
$ osascript -e 'tell application "System Events" to tell (first process whose name contains "GenHub") to get name of menu bar item 2 of menu bar 1'
GenHub
```

A screenshot of the menu bar confirms the same.
