### PR TITLE
fix(config): recover alpha 3 profiles stored beside a custom data path

### DIFF
--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
@@ -371,6 +371,112 @@ public class LegacyRootUpgradeTests : IDisposable
         return appConfig;
     }
 
+    /// <summary>
+    /// Verifies that profiles v0.0.3 wrote beside a custom data path, rather than inside it, are
+    /// recovered into the directory this release reads from. v0.0.3 derived the profiles directory
+    /// from the parent of the application data path, so an override left them one level too high and
+    /// the profile list came up empty after upgrading.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithOverride_RecoversProfilesStoredBesideTheDataPath()
+    {
+        var overridePath = Path.Combine(_testRoot, "custom", "Data");
+        var strandedProfiles = Path.Combine(_testRoot, "custom", DirectoryNames.Profiles);
+        WriteLegacySettings($$"""
+        {
+          "applicationDataPath": "{{overridePath.Replace("\\", "\\\\")}}"
+        }
+        """);
+        WriteLegacyFile(Path.Combine(strandedProfiles, "stranded.json"), "stranded-profile");
+
+        var appConfig = CreateAppConfig();
+        var provider = new ConfigurationProviderService(
+            appConfig,
+            CreateSettingsService(appConfig),
+            Mock.Of<ILogger<ConfigurationProviderService>>());
+
+        var recovered = Path.Combine(provider.GetProfilesPath(), "stranded.json");
+        Assert.True(File.Exists(recovered));
+        Assert.Equal("stranded-profile", File.ReadAllText(recovered));
+        Assert.False(Directory.Exists(strandedProfiles));
+    }
+
+    /// <summary>
+    /// Verifies that recovery never overwrites a profile that already exists under the current data
+    /// path, and leaves the conflicting file where it is so nothing is lost.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithOverride_DoesNotOverwriteExistingProfileOnRecovery()
+    {
+        var overridePath = Path.Combine(_testRoot, "custom", "Data");
+        var strandedProfiles = Path.Combine(_testRoot, "custom", DirectoryNames.Profiles);
+        WriteLegacySettings($$"""
+        {
+          "applicationDataPath": "{{overridePath.Replace("\\", "\\\\")}}"
+        }
+        """);
+        WriteLegacyFile(Path.Combine(strandedProfiles, "same.json"), "stranded-version");
+        WriteLegacyFile(Path.Combine(overridePath, DirectoryNames.Profiles, "same.json"), "current-version");
+
+        var appConfig = CreateAppConfig();
+        var provider = new ConfigurationProviderService(
+            appConfig,
+            CreateSettingsService(appConfig),
+            Mock.Of<ILogger<ConfigurationProviderService>>());
+
+        Assert.Equal("current-version", File.ReadAllText(Path.Combine(provider.GetProfilesPath(), "same.json")));
+        Assert.Equal("stranded-version", File.ReadAllText(Path.Combine(strandedProfiles, "same.json")));
+    }
+
+    /// <summary>
+    /// Verifies that recovery is idempotent, so a second launch neither fails nor disturbs the
+    /// profiles the first launch already moved.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithOverride_ProfileRecoveryIsIdempotent()
+    {
+        var overridePath = Path.Combine(_testRoot, "custom", "Data");
+        var strandedProfiles = Path.Combine(_testRoot, "custom", DirectoryNames.Profiles);
+        WriteLegacySettings($$"""
+        {
+          "applicationDataPath": "{{overridePath.Replace("\\", "\\\\")}}"
+        }
+        """);
+        WriteLegacyFile(Path.Combine(strandedProfiles, "stranded.json"), "stranded-profile");
+
+        var appConfig = CreateAppConfig();
+        var first = new ConfigurationProviderService(appConfig, CreateSettingsService(appConfig), Mock.Of<ILogger<ConfigurationProviderService>>());
+        var profilesPath = first.GetProfilesPath();
+
+        var second = new ConfigurationProviderService(appConfig, CreateSettingsService(appConfig), Mock.Of<ILogger<ConfigurationProviderService>>());
+        second.GetApplicationDataPath();
+
+        Assert.Equal("stranded-profile", File.ReadAllText(Path.Combine(profilesPath, "stranded.json")));
+        Assert.Single(Directory.GetFiles(profilesPath, "*.json"));
+    }
+
+    /// <summary>
+    /// Verifies that an upgrade without an application data path override is untouched by the
+    /// recovery, so the ordinary migration path keeps behaving exactly as before.
+    /// </summary>
+    [Fact]
+    public void FirstLaunch_WithoutOverride_LeavesDefaultPathMigrationUnchanged()
+    {
+        WriteLegacySettings("""
+        { "theme": "Light" }
+        """);
+        SeedLegacyDataDirectories();
+
+        var appConfig = CreateAppConfig();
+        var provider = new ConfigurationProviderService(
+            appConfig,
+            CreateSettingsService(appConfig),
+            Mock.Of<ILogger<ConfigurationProviderService>>());
+
+        Assert.Equal("profile", File.ReadAllText(Path.Combine(provider.GetProfilesPath(), "profile.json")));
+        Assert.Equal(Path.Combine(_newRoot, DirectoryNames.Profiles), provider.GetProfilesPath());
+    }
+
     private Mock<IAppConfiguration> CreateAppConfigMock()
     {
         var appConfig = CreateBaseAppConfigMock();

--- a/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
+++ b/GenHub/GenHub.Tests/GenHub.Tests.Core/Common/Services/LegacyRootUpgradeTests.cs
@@ -359,18 +359,6 @@ public class LegacyRootUpgradeTests : IDisposable
         Assert.Equal(AppConstants.DefaultThemeName, service.Get().Theme);
     }
 
