### PR TITLE
fix(installations): restore the IGameInstallation members removed by accident

### DIFF
--- a/GenHub/GenHub.Core/Interfaces/GameInstallations/IGameInstallation.cs
+++ b/GenHub/GenHub.Core/Interfaces/GameInstallations/IGameInstallation.cs
@@ -53,4 +53,22 @@ public interface IGameInstallation
     /// Gets the available game clients for this installation.
     /// </summary>
     List<GameClient> AvailableGameClients { get; }
+
+    /// <summary>
+    /// Fetch the game installations.
+    /// </summary>
+    void Fetch();
+
+    /// <summary>
+    /// Sets the paths for Generals and Zero Hour.
+    /// </summary>
+    /// <param name="generalsPath">The path to Generals, or null if not present.</param>
+    /// <param name="zeroHourPath">The path to Zero Hour, or null if not present.</param>
+    void SetPaths(string? generalsPath, string? zeroHourPath);
+
+    /// <summary>
+    /// Populates the available game clients for this installation.
+    /// </summary>
+    /// <param name="clients">The clients to add.</param>
+    void PopulateGameClients(IEnumerable<GameClient> clients);
 }

--- a/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
+++ b/GenHub/GenHub.Core/Models/GameInstallations/GameInstallation.cs
@@ -161,7 +161,7 @@ public class GameInstallation : IGameInstallation
     /// </summary>
     /// <remarks>
     /// This method is primarily used for testing and initialization purposes.
-    /// For production code, prefer using <see cref="SetPaths(string?, string?)"/> with explicit paths technique.
+    /// For production code, prefer using <see cref="SetPaths(string?, string?)"/> with explicit paths.
     /// </remarks>
     public void Fetch()
     {


### PR DESCRIPTION
Closes #471.

## Problem

`IGameInstallation` lost `Fetch()`, `SetPaths()` and `PopulateGameClients()`. The removal was accidental. The concrete installations still implement those members and still document them with `/// <inheritdoc/>`, which left nothing to inherit from and produced 21 SA1648 warnings across 7 files in `GenHub.Windows` and `GenHub.Linux`.

The file had also lost its trailing newline, and a doc comment in `GameInstallation.cs` read "with explicit paths technique".

## Change

Restore the three members to the interface with their original documentation. Restore the trailing newline. Correct the doc comment.

No implementation changed. The members were never removed from the concrete types, so this only puts the contract back.

## Verification

Clean `--no-incremental` Release builds.

Before, on `development`:

```
21 SA1648 warnings across GenHub.Windows and GenHub.Linux
```

After:

```
GenHub.Windows   Build succeeded.  0 Warning(s)  0 Error(s)
GenHub.Linux     Build succeeded.  0 Warning(s)  0 Error(s)
```

SA1648 and SA1518 occurrences are both zero.
