### PR TITLE
fix(gameprofiles): persist the active workspace id prepared by a profile's own launch

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/GameProfileManagerHotswapTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Features/GameProfiles/Services/GameProfileManagerHotswapTests.cs
@@ -529,6 +529,75 @@ public class GameProfileManagerHotswapTests
         Assert.Equal("-restoredargs", rollbackResult.Data?.CommandLineArguments);
     }
 
+    /// <summary>
+    /// Verifies that a running profile accepts the workspace id its own active launch prepared.
+    /// The launch path persists this after the placeholder launch has already been registered,
+    /// so the running-profile guard must not reject it.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Fact]
+    public async Task UpdateProfileAsync_WhenRunning_PersistsActiveWorkspaceIdFromOwnLaunchAsync()
+    {
+        // Arrange
+        const string profileId = "profile-launch";
+        const string workspaceId = "ws-launched";
+        var existingProfile = new GameProfile
+        {
+            Id = profileId,
+            Name = "Launching Profile",
+            ActiveWorkspaceId = string.Empty,
+        };
+
+        _profileRepositoryMock.Setup(r => r.LoadProfileAsync(profileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(existingProfile));
+        _profileRepositoryMock.Setup(r => r.SaveProfileAsync(It.IsAny<GameProfile>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(existingProfile));
+        _launchRegistryMock.Setup(l => l.GetAllActiveLaunchesAsync())
+            .ReturnsAsync([CreateActiveLaunch(profileId, workspaceId: workspaceId)]);
+
+        var request = new UpdateProfileRequest { ActiveWorkspaceId = workspaceId };
+
+        // Act
+        var result = await _profileManager.UpdateProfileAsync(profileId, request);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(workspaceId, existingProfile.ActiveWorkspaceId);
+    }
+
+    /// <summary>
+    /// Verifies that a running profile still rejects an attempt to point it at a workspace
+    /// other than the one its active launch prepared.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Fact]
+    public async Task UpdateProfileAsync_WhenRunning_RejectsDifferentActiveWorkspaceIdAsync()
+    {
+        // Arrange
+        const string profileId = "profile-running";
+        var existingProfile = new GameProfile
+        {
+            Id = profileId,
+            Name = "Running Profile",
+            ActiveWorkspaceId = "ws-current",
+        };
+
+        _profileRepositoryMock.Setup(r => r.LoadProfileAsync(profileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProfileOperationResult<GameProfile>.CreateSuccess(existingProfile));
+        _launchRegistryMock.Setup(l => l.GetAllActiveLaunchesAsync())
+            .ReturnsAsync([CreateActiveLaunch(profileId, workspaceId: "ws-current")]);
+
+        var request = new UpdateProfileRequest { ActiveWorkspaceId = "ws-somewhere-else" };
+
+        // Act
+        var result = await _profileManager.UpdateProfileAsync(profileId, request);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("ws-current", existingProfile.ActiveWorkspaceId);
+        _profileRepositoryMock.Verify(r => r.SaveProfileAsync(It.IsAny<GameProfile>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static GameLaunchInfo CreateActiveLaunch(string profileId, string launchId = "launch-1", string workspaceId = "ws-1") => new()
     {
         LaunchId = launchId,

--- a/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/GameProfileManager.cs
@@ -315,7 +315,10 @@ public class GameProfileManager(
         }
     }
 
-    private static ProfileOperationResult<GameProfile>? ValidateRunningProfileImmutableSettings(GameProfile profile, UpdateProfileRequest request)
+    private static ProfileOperationResult<GameProfile>? ValidateRunningProfileImmutableSettings(
+        GameProfile profile,
+        UpdateProfileRequest request,
+        string? runningWorkspaceId)
     {
         if ((request.WorkspaceStrategy.HasValue && request.WorkspaceStrategy.Value != profile.WorkspaceStrategy) ||
             (request.ClearWorkspaceStrategy && profile.WorkspaceStrategy.HasValue))
@@ -328,7 +331,9 @@ public class GameProfileManager(
             return ProfileOperationResult<GameProfile>.CreateFailure("Cannot change game installation while profile is running.");
         }
 
-        if (request.ActiveWorkspaceId != null && !string.Equals(request.ActiveWorkspaceId, profile.ActiveWorkspaceId, StringComparison.OrdinalIgnoreCase))
+        if (request.ActiveWorkspaceId != null &&
+            !string.Equals(request.ActiveWorkspaceId, profile.ActiveWorkspaceId, StringComparison.OrdinalIgnoreCase) &&
+            !IsReconcilingWithRunningWorkspace(request.ActiveWorkspaceId, runningWorkspaceId))
         {
             return ProfileOperationResult<GameProfile>.CreateFailure("Cannot change active workspace while profile is running.");
         }
@@ -349,6 +354,19 @@ public class GameProfileManager(
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Determines whether an <see cref="UpdateProfileRequest"/> is recording the workspace that the
+    /// profile's own active launch already prepared, rather than pointing the profile at a different one.
+    /// </summary>
+    /// <param name="requestedWorkspaceId">The workspace id carried by the update request.</param>
+    /// <param name="runningWorkspaceId">The workspace id of the profile's active launch, if known.</param>
+    /// <returns><c>true</c> when the request matches the running workspace.</returns>
+    private static bool IsReconcilingWithRunningWorkspace(string requestedWorkspaceId, string? runningWorkspaceId)
+    {
+        return !string.IsNullOrEmpty(runningWorkspaceId)
+            && string.Equals(requestedWorkspaceId, runningWorkspaceId, StringComparison.OrdinalIgnoreCase);
     }
 
     private static ProfileOperationResult<GameProfile>? ValidateRunningProfileGameClient(GameProfile profile, GameClient? requestedClient)
@@ -440,6 +458,24 @@ public class GameProfileManager(
         }
     }
 
+    /// <summary>
+    /// Gets the workspace id of the profile's active launch, if one is registered.
+    /// </summary>
+    /// <param name="profileId">The profile id to inspect.</param>
+    /// <returns>The active launch's workspace id, or <c>null</c> when none is available.</returns>
+    private async Task<string?> GetActiveLaunchWorkspaceIdAsync(string profileId)
+    {
+        if (launchRegistry == null)
+        {
+            return null;
+        }
+
+        var activeLaunches = await launchRegistry.GetAllActiveLaunchesAsync();
+        var launch = activeLaunches.FirstOrDefault(l =>
+            string.Equals(l.ProfileId, profileId, StringComparison.OrdinalIgnoreCase) && !l.TerminatedAt.HasValue);
+        return string.IsNullOrEmpty(launch?.WorkspaceId) ? null : launch.WorkspaceId;
+    }
+
     private async Task<bool> CheckIsProfileRunningAsync(string profileId)
     {
         if (launchRegistry == null)
@@ -466,7 +502,8 @@ public class GameProfileManager(
             return null;
         }
 
-        return await ValidateRunningProfileUpdateRequestAsync(profile, request, previousEnabledContentIds, cancellationToken);
+        var runningWorkspaceId = await GetActiveLaunchWorkspaceIdAsync(profileId);
+        return await ValidateRunningProfileUpdateRequestAsync(profile, request, previousEnabledContentIds, runningWorkspaceId, cancellationToken);
     }
 
     private async Task<ProfileOperationResult<GameProfile>> SaveAndNotifyProfileUpdatedAsync(GameProfile profile, CancellationToken cancellationToken)
@@ -492,9 +529,10 @@ public class GameProfileManager(
         GameProfile profile,
         UpdateProfileRequest request,
         List<string> previousEnabledContentIds,
+        string? runningWorkspaceId,
         CancellationToken cancellationToken)
     {
-        var settingsError = ValidateRunningProfileImmutableSettings(profile, request);
+        var settingsError = ValidateRunningProfileImmutableSettings(profile, request, runningWorkspaceId);
         if (settingsError != null)
         {
             return settingsError;

--- a/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
+++ b/GenHub/GenHub/Features/GameProfiles/Services/ProfileLauncherFacade.cs
@@ -835,8 +835,9 @@ public class ProfileLauncherFacade(
                     }
                     else
                     {
-                        logger.LogWarning(
-                            "Failed to persist active workspace ID to profile '{ProfileId}': {Error}",
+                        logger.LogError(
+                            "Failed to persist active workspace ID '{WorkspaceId}' to profile '{ProfileId}': {Error}. The game is running; content reconciliation will not be able to invalidate this workspace.",
+                            launchInfo.WorkspaceId,
                             profileId,
                             updateResult.FirstError);
                     }


### PR DESCRIPTION
Closes #460.

## Problem

`GameLauncher` registers a placeholder launch before it prepares the workspace, so the profile already counts as running by the time `ProfileLauncherFacade` persists the prepared workspace id. `ValidateRunningProfileImmutableSettings` then rejects the update with "Cannot change active workspace while profile is running."

The launch succeeds but `ActiveWorkspaceId` stays empty, so `ContentReconciliationService` cannot find and invalidate the workspace later.

Observed on a real launch:

```
[GameLauncher] Process started successfully - PID: 22508
Registered launch 825eafc1-... for profile c1afa642...
=== LAUNCH SUCCESS: Profile c1afa642..., ProcessId 22508 ===
[WRN] Failed to persist active workspace ID to profile 'c1afa642...':
      Cannot change active workspace while profile is running.
```

## Change

The guard now distinguishes a profile recording the workspace its **own active launch** prepared from a user pointing the profile at a **different** workspace. The first is reconciliation and is allowed. The second is still rejected.

`GameProfileManager` reads the active launch's `WorkspaceId` from `ILaunchRegistry` and passes it into the immutable-settings check. By the time the facade persists, the registry already holds the real workspace id, so the match succeeds.

The guard is not weakened: every other immutable setting is untouched, and an update naming a workspace other than the running one still fails.

## Tests

Two regression tests in `GameProfileManagerHotswapTests`:

- `UpdateProfileAsync_WhenRunning_PersistsActiveWorkspaceIdFromOwnLaunchAsync` covers launch from an empty `ActiveWorkspaceId`.
- `UpdateProfileAsync_WhenRunning_RejectsDifferentActiveWorkspaceIdAsync` confirms the guard still blocks user-initiated changes and saves nothing.

Verified the first test genuinely catches the defect. With the production change reverted:

```
UpdateProfileAsync_WhenRunning_PersistsActiveWorkspaceIdFromOwnLaunchAsync [FAIL]
Failed! - Failed: 1, Passed: 11, Total: 12
```

With the change applied:

```
Passed! - Failed: 0, Passed: 12, Total: 12
```

Release build of `GenHub.csproj` reports no warnings.

## Note on the third acceptance criterion

"Do not report launch success if required workspace state cannot be persisted safely" is not addressed here. After this change the persist succeeds, so the case no longer arises on the normal path. Turning a late persistence failure into a launch failure while the game is already running looked like a worse outcome than surfacing it, so I left that decision open rather than guess.