-    private static Mock<IAppConfiguration> CreateBaseAppConfigMock()
-    {
-        var appConfig = new Mock<IAppConfiguration>();
-        appConfig.Setup(config => config.GetMinConcurrentDownloads()).Returns(1);
-        appConfig.Setup(config => config.GetMaxConcurrentDownloads()).Returns(8);
-        appConfig.Setup(config => config.GetMinDownloadTimeoutSeconds()).Returns(30);
-        appConfig.Setup(config => config.GetMaxDownloadTimeoutSeconds()).Returns(600);
-        appConfig.Setup(config => config.GetMinDownloadBufferSizeBytes()).Returns(4096);
-        appConfig.Setup(config => config.GetMaxDownloadBufferSizeBytes()).Returns(1048576);
-        return appConfig;
-    }
-
     /// <summary>
     /// Verifies that profiles v0.0.3 wrote beside a custom data path, rather than inside it, are
     /// recovered into the directory this release reads from. v0.0.3 derived the profiles directory
@@ -475,6 +463,18 @@ public class LegacyRootUpgradeTests : IDisposable
 
         Assert.Equal("profile", File.ReadAllText(Path.Combine(provider.GetProfilesPath(), "profile.json")));
         Assert.Equal(Path.Combine(_newRoot, DirectoryNames.Profiles), provider.GetProfilesPath());
+    }
+
+    private static Mock<IAppConfiguration> CreateBaseAppConfigMock()
+    {
+        var appConfig = new Mock<IAppConfiguration>();
+        appConfig.Setup(config => config.GetMinConcurrentDownloads()).Returns(1);
+        appConfig.Setup(config => config.GetMaxConcurrentDownloads()).Returns(8);
+        appConfig.Setup(config => config.GetMinDownloadTimeoutSeconds()).Returns(30);
+        appConfig.Setup(config => config.GetMaxDownloadTimeoutSeconds()).Returns(600);
+        appConfig.Setup(config => config.GetMinDownloadBufferSizeBytes()).Returns(4096);
+        appConfig.Setup(config => config.GetMaxDownloadBufferSizeBytes()).Returns(1048576);
+        return appConfig;
     }
 
     private Mock<IAppConfiguration> CreateAppConfigMock()

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -419,8 +419,10 @@ public class ConfigurationProviderService(
     /// Releases up to v0.0.3 nested the manifests, tracked user data and workspace metadata under a
     /// <c>Content</c> directory, so both that layout and the flat one are probed and flattened into
     /// the destination. Data that a v0.0.3 install kept outside the legacy root, because an
-    /// <see cref="UserSettings.ApplicationDataPath"/> override pointed elsewhere, is out of scope and
-    /// stays where it is.
+    /// <see cref="UserSettings.ApplicationDataPath"/> override pointed elsewhere, is out of scope
+    /// here. Profiles are the exception and are recovered separately by
+    /// <see cref="MigrateLegacyCustomPathProfiles()"/>, because v0.0.3 wrote them beside the
+    /// override rather than inside it.
     /// </para>
     /// <para>
     /// The CAS pool is migrated alongside profiles, manifests, and user data so that no files are
@@ -550,6 +552,7 @@ public class ConfigurationProviderService(
 
             MigrateLegacyDataRoot();
             MigrateContentDirectory();
+            MigrateLegacyCustomPathProfiles();
             _migrated = true;
         }
     }
@@ -580,6 +583,97 @@ public class ConfigurationProviderService(
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
         {
             _logger.LogError(ex, "Failed to migrate legacy data root");
+        }
+    }
+
+    /// <summary>
+    /// Recovers profiles that releases up to v0.0.3 wrote beside an explicit
+    /// <see cref="UserSettings.ApplicationDataPath"/> rather than inside it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// v0.0.3 derived its profiles directory from the <em>parent</em> of the application data path.
+    /// With the default path that landed correctly, because the value it resolved carried a trailing
+    /// <c>Content</c> segment. With an explicit override there is no such segment, so the parent sits one
+    /// level above the data root: an override of <c>D:\GenHub\Data</c> put profiles in
+    /// <c>D:\GenHub\Profiles</c>, and an override of <c>C:\GenHubData</c> put them at the drive root.
+    /// This release reads profiles from inside the data root, so those files are invisible and the
+    /// profile list comes up empty after upgrading.
+    /// </para>
+    /// <para>
+    /// Only <c>*.json</c> files are taken, and only into a destination that does not already hold a file
+    /// of that name, so an unrelated <c>Profiles</c> directory that happens to sit beside the override is
+    /// never emptied and an existing profile is never overwritten. Anything left behind is reported.
+    /// </para>
+    /// </remarks>
+    private void MigrateLegacyCustomPathProfiles()
+    {
+        try
+        {
+            var settings = _userSettings.Get();
+            if (!settings.IsExplicitlySet(nameof(UserSettings.ApplicationDataPath)) ||
+                string.IsNullOrWhiteSpace(settings.ApplicationDataPath))
+            {
+                return;
+            }
+
+            var overrideParent = Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(settings.ApplicationDataPath));
+            if (string.IsNullOrEmpty(overrideParent))
+            {
+                return;
+            }
+
+            var legacyProfiles = Path.Combine(overrideParent, DirectoryNames.Profiles);
+            var currentProfiles = Path.Combine(ResolveApplicationDataPath(), DirectoryNames.Profiles);
+
+            if (!Directory.Exists(legacyProfiles) || PathHelper.AreSamePath(legacyProfiles, currentProfiles))
+            {
+                return;
+            }
+
+            var candidates = Directory.GetFiles(legacyProfiles, "*.json");
+            if (candidates.Length == 0)
+            {
+                return;
+            }
+
+            _logger.LogInformation(
+                "Recovering {Count} v0.0.3 profile(s) from {LegacyProfiles} into {CurrentProfiles}",
+                candidates.Length,
+                legacyProfiles,
+                currentProfiles);
+
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    MigrateFile(candidate, Path.Combine(currentProfiles, Path.GetFileName(candidate)));
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+                {
+                    _logger.LogError(ex, "Failed to recover legacy profile {Source}, leaving it in place", candidate);
+                }
+            }
+
+            var remaining = Directory.Exists(legacyProfiles)
+                ? Directory.GetFiles(legacyProfiles, "*.json").Length
+                : 0;
+            if (remaining > 0)
+            {
+                _logger.LogWarning(
+                    "{Count} profile(s) could not be recovered from {LegacyProfiles} and were left untouched because a profile file of the same name already exists in {CurrentProfiles}.",
+                    remaining,
+                    legacyProfiles,
+                    currentProfiles);
+            }
+            else
+            {
+                TryDeleteEmptyDirectory(legacyProfiles);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or NotSupportedException or ArgumentException)
+        {
+            _logger.LogError(ex, "Failed to recover v0.0.3 profiles stored beside a custom data path");
         }
     }
 

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -631,7 +631,7 @@ public class ConfigurationProviderService(
                 return;
             }
 
-            var candidates = Directory.GetFiles(legacyProfiles, "*.json");
+            var candidates = Directory.GetFiles(legacyProfiles, FileTypes.JsonFilePattern);
             if (candidates.Length == 0)
             {
                 return;
@@ -656,7 +656,7 @@ public class ConfigurationProviderService(
             }
 
             var remaining = Directory.Exists(legacyProfiles)
-                ? Directory.GetFiles(legacyProfiles, "*.json").Length
+                ? Directory.GetFiles(legacyProfiles, FileTypes.JsonFilePattern).Length
                 : 0;
             if (remaining > 0)
             {

--- a/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
+++ b/GenHub/GenHub/Common/Services/ConfigurationProviderService.cs
@@ -661,7 +661,7 @@ public class ConfigurationProviderService(
             if (remaining > 0)
             {
                 _logger.LogWarning(
-                    "{Count} profile(s) could not be recovered from {LegacyProfiles} and were left untouched because a profile file of the same name already exists in {CurrentProfiles}.",
+                    "{Count} profile(s) remain in {LegacyProfiles} and were left untouched. A profile of the same name may already exist in {CurrentProfiles}, or recovery failed for that file; see any errors logged above.",
                     remaining,
                     legacyProfiles,
                     currentProfiles);


### PR DESCRIPTION
Closes #458.

## Problem

`GetApplicationDataPath()` returns `<root>\Content` by default, but the bare root when the
data path is set explicitly. `GetProfilesDirectory()` applies `Path.GetDirectoryName` to both.
With a custom data path of `D:\GenHub\Data`, alpha 3 wrote profiles to `D:\GenHub\Profiles`,
one level above where alpha 4 looks for them. The files survive the upgrade, but the UI shows
no profiles at all.

## Change

`MigrateLegacyCustomPathProfiles()` runs in the first-launch migration sequence, after
`MigrateContentDirectory()`. When an explicit data path override is in effect, it probes the
alpha 3 sibling location and moves any `*.json` profiles into the current profiles directory.

Against the acceptance criteria:

- **Never overwrites.** It reuses `MigrateFile`, which skips a destination that already exists.
- **Idempotent.** A second run finds the source drained and does nothing.
- **Warns.** Anything left behind after the pass is logged as a warning with the path.
- **Conservative cleanup.** `TryDeleteEmptyDirectory` runs only when the legacy directory is
  fully drained, so nothing is removed while files remain.

Only `*.json` is migrated, so unrelated files in that directory are left alone.

## Tests

Four regression tests added to `LegacyRootUpgradeTests` (18 total in the class):

- `FirstLaunch_WithOverride_RecoversProfilesStoredBesideTheDataPath`
- `FirstLaunch_WithOverride_DoesNotOverwriteExistingProfileOnRecovery`
- `FirstLaunch_WithOverride_ProfileRecoveryIsIdempotent`
- `FirstLaunch_WithoutOverride_LeavesDefaultPathMigrationUnchanged`

Evidence:

- Clean `--no-incremental` Release build of the solution: 0 errors, and no new warnings. The
  21 SA1648 occurrences that remain are pre-existing on `development` and are fixed by #476.
  An earlier revision of this branch added one SA1202, since corrected by ordering the new
  tests ahead of the private helpers
- `LegacyRootUpgradeTests`: 18/18 pass
- With the production change reverted, the two recovery tests fail as expected, so they are
  pinning the fix rather than passing vacuously
- Full `GenHub.Tests.Core`: 3469 passed, 1 failed

The single failure is `NativeClientLaunchIntegrationTests.RealNativeClient_LaunchesThroughGameProcessManagerAsync`,
a real-engine integration test that needs retail game data not present on this machine. It fails
identically on a branch without this change.

